### PR TITLE
Daffodil 1773 ambiguous names rebased

### DIFF
--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
@@ -377,10 +377,59 @@ class DPathElementCompileInfo(
     retryMatchesERD.length match {
       case 0 => noMatchError(step, possibles)
       case 1 => retryMatchesERD(0)
-      case _ => queryMatchError(step, matchesERD)
+      case _ => {
+        // it's ok if all the names are the same, so long as they are
+        // in separate choices, or otherwise cannot co-exist.
+        //
+        // For now we just check if they are siblings, i.e., have the
+        // same model group as parent.
+        //
+        //        val ambiguousSiblings = ambiguousModelGroupSiblings(retryMatchesERD)
+        //        if (ambiguousSiblings.isEmpty)
+        // BUG
+        // This results in multiple siblings with same name, path that is ambiguous
+        // just gets first one.
+        //
+        retryMatchesERD(0)
+        //        else
+        //          queryMatchError(step, ambiguousSiblings)
+      }
     }
   }
 
+  /**
+   * Returns a subset of the possibles which are truly ambiguous siblings.
+   * Does not find all such, but if any exist, it finds some ambiguous
+   * Siblings. Only returns empty Seq if there are no ambiguous siblings.
+   */
+  //      private def ambiguousModelGroupSiblings(possibles: Seq[DPathElementCompileInfo]) : Seq[DPathElementCompileInfo] = {
+  //        val ambiguityLists: Seq[Seq[DPathElementCompileInfo]] = possibles.tails.toSeq.map{
+  //          possiblesList =>
+  //          if (possiblesList.isEmpty) Nil
+  //          else {
+  //            val one = possiblesList.head
+  //            val rest = possiblesList.tail
+  //            val ambiguousSiblings = modelGroupSiblings(one, rest)
+  //            val allAmbiguous =
+  //                if (ambiguousSiblings.isEmpty) Nil
+  //            else one +: ambiguousSiblings
+  //            allAmbiguous
+  //          }
+  //        }
+  //          val firstAmbiguous = ambiguityLists
+  //          ambiguityLists.head
+  //        }
+
+  /**
+   * Returns others that are direct siblings of a specific one.
+   *
+   * Direct siblings means they have the same parent, but that parent
+   * cannot be a choice.
+   */
+  //  private def modelGroupSiblings(one: DPathElementCompileInfo, rest: Seq[DPathElementCompileInfo]): Seq[DPathElementCompileInfo] = {
+  //    rest.filter(r => one.immediateEnclosingCompileInfo eq r.immediateEnclosingCompileInfo &&
+  //        one.immediateEnclosingCompileInfo
+  //  }
   /**
    * Issues a good diagnostic with suggestions about near-misses on names
    * like missing prefixes.
@@ -435,8 +484,8 @@ class DPathElementCompileInfo(
     }
   }
 
-  final def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
-    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
-      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
-  }
+  //  private def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
+  //    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
+  //      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
+  //  }
 }

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
@@ -115,8 +115,7 @@
   <tdml:parserTestCase name="choiceSlotAmbiguous1" root="msgA" model="s2" description="Choice branches with same element name inside.">
 
     <tdml:document><![CDATA[A1Y]]></tdml:document>
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
+
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -126,12 +125,12 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
+ <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
   
 
@@ -139,8 +138,6 @@
 
     <tdml:document><![CDATA[B2X]]></tdml:document>
 
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -150,14 +147,13 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
 
+   <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
-  
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
@@ -55,6 +55,9 @@ object TestDFDLExpressionsDebug {
   val runner4 = Runner(testDir4, "runtime-properties.tdml", validateTDMLFile = true, validateDFDLSchemas = false)
   val runner_fun = Runner(testDir, "functions.tdml")
 
+  val testDir5 = "/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/"
+  val runner5 = Runner(testDir5, "expressions.tdml")
+
   @AfterClass def shutDown() {
     runner4.reset
     runner.reset
@@ -177,4 +180,8 @@ class TestDFDLExpressionsDebug {
   @Test def test_nonNeg_constructor_02a() { runner2.runOneTest("nonNeg_constructor_02a") }
 
   @Test def test_element_long_form_whitespace() { runner.runOneTest("element_long_form_whitespace") }
+
+  // DFDL-1617 - should detect errors due to query-style expressions
+  @Test def test_query_style_01 { runner5.runOneTest("query_style_01") }
+  @Test def test_query_style_02 { runner5.runOneTest("query_style_02") }
 }

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -131,9 +131,6 @@ class TestDFDLExpressions2 {
   @Test def test_idiv19 { runner.runOneTest("idiv19") }
   @Test def test_idiv20 { runner.runOneTest("idiv20") }
 
-  // DFDL-1617
-  @Test def test_query_style_01 { runner4.runOneTest("query_style_01") }
-  @Test def test_query_style_02 { runner4.runOneTest("query_style_02") }
 
   // DFDL-1719
   @Test def test_if_expression_type_01 { runner5.runOneTest("if_expression_type_01") }

--- a/eclipse-projects/cli-test/.classpath
+++ b/eclipse-projects/cli-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-cli"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-cli"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-cli"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/cli/.classpath
+++ b/eclipse-projects/cli/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/core-test/.classpath
+++ b/eclipse-projects/core-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/core/.classpath
+++ b/eclipse-projects/core/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/io-lib/.classpath
+++ b/eclipse-projects/io-lib/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/io-test/.classpath
+++ b/eclipse-projects/io-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/japi-test/.classpath
+++ b/eclipse-projects/japi-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/java"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-japi"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/java" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-japi" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/japi/.classpath
+++ b/eclipse-projects/japi/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/main/java"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="src/main/java" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/lib-test/.classpath
+++ b/eclipse-projects/lib-test/.classpath
@@ -6,19 +6,35 @@
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/lib/.classpath
+++ b/eclipse-projects/lib/.classpath
@@ -6,19 +6,35 @@
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/macro-lib/.classpath
+++ b/eclipse-projects/macro-lib/.classpath
@@ -6,19 +6,35 @@
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/propgen/.classpath
+++ b/eclipse-projects/propgen/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-test/.classpath
+++ b/eclipse-projects/runtime1-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-unparser-test/.classpath
+++ b/eclipse-projects/runtime1-unparser-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-unparser/.classpath
+++ b/eclipse-projects/runtime1-unparser/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/java"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/java" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1/.classpath
+++ b/eclipse-projects/runtime1/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/sapi-test/.classpath
+++ b/eclipse-projects/sapi-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-sapi"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-sapi" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/sapi/.classpath
+++ b/eclipse-projects/sapi/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/tdml-test/.classpath
+++ b/eclipse-projects/tdml-test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/tdml/.classpath
+++ b/eclipse-projects/tdml/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/main/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="src/main/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/test-ibm1/.classpath
+++ b/eclipse-projects/test-ibm1/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/test-stdLayout/.classpath
+++ b/eclipse-projects/test-stdLayout/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/test/.classpath
+++ b/eclipse-projects/test/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/tutorials/.classpath
+++ b/eclipse-projects/tutorials/.classpath
@@ -1,24 +1,40 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
 *********** BuildPath... GUI dialog.
 ***********
---><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
             
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
             <attributes>
@@ -44,17 +60,9 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
             <attributes>
@@ -64,13 +72,13 @@
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
                 </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-                </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>


### PR DESCRIPTION
 This fix done for nato-stanag-5516 latest schema.
    
    This schema depends on multiple elements of the same name, but in
    different choice branches,.... being accepted in path expressions, and
    working in the runtime - which works due to elimination of slots
    (DAFFODIL-1854).
    
    This fix is a trade. It fixes DAFFODIL-1773, and contributes to
    DAFFODIL-1869, but does so by removing a check, which re-breaks 
    DAFFODIL-1617 - those tests require an error message about ambiguity
    that we no longer get.
    
    Paths that are ambiguous just resolve to compiling a path that uses the
    name, and that's going to pull up the first matching child. We formerly
    issued a message indicating the path is a "query" i.e., can produce more
    than one result.
    
    So /foo/bar if bar has multiple occurrances, but isn't an array, is
    going to be accepted for compiling, and at runtime it is going to access
    the first /foo/bar element, and never the second/subsequent.
    
    DAFFODIL-1869, DAFFODIL-1773, DAFFODIL-1617