### PR TITLE
Fix LICENSE/NOTICE issues

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -13,20 +13,6 @@ src_managed
 .jupiter
 .ensime
 
-# passera is 3-clause BSD
-passera
-
-# copyright Scala BSD license
-Utility.scala
-UniquenessCache.scala
-
-# copyright w3c with permissive license
-XMLSchema.dtd
-XMLSchema.xsd
-XMLSchema_for_DFDL.xsd
-datatypes.dtd
-xml.xsd
-
 # UTF-16BE, Apache Rat thinks it is a binary and cannot tell it includes the Apache v2 license
 multi_base_09.dfdl.xsd
 

--- a/LICENSE
+++ b/LICENSE
@@ -211,9 +211,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
   This product bundles source from 'Passera'. The source is available under a BSD
   LICENSE.
 
-    Copyright (c) 2011-2013, Nate Nystrom
-    All rights reserved.
-
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
 
@@ -237,11 +234,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
 
   This product bundles source from 'Scala'. Specifically 'Utility.scala' and
   'UniquenessCache.scala' The source is available under a BSD LICENSE.
-
-    Copyright (c) 2002-  EPFL
-    Copyright (c) 2011-  Lightbend, Inc.
-
-    All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -346,9 +338,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
     fitness for a particular purpose.
 
     Full Copyright Notice
-
-    * Copyright (C) Open Grid Forum (insert applicable years). Some Rights
-    * Reserved. *
 
     This document and translations of it may be copied and furnished to others,
     and derivative works that comment on or otherwise explain it or assist in

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,67 @@ Copyright 2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+******************
+BSD License
+******************
+
+The following components are provided under a BSD style License
+
+  (BSD) Passera
+    The following NOTICE information applies:
+      Copyright (c) 2011-2013, Nate Nystrom
+      All rights reserved.
+
+  (BSD) Scala
+    The following NOTICE information applies:
+      Copyright (c) 2002-  EPFL
+      Copyright (c) 2011-  Lightbend, Inc.
+
+      All rights reserved.
+
+******************
+W3C Document License
+******************
+
+The following components are provided under the W3C Document License
+
+  (W3CD) W3C XML Schemas
+    The following NOTICE information applies:
+      Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+      http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+
+******************
+Open Grid Forum
+******************
+
+The following components are provided under the Open Grid Forum license
+
+  (OGF) Open Grid Forum Data Format Description Language (DFDL) v1.0 Specification
+    The following NOTICE information applies:
+      Copyright (C) Open Grid Forum (2005-2014). Some Rights Reserved.
+
+      This document and translations of it may be copied and furnished to
+      others, and derivative works that comment on or otherwise explain it or
+      assist in its implementation may be prepared, copied, published and
+      distributed, in whole or in part, without restriction of any kind,
+      provided that the above copyright notice and this paragraph are included
+      as references to the derived portions on all such copies and derivative
+      works. The published OGF document from which such works are derived,
+      however, may not be modified in any way, such as by removing the
+      copyright notice or references to the OGF or other organizations, except
+      as needed for the purpose of developing new or updated OGF documents in
+      conformance with the procedures defined in the OGF Document Process, or
+      as required to translate it into languages other than English. OGF, with
+      the approval of its board, may remove this restriction for inclusion of
+      OGF document content for the purpose of producing standards in
+      cooperation with other international standards bodies.
+
+      The limited permissions granted above are perpetual and will not be
+      revoked by the OGF or its successors or assignees.
+
+      ICU - Copyright (c) 1995-2014 International Business Machines Corporation
+      and others
+
+      XPATH - Copyright © 2007  W3C® (MIT, ERCIM, Keio), All Rights Reserved.
+      W3C liability, trademark and document use rules apply.

--- a/daffodil-cli/LICENSE
+++ b/daffodil-cli/LICENSE
@@ -211,9 +211,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
   This product bundles source from 'Passera'. The source is available under a BSD
   LICENSE.
 
-    Copyright (c) 2011-2013, Nate Nystrom
-    All rights reserved.
-
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
 
