### PR TITLE
Clean up SBT warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,8 +130,8 @@ lazy val debugTestSettings = inConfig(TestDebug)(Defaults.testSettings ++ Seq(
 lazy val nopublish = Seq(
   publish := {},
   publishLocal := {},
-  packagedArtifacts := Map.empty,
-  publishArtifact := false,
+  publishM2 := {},
+  skip in publish := true
 )
 
 lazy val usesMacros = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,15 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
 
+// Both sbt and the sbt-native-pacakger plugin have transitive dependencies to
+// different versions of plexus-utils and guava, but with different major
+// version numbers. SBT interprets this major version number difference as
+// having dependencies that are potentially not binary compatible, resulting in
+// a warning message when starting SBT. It appears the binary incompatibilities
+// (if they exist) do not affect building Daffodil, so this overrides the
+// dependencies to the latest versions and removes the warning.
+dependencyOverrides ++= Seq(
+  "org.codehaus.plexus" % "plexus-utils" % "3.0.17",
+  "com.google.guava" % "guava" % "18.0"
+)
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")


### PR DESCRIPTION
- Change how we disable publishing some subprojects by setting "skip in
  publish" to true. The previous method of changing publishArtifact and
  packagedArtifacts was a hack that broke some things, including "sbt
  updateClassifiers", which resulted in an error message about "a
  required artifact is not listed by module descriptor".
- Both sbt and the sbt-native-pacakger plugin have transitive
  dependencies to different versions of plexus-utils and guava, but with
  different major version numbers. SBT interprets the major version
  number differences as having dependencies that are potentially not
  binary compatible, resulting in a warning message when starting SBT.
  It appears the binary incompatibilities, if they exist, do not affect
  building Daffodil, so this specifies dependencyOverrides in
  plugins.sbt to force use of the latest dependencies and remove the
  warning.
- Modify the 'nopublish' val to also disable 'sbt publishM2' when
  publishing to a local maven repository.

DAFFODIL-1873