### PR TITLE
Added test to illustrate issue DAFFODIL-1907.

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/otherAnnotationLanguage.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/otherAnnotationLanguage.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:otherAnnotationLanguage" 
+  xmlns:tns="urn:otherAnnotationLanguage"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+  <element name="otherAnnotation">
+    <complexType>
+       <attribute ref="tns:otherAnnotationAttribute"/>
+    </complexType>
+  </element>
+
+  <!-- 
+  Some other annotation elements that are not DFDL annotations may also
+  have attributes. These attributes should be legal in DFDL, as they're not describing data, they're
+  just describing annotations on the schema that a DFDL processor should be ignoring.
+   -->
+  <attribute name="otherAnnotationAttribute" type="string"/>
+
+</schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:oth="urn:otherAnnotationLanguage"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+  <xs:include schemaLocation="org/apache/daffodil/DFDLGeneralFormat.dfdl.xsd" />
+
+  <xs:import namespace="urn:otherAnnotationLanguage" schemaLocation="otherAnnotationLanguage.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="r1" type="xs:string" dfdl:lengthKind="delimited">
+    <xs:annotation>
+      <xs:appinfo source="urn:otherAnnotationLanguage">
+        <oth:otherAnnotation oth:otherAnnotationAttribute="other"/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  
+</schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testImportOtherAnnotationSchema.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testImportOtherAnnotationSchema.tdml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="ImportOtherAnnotationSchema"
+  description="Tests for importing other annotation languages to determine if DFDL interacts with them." 
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com" 
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:oth="urn:otherAnnotationLanguage">
+  
+
+  <tdml:parserTestCase name="importOtherAnnotationSchema1" root="r1" model="schemaWithOtherAnnotations.dfdl.xsd">
+
+  <tdml:document>foo</tdml:document>
+  <tdml:infoset>
+    <tdml:dfdlInfoset>
+      <ex:r1>foo</ex:r1>
+    </tdml:dfdlInfoset>
+  </tdml:infoset>
+
+</tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestImportOtherAnnotationSchema {
+  val testDir = "/org/apache/daffodil/section00/general/"
+  val runner = Runner(testDir, "testImportOtherAnnotationSchema.tdml")
+
+  @AfterClass def shutDown {
+    runner.reset
+  }
+}
+
+class TestImportOtherAnnotationSchema {
+
+  import TestImportOtherAnnotationSchema._
+
+  //DFDL-1907
+  @Test def test_importOtherAnnotationSchema1() { runner.runOneTest("importOtherAnnotationSchema1") }
+
+}


### PR DESCRIPTION
(Just adds a test to scala debug)

This bug reported by users trying to annotate an XSD with both DFDL 
annotations and an unrelated annotation language.

Problem is that like DFDL, this additional annotation language defines
annotation elements that have xsd:attribute definitions in them. 

And Daffodil issues SDE on those attribute definitions because DFDL
doesn't use attributes.

But they're not being used to describe data. They're just being used in 
annotation elements that Daffodil (or any DFDL processor) can simply
ignore. 

DAFFODIL-1907