@@ -237,11 +234,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
 
   This product bundles source from 'Scala'. Specifically 'Utility.scala' and
   'UniquenessCache.scala' The source is available under a BSD LICENSE.
-
-    Copyright (c) 2002-  EPFL
-    Copyright (c) 2011-  Lightbend, Inc.
-
-    All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -347,9 +339,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
 
     Full Copyright Notice
 
-    * Copyright (C) Open Grid Forum (insert applicable years). Some Rights
-    * Reserved. *
-
     This document and translations of it may be copied and furnished to others,
     and derivative works that comment on or otherwise explain it or assist in
     its implementation may be prepared, copied, published and distributed, in
@@ -371,10 +360,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
 
   This product bundles 'ICU4J' which is available under a "ICU" License. For
   details, see https://ssl.icu-project.org/repos/icu/icu4j/tags/release-51-2/main/shared/licenses/license.html
-
-    Copyright (c) 1995-2013 International Business Machines Corporation and others
-
-    All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -401,10 +386,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
 
   This product bundles 'JDOM2' which is available under an Apache style License:
 
-    Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
-
-    All rights reserved.
-     
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions
     are met:
@@ -457,9 +438,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
   This product bundles 'JLine' which is available under a BSD license. For
   details, see https://github.com/jline/jline2/blob/master/LICENSE.txt
 
-    Copyright (c) 2002-2016, the original author or authors.
-    All rights reserved.
-
     http://www.opensource.org/licenses/bsd-license.php
 
     Redistribution and use in source and binary forms, with or
@@ -495,8 +473,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
   This product bundles 'Scallop' which is available under an MIT License. For
   details, see https://github.com/scallop/scallop/blob/develop/license.txt
 
-    Copyright (C) 2012 Platon Pronko and Chris Hodapp
-
     Permission is hereby granted, free of charge, to any person obtaining a copy of
     this software and associated documentation files (the "Software"), to deal in
     the Software without restriction, including without limitation the rights to
@@ -516,8 +492,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
     SOFTWARE. scallop_2.11-0.9.5.jar
 
   This product product bundles 'Stax 2 API' which is licensed under a BSD license:
-
-    Copyright 2010- FasterXML.com
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/daffodil-cli/NOTICE
+++ b/daffodil-cli/NOTICE
@@ -27,18 +27,22 @@ The following binary components are provided under the Apache Software License v
       Portions of this software were originally based on the following:
         - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
         - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-        - voluntary contributions made by Paul Eng on behalf of the 
+        - voluntary contributions made by Paul Eng on behalf of the
           Apache Software Foundation that were originally developed at iClick, Inc.,
           software copyright (c) 1999.
 
   (ASLv2) JDOM2
     The following NOTICE information applies:
