### PR TITLE
Property Resolution - part of fixing schema compilation

### DIFF
--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/compiler/Compiler.scala
@@ -67,6 +67,7 @@ import edu.illinois.ncsa.daffodil.processors.parsers.NotParsableParser
 import edu.illinois.ncsa.daffodil.processors.unparsers.NotUnparsableUnparser
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.ParseUnparsePolicy
 import edu.illinois.ncsa.daffodil.dsom.SchemaComponent
+import edu.illinois.ncsa.daffodil.dsom.SchemaComponentImpl
 import edu.illinois.ncsa.daffodil.api.DaffodilTunables
 
 /**
@@ -85,8 +86,8 @@ object ForParser extends ParserOrUnparser
 object ForUnparser extends ParserOrUnparser
 object BothParserAndUnparser extends ParserOrUnparser
 
-class ProcessorFactory(val sset: SchemaSet)
-  extends SchemaComponent(<pf/>, sset)
+final class ProcessorFactory(val sset: SchemaSet)
+  extends SchemaComponentImpl(<pf/>, sset)
   with DFDL.ProcessorFactory
   with HavingRootSpec {
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/Expression.scala
@@ -32,7 +32,7 @@
 
 package edu.illinois.ncsa.daffodil.dpath
 
-import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHost
+import edu.illinois.ncsa.daffodil.oolag.OOLAG._
 import edu.illinois.ncsa.daffodil.exceptions._
 import edu.illinois.ncsa.daffodil.dsom._
 import scala.xml.NamespaceBinding
@@ -54,7 +54,7 @@ import edu.illinois.ncsa.daffodil.util.Numbers
  *
  * This is the OOLAG pattern again.
  */
-abstract class Expression extends OOLAGHost
+abstract class Expression extends OOLAGHostImpl()
   with ImplementsThrowsOrSavesSDE {
 
   /**
@@ -294,8 +294,8 @@ case class ComparisonExpression(op: String, adds: List[Expression])
       case ("=", _) => subsetError("Unsupported operation '%s'. Use 'eq' instead.", op)
       case ("!=", _) => subsetError("Unsupported operation '%s'. Use 'ne' instead.", op)
 
-      case("eq", HexBinary) => EQ_CompareByteArray
-      case("ne", HexBinary) => NE_CompareByteArray
+      case ("eq", HexBinary) => EQ_CompareByteArray
+      case ("ne", HexBinary) => NE_CompareByteArray
       case ("eq", _) => EQ_Compare
       case ("ne", _) => NE_Compare
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ComplexTypes.scala
@@ -1,7 +1,7 @@
 /* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
  *
  * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *               http://woverride val ww.tresys.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal with
@@ -37,9 +37,10 @@ import edu.illinois.ncsa.daffodil.grammar.ComplexTypeBaseGrammarMixin
 import edu.illinois.ncsa.daffodil.dpath.NodeInfo
 import edu.illinois.ncsa.daffodil.xml.QName
 
-abstract class ComplexTypeBase(xmlArg: Node, parent: SchemaComponent)
-  extends SchemaComponent(xmlArg, parent)
+abstract class ComplexTypeBase(xml: Node, parent: SchemaComponent)
+  extends SchemaComponentImpl(xml, parent)
   with TypeBase
+  with NonPrimTypeMixin
   with ComplexTypeBaseGrammarMixin {
 
   final override def optRestriction = None
@@ -48,7 +49,7 @@ abstract class ComplexTypeBase(xmlArg: Node, parent: SchemaComponent)
 
   requiredEvaluations(modelGroup)
 
-  def element: ElementBase
+  def elementDecl: ElementDeclMixin
 
   protected final lazy val <complexType>{ xmlChildren @ _* }</complexType> = xml
 
@@ -101,7 +102,7 @@ final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaD
   extends SchemaComponentFactory(xmlArg, schemaDocumentArg)
   with GlobalNonElementComponentMixin {
 
-  def forElement(element: ElementBase) = new GlobalComplexTypeDef(xml, schemaDocument, element)
+  def forElement(elementDecl: ElementDeclMixin) = new GlobalComplexTypeDef(xml, schemaDocument, elementDecl)
 
   override lazy val namedQName = QName.createGlobal(name, targetNamespace, xml.scope)
 }
@@ -109,17 +110,17 @@ final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaD
 /**
  * For unit testing purposes, the element argument might be supplied as null.
  */
-final class GlobalComplexTypeDef(xmlArg: Node, schemaDocumentArg: SchemaDocument, val element: ElementBase)
+final class GlobalComplexTypeDef(xmlArg: Node, schemaDocumentArg: SchemaDocument, override val elementDecl: ElementDeclMixin)
   extends ComplexTypeBase(xmlArg, schemaDocumentArg)
   with GlobalNonElementComponentMixin
   with NestingTraversesToReferenceMixin {
 
-  lazy val referringComponent = Option(element)
+  override lazy val referringComponent = Option(elementDecl)
 
 }
 
-final class LocalComplexTypeDef(xmlArg: Node, val element: ElementBase)
-  extends ComplexTypeBase(xmlArg, element)
+final class LocalComplexTypeDef(xmlArg: Node, override val elementDecl: ElementDeclMixin)
+  extends ComplexTypeBase(xmlArg, elementDecl)
   with LocalNonElementComponentMixin
   with NestingLexicalMixin {
   // nothing

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLAssertion.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLAssertion.scala
@@ -80,13 +80,16 @@ abstract class DFDLAssertionBase(node: Node, decl: AnnotatedSchemaComponent)
       } catch { case e: PatternSyntaxException => SDE("The pattern contained invalid syntax: %s", e.getMessage()) }
 
       val hasWord = thePattern.contains("\\w")
-
-      if (decl.term.termRuntimeData.encodingInfo.knownEncodingIsUnicode && hasWord) {
-        SDW("The encoding is '%s' and \\w was detected in the pattern '%s'.  This is not recommended with Unicode encodings.",
-          decl.term.termRuntimeData.encodingInfo.knownEncodingName, thePattern)
+      decl match {
+        case term: Term => {
+          val encInfo = term.termRuntimeData.encodingInfo
+          if (encInfo.knownEncodingIsUnicode && hasWord)
+            SDW("The encoding is '%s' and \\w was detected in the pattern '%s'.  This is not recommended with Unicode encodings.",
+              encInfo.knownEncodingName, thePattern)
+        }
+        case _ => // ok
       }
     }
-
     optPattern
   }
 
@@ -131,8 +134,8 @@ final class DFDLAssert(node: Node, decl: AnnotatedSchemaComponent)
 
   final def gram = LV('gram) {
     testKind match {
-      case TestKind.Pattern => AssertPatternPrim(decl, this)
-      case TestKind.Expression => AssertBooleanPrim(decl, this)
+      case TestKind.Pattern => AssertPatternPrim(decl.term, this)
+      case TestKind.Expression => AssertBooleanPrim(decl.term, this)
     }
   }.value
 }
@@ -142,8 +145,8 @@ final class DFDLDiscriminator(node: Node, decl: AnnotatedSchemaComponent)
 
   final def gram = LV('gram) {
     testKind match {
-      case TestKind.Pattern => DiscriminatorPatternPrim(decl, this)
-      case TestKind.Expression => DiscriminatorBooleanPrim(decl, this)
+      case TestKind.Pattern => DiscriminatorPatternPrim(decl.term, this)
+      case TestKind.Expression => DiscriminatorBooleanPrim(decl.term, this)
     }
   }.value
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLFormat.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLFormat.scala
@@ -47,7 +47,7 @@ final class DFDLFormat(node: Node, sd: SchemaDocument)
 abstract class DFDLNonDefaultFormatAnnotation(node: Node, sc: AnnotatedSchemaComponent)
   extends DFDLFormatAnnotation(node, sc)
 
-final class DFDLElement(node: Node, decl: ElementBase)
+final class DFDLElement(node: Node, decl: ElementLikeMixin)
   extends DFDLNonDefaultFormatAnnotation(node, decl)
 
 final class DFDLGroup(node: Node, decl: GroupBase)
@@ -56,10 +56,10 @@ final class DFDLGroup(node: Node, decl: GroupBase)
 abstract class DFDLModelGroup(node: Node, decl: ModelGroup)
   extends DFDLNonDefaultFormatAnnotation(node, decl)
 
-final class DFDLSequence(node: Node, decl: Sequence)
+final class DFDLSequence(node: Node, decl: SequenceBase)
   extends DFDLModelGroup(node, decl)
 
-final class DFDLChoice(node: Node, decl: Choice)
+final class DFDLChoice(node: Node, decl: ChoiceBase)
   extends DFDLModelGroup(node, decl)
 
 final class DFDLSimpleType(node: Node, decl: SimpleTypeDefBase)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLFormatAnnotation.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLFormatAnnotation.scala
@@ -249,7 +249,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
    * Needed for certain warnings, and also is the primitive from which the
    * ChainPropProvider is built up. That one DOES follow ref chains.
    */
