### PR TITLE
Update wiki links to daffodil.apache.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build the Daffodil command line interface:
 $ sbt daffodil-cli/stage
 ```
 
-The above will create Linux and Windows shell scripts in `daffodil-cli/target/universal/stage/bin/`. See the [Command Line Interface](https://cwiki.apache.org/confluence/display/DAFFODIL/Command+Line+Interface) documentation for details on its usage.
+The above will create Linux and Windows shell scripts in `daffodil-cli/target/universal/stage/bin/`. See the [Command Line Interface](https://daffodil.apache.org/cli/) documentation for details on its usage.
 
 ## Getting Help
 

--- a/daffodil-cli/README.md
+++ b/daffodil-cli/README.md
@@ -25,7 +25,7 @@ To execute Daffodil on Windows:
 $ .\bin\daffodil.bat [options]
 ```
 
-Use the `--help` option or see the [Command Line Interface](https://cwiki.apache.org/confluence/display/DAFFODIL/Command+Line+Interface) documentation for details on its usage.
+Use the `--help` option or see the [Command Line Interface](https://daffodil.apache.org/cli/) documentation for details on its usage.
 
 ### Debugging
 
@@ -37,7 +37,7 @@ $ ./bin/daffodil -d parse --schema <path/to/schema.dfdl.xsd> input-file
 
 When running the debugger, the user is provided with a command prompt, at which point the user can execute debugger commands to control the debugger and inspect state. Type `help` at the command prompt to get information on the debugger commands, or `help <command>` to get information about a specific command.
 
-See the [Interactive Debugger](https://cwiki.apache.org/confluence/display/DAFFODIL/Interactive+Debugger) page for its detailed usage.
+See the [Interactive Debugger](https://daffodil.apache.org/debugger/) page for its detailed usage.
 
 ## Getting Help
 

--- a/daffodil-cli/src/main/scala/edu/illinois/ncsa/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/edu/illinois/ncsa/daffodil/Main.scala
@@ -1278,7 +1278,7 @@ object Main extends Logging {
                           |
                           | Please report this bug and help us fix it:
                           |
-                          |  https://cwiki.apache.org/confluence/display/DAFFODIL/Report+a+Bug
+                          |  https://daffodil.apache.org/community/#issue-tracker
                           |
                           | Please include the following exception, the command you
                           | ran, and any input, schema, or tdml files used that led

--- a/daffodil-japi/src/main/scala/edu/illinois/ncsa/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/edu/illinois/ncsa/daffodil/japi/Daffodil.scala
@@ -232,7 +232,7 @@ class Compiler private[japi] () {
   /**
    * Read external variables from a Daffodil configuration file
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File'>Daffodil Configuration File</a> - Daffodil configuration file format
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVarsFile file to read DFDL variables from.
    */
@@ -250,7 +250,7 @@ class Compiler private[japi] () {
   /**
    * Set a Daffodil tunable parameter
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File#ConfigurationFile-TunableParameters'>Tunable Parameters</a> - list of tunables names of default values
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/#tunable-parameters'>Tunable Parameters</a> - list of tunables names of default values
    *
    * @param tunable name of the tunable parameter to set.
    * @param value value of the tunable parameter to set
@@ -262,7 +262,7 @@ class Compiler private[japi] () {
   /**
    * Set the value of multiple tunable parameters
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File#ConfigurationFile-TunableParameters'>Tunable Parameters</a> - list of tunables names of default values
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/#tunable-parameters'>Tunable Parameters</a> - list of tunables names of default values
    *
    * @param tunables a map of key/value pairs, where the key is the tunable name and the value is the value to set it to
    */
@@ -476,7 +476,7 @@ class DataProcessor private[japi] (dp: SDataProcessor)
   /**
    * Read external variables from a Daffodil configuration file
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File'>Daffodil Configuration File</a> - Daffodil configuration file format
+   * @see <a target="_blank" href='https://daffodil.apche.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVars file to read DFDL variables from.
    */

--- a/daffodil-japi/src/main/scala/edu/illinois/ncsa/daffodil/japi/debugger/Debugger.scala
+++ b/daffodil-japi/src/main/scala/edu/illinois/ncsa/daffodil/japi/debugger/Debugger.scala
@@ -46,7 +46,7 @@ abstract class DebuggerRunner {
    * Called by Daffodil when there is a pause in parsing to determine what
    * debugger actions should be taken.
 
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Interactive+Debugger'>Daffodil Interactive Debugger</a> - debugger commands
+   * @see <a target="_blank" href='https://daffodil.apache.org/debugger/'>Daffodil Interactive Debugger</a> - debugger commands
    *
    * @return a debugger command that tells the Daffodil debugger what step to
    *         take next.

--- a/daffodil-sapi/src/main/scala/edu/illinois/ncsa/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/edu/illinois/ncsa/daffodil/sapi/Daffodil.scala
@@ -220,7 +220,7 @@ class Compiler private[sapi] () {
   /**
    * Read external variables from a Daffodil configuration file
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File'>Daffodil Configuration File</a> - Daffodil configuration file format
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVarsFile file to read DFDL variables from.
    */
@@ -238,7 +238,7 @@ class Compiler private[sapi] () {
   /**
    * Set a Daffodil tunable parameter
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File#ConfigurationFile-TunableParameters'>Tunable Parameters</a> - list of tunables names of default values
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/#tunable-parameters'>Tunable Parameters</a> - list of tunables names of default values
    *
    * @param tunable name of the tunable parameter to set.
    * @param value value of the tunable parameter to set
@@ -250,7 +250,7 @@ class Compiler private[sapi] () {
   /**
    * Set the value of multiple tunable parameters
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File#ConfigurationFile-TunableParameters'>Tunable Parameters</a> - list of tunables names of default values
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/#tunable-parameters'>Tunable Parameters</a> - list of tunables names of default values
    *
    * @param tunables a map of key/value pairs, where the key is the tunable name and the value is the value to set it to
    */
@@ -452,7 +452,7 @@ class DataProcessor private[sapi] (dp: SDataProcessor)
   /**
    * Read external variables from a Daffodil configuration file
    *
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Configuration+File'>Daffodil Configuration File</a> - Daffodil configuration file format
+   * @see <a target="_blank" href='https://daffodil.apache.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVars file to read DFDL variables from.
    */

--- a/daffodil-sapi/src/main/scala/edu/illinois/ncsa/daffodil/sapi/debugger/Debugger.scala
+++ b/daffodil-sapi/src/main/scala/edu/illinois/ncsa/daffodil/sapi/debugger/Debugger.scala
@@ -46,7 +46,7 @@ abstract class DebuggerRunner {
    * Called by Daffodil when there is a pause in parsing to determine what
    * debugger actions should be taken.
 
-   * @see <a target="_blank" href='https://cwiki.apache.org/confluence/display/DAFFODIL/Interactive+Debugger'>Daffodil Interactive Debugger</a> - debugger commands
+   * @see <a target="_blank" href='https://daffodil.apache.org/debugger/'>Daffodil Interactive Debugger</a> - debugger commands
    *
    * @return a debugger command that tells the Daffodil debugger what step to
    *         take next.

--- a/tutorials/src/main/resources/bitorder.tutorial.tdml.xml
+++ b/tutorials/src/main/resources/bitorder.tutorial.tdml.xml
@@ -9,8 +9,8 @@ xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
   xmlns="http://www.w3.org/1999/xhtml">
   <tdml:tutorial xml:space="preserve">
     <p> DFDL has not only the dfdl:byteOrder property, but a property dfdl:bitOrder which is used when the data fields are not on byte boundaries. There are many formats which use individual bit flags, small 2 or 3 or 4 bit fields, or larger fields that do not use up an integral number of bytes. E.g., a 12-bit field. Given that the bits of these fields do not occupy whole bytes, the quesion arises of how we express which bits of a byte are the ones that make up a data field. </p>
-<p>The <a href='http://daffodil.apache.org/manual/#_Toc398030723'>DFDL Specification describes dfdl:bitOrder</a>:</p>
-<blockquote cite='http://daffodil.apache.org/manual/#_Toc398030723'>
+<p>The <a href='http://daffodil.apache.org/docs/dfdl/#_Toc398030723'>DFDL Specification describes dfdl:bitOrder</a>:</p>
+<blockquote cite='http://daffodil.apache.org/docs/dfdl/#_Toc398030723'>
 The bits of a byte each have a place value or significance of 2<sup>n</sup>, for n from 0 to 7. Hence, the byte value 255 = 2 <sup>7</sup> + 2<sup>6</sup> + 2<sup>5</sup> + 2<sup>4</sup> + 2<sup>3</sup> + 2<sup>2</sup> + 2<sup>1</sup> + 2<sup>0</sup>. A bit can always be unambiguously identified as the 2<sup>n</sup>-bit.
 The bit order is the correspondence of a bit's numeric significance to the bit position (1 to 8) within the byte. 
 </blockquote>

--- a/tutorials/src/main/resources/test1.tutorial.tdml.xml
+++ b/tutorials/src/main/resources/test1.tutorial.tdml.xml
@@ -14,10 +14,10 @@
     </p>
     <p>Here is some sample content. Anything XHTML works here.</p>
     <p>
-      DFDL has this <a href='http://daffodil.apache.org/manual/#_Toc398030723'>bitOrder property</a>. Let's talk about that.
+      DFDL has this <a href='http://daffodil.apache.org/docs/dfdl/#_Toc398030723'>bitOrder property</a>. Let's talk about that.
       Here's a quote from the spec., something I expect many TDML tutorials to want to do so as to highlight specific phrasing or language.
       </p>
-      <blockquote cite='http://daffodil.apache.org/manual/#_Toc398030723'>
+      <blockquote cite='http://daffodil.apache.org/docs/dfdl/#_Toc398030723'>
         The bits of a byte each have a place value or significance of 2
         <sup>n</sup>
         , for n from 0 to 7.


### PR DESCRIPTION
User related documentation is moved from the wiki to the
daffodil.apache.org website. Update the links to reference those pages.

DFDL-1890