### PR TITLE
Handle ChoiceGroups correctly in immediatelyEnclosingModelGroup

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
@@ -231,7 +231,7 @@ trait Term
         None
       }
       case gr: GroupRef => gr.asModelGroup.immediatelyEnclosingModelGroup
-      case gdd: GlobalGroupDef => gdd.groupRef.asModelGroup.immediatelyEnclosingModelGroup
+      case gdd: GlobalGroupDef => Some(gdd.groupRef.asModelGroup)
       case ged: GlobalElementDecl => ged.elementRef.immediatelyEnclosingModelGroup
       case ct: ComplexTypeBase => {
         None

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
@@ -628,4 +628,105 @@
     <tdml:document><![CDATA[[s2:abc][s1:123]]]></tdml:document>
   </tdml:unparserTestCase>
 
+  <tdml:defineSchema name="s3">
+    <dfdl:format ref="ex:GeneralFormat" />
+    <dfdl:defineFormat name="def">
+      <dfdl:format initiatedContent="yes"/>
+    </dfdl:defineFormat>
+
+    <xs:element name="e1" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="s" dfdl:lengthKind="implicit"
+            minOccurs="0" maxOccurs="unbounded" dfdl:occursCountKind='parsed'>
+            <xs:complexType>
+              <xs:choice dfdl:ref="def">
+                <xs:element name="s1" dfdl:initiator="[s1:"
+                  type="xs:int" dfdl:terminator="]" dfdl:lengthKind="explicit"
+                  dfdl:length="{ 3 }" />
+                <xs:group ref="group1"/>
+                <xs:element name="s2" dfdl:initiator="[s2:"
+                  type="xs:string" dfdl:terminator="]" dfdl:lengthKind="explicit"
+                  dfdl:length="{ 3 }" />
+              </xs:choice>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:group name="group1">
+      <xs:choice dfdl:initiator="[g1:" dfdl:terminator="]">
+        <xs:choice>
+          <xs:element name="c1" type="xs:int" dfdl:lengthKind="explicit"
+            dfdl:length="{ 1 }">
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:discriminator>{. eq 1}</dfdl:discriminator>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="c2" type="xs:int" dfdl:lengthKind="explicit"
+            dfdl:length="{ 1 }">
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:discriminator>{. eq 2}</dfdl:discriminator>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="c3" type="xs:int" dfdl:lengthKind="explicit"
+          dfdl:length="{ 1 }">
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:discriminator>{. eq 3}</dfdl:discriminator>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:group>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="initiatedContentNestedChoices1"
+    description="initiatedContent='yes' - DFDL-15-003R" model="s3" root="e1">
+    <tdml:document><![CDATA[[s2:abc][g1:3][s1:123]]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e1>
+          <s>
+            <s2>abc</s2>
+          </s>
+          <s>
+            <c3>3</c3>
+          </s>
+          <s>
+            <s1>123</s1>
+          </s>
+        </e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="initiatedContentNestedChoices2"
+    description="initiatedContent='yes' - DFDL-15-003R" model="s3" root="e1">
+    <tdml:document><![CDATA[[s2:abc][g1:2][s1:123]]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e1>
+          <s>
+            <s2>abc</s2>
+          </s>
+          <s>
+            <c2>2</c2>
+          </s>
+          <s>
+            <s1>123</s1>
+          </s>
+        </e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
@@ -55,4 +55,6 @@ class TestChoiceGroupInitiatedContent {
   @Test def test_Lesson5_choice_province() { runner_01.runOneTest("Lesson5_choice_province") }
 
   @Test def test_unparse_initiatedContentChoice1() { runner_01.runOneTest("unparse_initiatedContentChoice1") }
+  @Test def test_initiatedContentNestedChoices1() { runner_01.runOneTest("initiatedContentNestedChoices1") }
+  @Test def test_initiatedContentNestedChoices2() { runner_01.runOneTest("initiatedContentNestedChoices2") }
 }


### PR DESCRIPTION
This one took a while to track down for what ended up being a one line
change.  Before when immediatelyEnclosingModelGroup was called on a
child element of a ChoiceGroup, it would return the enclosing ModelGroup
of the ChoiceGroup, not the ChoiceGroup itself.  This caused issues
when the CoiceGroup's parent would have initiatedContent="yes", as the
child element of the ChoiceGroup would typically not have an initiator
defined.

This commit fixes one of the issues preventing the IBM-TLOG schema
project from working correctly.

DAFFODIL-1885