-  final override def justThisOneProperties: PropMap = LV('justThisOneProperties) {
+  final lazy val justThisOneProperties: PropMap = LV('justThisOneProperties) {
     val res = combinedJustThisOneProperties
     log(LogLevel.Debug, "%s::%s justThisOneProperties are: %s", annotatedSC.diagnosticDebugName, diagnosticDebugName, res)
     res

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLSchemaFile.scala
@@ -53,7 +53,7 @@ final class DFDLSchemaFile(val sset: SchemaSet,
   schemaSourceArg: => DaffodilSchemaSource, // fileName, URL, or a scala.xml.Node
   val iiParent: IIBase,
   seenBeforeArg: IIMap)
-  extends SchemaComponent(<file/>, sset)
+  extends SchemaComponentImpl(<file/>, sset)
   with org.xml.sax.ErrorHandler {
 
   requiredEvaluations(isValid)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLStatement.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLStatement.scala
@@ -46,4 +46,5 @@ abstract class DFDLStatement(node: Node,
   requiredEvaluations(gram)
 
   def gram: Gram
+
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ElementRef.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ElementRef.scala
@@ -1,7 +1,7 @@
 /* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
  *
  * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *               http://woverride val ww.tresys.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal with
@@ -35,43 +35,43 @@ package edu.illinois.ncsa.daffodil.dsom
 import scala.xml.Node
 import edu.illinois.ncsa.daffodil.grammar._
 import edu.illinois.ncsa.daffodil.xml._
-import edu.illinois.ncsa.daffodil.processors._
 import edu.illinois.ncsa.daffodil.grammar.ElementReferenceGrammarMixin
-import edu.illinois.ncsa.daffodil.schema.annotation.props.PropertyLookupResult
+import edu.illinois.ncsa.daffodil.dpath.NodeInfo
 
 /**
- * Note ElementRef isn't a first class citizen with the other schema components.
- * It gets bypassed in that most things here just delegate to the GlobalElementDecl
- * that this references.
- *
- * Most of the framework expects to be handling elements via the ElementBase abstract
- * class. That class is responsible for testing and reaching back over to an ElementRef.
- *
- * So for example, to find out if an element has a property, an Element has to consider
- * that the property might be expressed on an element ref (if there is one), the element
- * itself, or a simpleType def or a base simple type def. Element does this. ElementRef
- * doesn't.
+ * There are 3 first-class concrete children of ElementBase.
+ * Root, LocalElementDecl, and ElementRef
  */
 final class ElementRef(xmlArg: Node, parent: ModelGroup, position: Int)
-  extends LocalElementBase(xmlArg, parent, position)
+  extends AbstractElementRef(xmlArg, parent, position)
+
+abstract class AbstractElementRef(xmlArg: Node,
+  parentArg: SchemaComponent,
+  positionArg: Int)
+  extends LocalElementBase
   with ElementReferenceGrammarMixin
   with HasRefMixin
   with NamedMixin
   with NestingLexicalMixin {
 
+  final override lazy val xml = xmlArg
+  final override lazy val parent = parentArg
+  final override lazy val position = positionArg
+
   requiredEvaluations(referencedElement)
 
-  override def findPropertyOption(pname: String): PropertyLookupResult = {
-    val res = referencedElement.findPropertyOption(pname)
-    res
-  }
+  def complexType: ComplexTypeBase = this.referencedElement.complexType
+  def defaultValueAsString: String = this.referencedElement.defaultValueAsString
+  def hasDefaultValue: Boolean = this.referencedElement.hasDefaultValue
+  def isComplexType: Boolean = this.referencedElement.isComplexType
+  def isNillable: Boolean = this.referencedElement.isNillable
+  def isSimpleType: Boolean = this.referencedElement.isSimpleType
+  def simpleType: SimpleTypeBase = this.referencedElement.simpleType
+  def primType: NodeInfo.PrimType = this.referencedElement.primType
+  // lazy val elementRef: Option[ElementRef] = None
 
-  lazy val nonDefaultPropertySources = referencedElement.nonDefaultPropertySources
-  lazy val defaultPropertySources = referencedElement.defaultPropertySources
-
-  lazy val elementRef = None
-
-  override lazy val referredToComponent = referencedElement
+  // override def referencedComponent = referencedElement
+  override lazy val optReferredToComponent = Some(referencedElement)
 
   /**
    * Note: since the namedQName might not exist, we cannot use
@@ -83,10 +83,12 @@ final class ElementRef(xmlArg: Node, parent: ModelGroup, position: Int)
     referencedElement.namedQName
   }.value
 
-  override lazy val prefix = referencedElement.prefix
+  override lazy val name = refQName.local
+
+  override lazy val prefix = refQName.prefix.getOrElse(null)
 
   // Need to go get the Element we are referencing
-  final lazy val referencedElement: GlobalElementDecl = LV('referencedElement) {
+  lazy val referencedElement: GlobalElementDecl = LV('referencedElement) {
     val ged = this.schemaSet.getGlobalElementDecl(refQName)
     val res = ged match {
       case None => {
@@ -106,43 +108,27 @@ final class ElementRef(xmlArg: Node, parent: ModelGroup, position: Int)
     res
   }.value
 
-  override lazy val runtimeData = referencedElement.runtimeData
-  override lazy val termRuntimeData = referencedElement.termRuntimeData
-  override def erd = referencedElement.erd
-  override lazy val elementRuntimeData: ElementRuntimeData = LV('elementRuntimeData) {
-    referencedElement.elementRuntimeData
-  }.value
-  override lazy val dpathElementCompileInfo = referencedElement.dpathElementCompileInfo
-
-  // These will just delegate to the referenced element declaration
-  def isNillable = referencedElement.isNillable
-  def isSimpleType = referencedElement.isSimpleType
-  def isComplexType = referencedElement.isComplexType
-
-  def isDefaultable: Boolean = referencedElement.isDefaultable
-  def defaultValueAsString = referencedElement.defaultValueAsString
+  //  // These will just delegate to the referenced element declaration
+  //  override def isNillable = referencedElement.isNillable
+  //  override def isSimpleType = referencedElement.isSimpleType
+  //  override def isComplexType = referencedElement.isComplexType
+  //
+  //  override def isDefaultable: Boolean = referencedElement.isDefaultable
+  //  override def defaultValueAsString = referencedElement.defaultValueAsString
 
   override lazy val namespace = refQName.namespace
 
   override lazy val diagnosticDebugName = "element reference " + refQName
 
-  override lazy val name = this.ref
-
-  // TODO: perhaps many members of ElementRef are unused.
-  // Consider removing some. Although consider that
-  // some have to be here because of abstract bases or traits requiring them
-  // even if they aren't called.
   override def typeDef = referencedElement.typeDef
 
-  // Element references can have minOccurs and maxOccurs, and annotations, but nothing else.
-  override def inputValueCalcOption = referencedElement.inputValueCalcOption // can't have ivc on element reference
-  override def outputValueCalcOption = referencedElement.outputValueCalcOption // can't have ivc on element reference
+  // Can't do this - you won't get the array behaviors that an elementRef
+  // can describe. You'd just get the non-array aspects. All Element refs
+  // would behave as scalars.
+  //
+  // override lazy val dpathElementCompileInfo = referencedElement.dpathElementCompileInfo
 
-  //TODO: refactor and use shared code for creating resolved set of annotations for an annotation point.
-  override lazy val statements = localStatements
-  override lazy val newVariableInstanceStatements = localNewVariableInstanceStatements
-  override lazy val assertStatements = localAssertStatements
-  override lazy val discriminatorStatements = localDiscriminatorStatements
-  override lazy val setVariableStatements = localSetVariableStatements
+  //  override protected def maybeElementRefReferencedElementCompileInfo: Maybe[DPathElementCompileInfo] =
+  //    Maybe(referencedElement.dpathElementCompileInfo)
 
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/EscapeSchemeRefMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/EscapeSchemeRefMixin.scala
@@ -58,7 +58,7 @@ trait EscapeSchemeRefMixin { self: AnnotatedSchemaComponent =>
    * issue DFDL-77)
    */
   final lazy val optionEscapeScheme: Option[DFDLEscapeScheme] = {
-    val er = findPropertyOption("escapeSchemeRef")
+    val er = self.resolver.findPropertyOption("escapeSchemeRef")
     er match {
       case _: NotFound => {
         SDW(WarnID.EscapeSchemeRefUndefined,

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/GlobalElementDeclFactory.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/GlobalElementDeclFactory.scala
@@ -50,10 +50,16 @@ class GlobalElementDeclFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
   with GlobalElementComponentMixin {
 
   def forRoot() = asRoot // cache. Not a new one every time.
-  lazy val asRoot = new GlobalElementDecl(this, None)
+  lazy val asRoot = {
+    lazy val ged = new GlobalElementDecl(this, root)
+    lazy val root: Root = new Root(schemaDocument, namedQName, ged)
+    root
+  }
 
-  def forElementRef(eRef: ElementRef) = {
-    new GlobalElementDecl(this, Some(eRef))
+  def forElementRef(eRef: AbstractElementRef) = {
+    if (this.namedQName.local == "NS_06")
+      println("stop here")
+    new GlobalElementDecl(this, eRef)
   }
 
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/GroupBase.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/GroupBase.scala
@@ -32,14 +32,12 @@
 
 package edu.illinois.ncsa.daffodil.dsom
 
-import scala.xml.Node
-import scala.xml._
 import edu.illinois.ncsa.daffodil.schema.annotation.props.AlignmentType
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.AlignmentUnits
 import java.lang.{ Integer => JInt }
 
-abstract class GroupBase(xmlArg: Node, parentArg: SchemaComponent, position: Int)
-  extends Term(xmlArg, parentArg, position) {
+trait GroupBase
+  extends Term {
 
   final override def isScalar = true
   final override def isOptional = false
@@ -64,22 +62,22 @@ abstract class GroupBase(xmlArg: Node, parentArg: SchemaComponent, position: Int
   final lazy val enclosingComponentModelGroup = enclosingComponent.collect { case mg: ModelGroup => mg }
   final lazy val sequencePeers = enclosingComponentModelGroup.map { _.sequenceChildren }
   final lazy val choicePeers = enclosingComponentModelGroup.map { _.choiceChildren }
-  final lazy val groupRefPeers = enclosingComponentModelGroup.map { _.groupRefChildren }
+  // final lazy val groupRefPeers = enclosingComponentModelGroup.map { _.groupRefChildren }
 
   protected def myPeers: Option[Seq[GroupBase]]
 
   def group: ModelGroup
 
-  final lazy val immediateGroup: Option[ModelGroup] = {
-    val res: Option[ModelGroup] = this.group match {
-      case (s: Sequence) => Some(s)
-      case (c: Choice) => Some(c)
-      case _ => None
-    }
-    res
-  }
+  //  final lazy val immediateGroup: Option[ModelGroup] = {
+  //    val res: Option[ModelGroup] = this.group match {
+  //      case (s: Sequence) => Some(s)
+  //      case (c: Choice) => Some(c)
+  //      case _ => None
+  //    }
+  //    res
+  //  }
 
-  final lazy val alignmentValueInBits: JInt = {
+  override lazy val alignmentValueInBits: JInt = {
     this.alignment match {
       case AlignmentType.Implicit => 1
       case align: JInt => this.alignmentUnits match {

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/IIBase.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/IIBase.scala
@@ -137,9 +137,10 @@ object IIUtils {
 /**
  * Include/Import = "II" for short
  */
-abstract class IIBase(xml: Node, xsdArg: XMLSchemaDocument, val seenBefore: IIMap)
-  extends SchemaComponent(xml, xsdArg)
+abstract class IIBase( final override val xml: Node, xsdArg: XMLSchemaDocument, val seenBefore: IIMap)
+  extends SchemaComponent
   with NestingLexicalMixin {
+  final override def parent = xsdArg
 
   /**
    * An import/include requires only that we can access the

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/InitiatedTerminatedMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/InitiatedTerminatedMixin.scala
@@ -75,7 +75,7 @@ trait InitiatedTerminatedMixin
    * present, or there is an expression. (Such expressions are not allowed to evaluate to "" - you
    * can't turn off a delimiter by providing "" at runtime. Minimum length is 1 for these at runtime.
    * <p>
-   * Override in Sequence to also check for separator.
+   * Override in SequenceBase to also check for separator.
    */
   lazy val hasDelimiters = hasInitiator || hasTerminator
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/LocalElementBase.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/LocalElementBase.scala
@@ -32,10 +32,8 @@
 
 package edu.illinois.ncsa.daffodil.dsom
 
-import scala.xml.Node
-
-abstract class LocalElementBase(xmlArg: Node, parent: SchemaComponent, position: Int)
-  extends ElementBase(xmlArg, parent, position)
+trait LocalElementBase
+  extends ElementBase
   with LocalElementMixin {
 
   requiredEvaluations(checkForAlignmentAmbiguity)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/LocalElementDecl.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/LocalElementDecl.scala
@@ -1,7 +1,7 @@
 /* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
  *
  * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *               http://woverride val ww.tresys.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal with
@@ -34,7 +34,7 @@ package edu.illinois.ncsa.daffodil.dsom
 
 import scala.xml.Node
 
-final class LocalElementDeclFactory(override val xml: Node, sd: SchemaDocument)
+final class LocalElementDeclFactory(xml: Node, sd: SchemaDocument)
   extends SchemaComponentFactory(xml, sd)
   with LocalElementComponentMixin {
 
@@ -44,16 +44,18 @@ final class LocalElementDeclFactory(override val xml: Node, sd: SchemaDocument)
 }
 
 final class LocalElementDecl(factory: LocalElementDeclFactory,
-  override val parent: ModelGroup,
-  override val position: Int)
-  extends LocalElementBase(factory.xml, parent, position)
+  final override val parent: ModelGroup,
+  final override val position: Int)
+  extends LocalElementBase
   with LocalElementComponentMixin
   with ElementDeclMixin
   with NestingLexicalMixin {
 
-  override lazy val elementRef = None
+  final override lazy val xml = factory.xml
 
   requiredEvaluations(minOccurs, maxOccurs)
+
+  override protected lazy val enclosedElement = enclosedElementProd
 
   final override lazy val namedQName = factory.namedQName
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/NamedMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/NamedMixin.scala
@@ -176,7 +176,7 @@ trait GlobalElementComponentMixin
  * Namely the local element declaration class.
  */
 trait ElementFormDefaultMixin {
-  
+
   def tunable: DaffodilTunables
 
   def xml: Node

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/Nesting.scala
@@ -40,12 +40,12 @@ trait NestingMixin {
   def parent: SchemaComponent
 
   /**
-   * Define this for schema components that have back-references to ref 
+   * Define this for schema components that have back-references to ref
    * objects.
    * So group def to group ref, globalelementdecl to element ref,
    * type to element, base type to derived type.
-   * 
-   * Not for format annotations however. We don't backpoint those to 
+   *
+   * Not for format annotations however. We don't backpoint those to
    * other format annotations that ref them.
    */
   protected def enclosingComponentDef: Option[SchemaComponent]
@@ -62,11 +62,12 @@ trait NestingMixin {
    */
   final lazy val enclosingComponent: Option[SchemaComponent] = {
     val optECD = enclosingComponentDef
-    optECD match {
+    val res = optECD match {
       case Some(eref: ElementRef) => eref.enclosingComponent
       case Some(gref: GroupRef) => gref.enclosingComponent
       case _ => optECD
     }
+    res
   }
 }
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/PropProviders.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/PropProviders.scala
@@ -120,6 +120,7 @@ trait LeafPropProvider
 final class ChainPropProvider(leafProvidersArg: Seq[LeafPropProvider], forAnnotation: String)
   extends Logging with PropTypes {
 
+  override def toString() = Misc.getNameFromClass(this) + "(" + forAnnotation + ")"
   /**
    * for debug/test only
    */

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RestrictionUnion.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RestrictionUnion.scala
@@ -49,7 +49,7 @@ import edu.illinois.ncsa.daffodil.dpath.NodeInfo.PrimType
  * A schema component for simple type restrictions
  */
 final class Restriction(xmlArg: Node, val simpleType: SimpleTypeDefBase)
-  extends SchemaComponent(xmlArg, simpleType.schemaDocument)
+  extends SchemaComponentImpl(xmlArg, simpleType.schemaDocument)
   with NestingLexicalMixin
   with Facets
   with TypeChecks {
@@ -187,7 +187,7 @@ final class Restriction(xmlArg: Node, val simpleType: SimpleTypeDefBase)
  * A schema component for simple type unions
  */
 final class Union(xmlArg: Node, simpleType: SimpleTypeDefBase)
-  extends SchemaComponent(xmlArg, simpleType.schemaDocument)
+  extends SchemaComponentImpl(xmlArg, simpleType.schemaDocument)
   with NestingLexicalMixin {
 
   Assert.invariant(xmlArg.asInstanceOf[scala.xml.Elem].label == "union")
@@ -213,7 +213,7 @@ final class Union(xmlArg: Node, simpleType: SimpleTypeDefBase)
   private lazy val immediateTypeXMLs = xml \ "simpleType"
   private lazy val immediateTypes = immediateTypeXMLs.map { node =>
     {
-      schemaSet.LocalSimpleTypeDefFactory(node, schemaDocument).forElement(simpleType.element)
+      schemaSet.LocalSimpleTypeDefFactory(node, schemaDocument).forElement(simpleType.elementDecl)
     }
   }
 
@@ -226,7 +226,7 @@ final class Union(xmlArg: Node, simpleType: SimpleTypeDefBase)
   }
   private lazy val namedTypeQNames = namedTypeQNameStrings.map { qns => resolveQName(qns) }
   private lazy val namedTypes = namedTypeQNames.map {
-    qn => schemaSet.getGlobalSimpleTypeDef(qn).get.forElement(simpleType.element)
+    qn => schemaSet.getGlobalSimpleTypeDef(qn).get.forElement(simpleType.elementDecl)
   }
   private lazy val directMemberTypes: Seq[SimpleTypeDefBase] = namedTypes ++ immediateTypes
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/Root.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/Root.scala
@@ -1,0 +1,22 @@
+package edu.illinois.ncsa.daffodil.dsom
+
+import edu.illinois.ncsa.daffodil.grammar.RootGrammarMixin
+import edu.illinois.ncsa.daffodil.xml.NamedQName
+
+final class Root(parentArg: SchemaDocument,
+  namedQNameArg: NamedQName,
+  globalElementDecl: => GlobalElementDecl)
+  extends AbstractElementRef(
+    <root/>, // % Attribute(None, "ref", Text(refQName.toQNameString), Null), // have to have ref attribute.
+    parentArg, 1)
+  with RootGrammarMixin {
+
+  override lazy val refQName = namedQNameArg.toRefQName
+
+  override lazy val referencedElement = globalElementDecl
+
+  lazy val rootParseUnparsePolicy = defaultParseUnparsePolicy
+
+  override lazy val isHidden = false
+
+}

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RuntimePropertyMixins.scala
@@ -184,7 +184,7 @@ trait DelimitedRuntimeValuedPropertiesMixin
   with RawDelimitedRuntimeValuedPropertiesMixin { decl: Term =>
 
   lazy val isLengthKindDelimited = {
-    decl.referredToComponent match {
+    this match {
       case mg: ModelGroup => mg.enclosingElement.get.lengthKind == LengthKind.Delimited
       case eb: ElementBase => eb.lengthKind == LengthKind.Delimited
     }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SchemaComponentFactory.scala
@@ -1,7 +1,7 @@
 /* Copyright (c) 2017 Tresys Technology, LLC. All rights reserved.
  *
  * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *               http://www.troverride val esys.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal with
@@ -33,29 +33,40 @@
 package edu.illinois.ncsa.daffodil.dsom
 
 import edu.illinois.ncsa.daffodil.exceptions.SchemaFileLocatable
-import edu.illinois.ncsa.daffodil.xml.GetAttributesMixin
 import edu.illinois.ncsa.daffodil.xml.XMLUtils
 import edu.illinois.ncsa.daffodil.exceptions.ThrowsSDE
 import scala.xml.NamespaceBinding
 import edu.illinois.ncsa.daffodil.xml.NS
 import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHost
+import scala.xml.Node
 
 /**
  * Anything that can be computed without reference to the point of use
  * or point of reference can be computed here on these factory objects.
  */
-class SchemaComponentFactory(override val xml: scala.xml.Node,
-  override val schemaDocument: SchemaDocument)
-  extends OOLAGHost(schemaDocument)
-  with SchemaFileLocatableImpl
-  with CommonContextMixin
-  with GetAttributesMixin
-  with ImplementsThrowsSDE
+abstract class SchemaComponentFactory( final override val xml: Node,
+  final override val schemaDocument: SchemaDocument)
+  extends SchemaComponent
+  with NestingLexicalMixin {
+  //  extends OOLAGHost(schemaDocument)
+  //  with SchemaFileLocatableImpl
+  //  with CommonContextMixin
+  //  with GetAttributesMixin
+  //  with ImplementsThrowsSDE
+  //  with NestingLexicalMixin {
+
+  final override def parent = schemaDocument
+
+  //  final override def tunable = schemaDocument.tunable
+}
+
+abstract class AnnotatedSchemaComponentFactory( final override val xml: Node,
+  final override val schemaDocument: SchemaDocument)
+  extends AnnotatedSchemaComponent
   with NestingLexicalMixin {
 
-  override def parent = schemaDocument
-  
-  final override def tunable = schemaDocument.tunable
+  final override def parent = schemaDocument
+
 }
 
 trait SchemaFileLocatableImpl

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SchemaSet.scala
@@ -83,7 +83,7 @@ final class SchemaSet(
   checkAllTopLevelArg: Boolean,
   parent: SchemaComponent,
   override val tunable: DaffodilTunables)
-  extends SchemaComponent(<schemaSet/>, parent) // a fake schema component
+  extends SchemaComponentImpl(<schemaSet/>, parent) // a fake schema component
   with SchemaSetIncludesAndImportsMixin {
 
   requiredEvaluations(isValid)
@@ -333,7 +333,7 @@ final class SchemaSet(
    * grabs the first element declaration of the first schema file
    * to use as the root.
    */
-  def rootElement(rootSpecFromProcessorFactory: Option[RootSpec]): GlobalElementDecl = {
+  def rootElement(rootSpecFromProcessorFactory: Option[RootSpec]): Root = {
     val rootSpecFromCompiler = rootSpec
     val re =
       (rootSpecFromCompiler, rootSpecFromProcessorFactory) match {
@@ -352,8 +352,8 @@ final class SchemaSet(
           val gdeclf = firstSchemaDocument.globalElementDecls
           val firstElement = {
             schemaDefinitionUnless(gdeclf.length >= 1, "No global elements in: " + firstSchemaDocument.uriString)
-            val rootElement = gdeclf(0).forRoot()
-            rootElement
+            val root = gdeclf(0).forRoot()
+            root
           }
           firstElement
         }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/SimpleTypes.scala
@@ -1,7 +1,7 @@
 /* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
  *
  * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *               http://woverride val ww.tresys.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal with
@@ -43,6 +43,16 @@ trait TypeBase {
   def optRestriction: Option[Restriction] = None
   def optUnion: Option[Union] = None
   def typeNode: NodeInfo.AnyType.Kind
+
+}
+
+trait NonPrimTypeMixin {
+  def elementDecl: ElementDeclMixin
+
+  def elementBase: ElementBase = elementDecl match {
+    case eb: ElementBase => eb
+    case ged: GlobalElementDecl => ged.elementRef
+  }
 }
 
 sealed trait SimpleTypeBase extends TypeBase {
@@ -122,15 +132,14 @@ object PrimitiveType {
 
 }
 
-abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaComponent)
-  extends AnnotatedSchemaComponent(xmlArg, parent)
+abstract class SimpleTypeDefBase(xml: Node, parent: SchemaComponent)
+  extends AnnotatedSchemaComponentImpl(xml, parent)
   with SimpleTypeBase
+  with NonPrimTypeMixin
   with DFDLStatementMixin
   with OverlapCheckMixin {
 
-  requiredEvaluations(if (element.isSimpleType) simpleTypeRuntimeData.preSerialization)
-
-  def element: ElementBase
+  requiredEvaluations(if (elementDecl.isSimpleType) simpleTypeRuntimeData.preSerialization)
 
   override def typeNode = primType
 
@@ -141,25 +150,18 @@ abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaCompon
     res
   }
 
+  /**
+   * Exclusive of self.
+   */
   final lazy val bases: Seq[SimpleTypeDefBase] =
     if (restrictions.isEmpty) Nil
     else restrictions.tail.map { _.simpleType }
 
-  private lazy val sTypeNonDefault: Seq[ChainPropProvider] = bases.reverse.map { _.nonDefaultFormatChain }
-  private lazy val sTypeDefault: Seq[ChainPropProvider] = bases.reverse.map { _.defaultFormatChain }
+  override final def optReferredToComponent = optRestriction.flatMap { _.optBaseDef }
 
-  // want a QueueSet i.e., fifo order if iterated, but duplicates
-  // kept out of the set. Will simulate by calling distinct.
-  def nonDefaultPropertySources = LV('nonDefaultPropertySources) {
-    val seq = (this.nonDefaultFormatChain +: sTypeNonDefault).distinct
-    checkNonOverlap(seq)
-    seq
-  }.value
-
-  def defaultPropertySources = LV('defaultPropertySources) {
-    val seq = (this.defaultFormatChain +: sTypeDefault).distinct
-    seq
-  }.value
+  // Keep while Debugging - why are these reverse calls here?? TBD
+  //  private lazy val sTypeNonDefault: Seq[ChainPropProvider] = bases.reverse.map { _.nonDefaultFormatChain }
+  //  private lazy val sTypeDefault: Seq[ChainPropProvider] = bases.reverse.map { _.defaultFormatChain }
 
   protected final def emptyFormatFactory = new DFDLSimpleType(newDFDLAnnotationXML("simpleType"), this)
 
@@ -168,7 +170,7 @@ abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaCompon
   protected final def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
       case <dfdl:simpleType>{ contents @ _* }</dfdl:simpleType> => Some(new DFDLSimpleType(node, this))
-      case _ => annotationFactoryForDFDLStatement(node, this)
+      case _ => annotationFactoryForDFDLStatement(node, elementBase)
     }
   }
 
@@ -183,33 +185,8 @@ abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaCompon
     }
   }
 
-  /**
-   * Combine our statements with those of our base def (if there is one)
-   *
-   * The order is important here. I.e., we FIRST put in each list those from our base. Then our own local ones.
-   */
-  final lazy val statements: Seq[DFDLStatement] =
-    bases.flatMap { _.statements } ++ localStatements
+  // private lazy val optBaseDef = optRestriction.flatMap { _.optBaseDef }
 
-  private lazy val optBaseDef = optRestriction.flatMap { _.optBaseDef }
-
-  // TODO: refactor into shared code for combining all the annotations in the resolved set of annotations
-  // for a particular annotation point, checking that there is only one format annotation, that
-  // asserts and discriminators are properly excluding each-other, etc.
-  // Code should be sharable for many kinds of annotation points, perhaps specialized for groups, complex type
-  // elements, and simple type elements.
-  //
-  // See JIRA issue DFDL-481
-  final lazy val newVariableInstanceStatements: Seq[DFDLNewVariableInstance] =
-    optBaseDef.map { _.newVariableInstanceStatements }.getOrElse(Seq.empty) ++ localNewVariableInstanceStatements
-  final lazy val (discriminatorStatements, assertStatements) = checkDiscriminatorsAssertsDisjoint(combinedDiscrims, combinedAsserts)
-  private lazy val combinedAsserts: Seq[DFDLAssert] = optBaseDef.map { _.assertStatements }.getOrElse(Nil) ++ localAssertStatements
-  private lazy val combinedDiscrims: Seq[DFDLDiscriminator] = optBaseDef.map { _.discriminatorStatements }.getOrElse(Nil) ++ localDiscriminatorStatements
-
-  final lazy val setVariableStatements: Seq[DFDLSetVariable] = {
-    val combinedSvs = optBaseDef.map { _.setVariableStatements }.getOrElse(Nil) ++ localSetVariableStatements
-    checkDistinctVariableNames(combinedSvs)
-  }
   def toOpt[R <: AnyRef](b: Boolean, v: => R) = Misc.boolToOpt(b, v)
 
   lazy val simpleTypeRuntimeData: SimpleTypeRuntimeData = {
@@ -219,7 +196,7 @@ abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaCompon
       diagnosticDebugName,
       path,
       namespaces,
-      element.simpleType.primType,
+      primType,
       noFacetChecks,
       //
       // TODO: Cleanup code: really these should all have been option types
@@ -252,27 +229,25 @@ abstract class SimpleTypeDefBase(xmlArg: Node, override val parent: SchemaCompon
 
 sealed abstract class SimpleTypeDefFactory(xml: Node, schemaDocumentArg: SchemaDocument)
   extends SchemaComponentFactory(xml, schemaDocumentArg) {
-
 }
 
 final class LocalSimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
   extends SimpleTypeDefFactory(xmlArg, schemaDocumentArg)
   with LocalNonElementComponentMixin {
 
-  def forElement(element: ElementBase) =
+  def forElement(element: ElementDeclMixin) =
     new LocalSimpleTypeDef(this, element)
 
 }
 
 final class LocalSimpleTypeDef(
   val factory: LocalSimpleTypeDefFactory,
-  elementArg: ElementBase)
+  elementArg: ElementDeclMixin)
   extends SimpleTypeDefBase(factory.xml, elementArg)
   with LocalNonElementComponentMixin
   with NestingLexicalMixin {
 
-  override def term = element
-  override lazy val element = elementArg
+  override lazy val elementDecl = elementArg
 
   /**
    * For anonymous simple type def, uses the base name, or primitive type name
@@ -309,7 +284,7 @@ final class GlobalSimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDo
   /**
    * Create a private instance for this element's use.
    */
-  def forElement(element: ElementBase) = new GlobalSimpleTypeDef(None, this, Some(element))
+  def forElement(elementDecl: ElementDeclMixin) = new GlobalSimpleTypeDef(None, this, Some(elementDecl))
   def forDerivedType(derivedType: SimpleTypeDefBase) = new GlobalSimpleTypeDef(Some(derivedType), this, None)
 
 }
@@ -320,12 +295,12 @@ final class GlobalSimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDo
 final class GlobalSimpleTypeDef(
   derivedType: Option[SimpleTypeDefBase],
   val factory: GlobalSimpleTypeDefFactory,
-  val referringElement: Option[ElementBase])
+  val referringElement: Option[ElementDeclMixin])
   extends SimpleTypeDefBase(factory.xml, factory.schemaDocument)
   with GlobalNonElementComponentMixin
   with NestingTraversesToReferenceMixin {
 
-  override def term = element
+  // override def term = element
 
   override lazy val referringComponent: Option[SchemaComponent] =
     (derivedType, referringElement) match {
@@ -334,9 +309,9 @@ final class GlobalSimpleTypeDef(
       case _ => Assert.impossible("SimpleType must either have a derivedType or an element. Not both.")
     }
 
-  override lazy val element: ElementBase = referringComponent match {
-    case Some(dt: SimpleTypeDefBase) => dt.element
-    case Some(e: ElementBase) => e
+  override lazy val elementDecl: ElementDeclMixin = referringComponent match {
+    case Some(dt: SimpleTypeDefBase) => dt.elementDecl
+    case Some(e: ElementDeclMixin) => e
     case _ => Assert.invariantFailed("unexpected referringComponent")
   }
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/TermEncodingMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/TermEncodingMixin.scala
@@ -114,9 +114,6 @@ trait TermEncodingMixin extends KnownEncodingMixin { self: Term =>
         mg.hasNoSkipRegions &&
           hasTextAlignment
       }
-      case gr: GroupRef => {
-        gr.group.isLocallyTextOnly
-      }
     }
     res
   }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ChoiceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ChoiceGrammarMixin.scala
@@ -32,10 +32,10 @@
 
 package edu.illinois.ncsa.daffodil.grammar
 
-import edu.illinois.ncsa.daffodil.dsom.Choice
+import edu.illinois.ncsa.daffodil.dsom.ChoiceBase
 import edu.illinois.ncsa.daffodil.grammar.primitives.ChoiceCombinator
 
-trait ChoiceGrammarMixin extends GrammarMixin { self: Choice =>
+trait ChoiceGrammarMixin extends GrammarMixin { self: ChoiceBase =>
 
   override lazy val groupContent = prod("choiceContent") {
     ChoiceCombinator(this, alternatives)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -37,7 +37,6 @@ import edu.illinois.ncsa.daffodil.processors._
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen._
 import edu.illinois.ncsa.daffodil.dpath.NodeInfo.PrimType
 import edu.illinois.ncsa.daffodil.dsom.InitiatedTerminatedMixin
-import edu.illinois.ncsa.daffodil.dsom.SimpleTypeBase
 import edu.illinois.ncsa.daffodil.dsom.ElementBase
 import java.lang.{ Long => JLong }
 import edu.illinois.ncsa.daffodil.dpath.NodeInfo
@@ -657,11 +656,7 @@ trait ElementBaseGrammarMixin
     ConvertTextCombinator(this, stringValue, ConvertTextBooleanPrim(this))
   }
 
-  // shorthand
-  final lazy val primType = {
-    val res = typeDef.asInstanceOf[SimpleTypeBase].primType
-    res
-  }
+  def primType: PrimType
 
   protected final lazy val value = prod("value", isSimpleType) {
     // TODO: Consider issues with matching a stopValue. Can't say isScalar here because
@@ -1025,7 +1020,9 @@ trait ElementBaseGrammarMixin
 
   private lazy val elementRightFraming = prod("elementRightFraming") { TrailingSkipRegion(this) }
 
-  protected final lazy val enclosedElement = prod("enclosedElement") {
+  protected def enclosedElement: Gram
+
+  final lazy val enclosedElementProd = prod("enclosedElement") {
     //
     // not isScalar, because this is reused inside arrays
     // that is, we're counting on reusuing this production for array elements

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementDeclGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementDeclGrammarMixin.scala
@@ -33,11 +33,11 @@
 package edu.illinois.ncsa.daffodil.grammar
 
 import edu.illinois.ncsa.daffodil.grammar.primitives.UnicodeByteOrderMark
-import edu.illinois.ncsa.daffodil.dsom.GlobalElementDecl
+import edu.illinois.ncsa.daffodil.dsom.Root
 
-trait GlobalElementDeclGrammarMixin
+trait RootGrammarMixin
   extends LocalElementGrammarMixin // can be repeating if not root
-  { self: GlobalElementDecl =>
+  { self: Root =>
 
   final lazy val document = prod("document") {
     schemaDefinitionUnless(isScalar, "The document element cannot be an array.")
@@ -45,4 +45,5 @@ trait GlobalElementDeclGrammarMixin
   }
 
   private def documentElement = enclosedElement
+
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementReferenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementReferenceGrammarMixin.scala
@@ -32,10 +32,8 @@
 
 package edu.illinois.ncsa.daffodil.grammar
 
-import edu.illinois.ncsa.daffodil.dsom.ElementRef
+import edu.illinois.ncsa.daffodil.dsom.AbstractElementRef
 
-trait ElementReferenceGrammarMixin { self: ElementRef =>
-
-  final override lazy val termContentBody = self.referencedElement.termContentBody
+trait ElementReferenceGrammarMixin { self: AbstractElementRef =>
 
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/GrammarMixins.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/GrammarMixins.scala
@@ -37,8 +37,6 @@ import edu.illinois.ncsa.daffodil.grammar.primitives.ComplexTypeCombinator
 
 trait GroupRefGrammarMixin extends GrammarMixin { self: GroupRef =>
 
-  override lazy val termContentBody = self.group.termContentBody
-
 }
 
 /////////////////////////////////////////////////////////////////
@@ -50,6 +48,6 @@ trait ComplexTypeBaseGrammarMixin extends GrammarMixin { self: ComplexTypeBase =
   override protected final def grammarContext = this
 
   lazy val mainGrammar = prod("mainGrammar") {
-    ComplexTypeCombinator(this, modelGroup.group.asChildOfComplexType)
+    ComplexTypeCombinator(this, group.asChildOfComplexType)
   }
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/GrammarTerm.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/GrammarTerm.scala
@@ -37,7 +37,7 @@ import edu.illinois.ncsa.daffodil.processors.parsers.Parser
 import edu.illinois.ncsa.daffodil.processors.unparsers.Unparser
 import edu.illinois.ncsa.daffodil.grammar.primitives.Nada
 import edu.illinois.ncsa.daffodil.dsom.SchemaComponent
-import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHost
+import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHostImpl
 import edu.illinois.ncsa.daffodil.compiler.ParserOrUnparser
 import edu.illinois.ncsa.daffodil.util.Misc
 import edu.illinois.ncsa.daffodil.compiler.BothParserAndUnparser
@@ -55,7 +55,7 @@ trait HasNoUnparser {
  * because this one has to actually be operationalized.
  */
 abstract class Gram(contextArg: SchemaComponent)
-  extends OOLAGHost(contextArg) {
+  extends OOLAGHostImpl(contextArg) {
 
   final def SDE(str: String, args: Any*): Nothing = context.SDE(str, args: _*)
   final def SDW(str: String, args: Any*): Unit = context.SDW(str, args: _*)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/LocalElementGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/LocalElementGrammarMixin.scala
@@ -49,9 +49,8 @@ import edu.illinois.ncsa.daffodil.grammar.primitives.ArrayCombinator
 
 trait LocalElementGrammarMixin extends GrammarMixin { self: LocalElementBase =>
 
-  /**
-   * further overridden in ElementRefGrammarMixin
-   */
+   override protected lazy val enclosedElement: Gram = enclosedElementProd
+    
   override lazy val termContentBody = prod("termContentBody") { // override in ElementRef
     (if (isScalar) enclosedElement else recurrance)
   }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ModelGroupGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ModelGroupGrammarMixin.scala
@@ -35,13 +35,13 @@ package edu.illinois.ncsa.daffodil.grammar
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen._
 import edu.illinois.ncsa.daffodil.dsom.InitiatedTerminatedMixin
 import edu.illinois.ncsa.daffodil.dsom.ModelGroup
-import edu.illinois.ncsa.daffodil.dsom.Sequence
-import edu.illinois.ncsa.daffodil.dsom.Choice
 import edu.illinois.ncsa.daffodil.grammar.primitives.TrailingSkipRegion
 import edu.illinois.ncsa.daffodil.grammar.primitives.LeadingSkipRegion
 import edu.illinois.ncsa.daffodil.grammar.primitives.AlignmentFill
 import edu.illinois.ncsa.daffodil.grammar.primitives.DelimiterStackCombinatorSequence
 import edu.illinois.ncsa.daffodil.grammar.primitives.DelimiterStackCombinatorChoice
+import edu.illinois.ncsa.daffodil.dsom.SequenceBase
+import edu.illinois.ncsa.daffodil.dsom.ChoiceBase
 
 trait ModelGroupGrammarMixin
   extends InitiatedTerminatedMixin
@@ -78,8 +78,8 @@ trait ModelGroupGrammarMixin
         ) {
         val content = initiatorRegion ~ groupContent ~ terminatorRegion
         self match {
-          case c: Choice => DelimiterStackCombinatorChoice(c, content)
-          case s: Sequence => DelimiterStackCombinatorSequence(s, content)
+          case c: ChoiceBase => DelimiterStackCombinatorChoice(c, content)
+          case s: SequenceBase => DelimiterStackCombinatorSequence(s, content)
         }
       } else { groupContent }
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/SequenceGrammarMixin.scala
@@ -32,10 +32,10 @@
 
 package edu.illinois.ncsa.daffodil.grammar
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen._
-import edu.illinois.ncsa.daffodil.dsom.Sequence
 import edu.illinois.ncsa.daffodil.grammar.primitives.SequenceCombinator
+import edu.illinois.ncsa.daffodil.dsom.SequenceBase
 
-trait SequenceGrammarMixin extends GrammarMixin { self: Sequence =>
+trait SequenceGrammarMixin extends GrammarMixin { self: SequenceBase =>
 
   final override lazy val groupContent = prod("groupContent") {
     self.sequenceKind match {

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/Primitives.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/Primitives.scala
@@ -37,7 +37,7 @@ import edu.illinois.ncsa.daffodil.grammar.Terminal
 import edu.illinois.ncsa.daffodil.grammar.HasNoUnparser
 
 abstract class Primitive(e: Term, guard: Boolean = false)
-    extends Terminal(e, guard) {
+  extends Terminal(e, guard) {
   override def toString = "Prim[" + name + "]"
 }
 
@@ -45,14 +45,14 @@ abstract class Primitive(e: Term, guard: Boolean = false)
  * For stubbing out primitives that are placeholders
  */
 abstract class UnimplementedPrimitive(e: Term, guard: Boolean = false)
-    extends Primitive(e, guard)
-    with HasNoUnparser {
+  extends Primitive(e, guard)
+  with HasNoUnparser {
   override final lazy val parser = hasNoParser
 }
 
 // base stub classes
 
-case class NoValue(e: GlobalElementDecl, guard: Boolean = true) extends UnimplementedPrimitive(e, guard)
+// case class NoValue(e: GlobalElementDecl, guard: Boolean = true) extends UnimplementedPrimitive(e, guard)
 
 case class SaveInputStream(e: ElementBase, guard: Boolean = true) extends UnimplementedPrimitive(e, guard)
 
@@ -66,4 +66,4 @@ case class StopValue(e: ElementBase with LocalElementMixin) extends Unimplemente
 
 case class TheDefaultValue(e: ElementBase) extends UnimplementedPrimitive(e, e.isDefaultable)
 
-case class UnicodeByteOrderMark(e: GlobalElementDecl) extends UnimplementedPrimitive(e, false)
+case class UnicodeByteOrderMark(e: Root) extends UnimplementedPrimitive(e, false)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesDelimiters.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesDelimiters.scala
@@ -172,7 +172,7 @@ case class Initiator(e: Term) extends DelimiterText(e, e) {
   Assert.invariant(e.hasInitiator)
   val delimiterType: DelimiterTextType.Type = DelimiterTextType.Initiator
 }
-case class Separator(s: Sequence, t: Term) extends DelimiterText(s, t) {
+case class Separator(s: SequenceBase, t: Term) extends DelimiterText(s, t) {
   Assert.invariant(s.hasSeparator)
   val delimiterType: DelimiterTextType.Type = DelimiterTextType.Separator
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesElementKinds.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesElementKinds.scala
@@ -62,7 +62,7 @@ import edu.illinois.ncsa.daffodil.cookers.ChoiceBranchKeyCooker
 
 object ENoWarn3 { EqualitySuppressUnusedImportWarning() }
 
-case class DelimiterStackCombinatorSequence(sq: Sequence, body: Gram) extends Terminal(sq, !body.isEmpty) {
+case class DelimiterStackCombinatorSequence(sq: SequenceBase, body: Gram) extends Terminal(sq, !body.isEmpty) {
   lazy val pInit = if (sq.initiatorParseEv.isKnownNonEmpty) One(sq.initiatorParseEv) else Nope
   lazy val pSep = if (sq.separatorParseEv.isKnownNonEmpty) One(sq.separatorParseEv) else Nope
   lazy val pTerm = if (sq.terminatorParseEv.isKnownNonEmpty) One(sq.terminatorParseEv) else Nope
@@ -76,7 +76,7 @@ case class DelimiterStackCombinatorSequence(sq: Sequence, body: Gram) extends Te
   override lazy val unparser: DaffodilUnparser = new DelimiterStackUnparser(uInit, uSep, uTerm, sq.runtimeData, body.unparser)
 }
 
-case class DelimiterStackCombinatorChoice(ch: Choice, body: Gram) extends Terminal(ch, !body.isEmpty) {
+case class DelimiterStackCombinatorChoice(ch: ChoiceBase, body: Gram) extends Terminal(ch, !body.isEmpty) {
   lazy val pInit = if (ch.initiatorParseEv.isKnownNonEmpty) One(ch.initiatorParseEv) else Nope
   lazy val pTerm = if (ch.terminatorParseEv.isKnownNonEmpty) One(ch.terminatorParseEv) else Nope
 
@@ -113,7 +113,7 @@ case class DynamicEscapeSchemeCombinatorElement(e: ElementBase, body: Gram) exte
   override lazy val unparser: DaffodilUnparser = new DynamicEscapeSchemeUnparser(schemeUnparseOpt.get, e.runtimeData, body.unparser)
 }
 
-case class ComplexTypeCombinator(ct: ComplexTypeBase, body: Gram) extends Terminal(ct.element, !body.isEmpty) {
+case class ComplexTypeCombinator(ct: ComplexTypeBase, body: Gram) extends Terminal(ct.elementDecl, !body.isEmpty) {
 
   override def isEmpty = body.isEmpty
 
@@ -123,7 +123,7 @@ case class ComplexTypeCombinator(ct: ComplexTypeBase, body: Gram) extends Termin
     new ComplexTypeUnparser(ct.runtimeData, body.unparser)
 }
 
-case class SequenceCombinator(sq: Sequence, rawTerms: Seq[Gram])
+case class SequenceCombinator(sq: SequenceBase, rawTerms: Seq[Gram])
   extends Terminal(sq, !rawTerms.filterNot { _.isEmpty }.isEmpty) {
 
   private val mt: Gram = EmptyGram
@@ -167,7 +167,7 @@ case class OptionalCombinator(e: ElementBase, body: Gram) extends Terminal(e, !b
  * need to determine which branch of the choice to take at runtime. This
  * unparser uses a Map to make the determination based on the element seen.
  */
-case class ChoiceCombinator(ch: Choice, alternatives: Seq[Gram]) extends Terminal(ch, !alternatives.isEmpty) {
+case class ChoiceCombinator(ch: ChoiceBase, alternatives: Seq[Gram]) extends Terminal(ch, !alternatives.isEmpty) {
   lazy val parser: DaffodilParser = {
     if (!ch.isDirectDispatch) {
       val folded = alternatives.map { gf => gf }.foldRight(EmptyGram.asInstanceOf[Gram]) { _ | _ }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -270,7 +270,7 @@ case class InputValueCalc(e: ElementBase,
 //  }
 //}
 
-abstract class AssertPatternPrimBase(decl: AnnotatedSchemaComponent, stmt: DFDLAssertionBase)
+abstract class AssertPatternPrimBase(decl: Term, stmt: DFDLAssertionBase)
   extends Terminal(decl, true) {
 
   lazy val eName = decl.diagnosticDebugName
@@ -286,22 +286,22 @@ abstract class AssertPatternPrimBase(decl: AnnotatedSchemaComponent, stmt: DFDLA
   override def unparser: DaffodilUnparser = Assert.invariantFailed("should not request unparser for asserts/discriminators")
 }
 
-case class AssertPatternPrim(decl: AnnotatedSchemaComponent, stmt: DFDLAssert)
-  extends AssertPatternPrimBase(decl, stmt) {
+case class AssertPatternPrim(term: Term, stmt: DFDLAssert)
+  extends AssertPatternPrimBase(term, stmt) {
 
   val kindString = "AssertPatternPrim"
 
   lazy val parser: DaffodilParser = {
-    new AssertPatternParser(eName, kindString, decl.term.termRuntimeData, testPattern, stmt.message)
+    new AssertPatternParser(eName, kindString, term.termRuntimeData, testPattern, stmt.message)
   }
 
 }
 
-case class DiscriminatorPatternPrim(decl: AnnotatedSchemaComponent, stmt: DFDLAssertionBase)
-  extends AssertPatternPrimBase(decl, stmt) {
+case class DiscriminatorPatternPrim(term: Term, stmt: DFDLAssertionBase)
+  extends AssertPatternPrimBase(term, stmt) {
 
   val kindString = "DiscriminatorPatternPrim"
 
-  lazy val parser: DaffodilParser = new DiscriminatorPatternParser(testPattern, eName, kindString, decl.term.termRuntimeData, stmt.message)
+  lazy val parser: DaffodilParser = new DiscriminatorPatternParser(testPattern, eName, kindString, term.termRuntimeData, stmt.message)
 }
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesUnorderedSequence.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesUnorderedSequence.scala
@@ -36,7 +36,7 @@ import edu.illinois.ncsa.daffodil.grammar.Gram
 import edu.illinois.ncsa.daffodil.exceptions.Assert
 import edu.illinois.ncsa.daffodil.dsom.ElementBase
 import edu.illinois.ncsa.daffodil.dsom.Term
-import edu.illinois.ncsa.daffodil.dsom.Sequence
+import edu.illinois.ncsa.daffodil.dsom.SequenceBase
 import edu.illinois.ncsa.daffodil.grammar.UnaryGram
 import edu.illinois.ncsa.daffodil.grammar.HasNoUnparser
 import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
@@ -47,15 +47,15 @@ object UnorderedSequence {
     // mandatory little optimization here. If there are no statements (most common case), then let's
     // shortcut and just use the guts parser.
 
-    Assert.usageErrorUnless(context.isInstanceOf[Sequence], "The context passed to UnorderedSequence must be a Sequence.")
+    Assert.usageErrorUnless(context.isInstanceOf[SequenceBase], "The context passed to UnorderedSequence must be a Sequence.")
 
-    val ctxt = context.asInstanceOf[Sequence]
+    val ctxt = context.asInstanceOf[SequenceBase]
 
     new UnorderedSequence(ctxt, eGram)
   }
 }
 
-class UnorderedSequence private (context: Sequence, eGramArg: => Gram) // private to force use of the object as factory
+class UnorderedSequence private (context: SequenceBase, eGramArg: => Gram) // private to force use of the object as factory
   extends UnaryGram(context, eGramArg) with HasNoUnparser {
 
   lazy val eGram = eGramArg // once only
@@ -67,7 +67,7 @@ class UnorderedSequence private (context: Sequence, eGramArg: => Gram) // privat
   val sortOrder = {
     val members = context.groupMembers.map(t => {
       t match {
-        case s: Sequence => s.groupMembers
+        case s: SequenceBase => s.groupMembers
         case _ => Seq(t)
       }
     }).flatten

--- a/daffodil-core/src/test/resources/test/example-of-most-dfdl-constructs.dfdl.xml
+++ b/daffodil-core/src/test/resources/test/example-of-most-dfdl-constructs.dfdl.xml
@@ -8,6 +8,8 @@
   xsi:schemaLocation="http://www.ogf.org/dfdl/dfdl-1.0/ xsd/DFDL_part3_model.xsd 
   http://www.w3.org/2001/XMLSchema xsd/XMLSchema_for_DFDL.xsd">
 
+  <xs:include schemaLocation="edu/illinois/ncsa/daffodil/xsd/built-in-formats.xsd"/>
+
   <annotation>
     <documentation>
       The goal of this schema is to make one use of every XSD
@@ -79,7 +81,8 @@
       <!-- note use of Japanese Kanji in the name -->
       <dfdl:defineFormat name="def2年月日">
         <dfdl:format representation="binary"
-          textStandardBase="10" escapeSchemeRef="tns:quotingScheme" sequenceKind="ordered" />
+          textStandardBase="10" escapeSchemeRef="tns:quotingScheme" sequenceKind="ordered"
+          ref="ex:daffodilTest1" />
       </dfdl:defineFormat>
       <dfdl:defineEscapeScheme name="quotingScheme">
         <dfdl:escapeScheme escapeCharacter="%%"

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dsom/TestCouldBeNextElement.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dsom/TestCouldBeNextElement.scala
@@ -55,10 +55,10 @@ class TestCouldBeNextElement {
               </xs:sequence>
               <xs:sequence>
               </xs:sequence>
-              <xs:element name="bar1" type="xs:string"/>
+              <xs:element name="bar1" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1"/>
             </xs:choice>
-            <xs:element name="barOpt" minOccurs="0" dfdl:occursCountKind="implicit" type="xs:string"/>
-            <xs:element name="bar2" type="xs:string"/>
+            <xs:element name="barOpt" minOccurs="0" dfdl:occursCountKind="implicit" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1"/>
+            <xs:element name="bar2" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
@@ -83,6 +83,8 @@ class TestCouldBeNextElement {
     assertEquals("barOpt", root.possibleFirstChildElementsInInfoset(1).asInstanceOf[LocalElementBase].name)
     assertEquals("bar2", root.possibleFirstChildElementsInInfoset(2).asInstanceOf[LocalElementBase].name)
 
+    //val bar1PFCEII = bar1.possibleFirstChildElementsInInfoset
+    //val bar1PNCEII = bar1.possibleNextChildElementsInInfoset
     assertEquals(0, bar1.possibleFirstChildElementsInInfoset.length)
     assertEquals(2, bar1.possibleNextChildElementsInInfoset.length)
     assertEquals("barOpt", bar1.possibleNextChildElementsInInfoset(0).asInstanceOf[LocalElementBase].name)
@@ -220,15 +222,15 @@ class TestCouldBeNextElement {
       <xs:element name="root">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="e1" type="xs:string" />
-            <xs:sequence dfdl:hiddenGroupRef="g1_hidden" />
-            <xs:element name="e2" type="xs:string" dfdl:occursCountKind="parsed" />
+            <xs:element name="e1" type="xs:string"/>
+            <xs:sequence dfdl:hiddenGroupRef="g1_hidden"/>
+            <xs:element name="e2" type="xs:string" dfdl:occursCountKind="parsed"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:group name="g1_hidden">
         <xs:sequence>
-          <xs:element name="e2_hidden" type="xs:string" dfdl:occursCountKind="parsed" />
+          <xs:element name="e2_hidden" type="xs:string" dfdl:occursCountKind="parsed"/>
         </xs:sequence>
       </xs:group>)
 

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -264,9 +264,6 @@ class TestMiddleEndAttributes {
     val e3seqImmediatelyEnclosingModelGroup = e3seq.immediatelyEnclosingModelGroup
     // Sequence inside an element doesn't have an immediately enclosing model group
     assertEquals(None, e3seqImmediatelyEnclosingModelGroup)
-    // Global element instance appears inside the group that immediately contains the
-    // element reference.
-    assertEquals(Some(eMsgChoice), e3.immediatelyEnclosingModelGroup)
     // element reference also contained inside same
     assertEquals(Some(eMsgChoice), e2ref.immediatelyEnclosingModelGroup)
 

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/TestPropertyRuntime.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/TestPropertyRuntime.scala
@@ -35,7 +35,7 @@ package edu.illinois.ncsa.daffodil.schema.annotation.props
 import junit.framework.Assert._
 import edu.illinois.ncsa.daffodil.exceptions.ThrowsSDE
 import org.junit.Test
-import edu.illinois.ncsa.daffodil.dsom.SchemaComponent
+import edu.illinois.ncsa.daffodil.dsom.SchemaComponentImpl
 import edu.illinois.ncsa.daffodil.util.Fakes
 import edu.illinois.ncsa.daffodil.dsom.NestingLexicalMixin
 
@@ -88,7 +88,7 @@ class TestPropertyRuntime {
 
 }
 
-class HasMixin extends SchemaComponent(<foo/>, null)
+class HasMixin extends SchemaComponentImpl(<foo/>, null)
   with TheExamplePropMixin
   with NestingLexicalMixin {
 

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/util/TestUtils.scala
@@ -227,6 +227,9 @@ object Fakes {
   def fakeElem = new Fakes().fakeElem
   def fakeSD = new Fakes().fakeSD
   def fakeGroupRef = new Fakes().fakeGroupRef
+  def fakeChoiceGroupRef = new Fakes().fakeChoiceGroupRef
+  def fakeSequenceGroupRef = new Fakes().fakeSequenceGroupRef
+  def fakeGroupRefFactory = new Fakes().fakeGroupRefFactory
 }
 
 class Fakes private () {
@@ -236,14 +239,20 @@ class Fakes private () {
     <xs:element name="fake2" type="tns:fakeCT"/>
     <xs:complexType name="fakeCT">
       <xs:sequence>
-        <xs:group ref="tns:fakeGroup"/>
+        <xs:group ref="tns:fakeChoiceGroup"/>
         <xs:element ref="tns:fake"/>
+        <xs:group ref="tns:fakeSequenceGroup"/>
       </xs:sequence>
     </xs:complexType>
-    <xs:group name="fakeGroup">
+    <xs:group name="fakeChoiceGroup">
       <xs:choice>
         <xs:sequence/>
       </xs:choice>
+    </xs:group>
+    <xs:group name="fakeSequenceGroup">
+      <xs:sequence>
+        <xs:sequence/>
+      </xs:sequence>
     </xs:group>)
   val DummyPrimitiveFactory = null
   val tunable = DaffodilTunables()
@@ -253,8 +262,11 @@ class Fakes private () {
   lazy val fakeElem = fakeSD.getGlobalElementDecl("fake").get.forRoot()
   lazy val fakeCT = fakeSD.getGlobalElementDecl("fake2").get.forRoot().typeDef.asInstanceOf[GlobalComplexTypeDef]
   lazy val fakeSequence = fakeCT.sequence
-  lazy val Seq(fs1, fs2) = fakeSequence.groupMembers
-  lazy val fakeGroupRef = fs1.asInstanceOf[GroupRef]
+  lazy val Seq(fs1, fs2, fs3) = fakeSequence.groupMembers
+  lazy val fakeChoiceGroupRef = fs1.asInstanceOf[ChoiceGroupRef]
+  lazy val fakeGroupRef = fakeChoiceGroupRef
+  lazy val fakeSequenceGroupRef = fs3.asInstanceOf[SequenceGroupRef]
+  lazy val fakeGroupRefFactory = new GroupRefFactory(fs1.xml, fs1, 1)
 
   class FakeDataProcessor extends DFDL.DataProcessor {
     protected var tunablesObj = DaffodilTunables()
@@ -273,9 +285,9 @@ class Fakes private () {
     def isError: Boolean = false
     def setTunables(tunables: DaffodilTunables): Unit = {}
     def setTunable(tunable: String, value: String): Unit = {}
-    def setTunables(tunables: Map[String,String]): Unit = {}
+    def setTunables(tunables: Map[String, String]): Unit = {}
     def getTunables(): DaffodilTunables = { tunablesObj }
-    
+
   }
   lazy val fakeDP = new FakeDataProcessor
 

--- a/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/PropertyScoping.scala
+++ b/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/PropertyScoping.scala
@@ -209,8 +209,10 @@ trait FindPropertyMixin extends PropTypes {
    * For unit testing convenience
    */
   final def verifyPropValue(key: String, value: String): Boolean = {
-    findPropertyOption(key) match {
-      case Found(`value`, _, _, _) => true
+    val prop = findPropertyOption(key)
+    val valueLC = value.toLowerCase
+    prop match {
+      case Found(v, _, _, _) if (v.toLowerCase == valueLC) => true
       case _: Found => false
       case _: NotFound => false
     }

--- a/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/xml/QNameBase.scala
+++ b/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/xml/QNameBase.scala
@@ -357,6 +357,8 @@ sealed trait NamedQName
     Assert.usage(!namespace.isNoNamespace)
     Assert.usage(!namespace.isUnspecified)
   }
+
+  def toRefQName = RefQName(prefix, local, namespace)
 }
 
 /**
@@ -516,7 +518,7 @@ object StepQNameFactory extends RefQNameFactoryBase[StepQName] {
   override def constructor(prefix: Option[String], local: String, namespace: NS) =
     StepQName(prefix, local, namespace)
 
-    /* This is what needs Tunables and propagates into Expression */
+  /* This is what needs Tunables and propagates into Expression */
   override def resolveDefaultNamespace(scope: scala.xml.NamespaceBinding, tunable: DaffodilTunables) = {
     tunable.unqualifiedPathStepPolicy match {
       case UnqualifiedPathStepPolicy.NoNamespace => None // don't consider default namespace

--- a/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/oolag/TestOOLAG.scala
+++ b/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/oolag/TestOOLAG.scala
@@ -49,7 +49,7 @@ class MyException(msg: String)
 }
 
 abstract class MyBase(parentArg: MyBase)
-  extends OOLAGHost(parentArg) {
+  extends OOLAGHostImpl(parentArg) {
 
   def a1 = a1_.value
   def a1_ = LV('a1) {

--- a/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/TestGeneratedProperties.scala
+++ b/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/schema/annotation/props/TestGeneratedProperties.scala
@@ -35,7 +35,7 @@ package edu.illinois.ncsa.daffodil.schema.annotation.props
 import edu.illinois.ncsa.daffodil.schema.annotation.props.gen._
 import junit.framework.Assert._
 import org.junit.Test
-import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHost
+import edu.illinois.ncsa.daffodil.oolag.OOLAG.OOLAGHostImpl
 import edu.illinois.ncsa.daffodil.exceptions.SchemaFileLocation
 import edu.illinois.ncsa.daffodil.api.WarnID
 import edu.illinois.ncsa.daffodil.api.DaffodilTunables
@@ -54,7 +54,7 @@ class TestGeneratedProperties {
    * retrieves the property if it is present.
    */
   class HasLotsOfProperties
-    extends OOLAGHost(null)
+    extends OOLAGHostImpl(null)
     with LookupLocation
     with Format_AnnotationMixin
     with SeparatorSuppressionPolicyMixin {

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
@@ -221,7 +221,7 @@ class DPathCompileInfo(
   lazy val variableMap =
     variableMapArg
 
-  override def preSerialization = {
+  override def preSerialization: Any = {
     parent
     variableMap
   }
@@ -314,6 +314,7 @@ class DPathCompileInfo(
 class DPathElementCompileInfo(
   @TransientParam parentArg: => Option[DPathCompileInfo],
   @TransientParam variableMap: => VariableMap,
+  @TransientParam elementChildrenCompileInfoArg: => Seq[DPathElementCompileInfo],
   namespaces: scala.xml.NamespaceBinding,
   path: String,
   val name: String,
@@ -321,10 +322,17 @@ class DPathElementCompileInfo(
   val namedQName: NamedQName,
   val optPrimType: Option[PrimType],
   sfl: SchemaFileLocation,
-  val elementChildrenCompileInfo: Seq[DPathElementCompileInfo],
-  override val tunable: DaffodilTunables)
+  override val tunable: DaffodilTunables,
+  maybeReferencedElementCompileInfo: Maybe[DPathElementCompileInfo])
   extends DPathCompileInfo(parentArg, variableMap, namespaces, path, sfl, tunable)
   with HasSchemaFileLocation {
+
+  lazy val elementChildrenCompileInfo = elementChildrenCompileInfoArg
+
+  override def preSerialization: Any = {
+    super.preSerialization
+    elementChildrenCompileInfo
+  }
 
   override def toString = "DPathElementCompileInfo(%s)".format(name)
 

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/infoset/InfosetImpl.scala
@@ -213,7 +213,7 @@ case class InfosetValueLengthUnknownException(lengthState: LengthState, override
 final class FakeDINode extends DISimple(null) {
   private def die = throw new InfosetNoInfosetException(Nope)
 
-  override def parent = die
+  override val parent = die
   override def diParent = die
   override def setParent(p: InfosetComplexElement): Unit = die
 


### PR DESCRIPTION
(This is a test. Code doesn't pass all tests yet - 34 failures. Trying out code-review mechanisms.)

Refactors property resolving onto elementrefs and grouprefs so
as to eliminate use of backrefs when accessing properties. (DOES NOT YET
ELIMINATE THE BACKREFS THO)

Removed alignment logic that was getting tripped up.

Converted OOLAGHost, SchemaComponent etc. down to LocalElementBase
into traits so that I can mix them the way I need to so that
Global elements aren't terms, etc.