### PR TITLE
This fix done for nato-stanag-5516 latest schema.

### DIFF
--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DFDLExpressionParser.scala
@@ -37,9 +37,9 @@ import edu.illinois.ncsa.daffodil.dsom._
 import scala.xml.NamespaceBinding
 import edu.illinois.ncsa.daffodil.xml._
 import scala.util.parsing.input.CharSequenceReader
-import edu.illinois.ncsa.daffodil.oolag.ErrorsNotYetRecorded
 import scala.util.parsing.combinator.RegexParsers
 import java.math.{ BigDecimal => JBigDecimal, BigInteger => JBigInt }
+import edu.illinois.ncsa.daffodil.oolag.OOLAG._
 
 /**
  * Parses DPath expressions. Most real analysis is done later. This is
@@ -59,14 +59,15 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
   nodeInfoKind: NodeInfo.Kind,
   namespaces: NamespaceBinding,
   context: DPathCompileInfo,
-  isEvaluatedAbove: Boolean) extends RegexParsers {
+  isEvaluatedAbove: Boolean,
+  host: OOLAGHost) extends RegexParsers {
 
   def compile(expr: String): CompiledExpression[T] = {
-    val tree = getExpressionTree(expr)
+    val tree = getExpressionTree(expr, host)
 
-    if (tree.isError) {
-      throw new ErrorsNotYetRecorded(tree.getDiagnostics)
-    }
+    //    if (tree.isError) {
+    //      context.toss(new ErrorsNotYetRecorded(tree.getDiagnostics))
+    //    }
 
     val recipe = tree.compiledDPath // if we cannot get one this will fail by throwing out of here.
 
@@ -131,7 +132,7 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
       r
     }
 
-  def getExpressionTree(expr: String): WholeExpression = {
+  def getExpressionTree(expr: String, host: OOLAGHost): WholeExpression = {
     // This wrapping of phrase() prevents a memory leak in the scala parser
     // combinators in scala 2.10. See the following bug for more information:
     //
@@ -212,7 +213,7 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
   //
   // we don't care if it has braces around it or not.
   def TopLevel: Parser[WholeExpression] = ("{" ~> Expr <~ "}" | Expr) ^^ { xpr =>
-    WholeExpression(nodeInfoKind, xpr, namespaces, context)
+    WholeExpression(nodeInfoKind, xpr, namespaces, context, host)
   }
 
   val SuccessAtEnd = Parser { in => Success(in, new CharSequenceReader("")) }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DFDLExpressionParser.scala
@@ -65,10 +65,6 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
   def compile(expr: String): CompiledExpression[T] = {
     val tree = getExpressionTree(expr, host)
 
-    //    if (tree.isError) {
-    //      context.toss(new ErrorsNotYetRecorded(tree.getDiagnostics))
-    //    }
-
     val recipe = tree.compiledDPath // if we cannot get one this will fail by throwing out of here.
 
     val value = recipe.runExpressionForConstant(context.schemaFileLocation)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ChoiceGroup.scala
@@ -144,7 +144,7 @@ abstract class ChoiceTermBase( final override val xml: Node,
     val qn = this.qNameForProperty("choiceDispatchKey")
     val typeIfStaticallyKnown = NodeInfo.NonEmptyString
     val typeIfRuntimeKnown = NodeInfo.NonEmptyString
-    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, choiceDispatchKeyRaw)
+    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, choiceDispatchKeyRaw, this)
   }
 
   final lazy val choiceDispatchKeyEv = {

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLDefineVariable.scala
@@ -88,7 +88,7 @@ class DFDLDefineVariable(node: Node, doc: SchemaDocument)
     val compilationTargetType = primType
     val qn = this.qNameForProperty("defaultValue", XMLUtils.dafintURI)
     val defaultValExpr = defaultValue.map { e =>
-      ExpressionCompilers.AnyRef.compile(qn, compilationTargetType, Found(e, this.dpathCompileInfo, "defaultValue", false))
+      ExpressionCompilers.AnyRef.compile(qn, compilationTargetType, Found(e, this.dpathCompileInfo, "defaultValue", false), this)
     }
 
     Maybe.toMaybe(defaultValExpr)
@@ -109,7 +109,7 @@ class DFDLDefineVariable(node: Node, doc: SchemaDocument)
 
 abstract class VariableReference(node: Node, decl: AnnotatedSchemaComponent)
   extends DFDLStatement(node, decl) {
-  
+
   final lazy val ref = getAttributeRequired("ref")
   final lazy val varQName = resolveQName(ref)
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLEscapeScheme.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/DFDLEscapeScheme.scala
@@ -85,7 +85,7 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
 
   final def escapeCharacterEv = LV('escapeCharacterEv) {
     val qn = this.qNameForProperty("escapeCharacter")
-    val expr = ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, escapeCharacterRaw)
+    val expr = ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, escapeCharacterRaw, this)
     val ev = new EscapeCharEv(expr, runtimeData)
     ev.compile()
     ev
@@ -98,7 +98,7 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
       case found @ Found(v, loc, _, _) => {
         val typeIfStaticallyKnown = NodeInfo.String
         val typeIfRuntimeKnown = NodeInfo.NonEmptyString
-        val expr = ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, found)
+        val expr = ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, found, this)
         val ev = new EscapeEscapeCharEv(expr, runtimeData)
         ev.compile()
         One(ev)

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/RuntimePropertyMixins.scala
@@ -108,7 +108,7 @@ trait TermRuntimeValuedPropertiesMixin
         val exp = ConstantExpression(qn, PrimType.HexBinary, "iso-8859-1")
         exp
       }
-      case _ => ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, encodingRaw)
+      case _ => ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, encodingRaw, decl)
     }
   }.value
 
@@ -154,7 +154,7 @@ trait TermRuntimeValuedPropertiesMixin
   lazy val outputNewLineEv = {
     val outputNewLineExpr = {
       val qn = this.qNameForProperty("outputNewLine")
-      ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, outputNewLineRaw)
+      ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, outputNewLineRaw, decl)
     }
     val ev = new OutputNewLineEv(outputNewLineExpr, termRuntimeData)
     ev.compile()
@@ -203,7 +203,7 @@ trait DelimitedRuntimeValuedPropertiesMixin
     val qn = this.qNameForProperty("initiator")
     val typeIfStaticallyKnown = NodeInfo.String
     val typeIfRuntimeKnown = NodeInfo.NonEmptyString
-    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, initiatorRaw)
+    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, initiatorRaw, decl)
   }
 
   lazy val initiatorParseEv = {
@@ -224,7 +224,7 @@ trait DelimitedRuntimeValuedPropertiesMixin
     val typeIfStaticallyKnown = NodeInfo.String
     val typeIfRuntimeKnown = NodeInfo.NonEmptyString
     val raw = terminatorRaw
-    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, raw)
+    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, raw, decl)
   }.value
 
   final def terminatorLoc = (this.diagnosticDebugName, this.path)
@@ -258,7 +258,7 @@ trait ElementRuntimeValuedPropertiesMixin
 
   private lazy val byteOrderExpr = LV('byteOrder) {
     val qn = this.qNameForProperty("byteOrder")
-    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, byteOrderRaw)
+    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, byteOrderRaw, decl)
   }.value
 
   final lazy val byteOrderEv = {
@@ -278,7 +278,7 @@ trait ElementRuntimeValuedPropertiesMixin
 
   protected final lazy val lengthExpr = {
     val qn = this.qNameForProperty("length")
-    ExpressionCompilers.JLong.compile(qn, NodeInfo.Long, lengthRaw)
+    ExpressionCompilers.JLong.compile(qn, NodeInfo.Long, lengthRaw, decl)
   }
 
   private lazy val explicitLengthEv: ExplicitLengthEv = {
@@ -467,7 +467,7 @@ trait ElementRuntimeValuedPropertiesMixin
   private lazy val occursCountExpr = LV('occursCount) {
     val qn = this.qNameForProperty("occursCount")
     val isEvaluatedAbove = true
-    ExpressionCompilers.JLong.compile(qn, NodeInfo.Long, occursCountRaw, isEvaluatedAbove)
+    ExpressionCompilers.JLong.compile(qn, NodeInfo.Long, occursCountRaw, decl, isEvaluatedAbove)
   }.value
 
   lazy val occursCountEv = {
@@ -550,7 +550,7 @@ trait SequenceRuntimeValuedPropertiesMixin
     val qn = this.qNameForProperty("separator")
     val typeIfStaticallyKnown = NodeInfo.String
     val typeIfRuntimeKnown = NodeInfo.NonEmptyString
-    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, separatorRaw)
+    ExpressionCompilers.String.compile(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, separatorRaw, decl)
   }
 
   lazy val separatorParseEv = {
@@ -588,7 +588,7 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   private lazy val textStandardDecimalSeparatorExpr = LV('textStandardDecimalSeparator) {
     val qn = this.qNameForProperty("textStandardDecimalSeparator")
-    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardDecimalSeparatorRaw)
+    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardDecimalSeparatorRaw, decl)
     c
   }.value
 
@@ -600,7 +600,7 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   private lazy val textStandardGroupingSeparatorExpr = LV('textStandardGroupingSeparator) {
     val qn = this.qNameForProperty("textStandardGroupingSeparator")
-    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardGroupingSeparatorRaw)
+    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardGroupingSeparatorRaw, decl)
     c
   }.value
 
@@ -612,7 +612,7 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   private lazy val textStandardExponentRepExpr = LV('textStandardExponentRep) {
     val qn = this.qNameForProperty("textStandardExponentRep")
-    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardExponentRepRaw)
+    val c = ExpressionCompilers.String.compile(qn, NodeInfo.String, textStandardExponentRepRaw, decl)
     c
   }.value
 
@@ -624,7 +624,7 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   private lazy val binaryFloatRepExpr = LV('binaryFloatRep) {
     val qn = this.qNameForProperty("binaryFloatRep")
-    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, binaryFloatRepRaw)
+    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, binaryFloatRepRaw, decl)
   }.value
 
   final lazy val binaryFloatRepEv = {
@@ -644,12 +644,12 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   private lazy val textBooleanTrueRepExpr = LV('textBooleanTrueRep) {
     val qn = this.qNameForProperty("textBooleanTrueRep")
-    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, textBooleanTrueRepRaw)
+    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, textBooleanTrueRepRaw, decl)
   }.value
 
   private lazy val textBooleanFalseRepExpr = LV('textBooleanFalseRep) {
     val qn = this.qNameForProperty("textBooleanFalseRep")
-    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, textBooleanFalseRepRaw)
+    ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, textBooleanFalseRepRaw, decl)
   }.value
 
   final lazy val textBooleanTrueRepEv = {
@@ -668,7 +668,7 @@ trait SimpleTypeRuntimeValuedPropertiesMixin
 
   final lazy val calendarLanguage = LV('calendarLanguage) {
     val qn = this.qNameForProperty("calendarLanguage")
-    val c = ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, calendarLanguageRaw)
+    val c = ExpressionCompilers.String.compile(qn, NodeInfo.NonEmptyString, calendarLanguageRaw, decl)
     c
   }.value
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -1061,7 +1061,7 @@ trait ElementBaseGrammarMixin
     val exprNamespaces = exprProp.location.namespaces
     val qn = GlobalQName(Some("daf"), "outputValueCalc", XMLUtils.dafintURI)
     val expr = ExpressionCompilers.AnyRef.compile(qn,
-      primType, exprText, exprNamespaces, dpathCompileInfo, false)
+      primType, exprText, exprNamespaces, dpathCompileInfo, false, self)
     expr
   }
 

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -183,7 +183,7 @@ abstract class ExpressionEvaluatorBase(e: AnnotatedSchemaComponent) extends Term
 
   lazy val expr = LV('expr) {
     ExpressionCompilers.AnyRef.compile(qn,
-      nodeKind, exprText, exprNamespaces, exprComponent.dpathCompileInfo, false)
+      nodeKind, exprText, exprNamespaces, exprComponent.dpathCompileInfo, false, this)
   }.value
 }
 

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dpath/TestDFDLExpressionEvaluation.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/dpath/TestDFDLExpressionEvaluation.scala
@@ -62,7 +62,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     val erd = decl.elementRuntimeData
     val infosetRootElem = TestInfoset.elem2Infoset(erd, infosetAsXML)
     val qn = GlobalQName(Some("daf"), "testExpr", XMLUtils.dafintURI)
-    val exprCompiler = new DFDLPathExpressionParser[AnyRef](qn, NodeInfo.AnyType, testSchema.scope, erd.dpathCompileInfo, false)
+    val exprCompiler = new DFDLPathExpressionParser[AnyRef](qn, NodeInfo.AnyType, testSchema.scope, erd.dpathCompileInfo, false, sset)
     val compiledExpr = exprCompiler.compile(expr)
     val doc = infosetRootElem.parent.asInstanceOf[DIDocument]
 

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DPath.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dpath/DPath.scala
@@ -60,11 +60,11 @@ class ExpressionEvaluationException(e: Throwable, s: ParseOrUnparseState)
 // Misc.getSomeMessage(e).get
 
 final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kind, recipe: CompiledDPath,
-                                                dpathText: String,
-                                                ci: DPathCompileInfo,
-                                                isEvaluatedAbove: Boolean,
-                                                override val contentReferencedElementInfos: Set[DPathElementCompileInfo],
-                                                override val valueReferencedElementInfos: Set[DPathElementCompileInfo])
+  dpathText: String,
+  ci: DPathCompileInfo,
+  isEvaluatedAbove: Boolean,
+  override val contentReferencedElementInfos: Set[DPathElementCompileInfo],
+  override val valueReferencedElementInfos: Set[DPathElementCompileInfo])
   extends CompiledExpression[T](qn, dpathText) with DoSDEMixin {
 
   override def targetType = tt

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
@@ -377,10 +377,59 @@ class DPathElementCompileInfo(
     retryMatchesERD.length match {
       case 0 => noMatchError(step, possibles)
       case 1 => retryMatchesERD(0)
-      case _ => queryMatchError(step, matchesERD)
+      case _ => {
+        // it's ok if all the names are the same, so long as they are
+        // in separate choices, or otherwise cannot co-exist.
+        //
+        // For now we just check if they are siblings, i.e., have the
+        // same model group as parent.
+        //
+        //        val ambiguousSiblings = ambiguousModelGroupSiblings(retryMatchesERD)
+        //        if (ambiguousSiblings.isEmpty)
+        // BUG
+        // This results in multiple siblings with same name, path that is ambiguous
+        // just gets first one.
+        //
+        retryMatchesERD(0)
+        //        else
+        //          queryMatchError(step, ambiguousSiblings)
+      }
     }
   }
 
+  /**
+   * Returns a subset of the possibles which are truly ambiguous siblings.
+   * Does not find all such, but if any exist, it finds some ambiguous
+   * Siblings. Only returns empty Seq if there are no ambiguous siblings.
+   */
+  //      private def ambiguousModelGroupSiblings(possibles: Seq[DPathElementCompileInfo]) : Seq[DPathElementCompileInfo] = {
+  //        val ambiguityLists: Seq[Seq[DPathElementCompileInfo]] = possibles.tails.toSeq.map{
+  //          possiblesList =>
+  //          if (possiblesList.isEmpty) Nil
+  //          else {
+  //            val one = possiblesList.head
+  //            val rest = possiblesList.tail
+  //            val ambiguousSiblings = modelGroupSiblings(one, rest)
+  //            val allAmbiguous =
+  //                if (ambiguousSiblings.isEmpty) Nil
+  //            else one +: ambiguousSiblings
+  //            allAmbiguous
+  //          }
+  //        }
+  //          val firstAmbiguous = ambiguityLists
+  //          ambiguityLists.head
+  //        }
+
+  /**
+   * Returns others that are direct siblings of a specific one.
+   *
+   * Direct siblings means they have the same parent, but that parent
+   * cannot be a choice.
+   */
+  //  private def modelGroupSiblings(one: DPathElementCompileInfo, rest: Seq[DPathElementCompileInfo]): Seq[DPathElementCompileInfo] = {
+  //    rest.filter(r => one.immediateEnclosingCompileInfo eq r.immediateEnclosingCompileInfo &&
+  //        one.immediateEnclosingCompileInfo
+  //  }
   /**
    * Issues a good diagnostic with suggestions about near-misses on names
    * like missing prefixes.
@@ -435,8 +484,8 @@ class DPathElementCompileInfo(
     }
   }
 
-  final def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
-    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
-      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
-  }
+  //  private def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
+  //    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
+  //      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
+  //  }
 }

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ExpressionCompiler.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ExpressionCompiler.scala
@@ -36,12 +36,14 @@ import edu.illinois.ncsa.daffodil.dpath.NodeInfo
 import edu.illinois.ncsa.daffodil.xml.NamedQName
 import scala.xml.NamespaceBinding
 import java.lang.{ Long => JLong, Boolean => JBoolean }
+import edu.illinois.ncsa.daffodil.oolag.OOLAG._
 
 trait ExpressionCompilerBase[T <: AnyRef] {
 
   def compile(qn: NamedQName, nodeInfoKind: NodeInfo.Kind, exprWithBracesMaybe: String, namespaces: NamespaceBinding,
     compileInfoWherePropertyWasLocated: DPathCompileInfo,
-    isEvaluatedAbove: Boolean): CompiledExpression[T]
+    isEvaluatedAbove: Boolean,
+    host: OOLAGHost): CompiledExpression[T]
 
 }
 

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/RuntimeData.scala
@@ -943,11 +943,11 @@ final class VariableRuntimeData(
   @throws(classOf[java.io.IOException])
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
-  private val state =
+  private lazy val state =
     if (!maybeDefaultValueExpr.isDefined) VariableUndefined
     else VariableDefined
 
-  private val maybeValue: Maybe[AnyRef] =
+  private lazy val maybeValue: Maybe[AnyRef] =
     if (maybeDefaultValueExpr.isEmpty) Nope
     else {
       val defaultValueExpr = maybeDefaultValueExpr.get

--- a/daffodil-tdml/src/test/resources/test/tdml/testWarnings.tdml
+++ b/daffodil-tdml/src/test/resources/test/tdml/testWarnings.tdml
@@ -47,6 +47,19 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  
+    <xs:element name="errUnparsing" dfdl:lengthKind="implicit">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="A" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" />
+        <xs:element name="B" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0" />
+        <xs:element name="UnparseFails" type="xs:string" dfdl:length="1"
+           dfdl:outputValueCalc="{ ../AmbigElt }"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
 </tdml:defineSchema>
 
@@ -66,6 +79,34 @@
     <tdml:warning>query-style</tdml:warning>
   </tdml:warnings>
 </tdml:parserTestCase>
+
+<tdml:unparserTestCase name="unparserWarningWhenExpectingError" root="errUnparsing" model="causesWarnings" description="TDML runner verifies warnings and errors.">
+  <tdml:infoset>
+    <tdml:dfdlInfoset>
+      <ex:errUnparsing>
+        <A>1</A>
+        <AmbigElt>2</AmbigElt>
+        <B>3</B>
+        <AmbigElt>4</AmbigElt>
+      </ex:errUnparsing>
+    </tdml:dfdlInfoset>
+  </tdml:infoset>
+  
+  <tdml:document><![CDATA[12344]]></tdml:document>
+
+  <tdml:errors>
+    <tdml:error>Schema Definition Error</tdml:error>
+    <tdml:error>query-style</tdml:error>
+    <tdml:error>AmbigElt</tdml:error>
+  </tdml:errors>
+
+  <tdml:warnings>
+    <tdml:warning>Schema Definition Warning</tdml:warning>
+    <tdml:warning>AmbigElt</tdml:warning>
+    <tdml:warning>query-style</tdml:warning>
+  </tdml:warnings>
+</tdml:unparserTestCase>
+
 
 <tdml:parserTestCase name="warningWhenExpectingSuccess" root="causesWarnings" model="causesWarnings" description="TDML runner verifies warnings and infoset.">
 
@@ -87,5 +128,27 @@
     <tdml:warning>AmbigElt</tdml:warning>
   </tdml:warnings>
 </tdml:parserTestCase>
+
+<tdml:unparserTestCase name="unparserWarningWhenExpectingSuccess" root="causesWarnings" model="causesWarnings" description="TDML runner verifies warnings and infoset.">
+
+  <tdml:document><![CDATA[123]]></tdml:document>
+
+  <tdml:infoset>
+    <tdml:dfdlInfoset>
+      <ex:causesWarnings>
+        <A>1</A>
+        <AmbigElt>2</AmbigElt>
+        <B>3</B>
+      </ex:causesWarnings>
+    </tdml:dfdlInfoset>
+  </tdml:infoset>
+
+  <tdml:warnings>
+    <tdml:warning>Schema Definition Warning</tdml:warning>
+    <tdml:warning>query-style</tdml:warning>
+    <tdml:warning>AmbigElt</tdml:warning>
+  </tdml:warnings>
+</tdml:unparserTestCase>
+
 
 </tdml:testSuite>

--- a/daffodil-tdml/src/test/resources/test/tdml/testWarnings.tdml
+++ b/daffodil-tdml/src/test/resources/test/tdml/testWarnings.tdml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite 
+  suiteName="tdml warnings" 
+  description="Tests for TDML Runner warnings features." 
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+<tdml:defineSchema name="causesWarnings" elementFormDefault="unqualified">
+
+  <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit" />
+
+  <xs:element name="causesWarnings" dfdl:lengthKind="implicit">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="A" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" />
+        <xs:element name="B" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0" />
+        <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:discriminator>{ ./AmbigElt eq '2' }</dfdl:discriminator>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</tdml:defineSchema>
+
+<tdml:parserTestCase name="warningWhenExpectingError" root="causesWarnings" model="causesWarnings" description="TDML runner verifies warnings and errors.">
+
+  <tdml:document><![CDATA[1234]]></tdml:document>
+
+  <tdml:errors>
+    <tdml:error>Schema Definition Error</tdml:error>
+    <tdml:error>query-style</tdml:error>
+    <tdml:error>AmbigElt</tdml:error>
+  </tdml:errors>
+
+  <tdml:warnings>
+    <tdml:warning>Schema Definition Warning</tdml:warning>
+    <tdml:warning>AmbigElt</tdml:warning>
+    <tdml:warning>query-style</tdml:warning>
+  </tdml:warnings>
+</tdml:parserTestCase>
+
+<tdml:parserTestCase name="warningWhenExpectingSuccess" root="causesWarnings" model="causesWarnings" description="TDML runner verifies warnings and infoset.">
+
+  <tdml:document><![CDATA[123]]></tdml:document>
+
+  <tdml:infoset>
+    <tdml:dfdlInfoset>
+      <ex:causesWarnings>
+        <A>1</A>
+        <AmbigElt>2</AmbigElt>
+        <B>3</B>
+      </ex:causesWarnings>
+    </tdml:dfdlInfoset>
+  </tdml:infoset>
+
+  <tdml:warnings>
+    <tdml:warning>Schema Definition Warning</tdml:warning>
+    <tdml:warning>query-style</tdml:warning>
+    <tdml:warning>AmbigElt</tdml:warning>
+  </tdml:warnings>
+</tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-tdml/src/test/scala/edu/illinois/ncsa/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml/src/test/scala/edu/illinois/ncsa/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -16,6 +16,8 @@ package edu.illinois.ncsa.daffodil.tdml
 
 import org.junit.Test
 import org.junit.AfterClass
+import edu.illinois.ncsa.daffodil.Implicits._
+import junit.framework.Assert.fail
 
 object TestTDMLRunnerWarnings {
   val runner = Runner("/test/tdml/", "testWarnings.tdml")
@@ -31,5 +33,211 @@ class TestTDMLRunnerWarnings {
   // DAFFODIL-1583
   @Test def test_warningWhenExpectingSuccess() = { runner.runOneTest("warningWhenExpectingSuccess") }
   @Test def test_warningWhenExpectingError() = { runner.runOneTest("warningWhenExpectingError") }
+  @Test def test_unparserWarningWhenExpectingSuccess() = { runner.runOneTest("unparserWarningWhenExpectingSuccess") }
+  @Test def test_unparserWarningWhenExpectingError() = { runner.runOneTest("unparserWarningWhenExpectingError") }
 
+  /*
+   * These tests insure that the TDML runner is actually testing the warnings.
+   * A TDML test could silently not even be checking the warnings and pass with false positive.
+   * These tests cause the TDML runner test to fail to find warnings, and check
+   * that we got the TDML runner to detect this.
+   */
+
+  @Test def testWarningsCheckedParserExpectingSuccess() = {
+    val testSuite =
+      <tdml:testSuite suiteName="tdml warnings" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+        <tdml:defineSchema name="causesWarnings" elementFormDefault="unqualified">
+          <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit"/>
+          <xs:element name="causesWarnings" dfdl:lengthKind="implicit">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="A" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1"/>
+                <xs:element name="B" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+                <xs:sequence>
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:discriminator test="{ ./AmbigElt eq '2' }"/>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:sequence>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </tdml:defineSchema>
+        <tdml:parserTestCase name="warningWhenExpectingSuccess" root="causesWarnings" model="causesWarnings">
+          <tdml:document><![CDATA[123]]></tdml:document>
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <ex:causesWarnings>
+                <A>1</A>
+                <AmbigElt>2</AmbigElt>
+                <B>3</B>
+              </ex:causesWarnings>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+          <tdml:warnings>
+            <tdml:warning>This will not be found</tdml:warning>
+          </tdml:warnings>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[Exception] {
+      ts.runOneTest("warningWhenExpectingSuccess")
+    }
+    val msg = e.getMessage()
+    System.err.println(msg)
+    if (!msg.contains("This will not be found")) {
+      println(msg)
+      fail("TDML Warnings were not checked")
+    }
+  }
+
+  @Test def testWarningsCheckedParserExpectingError() = {
+    val testSuite =
+      <tdml:testSuite suiteName="tdml warnings" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+        <tdml:defineSchema name="causesWarnings" elementFormDefault="unqualified">
+          <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit"/>
+          <xs:element name="causesWarnings" dfdl:lengthKind="implicit">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="A" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1"/>
+                <xs:element name="B" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+                <xs:sequence>
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:discriminator test="{ ./AmbigElt eq '2' }"/>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:sequence>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </tdml:defineSchema>
+        <tdml:parserTestCase name="warningWhenExpectingError" root="causesWarnings" model="causesWarnings" description="TDML runner verifies warnings and errors.">
+          <tdml:document><![CDATA[1234]]></tdml:document>
+          <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>query-style</tdml:error>
+            <tdml:error>AmbigElt</tdml:error>
+          </tdml:errors>
+          <tdml:warnings>
+            <tdml:warning>This will not be found</tdml:warning>
+          </tdml:warnings>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[Exception] {
+      ts.runOneTest("warningWhenExpectingError")
+    }
+    val msg = e.getMessage()
+    System.err.println(msg)
+    if (!msg.contains("This will not be found")) {
+      println(msg)
+      fail("TDML Warnings were not checked")
+    }
+  }
+
+  @Test def testWarningsCheckedUnparserExpectingSuccess() = {
+    val testSuite =
+      <tdml:testSuite suiteName="tdml warnings" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+        <tdml:defineSchema name="causesWarnings" elementFormDefault="unqualified">
+          <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit"/>
+          <xs:element name="errUnparsing" dfdl:lengthKind="implicit">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="A" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1"/>
+                <xs:element name="B" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+                <xs:element name="UnparseFails" type="xs:string" dfdl:length="1" dfdl:outputValueCalc="{ ../AmbigElt }"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </tdml:defineSchema>
+        <tdml:unparserTestCase name="unparserWarningWhenExpectingSuccess" root="errUnparsing" model="causesWarnings" roundTrip="false">
+          <tdml:document><![CDATA[1232]]></tdml:document>
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <ex:errUnparsing>
+                <A>1</A>
+                <AmbigElt>2</AmbigElt>
+                <B>3</B>
+              </ex:errUnparsing>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+          <tdml:warnings>
+            <tdml:warning>This will not be found</tdml:warning>
+          </tdml:warnings>
+        </tdml:unparserTestCase>
+      </tdml:testSuite>
+
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[Exception] {
+      ts.runOneTest("unparserWarningWhenExpectingSuccess")
+    }
+    val msg = e.getMessage()
+    System.err.println(msg)
+    if (!msg.contains("This will not be found")) {
+      println(msg)
+      fail("TDML Warnings were not checked")
+    }
+  }
+
+  @Test def testWarningsCheckedUnparserExpectingError() = {
+    val testSuite =
+      <tdml:testSuite suiteName="tdml warnings" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+        <tdml:defineSchema name="causesWarnings" elementFormDefault="unqualified">
+          <dfdl:format ref="ex:daffodilTest1" lengthKind="explicit"/>
+          <xs:element name="errUnparsing" dfdl:lengthKind="implicit">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="A" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1"/>
+                <xs:element name="B" type="xs:string" dfdl:length="1"/>
+                <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+                <xs:element name="UnparseFails" type="xs:string" dfdl:length="1" dfdl:outputValueCalc="{ ../AmbigElt }"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </tdml:defineSchema>
+        <tdml:unparserTestCase name="unparserWarningWhenExpectingError" root="errUnparsing" model="causesWarnings" roundTrip="false">
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <ex:errUnparsing>
+                <A>1</A>
+                <AmbigElt>2</AmbigElt>
+                <B>3</B>
+                <AmbigElt>4</AmbigElt>
+              </ex:errUnparsing>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+          <tdml:document><![CDATA[1234]]></tdml:document>
+          <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>query-style</tdml:error>
+            <tdml:error>AmbigElt</tdml:error>
+          </tdml:errors>
+          <tdml:warnings>
+            <tdml:warning>This will not be found</tdml:warning>
+          </tdml:warnings>
+        </tdml:unparserTestCase>
+      </tdml:testSuite>
+
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[Exception] {
+      ts.runOneTest("unparserWarningWhenExpectingError")
+    }
+    val msg = e.getMessage()
+    System.err.println(msg)
+    if (!msg.contains("This will not be found")) {
+      println(msg)
+      fail("TDML Warnings were not checked")
+    }
+  }
 }

