### PR TITLE
Improve XMLTextInfosetOutputter output

### DIFF
--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/infoset/XMLTextInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/infoset/XMLTextInfosetOutputter.scala
@@ -137,12 +137,13 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
   }
 
   override def startDocument(): Boolean = {
-    // do nothing
+    writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>")
+    if (pretty) writer.write(System.lineSeparator())
     true
   }
 
   override def endDocument(): Boolean = {
-    // do nothing
+    writer.flush()
     true
   }
 }


### PR DESCRIPTION
- Write the XML declaration in startDocument so that some tools (e.g.
  file) see the output as XML, instead of something else like HTML
- Call flush() in endDocument to ensure all XML output is written

DAFFODIL-1844, DAFFODIL-1871