### PR TITLE
Ensure marks are always returned to the markpool

### DIFF
--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/RepParsers.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/RepParsers.scala
@@ -271,24 +271,6 @@ class RepUnboundedParser(occursCountKind: OccursCountKind.Value, rParser: Parser
       var returnFlag = false
       while (!returnFlag && (pstate.processorStatus eq Success)) {
 
-        //      erd.maxOccurs.foreach { maxOccurs =>
-        //        if ((occursCountKind == OccursCountKind.Implicit) &&
-        //          (maxOccurs == -1)) {
-        //          erd.minOccurs.foreach { minOccurs =>
-        //            if (pstate.mpstate.arrayPos - 1 <= minOccurs) {
-        //              // Is required element
-        //              // Need to trigger default value creation
-        //              // in right situations (like the element is defaultable)
-        //              // This is relatively easy for simple types
-        //              // for complex types, defaulting is trickier as one
-        //              // must recursively traverse the type, and then determine one
-        //              // has not advanced the data at all.
-        //            }
-        //          }
-        //        }
-        //      }
-
-        //
         // Every parse is a new point of uncertainty.
         pstate.pushDiscriminator
         if (pstate.dataProc.isDefined) pstate.dataProc.get.beforeRepetition(pstate, this)


### PR DESCRIPTION
MarkPool leaks have been notoriously difficult to track down. This is
partly due to the fact that we don't check for leaks until the very end
of parsing, so we don't know there is a leak until well after it has
happened, giving us little information about where or why.

Additionally, we do not currently return leaked marks. Since marks are
stored in a ThreadLocal, and since they aren't returned, leaked marks
are forever leaked, and every subsequent parse will cause an assertion
due to the final validation check.

This modifies the users of marks to always return marks so the
processing could potentially continue if an API user wanted to (like in
the case of NiFi). This also throws an invariant failed assertion a mark
is leaked so we know exactly where it occurred. Furthermore, if an
exception was the cause of a mark leak, the stack trace of the exception
is captured to help determine the original cause.

DAFFODIL-1862