--- a/daffodil-tdml/src/test/scala/edu/illinois/ncsa/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml/src/test/scala/edu/illinois/ncsa/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.illinois.ncsa.daffodil.tdml
+
+import org.junit.Test
+import org.junit.AfterClass
+
+object TestTDMLRunnerWarnings {
+  val runner = Runner("/test/tdml/", "testWarnings.tdml")
+
+  @AfterClass def shutDown {
+    runner.reset
+  }
+}
+
+class TestTDMLRunnerWarnings {
+  import TestTDMLRunnerWarnings._
+
+  // DAFFODIL-1583
+  @Test def test_warningWhenExpectingSuccess() = { runner.runOneTest("warningWhenExpectingSuccess") }
+  @Test def test_warningWhenExpectingError() = { runner.runOneTest("warningWhenExpectingError") }
+
+}

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
@@ -115,8 +115,7 @@
   <tdml:parserTestCase name="choiceSlotAmbiguous1" root="msgA" model="s2" description="Choice branches with same element name inside.">
 
     <tdml:document><![CDATA[A1Y]]></tdml:document>
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
+
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -126,12 +125,12 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
+ <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
   
 
@@ -139,8 +138,6 @@
 
     <tdml:document><![CDATA[B2X]]></tdml:document>
 
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -150,14 +147,13 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
 