+      Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
+
+      All rights reserved.
+
       This product includes software developed by the
       JDOM Project (http://www.jdom.org/).
-    
+
   (ASLv2) Jansi
     The following NOTICE information applies:
-      Copyright (C) 2009, Progress Software Corporation and/or its 
+      Copyright (C) 2009, Progress Software Corporation and/or its
       subsidiaries or affiliates.  All rights reserved.
 
   (ASLv2) Jackson JSON processor
@@ -71,3 +75,98 @@ The following binary components are provided under the Apache Software License v
 
       Since product implements StAX API, it has dependencies to StAX API
       classes.
+
+******************
+BSD License
+******************
+
+The following components are provided under a BSD style License
+
+  (BSD) Passera
+    The following NOTICE information applies:
+      Copyright (c) 2011-2013, Nate Nystrom
+      All rights reserved.
+
+  (BSD) Scala
+    The following NOTICE information applies:
+      Copyright (c) 2002-  EPFL
+      Copyright (c) 2011-  Lightbend, Inc.
+
+      All rights reserved.
+
+  (BSD) JLine
+    The following NOTICE information applies:
+      Copyright (c) 2002-2016, the original author or authors.
+      All rights reserved.
+
+  (BSD) Stax 2 API
+    The following NOTICE information applies:
+      Copyright 2010- FasterXML.com
+
+******************
+W3C Document License
+******************
+
+The following components are provided under the W3C Document License
+
+  (W3CD) W3C XML Schemas
+    The following NOTICE information applies:
+      Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+      http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+
+******************
+Open Grid Forum
+******************
+
+The following components are provided under the Open Grid Forum license
+
+  (OGF) Open Grid Forum Data Format Description Language (DFDL) v1.0 Specification
+    The following NOTICE information applies:
+      Copyright (C) Open Grid Forum (2005-2014). Some Rights Reserved.
+
+      This document and translations of it may be copied and furnished to
+      others, and derivative works that comment on or otherwise explain it or
+      assist in its implementation may be prepared, copied, published and
+      distributed, in whole or in part, without restriction of any kind,
+      provided that the above copyright notice and this paragraph are included
+      as references to the derived portions on all such copies and derivative
+      works. The published OGF document from which such works are derived,
+      however, may not be modified in any way, such as by removing the
+      copyright notice or references to the OGF or other organizations, except
+      as needed for the purpose of developing new or updated OGF documents in
+      conformance with the procedures defined in the OGF Document Process, or
+      as required to translate it into languages other than English. OGF, with
+      the approval of its board, may remove this restriction for inclusion of
+      OGF document content for the purpose of producing standards in
+      cooperation with other international standards bodies.
+
+      The limited permissions granted above are perpetual and will not be
+      revoked by the OGF or its successors or assignees.
+
+      ICU - Copyright (c) 1995-2014 International Business Machines Corporation
+      and others
+
+      XPATH - Copyright © 2007  W3C® (MIT, ERCIM, Keio), All Rights Reserved.
+      W3C liability, trademark and document use rules apply.
+
+******************
+ICU License
+******************
+
+The following components are provided under the ICU license
+
+  (ICU) ICU4J
+    The following NOTICE information applies:
+      Copyright (c) 1995-2013 International Business Machines Corporation and others
+
+      All rights reserved.
+
+******************
+MIT License
+******************
+
+The following components are provided under the MIT license
+
+  (MIT) Scallop
+    The following NOTICE information applies:
+      Copyright (C) 2012 Platon Pronko and Chris Hodapp

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.dtd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.dtd
@@ -1,3 +1,8 @@
+<!--
+ Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+ http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+-->
+
 <!-- DTD for XML Schemas: Part 1: Structures
      Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
      Official Location: http://www.w3.org/2001/XMLSchema.dtd -->

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.xsd
@@ -1,5 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
+<!--
+ Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+ http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+-->
+
 <!-- XML Schema schema for XML Schemas: Part 1: Structures -->
 <!-- Note this schema is NOT the normative structures schema. -->
 <!-- The prose copy in the structures REC is the normative -->

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
@@ -1,4 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--
+ Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+ http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+-->
+
 <!-- 
 
 To get enforcement of the XML Schema Subset for DFDL, but at the 

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/datatypes.dtd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/datatypes.dtd
@@ -1,4 +1,9 @@
 <!--
+ Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+ http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+-->
+
+<!--
         DTD for XML Schemas: Part 2: Datatypes
         $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
         Note this DTD is NOT normative, or even definitive. - - the

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/xml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/xml.xsd
@@ -1,4 +1,9 @@
 <?xml version='1.0'?>
+<!--
+ Copyright © 2018 World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang). All Rights Reserved.
+ http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+-->
+
 <xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2002-  EPFL
+ * Copyright (c) 2011-  Lightbend, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the EPFL nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
 **    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/scalaLib/Utility.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/scalaLib/Utility.scala
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2002-  EPFL
+ * Copyright (c) 2011-  Lightbend, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the EPFL nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
 **    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **


### PR DESCRIPTION
- Moves copyright statements from LICENSE to NOTICE
- Add missing copyright headers for w3c documents so that Apache Rat can
  detect the license
- Add BSD license to top of ScalaLib files to clarify that they are BSD
  licensed and not Apache
- Remove Passera, ScalaLib, and W3C paths from .rat-excludes. Although
  Apache Rat is unable to detect passera and ScalaLib and will cause
  failures, this makes it more visible that some files are not Apache
  licensed.

DAFFODIL-1988, DAFFODIL-1901