### PR TITLE
Fix invalid URLs in source files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,8 +103,8 @@ lazy val commonSettings = Seq(
   pomIncludeRepository in ThisBuild := { _ => false },
   scmInfo := Some(
     ScmInfo(
-      browseUrl = url("https://git-wip-us.apache.org/repos/asf?p=incubator-daffodil.git"),
-      connection = "scm:git:git://git.apache.org/incubator-daffodil.git"
+      browseUrl = url("https://gitbox.apache.org/repos/asf/incubator-daffodil.git"),
+      connection = "scm:git:https://gitbox.apache.org/repos/asf/incubator-daffodil.git"
     )
   ),
   licenses := Seq("University of Illinois/NCSA Open Source License" -> url("http://opensource.org/licenses/UoI-NCSA.php")),

--- a/tutorials/src/main/resources/DFDLTutorialStylesheet.xsl
+++ b/tutorials/src/main/resources/DFDLTutorialStylesheet.xsl
@@ -150,7 +150,7 @@
             </h1>
             <p>
               For quick reference here is the
-              <a href="https://daffodil.apache.org/manual/">DFDL Specification (HTML)</a>
+              <a href="https://daffodil.apache.org/docs/dfdl/">DFDL Specification (HTML)</a>
             </p>
             <hr/>
           </div>


### PR DESCRIPTION
- Fixes SCM information for the move to gitbox
- Fixes location of the DFDL specification on https://daffodil.apache.org

DAFFODIL-1870