+   <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
-  
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
@@ -110,6 +110,25 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="msgB" dfdl:ref="ex:complex">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="A" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" />
+        <xs:element name="B" type="xs:string" dfdl:length="1" />
+        <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+        <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:discriminator>{ ./AmbigElt eq '2' }</dfdl:discriminator>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+               
+
 </tdml:defineSchema>
 
   <tdml:parserTestCase name="choiceSlotAmbiguous1" root="msgA" model="s2" description="Choice branches with same element name inside.">
@@ -125,12 +144,6 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
- <!-- 
-    <tdml:errors>
-      <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
-      <tdml:error>{}C</tdml:error>
-    </tdml:errors>
-  -->
   </tdml:parserTestCase>
   
 
@@ -148,12 +161,43 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
 
-   <!-- 
-    <tdml:errors>
-      <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
-      <tdml:error>{}C</tdml:error>
-    </tdml:errors>
-  -->
   </tdml:parserTestCase>
+  
+   <tdml:parserTestCase name="queryStyle1" root="msgB" model="s2" description="Query style expression gives warning and runtime SDE.">
+
+    <tdml:document><![CDATA[1234]]></tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>query-style</tdml:error>
+      <tdml:error>AmbigElt</tdml:error>
+    </tdml:errors>
+    
+    <tdml:warnings>
+      <tdml:warning>Warning</tdml:warning>
+    </tdml:warnings>
+  </tdml:parserTestCase>   
+  
+  <tdml:parserTestCase name="queryStyle2" root="msgB" model="s2" description="Query style expression gives warning but not runtime SDE.">
+
+    <tdml:document><![CDATA[123]]></tdml:document>
+    
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:msgB>
+         <A>1</A>
+         <AmbigElt>2</AmbigElt>
+         <B>3</B>
+        </ex:msgB>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    
+    <tdml:warnings>
+      <tdml:warning>Warning</tdml:warning>
+      <tdml:warning>query-style</tdml:warning>
+      <tdml:warning>AmbigElt</tdml:warning>
+    </tdml:warnings>
+  </tdml:parserTestCase>
+  
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
@@ -55,6 +55,9 @@ object TestDFDLExpressionsDebug {
   val runner4 = Runner(testDir4, "runtime-properties.tdml", validateTDMLFile = true, validateDFDLSchemas = false)
   val runner_fun = Runner(testDir, "functions.tdml")
 
+  val testDir5 = "/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/"
+  val runner5 = Runner(testDir5, "expressions.tdml")
+
   @AfterClass def shutDown() {
     runner4.reset
     runner.reset
@@ -177,4 +180,8 @@ class TestDFDLExpressionsDebug {
   @Test def test_nonNeg_constructor_02a() { runner2.runOneTest("nonNeg_constructor_02a") }
 
   @Test def test_element_long_form_whitespace() { runner.runOneTest("element_long_form_whitespace") }
+
+  // DFDL-1617 - should detect errors due to query-style expressions
+  @Test def test_query_style_01 { runner5.runOneTest("query_style_01") }
+  @Test def test_query_style_02 { runner5.runOneTest("query_style_02") }
 }

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section15/choice_groups/TestChoice2.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section15/choice_groups/TestChoice2.scala
@@ -61,4 +61,8 @@ class TestChoice2 {
   // DFDL-1773
   @Test def test_choiceSlotAmbiguous1(): Unit = { runner1773.runOneTest("choiceSlotAmbiguous1") }
   @Test def test_choiceSlotAmbiguous2(): Unit = { runner1773.runOneTest("choiceSlotAmbiguous2") }
+
+  // DAFFODIL-1773
+  @Test def test_queryStyle1(): Unit = { runner1773.runOneTest("queryStyle1") }
+  @Test def test_queryStyle2(): Unit = { runner1773.trace.runOneTest("queryStyle2") }
 }

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -131,9 +131,6 @@ class TestDFDLExpressions2 {
   @Test def test_idiv19 { runner.runOneTest("idiv19") }
   @Test def test_idiv20 { runner.runOneTest("idiv20") }
 
-  // DFDL-1617
-  @Test def test_query_style_01 { runner4.runOneTest("query_style_01") }
-  @Test def test_query_style_02 { runner4.runOneTest("query_style_02") }
 
   // DFDL-1719
   @Test def test_if_expression_type_01 { runner5.runOneTest("if_expression_type_01") }


### PR DESCRIPTION
This schema depends on multiple elements of the same name, but in
different choice branches,.... being accepted in path expressions, and
working in the runtime - which works due to elimination of slots
(DAFFODIL-1854).

This fix is a trade. It fixes DAFFODIL-1773, and contributes to
DAFFODIL-1869, but does so by removing a check, which re-breaks 
DAFFODIL-1617 - those tests require an error message about ambiguity
that we no longer get.

Paths that are ambiguous just resolve to compiling a path that uses the
name, and that's going to pull up the first matching child. We formerly
issued a message indicating the path is a "query" i.e., can produce more
than one result.

So /foo/bar if bar has multiple occurrances, but isn't an array, is
going to be accepted for compiling, and at runtime it is going to access
the first /foo/bar element, and never the second/subsequent.

DAFFODIL-1869, DAFFODIL-1773, DAFFODIL-1617