### PR TITLE
Implemented packed binary formats

### DIFF
--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesBCD.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesBCD.scala
@@ -1,38 +1,53 @@
-/* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal with
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
- * so, subject to the following conditions:
- *
- *  1. Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimers.
- *
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimers in the
- *     documentation and/or other materials provided with the distribution.
- *
- *  3. Neither the names of Tresys Technology, nor the names of its contributors
- *     may be used to endorse or promote products derived from this Software
- *     without specific prior written permission.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
- * SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package edu.illinois.ncsa.daffodil.grammar.primitives
 
-import edu.illinois.ncsa.daffodil.dsom._
+import edu.illinois.ncsa.daffodil.grammar.Terminal
 import edu.illinois.ncsa.daffodil.dsom.ElementBase
+import edu.illinois.ncsa.daffodil.processors.parsers.BCDIntegerRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.BCDIntegerKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.BCDDecimalRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.BCDDecimalKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.unparsers.Unparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.BCDIntegerRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.BCDIntegerKnownLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.BCDDecimalRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.BCDDecimalKnownLengthUnparser
 
-case class BCDIntPrim(e: ElementBase) extends UnimplementedPrimitive(e, false)
+class BCDIntegerRuntimeLength(val e: ElementBase) extends Terminal(e, true) {
+  override lazy val parser = new BCDIntegerRuntimeLengthParser(e.elementRuntimeData, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new BCDIntegerRuntimeLengthUnparser(e.elementRuntimeData, e.lengthEv, e.lengthUnits)
+}
+
+class BCDIntegerKnownLength(val e: ElementBase, lengthInBits: Long) extends Terminal(e, true) {
+
+  override lazy val parser = new BCDIntegerKnownLengthParser(e.elementRuntimeData, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new BCDIntegerKnownLengthUnparser(e.elementRuntimeData, lengthInBits.toInt)
+}
+
+class BCDDecimalRuntimeLength(val e: ElementBase) extends Terminal(e, true) {
+  override lazy val parser = new BCDDecimalRuntimeLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new BCDDecimalRuntimeLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, e.lengthEv, e.lengthUnits)
+
+}
+
+class BCDDecimalKnownLength(val e: ElementBase, lengthInBits: Long) extends Terminal(e, true) {
+  override lazy val parser = new BCDDecimalKnownLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new BCDDecimalKnownLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, lengthInBits.toInt)
+}

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesIBM4690Packed.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesIBM4690Packed.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package edu.illinois.ncsa.daffodil.grammar.primitives
+
+import edu.illinois.ncsa.daffodil.grammar.Terminal
+import edu.illinois.ncsa.daffodil.dsom.ElementBase
+import edu.illinois.ncsa.daffodil.processors.parsers.IBM4690PackedIntegerRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.IBM4690PackedIntegerKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.IBM4690PackedDecimalRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.IBM4690PackedDecimalKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.unparsers.Unparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.IBM4690PackedIntegerRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.IBM4690PackedIntegerKnownLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.IBM4690PackedDecimalRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.IBM4690PackedDecimalKnownLengthUnparser
+
+class IBM4690PackedIntegerRuntimeLength(val e: ElementBase, signed: Boolean) extends Terminal(e, true) {
+  override lazy val parser = new IBM4690PackedIntegerRuntimeLengthParser(e.elementRuntimeData, signed, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new IBM4690PackedIntegerRuntimeLengthUnparser(e.elementRuntimeData, e.lengthEv, e.lengthUnits)
+}
+
+class IBM4690PackedIntegerKnownLength(val e: ElementBase, signed: Boolean, lengthInBits: Long) extends Terminal(e, true) {
+
+  override lazy val parser = new IBM4690PackedIntegerKnownLengthParser(e.elementRuntimeData, signed, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new IBM4690PackedIntegerKnownLengthUnparser(e.elementRuntimeData, lengthInBits.toInt)
+}
+
+class IBM4690PackedDecimalRuntimeLength(val e: ElementBase) extends Terminal(e, true) {
+  override lazy val parser = new IBM4690PackedDecimalRuntimeLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new IBM4690PackedDecimalRuntimeLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, e.lengthEv, e.lengthUnits)
+
+}
+
+class IBM4690PackedDecimalKnownLength(val e: ElementBase, lengthInBits: Long) extends Terminal(e, true) {
+  override lazy val parser = new IBM4690PackedDecimalKnownLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new IBM4690PackedDecimalKnownLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, lengthInBits.toInt)
+}
+

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesPacked.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesPacked.scala
@@ -1,37 +1,54 @@
-/* Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Developed by: Tresys Technology, LLC
- *               http://www.tresys.com
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal with
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is furnished to do
- * so, subject to the following conditions:
- *
- *  1. Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimers.
- *
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimers in the
- *     documentation and/or other materials provided with the distribution.
- *
- *  3. Neither the names of Tresys Technology, nor the names of its contributors
- *     may be used to endorse or promote products derived from this Software
- *     without specific prior written permission.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
- * SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package edu.illinois.ncsa.daffodil.grammar.primitives
 
+import edu.illinois.ncsa.daffodil.grammar.Terminal
 import edu.illinois.ncsa.daffodil.dsom.ElementBase
+import edu.illinois.ncsa.daffodil.util.PackedSignCodes
+import edu.illinois.ncsa.daffodil.processors.parsers.PackedIntegerRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.PackedIntegerKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.PackedDecimalRuntimeLengthParser
+import edu.illinois.ncsa.daffodil.processors.parsers.PackedDecimalKnownLengthParser
+import edu.illinois.ncsa.daffodil.processors.unparsers.Unparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.PackedIntegerRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.PackedIntegerKnownLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.PackedDecimalRuntimeLengthUnparser
+import edu.illinois.ncsa.daffodil.processors.unparsers.PackedDecimalKnownLengthUnparser
 
-case class PackedIntPrim(e: ElementBase) extends UnimplementedPrimitive(e, false)
+class PackedIntegerRuntimeLength(val e: ElementBase, signed: Boolean, packedSignCodes: PackedSignCodes) extends Terminal(e, true) {
+  override lazy val parser = new PackedIntegerRuntimeLengthParser(e.elementRuntimeData, signed, packedSignCodes, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new PackedIntegerRuntimeLengthUnparser(e.elementRuntimeData, packedSignCodes, e.lengthEv, e.lengthUnits)
+}
+
+class PackedIntegerKnownLength(val e: ElementBase, signed: Boolean, packedSignCodes: PackedSignCodes, lengthInBits: Long) extends Terminal(e, true) {
+
+  override lazy val parser = new PackedIntegerKnownLengthParser(e.elementRuntimeData, signed, packedSignCodes, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new PackedIntegerKnownLengthUnparser(e.elementRuntimeData, packedSignCodes, lengthInBits.toInt)
+}
+
+class PackedDecimalRuntimeLength(val e: ElementBase, packedSignCodes: PackedSignCodes) extends Terminal(e, true) {
+  override lazy val parser = new PackedDecimalRuntimeLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, packedSignCodes, e.lengthEv, e.lengthUnits)
+
+  override lazy val unparser: Unparser = new PackedDecimalRuntimeLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, packedSignCodes, e.lengthEv, e.lengthUnits)
+
+}
+
+class PackedDecimalKnownLength(val e: ElementBase, packedSignCodes: PackedSignCodes, lengthInBits: Long) extends Terminal(e, true) {
+  override lazy val parser = new PackedDecimalKnownLengthParser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, packedSignCodes, lengthInBits.toInt)
+
+  override lazy val unparser: Unparser = new PackedDecimalKnownLengthUnparser(e.elementRuntimeData, e.binaryDecimalVirtualPoint, packedSignCodes, lengthInBits.toInt)
+}

--- a/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/util/DecimalUtils.scala
+++ b/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/util/DecimalUtils.scala
@@ -1,0 +1,327 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.util
+
+import edu.illinois.ncsa.daffodil.exceptions.Assert
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.BinaryNumberCheckPolicy
+
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+
+object PackedSignCodes {
+  def apply(signCodes: String, policy: BinaryNumberCheckPolicy) = {
+    val str = signCodes.replaceAll("\\s", "")
+    val chars = str.toCharArray()
+    Assert.invariant(chars.length == 4)
+
+    //We can convert hex to an integer value simply by subtracting 55
+    val positive = policy match {
+      case BinaryNumberCheckPolicy.Strict => List(chars(0) - 55)
+      case BinaryNumberCheckPolicy.Lax => List(chars(0) - 55, 0xA, 0xC, 0xE, 0xF)
+    }
+    val negative = policy match {
+      case BinaryNumberCheckPolicy.Strict => List(chars(1) - 55)
+      case BinaryNumberCheckPolicy.Lax => List(chars(1) - 55, 0xB, 0xD)
+    }
+    val unsigned = policy match {
+      case BinaryNumberCheckPolicy.Strict => List(chars(2) - 55)
+      case BinaryNumberCheckPolicy.Lax => List(chars(2) - 55, 0xF)
+    }
+    val zero_sign = policy match {
+      case BinaryNumberCheckPolicy.Strict => List(chars(3) - 55)
+      case BinaryNumberCheckPolicy.Lax => List(chars(3) - 55, 0xA, 0xC, 0xE, 0xF, 0x0)
+    }
+
+    new PackedSignCodes(positive, negative, unsigned, zero_sign)
+  }
+}
+
+case class PackedSignCodes(
+  positive: List[Int],
+  negative: List[Int],
+  unsigned: List[Int],
+  zero_sign: List[Int]
+) {}
+
+object DecimalUtils {
+
+  def packedToBigInteger(num: Array[Byte], signCodes: PackedSignCodes): JBigInteger = {
+    val numDigits = num.size * 2  // 2 digits stored per byte
+    val outputData = new Array[Char](numDigits-1)
+    var outputPos = 0
+    var offset = 0
+
+    // Parse and validate the last (sign) bit
+    val signNibble = (num(offset +  num.size - 1) & 0x0F)
+    val negative = signCodes.negative.contains(signNibble)
+    if (!negative && !signCodes.positive.contains(signNibble) &&
+      !signCodes.unsigned.contains(signNibble) && !signCodes.zero_sign.contains(signNibble)) {
+      throw new NumberFormatException("Invalid sign nibble: " + signNibble)
+    }
+
+    while (outputPos < outputData.size - 1) {
+      // Parse high nibble
+      val highNibble = (num(offset) & 0xFF) >>> 4
+      if (highNibble > 0x09) {
+        throw new NumberFormatException("Invalid high nibble: " + highNibble)
+      }
+
+      outputData(outputPos) = (highNibble | 0x0030).toChar
+      outputPos = outputPos + 1
+
+      // Parse low nibble
+      val lowNibble = (num(offset) & 0x0F)
+      if (lowNibble > 0x09) {
+        throw new NumberFormatException("Invalid low nibble: " + lowNibble)
+      }
+
+      outputData(outputPos) = (lowNibble | 0x0030).toChar
+      outputPos = outputPos + 1
+      offset = offset + 1
+    }
+
+    // Parse last digit
+    val lastNibble = (num(offset) & 0xFF) >>> 4
+    if (lastNibble > 0x09) {
+      throw new NumberFormatException("Invalid high nibble: " + lastNibble)
+    }
+
+    outputData(outputPos) = (lastNibble | 0x0030).toChar
+
+    val jbi = new JBigInteger(new String(outputData))
+    if (negative)
+      jbi.negate()
+    else
+      jbi
+
+  }
+
+  def packedToBigDecimal(num: Array[Byte], scale: Int, signCodes: PackedSignCodes): JBigDecimal = {
+    return new JBigDecimal(packedToBigInteger(num, signCodes), scale)
+  }
+
+  def packedFromBigInteger(bigInt: JBigInteger, nBits: Int, signCodes: PackedSignCodes): Array[Byte] = {
+    val negative = (bigInt.signum != 1)
+    val inChars = bigInt.abs.toString.toCharArray
+    var offset = 0
+    var inPos = 0
+    // Don't count the '-' symbol when determing the number of digits
+    val numDigits = inChars.length
+    val outArray = new Array[Byte](nBits/8)
+    val leadingZeros = if (numDigits % 2 == 0) (nBits/4 - numDigits - 1) else (nBits/4 - numDigits)
+
+    // Add leading double zeros if necessary
+    while ((offset * 2) < (leadingZeros - 1)) {
+      outArray(offset) = 0x00.asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    // Need odd number of digits, pad with 0x0 if necessary
+    if (numDigits % 2 == 0) {
+      outArray(offset) = (((0x0 & 0x000F) << 4) + (inChars(inPos) & 0x000F)).asInstanceOf[Byte]
+      inPos = inPos + 1
+      offset = offset + 1
+    }
+
+    while (inPos < numDigits - 1) {
+      val firstNibble = (inChars(inPos) & 0x000F) << 4
+      inPos = inPos + 1
+      val secondNibble = inChars(inPos) & 0x000F
+      inPos = inPos + 1
+      outArray(offset) = (firstNibble + secondNibble).asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    // Write out the last digit and sign code
+
+    val lastNibble = (inChars(inPos) & 0x000F) << 4
+    val signNibble = if (negative) (signCodes.negative(0) & 0x000F) else (signCodes.positive(0) & 0x000F)
+    outArray(offset) = (lastNibble + signNibble).asInstanceOf[Byte]
+
+    outArray
+  }
+
+  def bcdToBigInteger(bcdNum: Array[Byte]): JBigInteger = {
+    val numDigits = bcdNum.size * 2  // 2 digits stored per byte
+    val outputData = new Array[Char](numDigits)
+    var outputPos = 0
+    var offset = 0
+
+    while (offset < bcdNum.size) {
+      val highNibble = (bcdNum(offset) & 0xFF) >>> 4
+      if (highNibble > 0x09)
+        throw new NumberFormatException("Invalid high nibble: " + highNibble)
+
+      outputData(outputPos) = (highNibble | 0x0030).toChar
+      outputPos = outputPos + 1
+
+      val lowNibble = (bcdNum(offset) & 0x0F)
+      if (lowNibble > 0x09) {
+        throw new NumberFormatException("Invalid low nibble: " + lowNibble)
+      }
+
+      outputData(outputPos) = (lowNibble | 0x0030).toChar
+      outputPos = outputPos + 1
+      offset = offset + 1
+    }
+
+    new JBigInteger(new String(outputData))
+  }
+
+  def bcdToBigDecimal(bcdNum: Array[Byte], scale: Int): JBigDecimal = {
+    new JBigDecimal(bcdToBigInteger(bcdNum), scale)
+  }
+
+  def bcdFromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = {
+    val inChars = bigInt.toString.toCharArray
+    var offset = 0
+    var inPos = 0
+    val outArray = new Array[Byte](nBits/8)
+    val leadingZeros = nBits/4 - inChars.length
+
+    // Add leading double zeros if necessary
+    while ((offset * 2) < (leadingZeros - 1)) {
+      outArray(offset) = 0x00.asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    // Need even number of digits, pad with a single 0 if necessary
+    if (inChars.length % 2 != 0) {
+      outArray(offset) = (((0x0 & 0x000F) << 4) + (inChars(inPos) & 0x000F)).asInstanceOf[Byte]
+      offset = offset + 1
+      inPos = inPos + 1
+    }
+
+    while (inPos < inChars.length) {
+      val firstNibble = (inChars(inPos) & 0x000F) << 4
+      inPos = inPos + 1
+      val secondNibble = inChars(inPos) & 0x000F
+      inPos = inPos + 1
+      outArray(offset) = (firstNibble + secondNibble).asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    outArray
+  }
+
+  def ibm4690ToBigInteger(num: Array[Byte]): JBigInteger = {
+    val numDigits = num.size * 2  // 2 digits stored per byte
+    val outputData = new Array[Char](numDigits)
+    var outputPos = 0
+    var offset = 0
+    var negative = false
+    // We've started parsing non-padding/sign nibbles
+    var inDigits = false
+
+    while (offset < num.size) {
+      // Parse high nibble
+      val highNibble = (num(offset) & 0xFF) >>> 4
+      if (highNibble > 0x09) {
+        outputData(outputPos) = '0'
+        if ((highNibble == 0xD) && !inDigits) {
+          negative = true
+          inDigits = true
+        } else if ((highNibble != 0xF) || inDigits) {
+          throw new NumberFormatException("Invalid high nibble: " + highNibble)
+        }
+
+        outputPos = outputPos + 1
+      }
+
+      if (highNibble <= 0x09) {
+        inDigits = true
+        outputData(outputPos) = (highNibble | 0x0030).toChar
+        outputPos = outputPos + 1
+      }
+
+      // Parse low nibble
+      val lowNibble = (num(offset) & 0x0F)
+      if (lowNibble > 0x09) {
+        outputData(outputPos) = '0'
+        outputPos = outputPos + 1
+        if (lowNibble == 0xD && !inDigits) {
+          negative = true
+          inDigits = true
+        } else if ((lowNibble != 0xF) || inDigits) {
+          throw new NumberFormatException("Invalid low nibble: " + lowNibble)
+        }
+      }
+
+      if (lowNibble <= 0x09) {
+        inDigits = true
+        outputData(outputPos) = (lowNibble | 0x0030).toChar
+        outputPos = outputPos + 1
+      }
+      offset = offset + 1
+    }
+
+    val jbi = new JBigInteger(new String(outputData))
+    if (negative)
+      jbi.negate()
+    else
+      jbi
+  }
+
+  def ibm4690ToBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = {
+    new JBigDecimal(ibm4690ToBigInteger(num), scale)
+  }
+
+  def ibm4690FromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = {
+    val negative = (bigInt.signum != 1)
+    val inChars = bigInt.abs.toString.toCharArray
+    var wrote_negative = false
+    var offset = 0
+    var inPos = 0
+    val numDigits = if (negative) inChars.length + 1 else inChars.length
+    val outArray = new Array[Byte](nBits/8)
+    val leadingZeros = if (numDigits % 2 == 0) (nBits/4 - numDigits) else (nBits/4 - (numDigits + 1))
+
+    // Add leading double zeros if necessary
+    while ((offset * 2) < (leadingZeros - 1)) {
+      outArray(offset) = 0xFF.asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    // Need even number of digits, pad with 0xF if necessary
+    if (numDigits % 2 != 0) {
+      val padNibble = (0xF & 0x000F) << 4
+      val signNibble = if (negative) {
+        wrote_negative = true
+        0xD & 0x000F
+      } else {
+        inPos = inPos + 1
+        inChars(inPos-1) & 0x000F
+      }
+      outArray(offset) = (padNibble + signNibble).asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    while (inPos < numDigits - 1) {
+      val firstNibble = if (negative && !wrote_negative) {
+        wrote_negative = true
+        (0xD & 0x000F) << 4
+      } else {
+        inPos = inPos + 1
+        (inChars(inPos-1) & 0x000F) << 4
+      }
+      val secondNibble = inChars(inPos) & 0x000F
+      inPos = inPos + 1
+      outArray(offset) = (firstNibble + secondNibble).asInstanceOf[Byte]
+      offset = offset + 1
+    }
+
+    outArray
+  }
+
+}

--- a/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/util/TestDecimalUtils.scala
+++ b/daffodil-lib/src/test/scala/edu/illinois/ncsa/daffodil/util/TestDecimalUtils.scala
@@ -1,0 +1,1249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.util
+
+import edu.illinois.ncsa.daffodil.util.DecimalUtils._
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.BinaryNumberCheckPolicy
+
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+import org.junit.Test
+import org.junit.Assert._
+
+class TestDecimalUtils {
+
+  @Test def packedInt1StrictPos() {
+    val num = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x1C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt2StrictPos() {
+    val num = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("12"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt3StrictPos() {
+    val num = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("123"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt4StrictPos() {
+    val num = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt5StrictPos() {
+    val num = new Array[Byte](11)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt1StrictNeg() {
+    val num = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x1D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt2StrictNeg() {
+    val num = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-12"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt3StrictNeg() {
+    val num = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-123"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt4StrictNeg() {
+    val num = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt5StrictNeg() {
+    val num = new Array[Byte](11)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
+  }
+
+  @Test def packedInt1LaxPos() {
+    val num = new Array[Byte](1)
+    val expected = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x1A.toByte
+    expected(0) = 0x1C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt2LaxPos() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2C.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x2C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("12"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt3LaxPos() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3E.toByte
+    expected(0) = 0x12.toByte
+    expected(1) = 0x3C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("123"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt4LaxPos() {
+    val num = new Array[Byte](6)
+    val expected = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0F.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x23.toByte
+    expected(2) = 0x45.toByte
+    expected(3) = 0x67.toByte
+    expected(4) = 0x89.toByte
+    expected(5) = 0x0C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt5LaxPos() {
+    val num = new Array[Byte](11)
+    val expected = new Array[Byte](11)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0A.toByte
+    expected(0) = 0x00.toByte
+    expected(1) = 0x00.toByte
+    expected(2) = 0x00.toByte
+    expected(3) = 0x00.toByte
+    expected(4) = 0x00.toByte
+    expected(5) = 0x01.toByte
+    expected(6) = 0x23.toByte
+    expected(7) = 0x45.toByte
+    expected(8) = 0x67.toByte
+    expected(9) = 0x89.toByte
+    expected(10) = 0x0C.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt1LaxNeg() {
+    val num = new Array[Byte](1)
+    val expected = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x1B.toByte
+    expected(0) = 0x1D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt2LaxNeg() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2D.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x2D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-12"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt3LaxNeg() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3B.toByte
+    expected(0) = 0x12.toByte
+    expected(1) = 0x3D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-123"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt4LaxNeg() {
+    val num = new Array[Byte](6)
+    val expected = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0D.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x23.toByte
+    expected(2) = 0x45.toByte
+    expected(3) = 0x67.toByte
+    expected(4) = 0x89.toByte
+    expected(5) = 0x0D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedInt5LaxNeg() {
+    val num = new Array[Byte](11)
+    val expected = new Array[Byte](11)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0B.toByte
+    expected(0) = 0x00.toByte
+    expected(1) = 0x00.toByte
+    expected(2) = 0x00.toByte
+    expected(3) = 0x00.toByte
+    expected(4) = 0x00.toByte
+    expected(5) = 0x01.toByte
+    expected(6) = 0x23.toByte
+    expected(7) = 0x45.toByte
+    expected(8) = 0x67.toByte
+    expected(9) = 0x89.toByte
+    expected(10) = 0x0D.toByte
+    val bignum = packedToBigInteger(num, signCodes)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec1StrictPos() {
+    val num = new Array[Byte](1)
+    val scale = 0
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x1C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("1"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec2StrictPos() {
+    val num = new Array[Byte](2)
+    val scale = 1
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("1.2"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec3StrictPos() {
+    val num = new Array[Byte](2)
+    val scale = 3
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal(".123"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec4StrictPos() {
+    val num = new Array[Byte](6)
+    val scale = 5
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("12345.67890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec5StrictPos() {
+    val num = new Array[Byte](11)
+    val scale = 19
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("0.0000000001234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec1StrictNeg() {
+    val num = new Array[Byte](1)
+    val scale = 0
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x1D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-1"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec2StrictNeg() {
+    val num = new Array[Byte](2)
+    val scale = 1
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-1.2"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec3StrictNeg() {
+    val num = new Array[Byte](2)
+    val scale = 3
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-.123"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec4StrictNeg() {
+    val num = new Array[Byte](6)
+    val scale = 5
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-12345.67890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec5StrictNeg() {
+    val num = new Array[Byte](11)
+    val scale = 19
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-0.0000000001234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
+  }
+
+  @Test def packedDec1LaxPos() {
+    val num = new Array[Byte](1)
+    val expected = new Array[Byte](1)
+    val scale = 0
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x1A.toByte
+    expected(0) = 0x1C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("1"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec2LaxPos() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val scale = 1
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2C.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x2C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("1.2"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec3LaxPos() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val scale = 3
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3E.toByte
+    expected(0) = 0x12.toByte
+    expected(1) = 0x3C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal(".123"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec4LaxPos() {
+    val num = new Array[Byte](6)
+    val expected = new Array[Byte](6)
+    val scale = 5
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0F.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x23.toByte
+    expected(2) = 0x45.toByte
+    expected(3) = 0x67.toByte
+    expected(4) = 0x89.toByte
+    expected(5) = 0x0C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("12345.67890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec5LaxPos() {
+    val num = new Array[Byte](11)
+    val expected = new Array[Byte](11)
+    val scale = 19
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0A.toByte
+    expected(0) = 0x00.toByte
+    expected(1) = 0x00.toByte
+    expected(2) = 0x00.toByte
+    expected(3) = 0x00.toByte
+    expected(4) = 0x00.toByte
+    expected(5) = 0x01.toByte
+    expected(6) = 0x23.toByte
+    expected(7) = 0x45.toByte
+    expected(8) = 0x67.toByte
+    expected(9) = 0x89.toByte
+    expected(10) = 0x0C.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("0.0000000001234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec1LaxNeg() {
+    val num = new Array[Byte](1)
+    val expected = new Array[Byte](1)
+    val scale = 0
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x1B.toByte
+    expected(0) = 0x1D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-1"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec2LaxNeg() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val scale = 1
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x2D.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x2D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-1.2"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec3LaxNeg() {
+    val num = new Array[Byte](2)
+    val expected = new Array[Byte](2)
+    val scale = 3
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x3B.toByte
+    expected(0) = 0x12.toByte
+    expected(1) = 0x3D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-.123"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec4LaxNeg() {
+    val num = new Array[Byte](6)
+    val expected = new Array[Byte](6)
+    val scale = 5
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0D.toByte
+    expected(0) = 0x01.toByte
+    expected(1) = 0x23.toByte
+    expected(2) = 0x45.toByte
+    expected(3) = 0x67.toByte
+    expected(4) = 0x89.toByte
+    expected(5) = 0x0D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-12345.67890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def packedDec5LaxNeg() {
+    val num = new Array[Byte](11)
+    val expected = new Array[Byte](11)
+    val scale = 19
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x01.toByte
+    num(6) = 0x23.toByte
+    num(7) = 0x45.toByte
+    num(8) = 0x67.toByte
+    num(9) = 0x89.toByte
+    num(10) = 0x0B.toByte
+    expected(0) = 0x00.toByte
+    expected(1) = 0x00.toByte
+    expected(2) = 0x00.toByte
+    expected(3) = 0x00.toByte
+    expected(4) = 0x00.toByte
+    expected(5) = 0x01.toByte
+    expected(6) = 0x23.toByte
+    expected(7) = 0x45.toByte
+    expected(8) = 0x67.toByte
+    expected(9) = 0x89.toByte
+    expected(10) = 0x0D.toByte
+    val bignum = packedToBigDecimal(num, scale, signCodes)
+    assertEquals(bignum, new JBigDecimal("-0.0000000001234567890"))
+    assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
+  }
+
+  @Test def ibm4690Int1Pos() {
+    val num = new Array[Byte](1)
+
+    num(0) = 0xF1.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int2Pos() {
+    val num = new Array[Byte](1)
+
+    num(0) = 0x12.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("12"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int3Pos() {
+    val num = new Array[Byte](2)
+
+    num(0) = 0xF1.toByte
+    num(1) = 0x23.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("123"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int4Pos() {
+    val num = new Array[Byte](5)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x56.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int5Pos() {
+    val num = new Array[Byte](10)
+
+    num(0) = 0xFF.toByte
+    num(1) = 0xFF.toByte
+    num(2) = 0xFF.toByte
+    num(3) = 0xFF.toByte
+    num(4) = 0xFF.toByte
+    num(5) = 0x12.toByte
+    num(6) = 0x34.toByte
+    num(7) = 0x56.toByte
+    num(8) = 0x78.toByte
+    num(9) = 0x90.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int1Neg() {
+    val num = new Array[Byte](1)
+
+    num(0) = 0xD1.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("-1"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int2Neg() {
+    val num = new Array[Byte](2)
+
+    num(0) = 0xFD.toByte
+    num(1) = 0x12.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("-12"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int3Neg() {
+    val num = new Array[Byte](2)
+
+    num(0) = 0xD1.toByte
+    num(1) = 0x23.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("-123"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int4Neg() {
+    val num = new Array[Byte](6)
+
+    num(0) = 0xFD.toByte
+    num(1) = 0x12.toByte
+    num(2) = 0x34.toByte
+    num(3) = 0x56.toByte
+    num(4) = 0x78.toByte
+    num(5) = 0x90.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Int5Neg() {
+    val num = new Array[Byte](11)
+
+    num(0) = 0xFF.toByte
+    num(1) = 0xFF.toByte
+    num(2) = 0xFF.toByte
+    num(3) = 0xFF.toByte
+    num(4) = 0xFF.toByte
+    num(5) = 0xFD.toByte
+    num(6) = 0x12.toByte
+    num(7) = 0x34.toByte
+    num(8) = 0x56.toByte
+    num(9) = 0x78.toByte
+    num(10) = 0x90.toByte
+    val bignum = ibm4690ToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("-1234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec1Pos() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0xF1.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("1"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec2Pos() {
+    val num = new Array[Byte](1)
+    val scale = 1
+
+    num(0) = 0x12.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("1.2"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec3Pos() {
+    val num = new Array[Byte](2)
+    val scale = 3
+
+    num(0) = 0xF1.toByte
+    num(1) = 0x23.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal(".123"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec4Pos() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x56.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("12345.67890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec5Pos() {
+    val num = new Array[Byte](10)
+    val scale = 19
+
+    num(0) = 0xFF.toByte
+    num(1) = 0xFF.toByte
+    num(2) = 0xFF.toByte
+    num(3) = 0xFF.toByte
+    num(4) = 0xFF.toByte
+    num(5) = 0x12.toByte
+    num(6) = 0x34.toByte
+    num(7) = 0x56.toByte
+    num(8) = 0x78.toByte
+    num(9) = 0x90.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("0.0000000001234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec1Neg() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0xD1.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("-1"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec2Neg() {
+    val num = new Array[Byte](2)
+    val scale = 1
+
+    num(0) = 0xFD.toByte
+    num(1) = 0x12.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("-1.2"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec3Neg() {
+    val num = new Array[Byte](2)
+    val scale = 3
+
+    num(0) = 0xD1.toByte
+    num(1) = 0x23.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("-.123"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec4Neg() {
+    val num = new Array[Byte](6)
+    val scale = 5
+
+    num(0) = 0xFD.toByte
+    num(1) = 0x12.toByte
+    num(2) = 0x34.toByte
+    num(3) = 0x56.toByte
+    num(4) = 0x78.toByte
+    num(5) = 0x90.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("-12345.67890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def ibm4690Dec5Neg() {
+    val num = new Array[Byte](11)
+    val scale = 19
+
+    num(0) = 0xFF.toByte
+    num(1) = 0xFF.toByte
+    num(2) = 0xFF.toByte
+    num(3) = 0xFF.toByte
+    num(4) = 0xFF.toByte
+    num(5) = 0xFD.toByte
+    num(6) = 0x12.toByte
+    num(7) = 0x34.toByte
+    num(8) = 0x56.toByte
+    num(9) = 0x78.toByte
+    num(10) = 0x90.toByte
+    val bignum = ibm4690ToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("-0.0000000001234567890"))
+    assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def bcdInt1Pos() {
+    val num = new Array[Byte](1)
+
+    num(0) = 0x01.toByte
+    val bignum = bcdToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1"))
+    assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def bcdInt2Pos() {
+    val num = new Array[Byte](1)
+
+    num(0) = 0x12.toByte
+    val bignum = bcdToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("12"))
+    assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def bcdInt3Pos() {
+    val num = new Array[Byte](2)
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    val bignum = bcdToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("123"))
+    assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def bcdInt4Pos() {
+    val num = new Array[Byte](5)
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x56.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    val bignum = bcdToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def bcdInt5Pos() {
+    val num = new Array[Byte](10)
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x12.toByte
+    num(6) = 0x34.toByte
+    num(7) = 0x56.toByte
+    num(8) = 0x78.toByte
+    num(9) = 0x90.toByte
+    val bignum = bcdToBigInteger(num)
+    assertEquals(bignum, new JBigInteger("1234567890"))
+    assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
+  }
+
+  @Test def bcdDec1Pos() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0x01.toByte
+    val bignum = bcdToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("1"))
+    assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def bcdDec2Pos() {
+    val num = new Array[Byte](1)
+    val scale = 1
+
+    num(0) = 0x12.toByte
+    val bignum = bcdToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("1.2"))
+    assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def bcdDec3Pos() {
+    val num = new Array[Byte](2)
+    val scale = 3
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    val bignum = bcdToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal(".123"))
+    assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def bcdDec4Pos() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x56.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    val bignum = bcdToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("12345.67890"))
+    assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def bcdDec5Pos() {
+    val num = new Array[Byte](10)
+    val scale = 19
+
+    num(0) = 0x00.toByte
+    num(1) = 0x00.toByte
+    num(2) = 0x00.toByte
+    num(3) = 0x00.toByte
+    num(4) = 0x00.toByte
+    num(5) = 0x12.toByte
+    num(6) = 0x34.toByte
+    num(7) = 0x56.toByte
+    num(8) = 0x78.toByte
+    num(9) = 0x90.toByte
+    val bignum = bcdToBigDecimal(num, scale)
+    assertEquals(bignum, new JBigDecimal("0.0000000001234567890"))
+    assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
+  }
+
+  @Test def packedInvalidHighNibble1() {
+    val num = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+    val scale = 0
+
+    num(0) = 0xDC.toByte
+    try {
+      val bignum = packedToBigDecimal(num, scale, signCodes)
+      assertEquals(bignum, new JBigDecimal("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def packedInvalidHighNibble2() {
+    val num = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+    val scale = 5
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0xD5.toByte
+    num(3) = 0x67.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0C.toByte
+    try {
+      val bignum = packedToBigDecimal(num, scale, signCodes)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def packedInvalidLowNibble1() {
+    val num = new Array[Byte](1)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+
+    num(0) = 0x10.toByte
+    try {
+      val bignum = packedToBigInteger(num, signCodes)
+      assertEquals(bignum, new JBigInteger("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid sign nibble"))
+    }
+  }
+
+  @Test def packedInvalidLowNibble2() {
+    val num = new Array[Byte](6)
+    val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
+    val scale = 5
+
+    num(0) = 0x01.toByte
+    num(1) = 0x23.toByte
+    num(2) = 0x45.toByte
+    num(3) = 0x6D.toByte
+    num(4) = 0x89.toByte
+    num(5) = 0x0C.toByte
+    try {
+      val bignum = packedToBigDecimal(num, scale, signCodes)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid low nibble"))
+    }
+  }
+
+  @Test def bcdInvalidHighNibble1() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0xD1.toByte
+    try {
+      val bignum = bcdToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def bcdInvalidHighNibble2() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0xD6.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    try {
+      val bignum = bcdToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def bcdInvalidLowNibble1() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0x1C.toByte
+    try {
+      val bignum = bcdToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid low nibble"))
+    }
+  }
+
+  @Test def bcdInvalidLowNibble2() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x5D.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    try {
+      val bignum = bcdToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid low nibble"))
+    }
+  }
+
+  @Test def ibm4690InvalidHighNibble1() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0xA1.toByte
+    try {
+      val bignum = ibm4690ToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def ibm4690InvalidHighNibble2() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0xD6.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    try {
+      val bignum = ibm4690ToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid high nibble"))
+    }
+  }
+
+  @Test def ibm4690InvalidLowNibble1() {
+    val num = new Array[Byte](1)
+    val scale = 0
+
+    num(0) = 0x1C.toByte
+    try {
+      val bignum = ibm4690ToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("1"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid low nibble"))
+    }
+  }
+
+  @Test def ibm4690InvalidLowNibble2() {
+    val num = new Array[Byte](5)
+    val scale = 5
+
+    num(0) = 0x12.toByte
+    num(1) = 0x34.toByte
+    num(2) = 0x5D.toByte
+    num(3) = 0x78.toByte
+    num(4) = 0x90.toByte
+    try {
+      val bignum = ibm4690ToBigDecimal(num, scale)
+      assertEquals(bignum, new JBigDecimal("12345.67890"))
+    } catch {
+      case nfe: NumberFormatException => assertTrue(nfe.getMessage().contains("Invalid low nibble"))
+    }
+  }
+}

--- a/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/BCDUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/BCDUnparsers.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.unparsers
+
+import edu.illinois.ncsa.daffodil.processors.parsers.HasKnownLengthInBits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.processors.ParseOrUnparseState
+import edu.illinois.ncsa.daffodil.util.DecimalUtils
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger }
+import edu.illinois.ncsa.daffodil.processors.parsers.HasRuntimeExplicitLength
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+
+abstract class BCDIntegerBaseUnparser(
+  e: ElementRuntimeData)
+  extends PackedBinaryIntegerBaseUnparser(e) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.bcdFromBigInteger(bigInt, nBits)
+}
+
+class BCDIntegerKnownLengthUnparser(
+  e: ElementRuntimeData,
+  override val lengthInBits: Int)
+  extends BCDIntegerBaseUnparser(e)
+  with HasKnownLengthInBits {
+}
+
+class BCDIntegerRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends BCDIntegerBaseUnparser(e)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class BCDIntegerMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData)
+  extends BCDIntegerBaseUnparser(e) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}
+
+abstract class BCDDecimalBaseUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends PackedBinaryDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.bcdFromBigInteger(bigInt, nBits)
+}
+
+class BCDDecimalKnownLengthUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  override val lengthInBits: Int)
+  extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
+  with HasKnownLengthInBits {
+}
+
+class BCDDecimalRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class BCDDecimalMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}

--- a/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/IBM4690PackedDecimalUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/IBM4690PackedDecimalUnparsers.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.unparsers
+
+import edu.illinois.ncsa.daffodil.processors.parsers.HasKnownLengthInBits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.processors.ParseOrUnparseState
+import edu.illinois.ncsa.daffodil.util.DecimalUtils
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger }
+import edu.illinois.ncsa.daffodil.processors.parsers.HasRuntimeExplicitLength
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+
+abstract class IBM4690PackedIntegerBaseUnparser(
+  e: ElementRuntimeData)
+  extends PackedBinaryIntegerBaseUnparser(e) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.ibm4690FromBigInteger(bigInt, nBits)
+}
+
+class IBM4690PackedIntegerKnownLengthUnparser(
+  e: ElementRuntimeData,
+  override val lengthInBits: Int)
+  extends IBM4690PackedIntegerBaseUnparser(e)
+  with HasKnownLengthInBits {
+}
+
+class IBM4690PackedIntegerRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends IBM4690PackedIntegerBaseUnparser(e)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class IBM4690PackedIntegerMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData)
+  extends IBM4690PackedIntegerBaseUnparser(e) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}
+
+abstract class IBM4690PackedDecimalBaseUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends PackedBinaryDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.ibm4690FromBigInteger(bigInt, nBits)
+}
+
+class IBM4690PackedDecimalKnownLengthUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  override val lengthInBits: Int)
+  extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
+  with HasKnownLengthInBits {
+}
+
+class IBM4690PackedDecimalRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class IBM4690PackedDecimalMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}

--- a/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/PackedBinaryUnparserTraits.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/PackedBinaryUnparserTraits.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.unparsers
+
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.processors.ParseOrUnparseState
+import edu.illinois.ncsa.daffodil.util.Maybe._
+import java.lang.{ Number => JNumber }
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+import edu.illinois.ncsa.daffodil.exceptions.Assert
+import edu.illinois.ncsa.daffodil.io.DataOutputStream
+import edu.illinois.ncsa.daffodil.io.FormatInfo
+
+trait PackedBinaryConversion {
+  def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte]
+}
+
+abstract class PackedBinaryBaseUnparser(
+  e: ElementRuntimeData)
+  extends PrimUnparserObject(e)
+  with PackedBinaryConversion {
+
+  protected def getBitLength(s: ParseOrUnparseState): Int
+
+  def putNumber(dos: DataOutputStream, number: JNumber, nBits: Int, finfo: FormatInfo): Boolean
+
+  def unparse(state: UState): Unit = {
+    val nBits = getBitLength(state)
+    val node = state.currentInfosetNode.asSimple
+    val value = node.dataValue.asInstanceOf[JNumber]
+    val dos = state.dataOutputStream
+
+    val res =
+      if (nBits > 0) {
+        putNumber(dos, value, nBits, state)
+      } else {
+        true
+      }
+
+    if (!res) {
+      Assert.invariant(dos.maybeRelBitLimit0b.isDefined)
+      UnparseError(One(state.schemaFileLocation), One(state.currentLocation), "Insufficient space to unparse element %s, required %s bits, but only %s were available.",
+        e.dpathElementCompileInfo.namedQName.toPrettyString, nBits, dos.maybeRelBitLimit0b.get)
+    }
+  }
+
+}
+
+abstract class PackedBinaryDecimalBaseUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends PackedBinaryBaseUnparser(e) {
+
+    override def putNumber(dos: DataOutputStream, number: JNumber, nBits: Int, finfo: FormatInfo): Boolean = {
+
+      val bigDec = number.asInstanceOf[JBigDecimal]
+      if (bigDec.movePointRight(binaryDecimalVirtualPoint).scale != 0)
+        e.schemaDefinitionError("Decimal point of number '%s' does not match the binaryVirtualDecmialPoint: %d", bigDec, binaryDecimalVirtualPoint)
+
+      dos.putByteArray(
+        fromBigInteger(bigDec.unscaledValue, nBits),
+        nBits,
+        finfo)
+    }
+}
+
+
+abstract class PackedBinaryIntegerBaseUnparser(
+  e: ElementRuntimeData)
+  extends PackedBinaryBaseUnparser(e) {
+
+    override def putNumber(dos: DataOutputStream, number: JNumber, nBits: Int, finfo: FormatInfo): Boolean = {
+
+      val bigInt = number.isInstanceOf[JBigInteger] match {
+        case true => number.asInstanceOf[JBigInteger]
+        case false => new JBigInteger(number.toString)
+      }
+
+      dos.putByteArray(
+        fromBigInteger(bigInt, nBits),
+        nBits,
+        finfo)
+    }
+}

--- a/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/PackedDecimalUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/edu/illinois/ncsa/daffodil/processors/unparsers/PackedDecimalUnparsers.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.unparsers
+
+import edu.illinois.ncsa.daffodil.processors.parsers.HasKnownLengthInBits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.processors.ParseOrUnparseState
+import edu.illinois.ncsa.daffodil.util.{ DecimalUtils, PackedSignCodes }
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger }
+import edu.illinois.ncsa.daffodil.processors.parsers.HasRuntimeExplicitLength
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+
+abstract class PackedIntegerBaseUnparser(
+  e: ElementRuntimeData,
+  packedSignCodes: PackedSignCodes)
+  extends PackedBinaryIntegerBaseUnparser(e) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.packedFromBigInteger(bigInt, nBits, packedSignCodes)
+}
+
+class PackedIntegerKnownLengthUnparser(
+  e: ElementRuntimeData,
+  packedSignCodes: PackedSignCodes,
+  override val lengthInBits: Int)
+  extends PackedIntegerBaseUnparser(e, packedSignCodes)
+  with HasKnownLengthInBits {
+}
+
+class PackedIntegerRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  packedSignCodes: PackedSignCodes,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedIntegerBaseUnparser(e, packedSignCodes)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class PackedIntegerMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData,
+  packedSignCodes: PackedSignCodes)
+  extends PackedIntegerBaseUnparser(e, packedSignCodes) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}
+
+
+abstract class PackedDecimalBaseUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes)
+  extends PackedBinaryDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
+
+  override def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.packedFromBigInteger(bigInt, nBits, packedSignCodes)
+}
+
+class PackedDecimalKnownLengthUnparser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes,
+  override val lengthInBits: Int)
+  extends PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, packedSignCodes)
+  with HasKnownLengthInBits {
+}
+
+class PackedDecimalRuntimeLengthUnparser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, packedSignCodes)
+  with HasRuntimeExplicitLength {
+
+  override val runtimeDependencies = List(lengthEv)
+}
+
+final class PackedDecimalMinLengthInBytesUnparser(
+  minLengthInBytes: Int,
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes)
+  extends PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, packedSignCodes) {
+
+  override def getBitLength(state: ParseOrUnparseState): Int = {
+    val len = state.currentNode.get.asSimple.dataValue.asInstanceOf[Array[Byte]].length * 8
+    val min = minLengthInBytes *  8
+    scala.math.max(len, min)
+  }
+}

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/BCDParsers.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/BCDParsers.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.parsers
+
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.util.DecimalUtils
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+
+class BCDDecimalKnownLengthParser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthInBits: Int)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class BCDDecimalRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class BCDIntegerRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryIntegerBaseParser(e)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class BCDIntegerKnownLengthParser(
+  e: ElementRuntimeData,
+  val lengthInBits: Int)
+  extends PackedBinaryIntegerBaseParser(e)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/DelimitedParsers.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/DelimitedParsers.scala
@@ -38,12 +38,15 @@ import edu.illinois.ncsa.daffodil.processors.FieldDFAParseEv
 import edu.illinois.ncsa.daffodil.processors.EscapeSchemeBlockParserHelper
 import edu.illinois.ncsa.daffodil.processors.dfa
 import edu.illinois.ncsa.daffodil.util.Maybe
+import edu.illinois.ncsa.daffodil.util.PackedSignCodes
 import edu.illinois.ncsa.daffodil.processors.dfa.TextDelimitedParserBase
 import edu.illinois.ncsa.daffodil.processors.dfa.TextDelimitedParserWithEscapeBlock
 import edu.illinois.ncsa.daffodil.exceptions.Assert
 import edu.illinois.ncsa.daffodil.equality._; object ENoWarn { EqualitySuppressUnusedImportWarning() }
 import java.nio.charset.StandardCharsets
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
 import edu.illinois.ncsa.daffodil.util.MaybeChar
+import edu.illinois.ncsa.daffodil.util.DecimalUtils
 import edu.illinois.ncsa.daffodil.processors.AllTerminatingMarkupDelimiterIterator
 import passera.unsigned.ULong
 
@@ -182,4 +185,82 @@ class HexBinaryDelimitedParser(
       return
     }
   }
+}
+
+
+class PackedIntegerDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean,
+  packedSignCodes: PackedSignCodes)
+  extends PackedBinaryIntegerDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}
+
+class PackedDecimalDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes)
+  extends PackedBinaryDecimalDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired, binaryDecimalVirtualPoint) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}
+
+class BCDIntegerDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean)
+  extends PackedBinaryIntegerDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class BCDDecimalDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean,
+  binaryDecimalVirtualPoint: Int)
+  extends PackedBinaryDecimalDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired, binaryDecimalVirtualPoint) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class IBM4690PackedIntegerDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean)
+  extends PackedBinaryIntegerDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
+}
+
+class IBM4690PackedDecimalDelimitedParser(
+  erd: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean,
+  binaryDecimalVirtualPoint: Int)
+  extends PackedBinaryDecimalDelimitedBaseParser(erd, textParser, fieldDFAEv, isDelimRequired, binaryDecimalVirtualPoint) {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.bcdToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.bcdToBigDecimal(num, scale)
+
 }

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/IBM4690PackedDecimalParsers.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/IBM4690PackedDecimalParsers.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.parsers
+
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.util.DecimalUtils
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+
+class IBM4690PackedDecimalKnownLengthParser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthInBits: Int)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.ibm4690ToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.ibm4690ToBigDecimal(num, scale)
+
+}
+
+class IBM4690PackedDecimalRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.ibm4690ToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.ibm4690ToBigDecimal(num, scale)
+
+}
+
+class IBM4690PackedIntegerRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  signed: Boolean,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryIntegerBaseParser(e, signed)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.ibm4690ToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.ibm4690ToBigDecimal(num, scale)
+
+}
+
+class IBM4690PackedIntegerKnownLengthParser(
+  e: ElementRuntimeData,
+  signed: Boolean,
+  val lengthInBits: Int)
+  extends PackedBinaryIntegerBaseParser(e, signed)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.ibm4690ToBigInteger(num)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.ibm4690ToBigDecimal(num, scale)
+
+}

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/PackedBinaryTraits.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/PackedBinaryTraits.scala
@@ -1,0 +1,193 @@
+/* Copyright (c) 2012-2014 Tresys Technology, LLC. All rights reserved.
+ *
+ * Developed by: Tresys Technology, LLC
+ *               http://www.tresys.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal with
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimers.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the names of Tresys Technology, nor the names of its contributors
+ *     may be used to endorse or promote products derived from this Software
+ *     without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+ * SOFTWARE.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.parsers
+
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.processors.ParseOrUnparseState
+import edu.illinois.ncsa.daffodil.processors.FieldDFAParseEv
+import edu.illinois.ncsa.daffodil.processors.TextJustificationType
+import edu.illinois.ncsa.daffodil.processors.dfa.TextDelimitedParserBase
+import edu.illinois.ncsa.daffodil.util.Maybe
+import edu.illinois.ncsa.daffodil.exceptions.Assert
+import edu.illinois.ncsa.daffodil.equality._
+import edu.illinois.ncsa.daffodil.processors.dfa
+import edu.illinois.ncsa.daffodil.util.MaybeChar
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+import java.nio.charset.StandardCharsets
+import passera.unsigned.ULong
+
+trait PackedBinaryConversion {
+  def toBigInteger(num: Array[Byte]): JBigInteger
+  def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal
+}
+
+abstract class PackedBinaryDecimalBaseParser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int)
+  extends PrimParserObject(e)
+  with PackedBinaryConversion {
+
+  protected def getBitLength(s: ParseOrUnparseState): Int
+
+  def parse(start: PState): Unit = {
+    val nBits = getBitLength(start)
+    if (nBits == 0) return // zero length is used for outputValueCalc often.
+    val dis = start.dataInputStream
+
+    if (!dis.isDefinedForLength(nBits)) {
+      PE(start, "Insufficient bits in data. Needed %d bit(s) but found only %d available.", nBits, dis.remainingBits.get)
+      return
+    }
+
+    try {
+      val bigDec = toBigDecimal(dis.getByteArray(nBits, start), binaryDecimalVirtualPoint)
+      start.simpleElement.overwriteDataValue(bigDec)
+    } catch {
+      case n: NumberFormatException => PE(start, "Error in packed data: \n%s", n.getMessage())
+    }
+  }
+}
+
+abstract class PackedBinaryIntegerBaseParser(
+  e: ElementRuntimeData,
+  signed: Boolean = false)
+  extends PrimParserObject(e)
+  with PackedBinaryConversion {
+
+  protected def getBitLength(s: ParseOrUnparseState): Int
+
+  def parse(start: PState): Unit = {
+    val nBits = getBitLength(start)
+    if (nBits == 0) return // zero length is used for outputValueCalc often.
+    val dis = start.dataInputStream
+
+    if (!dis.isDefinedForLength(nBits)) {
+      PE(start, "Insufficient bits in data. Needed %d bit(s) but found only %d available.", nBits, dis.remainingBits.get)
+      return
+    }
+
+    try {
+      val int = toBigInteger(dis.getByteArray(nBits, start))
+      if (!signed && (int.signum != 1))
+        PE(start, "Expected unsigned data but parsed a negative number")
+      else
+        start.simpleElement.overwriteDataValue(int)
+    } catch {
+      case n: NumberFormatException => PE(start, "Error in packed data: \n%s", n.getMessage())
+    }
+  }
+}
+
+abstract class PackedBinaryIntegerDelimitedBaseParser(
+  e: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean)
+  extends StringDelimitedParser(e, TextJustificationType.None, MaybeChar.Nope, textParser, fieldDFAEv, isDelimRequired)
+  with PackedBinaryConversion {
+
+  override def processResult(parseResult: Maybe[dfa.ParseResult], state: PState): Unit = {
+    Assert.invariant(e.encodingInfo.isKnownEncoding && e.encodingInfo.knownEncodingCharset.charset =:= StandardCharsets.ISO_8859_1)
+
+    if (!parseResult.isDefined) this.PE(state, "%s - %s - Parse failed.", this.toString(), e.diagnosticDebugName)
+    else {
+      val result = parseResult.get
+      val field = if (result.field.isDefined) result.field.get else ""
+      val fieldBytes = field.getBytes(StandardCharsets.ISO_8859_1)
+      captureValueLength(state, ULong(0), ULong(fieldBytes.length * 8))
+      if (field == "") {
+        this.PE(state, "%s - %s - Parse failed.", this.toString(), e.diagnosticDebugName)
+        return
+      } else {
+        try {
+          val num = toBigInteger(fieldBytes)
+          state.simpleElement.setDataValue(num)
+        } catch {
+          case n: NumberFormatException => PE(state, "Error in packed data: \n%s", n.getMessage())
+        }
+
+        if (result.matchedDelimiterValue.isDefined) state.saveDelimitedParseResult(parseResult)
+      }
+      return
+    }
+  }
+}
+
+
+abstract class PackedBinaryDecimalDelimitedBaseParser(
+  e: ElementRuntimeData,
+  textParser: TextDelimitedParserBase,
+  fieldDFAEv: FieldDFAParseEv,
+  isDelimRequired: Boolean,
+  binaryDecimalVirtualPoint: Int)
+  extends StringDelimitedParser(e, TextJustificationType.None, MaybeChar.Nope, textParser, fieldDFAEv, isDelimRequired)
+  with PackedBinaryConversion {
+
+  /**
+   * We are treating packed binary formats as just a string in iso-8859-1 encoding.
+   *
+   * This works because java/scala's decoder for iso-8859-1 does not implement any
+   * unmapping error detection. The official definition of iso-8859-1 has a few unmapped
+   * characters, but most interpretations of iso-8859-1 implement these code points anyway, with
+   * their unicode code points being exactly the byte values (interpreted unsigned).
+   *
+   * So, in scala/java anyway, it appears one can use iso-8859-1 as characters corresponding to
+   * raw byte values.
+   */
+
+  override def processResult(parseResult: Maybe[dfa.ParseResult], state: PState): Unit = {
+    Assert.invariant(e.encodingInfo.isKnownEncoding && e.encodingInfo.knownEncodingCharset.charset =:= StandardCharsets.ISO_8859_1)
+
+    if (!parseResult.isDefined) this.PE(state, "%s - %s - Parse failed.", this.toString(), e.diagnosticDebugName)
+    else {
+      val result = parseResult.get
+      val field = if (result.field.isDefined) result.field.get else ""
+      val fieldBytes = field.getBytes(StandardCharsets.ISO_8859_1)
+      captureValueLength(state, ULong(0), ULong(fieldBytes.length * 8))
+      if (field == "") {
+        this.PE(state, "%s - %s - Parse failed.", this.toString(), e.diagnosticDebugName)
+        return
+      } else {
+        try {
+          val num = toBigDecimal(fieldBytes, binaryDecimalVirtualPoint)
+          state.simpleElement.setDataValue(num)
+        } catch {
+          case n: NumberFormatException => PE(state, "Error in packed data: \n%s", n.getMessage())
+        }
+
+        if (result.matchedDelimiterValue.isDefined) state.saveDelimitedParseResult(parseResult)
+      }
+      return
+    }
+  }
+}

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/PackedDecimalParsers.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/parsers/PackedDecimalParsers.scala
@@ -1,0 +1,94 @@
+/* Copyright (c) 2012-2014 Tresys Technology, LLC. All rights reserved.
+ *
+ * Developed by: Tresys Technology, LLC
+ *               http://www.tresys.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal with
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimers.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the names of Tresys Technology, nor the names of its contributors
+ *     may be used to endorse or promote products derived from this Software
+ *     without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+ * SOFTWARE.
+ */
+
+package edu.illinois.ncsa.daffodil.processors.parsers
+
+import edu.illinois.ncsa.daffodil.processors.Evaluatable
+import edu.illinois.ncsa.daffodil.schema.annotation.props.gen.LengthUnits
+import edu.illinois.ncsa.daffodil.processors.ElementRuntimeData
+import edu.illinois.ncsa.daffodil.util.{ DecimalUtils, PackedSignCodes }
+import java.lang.{ Long => JLong }
+import java.math.{ BigInteger => JBigInteger, BigDecimal => JBigDecimal }
+
+class PackedDecimalKnownLengthParser(
+  e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes,
+  val lengthInBits: Int)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}
+
+class PackedDecimalRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  binaryDecimalVirtualPoint: Int,
+  packedSignCodes: PackedSignCodes,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryDecimalBaseParser(e, binaryDecimalVirtualPoint)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}
+
+class PackedIntegerRuntimeLengthParser(
+  val e: ElementRuntimeData,
+  signed: Boolean,
+  packedSignCodes: PackedSignCodes,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends PackedBinaryIntegerBaseParser(e, signed)
+  with HasRuntimeExplicitLength {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}
+
+class PackedIntegerKnownLengthParser(
+  e: ElementRuntimeData,
+  signed: Boolean,
+  packedSignCodes: PackedSignCodes,
+  val lengthInBits: Int)
+  extends PackedBinaryIntegerBaseParser(e, signed)
+  with HasKnownLengthInBits {
+
+  override def toBigInteger(num: Array[Byte]): JBigInteger = DecimalUtils.packedToBigInteger(num, packedSignCodes)
+  override def toBigDecimal(num: Array[Byte], scale: Int): JBigDecimal = DecimalUtils.packedToBigDecimal(num, scale, packedSignCodes)
+
+}

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpadelbcd_01.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpadelbcd_01.dfdl.xsd
@@ -15,7 +15,7 @@
 			-->
 			<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" 
 			    textBidi="no" floating="no"   encodingErrorPolicy="replace" encoding="utf-8" 
-			    byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" alignment="1" alignmentUnits="bytes" fillByte="f" 
+			    byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" alignment="1" alignmentUnits="bytes" fillByte="f" outputNewLine="%LF;"
 				occursCountKind="implicit"
 				truncateSpecifiedLengthString="no" ignoreCase="no" representation="binary"
 				textPadKind="none" textTrimKind="none" lengthKind="delimited"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpanum_bin.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpanum_bin.dfdl.xsd
@@ -13,7 +13,7 @@
 			<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" truncateSpecifiedLengthString="no"  textBidi="no" floating="no"   ref="numberStandardBinary" escapeSchemeRef=""
 				emptyValueDelimiterPolicy="none" useNilForDefault="yes"
 				nilValueDelimiterPolicy="none" nilKind="literalValue" nilValue="-"
-				encodingErrorPolicy="replace" encoding="utf-8" byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" lengthUnits="bytes"
+				encodingErrorPolicy="replace" encoding="utf-8" byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" lengthUnits="bytes" outputNewLine="%LF;"
 				textOutputMinLength="1" alignment="1" alignmentUnits="bytes"
 				fillByte="%NUL;"  occursCountKind="implicit" ignoreCase="no"
 				lengthKind="explicit" sequenceKind="ordered" initiatedContent="no" textPadKind="none" />

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc83_01.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc83_01.dfdl.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-	xmlns:cal="http://www.saf.cal/" elementFormDefault="qualified"
-	attributeFormDefault="qualified" >
+	xmlns:cal="http://www.saf.cal/" elementFormDefault="qualified">
 	
 	<!--  Portions of this schema taken from example in 
 	Data Format Description Language (DFDL) v1.0 Specification, Copyright © Global Grid Forum (2004-2006).  All Rights Reserved.
@@ -26,7 +25,7 @@ Copyright © Open Grid Forum, (2006-2010).  All Rights Reserved.
 				lengthUnits="bytes" length="4" 
 				alignmentUnits="bytes" fillByte="%#r66;"  alignment="1" occursCountKind="implicit"
 				binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"
-				textNumberPattern="###" textStandardGroupingSeparator=","
+				textNumberPattern="###" textStandardGroupingSeparator="," textOutputMinLength="0"
 				textStandardDecimalSeparator="." textStandardExponentRep="E"
 				textNumberCheckPolicy="lax" textStandardInfinityRep="~"
 				textStandardNaNRep="z" textNumberRoundingMode="roundHalfDown"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc83_02.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc83_02.dfdl.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-	xmlns:cal="http://www.saf.cal/" elementFormDefault="qualified"
-	attributeFormDefault="qualified" >
+	xmlns:cal="http://www.saf.cal/" elementFormDefault="qualified">
 	
 	<!--  Portions of this schema taken from example in 
 	Data Format Description Language (DFDL) v1.0 Specification, Copyright © Global Grid Forum (2004-2006).  All Rights Reserved.
@@ -23,7 +22,7 @@ Copyright © Open Grid Forum, (2006-2010).  All Rights Reserved.
 				lengthUnits="bytes" length="4" 
 				alignmentUnits="bytes" fillByte="%#r66;"  alignment="1" occursCountKind="implicit"
 				binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"
-				textNumberPattern="###" textStandardGroupingSeparator=","
+				textNumberPattern="###" textStandardGroupingSeparator="," textOutputMinLength="0"
 				textStandardDecimalSeparator="." textStandardExponentRep="E"
 				textNumberCheckPolicy="lax" textStandardInfinityRep="~"
 				textStandardNaNRep="z" textNumberRoundingMode="roundHalfDown"

--- a/daffodil-test-ibm1/src/test/scala-debug/edu/illinois/ncsa/daffodil/IBMTests2.scala
+++ b/daffodil-test-ibm1/src/test/scala-debug/edu/illinois/ncsa/daffodil/IBMTests2.scala
@@ -70,11 +70,11 @@ class IBMTestsThatThrow {
 
   @Test def test_length_implicit_12_02() { runner1.runOneTest("length_implicit_12_02") } // implicit length string - bug in IBM test (doesn't have minLength - both are required)
 
-  @Test def test_length_delimited_12_05() { runner1.runOneTest("length_delimited_12_05") } // DFDL-629 binaryNumberRep="bcd"
+  @Test def test_length_delimited_12_05() { runner1.runOneTest("length_delimited_12_05") } // DAFFODIL-1541 Need support for handling delimited data with encoding other than ISO-8859-1
 
   @Test def test_simple_type_properties_text_number_13_01() { runner2.runOneTest("simple_type_properties_text_number_13_01") } // DFDL-452 text number advanced props
   @Test def test_simple_type_properties_text_number_13_03() { runner2.runOneTest("simple_type_properties_text_number_13_03") } // DFDL-452 textStandardBase (base 16)
-  @Test def test_simple_type_properties_binary_number_13_01() { runner2.runOneTest("simple_type_properties_binary_number_13_01") } // DFDL-629 binaryNumberRep="bcd"
+  @Test def test_simple_type_properties_binary_number_13_01() { runner2.runOneTest("simple_type_properties_binary_number_13_01") } // DAFFODIL-1541 Need support for handling delimited data with encoding other than ISO-8859-1
 
   @Test def test_simple_type_properties_text_boolean_13_03() { runner2.runOneTest("simple_type_properties_text_boolean_13_03") } // DFDL-462 boolean type
   @Test def test_simple_type_properties_bin_boolean_13_01() { runner2.runOneTest("simple_type_properties_bin_boolean_13_01") } // DFDL-461 boolean type

--- a/daffodil-test-ibm1/src/test/scala/edu/illinois/ncsa/daffodil/IBMTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/edu/illinois/ncsa/daffodil/IBMTests.scala
@@ -73,6 +73,8 @@ class IBMTestsThatPass {
   // Used to work, but now we get NYI for attributeFormDefault='qualified'
   // @Test def test_scoping_default_format_8_01() { runner1.runOneTest("scoping_default_format_8_01") }
   // @Test def test_scoping_define_format_8_01() { runner1.runOneTest("scoping_define_format_8_01") }
+  @Test def test_scoping_define_format_8_02() { runner1.runOneTest("scoping_define_format_8_02") } //DFDL-565 - attributeFormDefault='qualified', packed
+  @Test def test_scoping_define_format_8_03() { runner1.runOneTest("scoping_define_format_8_03") } //DFDL-565 - attributeFormDefault='qualified', packed
 
   @Test def test_encoding_11_01() { runner1.runOneTest("encoding_11_01") }
 
@@ -87,6 +89,7 @@ class IBMTestsThatPass {
 
   @Test def test_simple_type_properties_text_number_13_02() { runner2.runOneTest("simple_type_properties_text_number_13_02") }
 
+  @Test def test_simple_type_properties_binary_number_13_01() { runner2.runOneTest("simple_type_properties_binary_number_13_01") }
   @Test def test_simple_type_properties_binary_number_13_02() { runner2.runOneTest("simple_type_properties_binary_number_13_02") }
 
   @Test def test_sequences_separated_14_01() { runner2.runOneTest("sequences_separated_14_01") }

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section12/lengthKind/DelimitedTests.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section12/lengthKind/DelimitedTests.tdml
@@ -1107,7 +1107,7 @@ C</MessageHeaders>
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Subset lengthKind='delimited' not yet supported.</tdml:error>
+      <tdml:error>Subset lengthKind='delimited' only supported for packed binary formats.</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section13/packed/packed.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section13/packed/packed.tdml
@@ -53,7 +53,139 @@
       
   </tdml:defineSchema>
   
-  
+  <tdml:defineSchema name="s2">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="3" dfdl:textNumberPattern="0000" />
+    <xs:element name="int02" type="xs:int" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+
+    <xs:element name="dec01" type="xs:decimal" dfdl:representation="binary" dfdl:binaryDecimalVirtualPoint="2" dfdl:length="3" dfdl:textNumberPattern="0000" />
+
+     <xs:element name="cal01" type="xs:date" dfdl:length="3"
+       dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="MMddyy"/>
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s3">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="bcd" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="uint01" type="xs:unsignedInt" dfdl:representation="binary" dfdl:length="4" dfdl:textNumberPattern="0000" />
+    <xs:element name="uint02" type="xs:unsignedInt" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+    <xs:element name="byte01" type="xs:byte" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+    <xs:element name="short01" type="xs:short" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+    <xs:element name="long01" type="xs:long" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+
+    <xs:element name="dec01" type="xs:decimal" dfdl:representation="binary" dfdl:binaryDecimalVirtualPoint="2" dfdl:length="2" dfdl:textNumberPattern="0000" />
+
+     <xs:element name="cal01" type="xs:date" dfdl:length="3"
+       dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="MMddyy"/>
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s4">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="ibm4690Packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+    <xs:element name="int02" type="xs:int" dfdl:representation="binary" dfdl:length="2" dfdl:textNumberPattern="0000" />
+
+    <xs:element name="dec01" type="xs:decimal" dfdl:representation="binary" dfdl:binaryDecimalVirtualPoint="2" dfdl:length="2" dfdl:textNumberPattern="0000" />
+
+     <xs:element name="cal01" type="xs:date" dfdl:length="3"
+       dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="MMddyy"/>
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s5">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="implicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s6">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="implicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="bcd" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="uint01" type="xs:unsignedInt" dfdl:representation="binary" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s7">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="implicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bytes" binaryNumberRep="ibm4690Packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s8">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="7" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s9">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="bcd" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="uint01" type="xs:unsignedInt" dfdl:representation="binary" dfdl:length="7" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s10">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="ibm4690Packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="7" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s11">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"
+    alignmentUnits="bits" alignment="1"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="8" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s12">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="bcd" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"
+    alignmentUnits="bits" alignment="1"/>
+
+    <xs:element name="uint01" type="xs:unsignedInt" dfdl:representation="binary" dfdl:length="8" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="s13">
+    <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" encoding="X-DFDL-HEX-MSBF" occursCountKind="implicit"
+    textNumberCheckPolicy="strict" textNumberPadCharacter="0" textNumberJustification="right"
+    lengthUnits="bits" binaryNumberRep="ibm4690Packed" binaryPackedSignCodes="C D F C" binaryNumberCheckPolicy="strict"
+    alignmentUnits="bits" alignment="1"/>
+
+    <xs:element name="int01" type="xs:int" dfdl:representation="binary" dfdl:length="8" dfdl:textNumberPattern="0000" />
+
+  </tdml:defineSchema>
+
 
   <tdml:parserTestCase name="hexCharset01" root="int01" model="s1"
     description="hex works as a charset encoding">
@@ -110,5 +242,411 @@
     </tdml:infoset>
 
   </tdml:parserTestCase>  
-      
+
+   <tdml:parserTestCase name="packedCharset01" root="int01" model="s2"
+    description="Using Packed Decimal formatted hex with C inicating a positive integer">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01988C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <int01>1988</int01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset02" root="int02" model="s2"
+    description="Using Packed Decimal formatted hex with D to indicate a negative integer">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">123D</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <int02>-123</int02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+   <tdml:parserTestCase name="packedCharset03" root="dec01" model="s2"
+    description="Using Packed Decimal formatted hex with a C indicating a positive decimal number">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01234C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dec01>12.34</dec01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+ 
+  <tdml:parserTestCase name="packedCharset04" root="cal01" model="s2"
+    description="Using Packed Decimal formatted hex for a calendar">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">020161</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <cal01>1961-02-01+00:00</cal01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase> 
+
+  <tdml:parserTestCase name="packedCharset05" root="int02" model="s2"
+    description="Using Packed Decimal formatted hex with an invalid sign nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">123B</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid sign nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset06" root="int02" model="s2"
+    description="Using Packed Decimal formatted hex with an invalid high nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">F23D</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid high nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset07" root="int02" model="s2"
+    description="Using Packed Decimal formatted hex with an invalid low nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">1F3D</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid low nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset08" root="int01" model="s5"
+    description="Using implicit length with Packed Decimal formatted hex should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">123D</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>lengthKind='implicit' is not allowed with packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset09" root="int01" model="s8"
+    description="Attempting to use a length of 7 bits with IBM4690 Packed Decimal should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0010101</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given length</tdml:error>
+      <tdml:error>must be a multiple of 4 when using packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="packedCharset10" root="int01" model="s11"
+    description="Attempting to use an alignment of 1 bit with Packed Decimal should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00101011</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given alignment</tdml:error>
+      <tdml:error>must be a multiple of 4</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+   <tdml:parserTestCase name="bcdCharset01" root="uint01" model="s3"
+    description="Using BCD formatted hex to indicate a positive number">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">00000011</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <uint01>11</uint01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset02" root="uint02" model="s3"
+    description="Using BCD formatted hex to indicate an integer number">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <uint02>123</uint02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+   <tdml:parserTestCase name="bcdCharset03" root="dec01" model="s3"
+    description="Using BCD formatted hex to indicate a decimal number">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">1234</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dec01>12.34</dec01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+ 
+  <tdml:parserTestCase name="bcdCharset04" root="cal01" model="s3"
+    description="Using BCD formatted hex for a calendar">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">020161</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <cal01>1961-02-01+00:00</cal01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase> 
+
+  <tdml:parserTestCase name="bcdCharset05" root="uint02" model="s3"
+    description="Using Packed Decimal formatted hex with an invalid high nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01F3</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid high nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset06" root="uint02" model="s3"
+    description="Using BCD Decimal formatted hex with an invalid low nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">012F</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid low nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset07" root="byte01" model="s3"
+    description="Using invalid type (byte) to store BCD value, should SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>not an allowed type for bcd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset08" root="short01" model="s3"
+    description="Using invalid type (short) to store BCD value, should SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>not an allowed type for bcd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  <tdml:parserTestCase name="bcdCharset09" root="int01" model="s3"
+    description="Using invalid type (int) to store BCD value, should SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>not an allowed type for bcd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  <tdml:parserTestCase name="bcdCharset10" root="long01" model="s3"
+    description="Using invalid type (long) to store BCD value, should SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>not an allowed type for bcd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset11" root="uint01" model="s6"
+    description="Attempting to use a length of 7 bits with IBM4690 Packed Decimal should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">0123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>lengthKind='implicit' is not allowed with packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset12" root="uint01" model="s9"
+    description="Using implicit length with Packed Decimal formatted hex should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0010101</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given length</tdml:error>
+      <tdml:error>must be a multiple of 4 when using packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="bcdCharset13" root="uint01" model="s12"
+    description="Attempting to use an alignment of 1 bit with BCD should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00101011</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given alignment</tdml:error>
+      <tdml:error>must be a multiple of 4</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="IBM4690Charset01" root="int01" model="s4"
+    description="Using IBM4690 packed decimal charset to indicate a positive int">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">1088</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <int01>1088</int01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset02" root="int02" model="s4"
+    description="Using IBM4690 packed decimal formatted hex with D signifying a negative int">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">D123</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <int02>-123</int02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+   <tdml:parserTestCase name="IBM4690Charset03" root="dec01" model="s4"
+    description="Using IBM4690 packed decimal formatted hex to indicate a decimal number">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">1234</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dec01>12.34</dec01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+ 
+  <tdml:parserTestCase name="IBM4690Charset04" root="cal01" model="s4"
+    description="Using IBM4690 packed decimal formatted hex for a calendar">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">020161</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <cal01>1961-02-01+00:00</cal01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase> 
+
+  <tdml:parserTestCase name="IBM4690Charset05" root="int02" model="s4"
+    description="Using Packed IBM4690 Decimal formatted hex with an invalid sign nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">B123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid high nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset06" root="int02" model="s4"
+    description="Using IBM4690 Packed Decimal formatted hex with an invalid high nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">D1F3</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid high nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset07" root="int02" model="s4"
+    description="Using IBM4690 Packed Decimal formatted hex with an invalid low nibble">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">D12F</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Invalid low nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset08" root="int01" model="s7"
+    description="Using implicit length with IBM4690 Packed Decimal formatted hex should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">D123</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>lengthKind='implicit' is not allowed with packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset09" root="int01" model="s10"
+    description="Attempting to use a length of 7 bits with IBM4690 Packed Decimal should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0010101</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given length</tdml:error>
+      <tdml:error>must be a multiple of 4 when using packed binary formats</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IBM4690Charset10" root="int01" model="s13"
+    description="Attempting to use an alignment of 1 bit with IBM4690 Packed Decimal should result in SDE">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00101011</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>The given alignment</tdml:error>
+      <tdml:error>must be a multiple of 4</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section13/packed/TestPacked.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section13/packed/TestPacked.scala
@@ -54,4 +54,39 @@ class TestPacked {
   // @Test def testHexCharset03(): Unit = { runner.runOneTest("hexCharset03") } // textNumberPattern V symbol
   @Test def testHexCharset04(): Unit = { runner.runOneTest("hexCharset04") }
 
+  @Test def testPackedCharset01(): Unit = { runner.runOneTest("packedCharset01") }
+  @Test def testPackedCharset02(): Unit = { runner.runOneTest("packedCharset02") }
+  @Test def testPackedCharset03(): Unit = { runner.runOneTest("packedCharset03") }
+  //@Test def testPackedCharset04(): Unit = { runner.runOneTest("packedCharset04") } // need packed calendar
+  @Test def testPackedCharset05(): Unit = { runner.runOneTest("packedCharset05") }
+  @Test def testPackedCharset06(): Unit = { runner.runOneTest("packedCharset06") }
+  @Test def testPackedCharset07(): Unit = { runner.runOneTest("packedCharset07") }
+  @Test def testPackedCharset08(): Unit = { runner.runOneTest("packedCharset08") }
+  @Test def testPackedCharset09(): Unit = { runner.runOneTest("packedCharset09") }
+  @Test def testPackedCharset10(): Unit = { runner.runOneTest("packedCharset10") }
+
+  @Test def testBCDCharset01(): Unit = { runner.runOneTest("bcdCharset01") }
+  @Test def testBCDCharset02(): Unit = { runner.runOneTest("bcdCharset02") }
+  @Test def testBCDCharset03(): Unit = { runner.runOneTest("bcdCharset03") }
+  //@Test def testBCDCharset04(): Unit = { runner.runOneTest("bcdCharset04") } // need bcd calendar
+  @Test def testBCDCharset05(): Unit = { runner.runOneTest("bcdCharset05") }
+  @Test def testBCDCharset06(): Unit = { runner.runOneTest("bcdCharset06") }
+  @Test def testBCDCharset07(): Unit = { runner.runOneTest("bcdCharset07") }
+  @Test def testBCDCharset08(): Unit = { runner.runOneTest("bcdCharset08") }
+  @Test def testBCDCharset09(): Unit = { runner.runOneTest("bcdCharset09") }
+  @Test def testBCDCharset10(): Unit = { runner.runOneTest("bcdCharset10") }
+  @Test def testBCDCharset11(): Unit = { runner.runOneTest("bcdCharset11") }
+  @Test def testBCDCharset12(): Unit = { runner.runOneTest("bcdCharset12") }
+  @Test def testBCDCharset13(): Unit = { runner.runOneTest("bcdCharset13") }
+
+  @Test def testIBM4690Charset01(): Unit = { runner.runOneTest("IBM4690Charset01") }
+  @Test def testIBM4690Charset02(): Unit = { runner.runOneTest("IBM4690Charset02") }
+  @Test def testIBM4690Charset03(): Unit = { runner.runOneTest("IBM4690Charset03") }
+  //@Test def testIBM4690Charset04(): Unit = { runner.runOneTest("IBM4690Charset04") } // need bcd calendar
+  @Test def testIBM4690Charset05(): Unit = { runner.runOneTest("IBM4690Charset05") }
+  @Test def testIBM4690Charset06(): Unit = { runner.runOneTest("IBM4690Charset06") }
+  @Test def testIBM4690Charset07(): Unit = { runner.runOneTest("IBM4690Charset07") }
+  @Test def testIBM4690Charset08(): Unit = { runner.runOneTest("IBM4690Charset08") }
+  @Test def testIBM4690Charset09(): Unit = { runner.runOneTest("IBM4690Charset09") }
+  @Test def testIBM4690Charset10(): Unit = { runner.runOneTest("IBM4690Charset10") }
 }


### PR DESCRIPTION
Implemented parsers and unparsers for Packed Decimal, BCD, and IBM4690
Packed Decimal.  Added some tests to verify the parsing of these formats
and enabled a test that we already have that now works.

For the delimited parsers of these formats, they are currently limited
to only supporting ISO-8895-1 encoding, just like hexBinary (see
DAFFODIL-1541).

There are still some issues that are preventing the IBM TLOG schemas
from parsing correctly, but they are part of a larger bug in the
Daffodil codebase regarding delimited data and handling separators.

DFDL-211, DFDL-629, DFDL-1739