### PR TITLE
Fix truncation bug when unparsing escapeKind="character"

### DIFF
--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section07/escapeScheme/escapeScenarios.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section07/escapeScheme/escapeScenarios.tdml
@@ -916,7 +916,23 @@
 
   </defineSchema>
   
-  
+  <defineSchema name="es5">
+    <dfdl:format ref="tns:daffodilTest1" lengthKind="delimited" />
+
+    <dfdl:defineEscapeScheme name="es">
+      <dfdl:escapeScheme escapeCharacter='\'
+        escapeKind="escapeCharacter" escapeEscapeCharacter="\" extraEscapedCharacters="" />
+    </dfdl:defineEscapeScheme>
+
+    <xs:element name="root" dfdl:initiator="START" dfdl:terminator="END END1 END2 END3 END4 END5">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="field" type="xs:string" dfdl:escapeSchemeRef="tns:es"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </defineSchema>
+
   <parserTestCase name="scenario4_1" model="es4"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo/;bar</document>
@@ -1122,4 +1138,29 @@
     </errors>
   </parserTestCase>
   
+  <!--
+       Test Name: scenario5
+          Schema: es5
+            Root: root
+         Purpose: This tests that if a character is found that could start a
+                  delimiter but does not, then that character is not escaped, but
+                  delimiters that do exist are escaped. The first 'E' in the
+                  data should look like a potential delimiter and force
+                  Daffodil to look at all potential delimiters for matches.
+                  Nothing should match, and E should just become part of the
+                  field.
+  -->
+
+  <parserTestCase name="scenario5_1" model="es5"
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="root">
+    <document><![CDATA[STARTfieldEcontents\ENDescaped\\contentEND]]></document>
+    <infoset>
+      <dfdlInfoset>
+        <root>
+          <field>fieldEcontentsENDescaped\content</field>
+        </root>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
 </testSuite>

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section07/escapeScheme/TestEscapeScheme.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section07/escapeScheme/TestEscapeScheme.scala
@@ -154,4 +154,5 @@ class TestEscapeScheme {
   @Test def test_scenario4_12() { runner2.runOneTest("scenario4_12") }
   @Test def test_scenario4_12_req_term() { runner2.runOneTest("scenario4_12_req_term") }
 
+  @Test def test_scenario5_1() { runner2.runOneTest("scenario5_1") }
 }


### PR DESCRIPTION
Daffodil had a logic bug when unparsing a field with an escape scheme
with escapeKind="character". In such a case, we run the field DFA
looking at each character to unparse to see if it could potentially
start a delimiter and thus may need to be escaped. If we do find such a
character, we then run each delimiter DFA on the input to determine if
the delimiter actually existed or if we just found a character the looks
like it starts a delimiter but actually doesn't. We then gather up
successful matches for a longest match check. This logic is all
correct.

The problem is that for escapeKind="character", each time a delimiter
DFA failed to match, we would move the field register to the next rule. So
if we checked for 10 delimiters and 9 failed, we would advance the field
register 9 times, which is wrong and would cause the field register to
end prematurely, leading to truncated unparsed data.

Instead, we should wait until all the delimiter DFAs are checked, and
only if none match (i.e. success.isEmpty is true) then we advance the
field register by one rule to add that character to the field. This
patch fixes the text delimited unparser to use this logic for
escapeKind="character". This is actually very similar logic that
escapeKind="block" had, so this matches that correct behavior. Comments
were also added to clarify this section of code.

DAFFODIL-1851