### PR TITLE
Add travis.yml file for continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+addons:
+  apt:
+    packages:
+      - rpm
+language: scala
+scala:
+  - 2.11.8
+jdk:
+  - oraclejdk8
+sudo: false
+before_script:
+  - unset _JAVA_OPTIONS
+script:
+  - sbt -J-Xms4g -J-Xmx4g ++$TRAVIS_SCALA_VERSION
+    compile
+    test:compile
+    debug:compile
+    test
+    cli:test
+    daffodil-cli/universal:packageBin
+    daffodil-cli/universal:packageZipTarball
+    daffodil-cli/rpm:packageBin
+    daffodil-japi/genjavadoc:doc
+    daffodil-sapi/doc


### PR DESCRIPTION
- This tests compiling source, tests, and debug tests, running all tests
  and cli tests, building CLI zip/tar/rpm, and building javadoc and
  scaladoc.
- The rpm package is needed for rpmbuild used by rpm:packageBin
- Unsets _JAVA_OPTS, which causes strings to be written to stdout,
  interfering with CLI tests

DAFFODIL-1858