### PR TITLE
Correctly check if an element is required

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -1124,7 +1124,7 @@ trait ElementBase
       case None => true
       case Some(s: SequenceTermBase) if s.isOrdered => {
         !possibleNextSiblingTerms.exists {
-          case e: ElementBase => !e.isOptional || e.isRequiredArrayElement
+          case e: ElementBase => e.isRequired
           case mg: ModelGroup => mg.mustHaveRequiredElement
         }
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
@@ -245,7 +245,7 @@ abstract class ModelGroup
     LV('allSelfContainedTermsTerminatedByRequiredElement) {
       val listOfTerms = groupMembers.map(m => {
         m match {
-          case e: ElementBase if e.isOptional => (Seq(e) ++ e.possibleNextTerms) // A LocalElement or ElementRef
+          case e: ElementBase if !e.isRequired => (Seq(e) ++ e.possibleNextTerms) // A LocalElement or ElementRef
           case e: ElementBase => Seq(e)
           case mg: ModelGroup => Seq(mg)
         }
@@ -356,7 +356,7 @@ abstract class ModelGroup
         // required next sibling if the last sibling element is required
         possibleNextSiblingTerms.lastOption match {
           case None => false
-          case Some(e: ElementBase) => !e.isOptional || e.isRequiredArrayElement
+          case Some(e: ElementBase) => e.isRequired
           case Some(mg: ModelGroup) => mg.mustHaveRequiredElement
           case Some(_) => Assert.invariantFailed()
         }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/UnparseArrayImplicitOptionalElem.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/UnparseArrayImplicitOptionalElem.tdml
@@ -82,6 +82,26 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="r5" dfdl:ref="ex:root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence>
+            <xs:sequence>
+              <xs:element name="sca1" type="xs:string" />
+            </xs:sequence>
+            <xs:element name="opt" type="xs:string" minOccurs="0" maxOccurs="3">
+              <xs:annotation>
+                <xs:appinfo source="http://www.ogf.org/dfdl/">
+                  <dfdl:assert test="{ xs:int(.) lt 6 }" />
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:element name="sca2" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
 <!--
@@ -382,6 +402,77 @@
       <tdml:error>received element start event</tdml:error>
     </tdml:errors>
 
+  </tdml:unparserTestCase>
+
+<!--
+  Test Name: scalarThenImpOptArray01
+     Schema: s1
+       Root: r5
+    Purpose: This test demonsrates unparsing a scalar with occursCountKind="implicit" followed
+             by an optional array with lots of nesting of sequences.
+-->
+
+  <tdml:unparserTestCase name="scalarThenImpOptArray01" root="r5"
+    model="s1" roundTrip="true">
+
+    <tdml:infoset xmlns="http://example.com">
+      <tdml:dfdlInfoset>
+        <r5>
+          <sca1>6</sca1>
+          <opt>1</opt>
+          <opt>2</opt>
+          <opt>3</opt>
+          <sca2>6</sca2>
+        </r5>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document><![CDATA[61236]]></tdml:document>
+
+  </tdml:unparserTestCase>
+
+<!--
+  Test Name: scalarThenImpOptArray02
+     Schema: s1
+       Root: r5
+    Purpose: This test demonsrates unparsing a scalar with occursCountKind="implicit" followed
+             by an optional array with lots of nesting of sequences.
+-->
+
+  <tdml:unparserTestCase name="scalarThenImpOptArray02" root="r5"
+    model="s1" roundTrip="true">
+
+    <tdml:infoset xmlns="http://example.com">
+      <tdml:dfdlInfoset>
+        <r5>
+          <sca1>6</sca1>
+          <opt>1</opt>
+          <sca2>6</sca2>
+        </r5>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document><![CDATA[616]]></tdml:document>
+  </tdml:unparserTestCase>
+
+<!--
+  Test Name: scalarThenImpOptArray03
+     Schema: s1
+       Root: r5
+    Purpose: This test demonsrates unparsing a scalar with occursCountKind="implicit" followed
+             by an optional array with lots of nesting of sequences.
+-->
+
+  <tdml:unparserTestCase name="scalarThenImpOptArray03" root="r5"
+    model="s1" roundTrip="true">
+
+    <tdml:infoset xmlns="http://example.com">
+      <tdml:dfdlInfoset>
+        <r5>
+          <sca1>6</sca1>
+          <sca2>6</sca2>
+        </r5>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document><![CDATA[66]]></tdml:document>
   </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayOptionalElem.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayOptionalElem.scala
@@ -85,6 +85,10 @@ class TestUnparseArrayOptionalElem {
   @Test def test_impOptArrayThenScalar02() { runner_imp.runOneTest("impOptArrayThenScalar02") }
   @Test def test_impOptArrayThenScalar02parse() { runner_imp.runOneTest("impOptArrayThenScalar02parse") }
 
+  @Test def test_scalarThenImpOptArray01() { runner_imp.runOneTest("scalarThenImpOptArray01") }
+  @Test def test_scalarThenImpOptArray02() { runner_imp.runOneTest("scalarThenImpOptArray02") }
+  @Test def test_scalarThenImpOptArray03() { runner_imp.runOneTest("scalarThenImpOptArray03") }
+
   @Test def test_parsedOptPresent() { runner_parsed.runOneTest("parsedOptPresent") }
   @Test def test_parsedOptPresentArray() { runner_parsed.runOneTest("parsedOptPresentArray") }
   @Test def test_parsedOptAbsentArray() { runner_parsed.runOneTest("parsedOptAbsentArray") }


### PR DESCRIPTION
When determining what elements could appear after an element in an
infoset for unparsing we need to determine if an element is optional of
not to know if it's sibling could also appear next. We use a mixture of
isOptional (for scalars) and isRequiredArrayElment (for arrays) to
determine if an element was optional. This logic was actually not
correct and has some edge cases it misses. Instead, we should just use
the isRequired function, which has the correct logic for determine if an
element could exist or not.

DAFFODIL-1910