### PR TITLE
Prepend rather than append when adding required evaluations to the root OOLAGContext

### DIFF
--- a/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/oolag/OOLAG.scala
+++ b/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/oolag/OOLAG.scala
@@ -167,7 +167,7 @@ object OOLAG extends Logging {
         Assert.usageError("Cannot set oolag context more than once.")
       oolagContextViaSet = Some(oolagContextArg)
       if (oolagContext != OOLAGRoot) {
-        oolagRoot.requiredEvalFunctions ++= this.requiredEvalFunctions
+        oolagRoot.requiredEvalFunctions = this.requiredEvalFunctions ::: oolagRoot.requiredEvalFunctions
         this.requiredEvalFunctions = Nil
       }
     }


### PR DESCRIPTION
Setting the OOLAG context causes an append the required evaluations to
the root requiredEvalFunctions list. Because it is an append, scala will
make a copy of the requiredEvalFunctions list and append the items to
that copy. For very large schemas with lots of Expressions (which calls
setOOLAGContext), this can result in a huge amount of copies, resulting
in large performance slowdowns during schema compilation. To prevent
this, change the append to a prepend, which does not require a copy of
the very large root requiredEvalFunctions list and will only copy the
much smaller requiredEvalFunctions list from the child. This greatly
reduces the copying and improves schema compilation time.

DAFFODIL-1877