### PR TITLE
Fix eclipse project files for daffodil-cli module.

### DIFF
--- a/daffodil-lib/src/test/scala/UpdateEclipseClasspaths.scala
+++ b/daffodil-lib/src/test/scala/UpdateEclipseClasspaths.scala
@@ -83,9 +83,16 @@ trait UpdateEclipseClasspaths {
     // Exception for org.scala-lang as those are on the classpath because these
     // projects are "scala" projects. If we don't exclude this, then we get double-entry
     // complaints about the classpath
+
+    // Also exception for com.typesafe.genjavadoc which is needed by tools
+    // and as a "compiler plugin" sbt puts a dependency on this into lib_managed.
+    // This is tool only used when we generate javadoc.
     //
-    val jars = jarsDir.listFiles().filterNot { _.getName == "org.scala-lang" }.
+    val jars = jarsDir.listFiles().
+      filterNot { _.getName == "org.scala-lang" }. // remove scala-lang
+      filterNot { _.getName == "com.typesafe.genjavadoc" }. // remove genjavadoc
       flatMap { _.listFiles().flatMap { _.listFiles() } }
+
     val srcs = srcsDir.listFiles().flatMap { _.listFiles().flatMap { _.listFiles() } }
     val docs = docsDir.listFiles().flatMap { _.listFiles().flatMap { _.listFiles() } }
 

--- a/eclipse-projects/cli-test/.classpath
+++ b/eclipse-projects/cli-test/.classpath
@@ -1,123 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/it/resources"/>
-	<classpathentry kind="src" path="src/it/scala"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-cli"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/it/resources" kind="src"/><classpathentry path="src/it/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-cli" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/cli-test/.project
+++ b/eclipse-projects/cli-test/.project
@@ -32,14 +32,14 @@
 			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
-			<name>src/test</name>
-			<type>2</type>
-			<locationURI>DAFFODIL_ROOT/daffodil-cli/src/test</locationURI>
-		</link>
-		<link>
 			<name>src/it</name>
 			<type>2</type>
 			<locationURI>DAFFODIL_ROOT/daffodil-cli/src/it</locationURI>
+		</link>
+		<link>
+			<name>src/test</name>
+			<type>2</type>
+			<locationURI>DAFFODIL_ROOT/daffodil-cli/src/test</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/eclipse-projects/cli/.classpath
+++ b/eclipse-projects/cli/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/core-test/.classpath
+++ b/eclipse-projects/core-test/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/core/.classpath
+++ b/eclipse-projects/core/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/io-lib/.classpath
+++ b/eclipse-projects/io-lib/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/io-test/.classpath
+++ b/eclipse-projects/io-test/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/japi-test/.classpath
+++ b/eclipse-projects/japi-test/.classpath
@@ -1,120 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-japi"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/java" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-japi" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/japi/.classpath
+++ b/eclipse-projects/japi/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/main/java"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="src/main/java" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/lib-test/.classpath
+++ b/eclipse-projects/lib-test/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/lib/.classpath
+++ b/eclipse-projects/lib/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry path="src_managed/main" kind="src"/><classpathentry path="resource_managed/main" kind="src"/><classpathentry path="src/main/java" kind="src"/><classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+        <classpathentry kind="src" path="src_managed/main"/><classpathentry kind="src" path="resource_managed/main"/><classpathentry kind="src" path="src/main/java"/><classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/macro-lib/.classpath
+++ b/eclipse-projects/macro-lib/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="bin" kind="output"/><!--
+        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="output" path="bin"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/propgen/.classpath
+++ b/eclipse-projects/propgen/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-test/.classpath
+++ b/eclipse-projects/runtime1-test/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/scala-debug"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-unparser-test/.classpath
+++ b/eclipse-projects/runtime1-unparser-test/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1-unparser/.classpath
+++ b/eclipse-projects/runtime1-unparser/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/java"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/java" kind="src"/><classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/runtime1/.classpath
+++ b/eclipse-projects/runtime1/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="bin"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="bin" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/sapi-test/.classpath
+++ b/eclipse-projects/sapi-test/.classpath
@@ -1,121 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-sapi"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-sapi" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/sapi/.classpath
+++ b/eclipse-projects/sapi/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/tdml-test/.classpath
+++ b/eclipse-projects/tdml-test/.classpath
@@ -1,123 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/test/scala-debug"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/tdml/.classpath
+++ b/eclipse-projects/tdml/.classpath
@@ -1,118 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/scala"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/main/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/test-ibm1/.classpath
+++ b/eclipse-projects/test-ibm1/.classpath
@@ -1,121 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/test/scala-debug"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/test-stdLayout/.classpath
+++ b/eclipse-projects/test-stdLayout/.classpath
@@ -1,6 +1,6 @@
 <classpath>
         <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
+        <classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
 ***********
 *********** Entries below this comment are maintained using the UpdateEclipseClasspaths
 *********** Utility and should not be modified by hand or using the Eclipse
@@ -75,10 +75,6 @@
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
             <attributes>
                   <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
                 </attributes>
           </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
             <attributes>

--- a/eclipse-projects/test/.classpath
+++ b/eclipse-projects/test/.classpath
@@ -1,124 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/test/scala-debug"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/resources" kind="src"/><classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/test/scala-debug" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4" kind="con"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>

--- a/eclipse-projects/tutorials/.classpath
+++ b/eclipse-projects/tutorials/.classpath
@@ -1,123 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/scala"/>
-	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10.jar" sourcepath="lib_managed/srcs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.typesafe.genjavadoc/genjavadoc-plugin_2.11.8/genjavadoc-plugin_2.11.8-0.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
-	<classpathentry kind="output" path="target/eclipse/classes"/>
-</classpath>
+        <!-- This file is updated by the UpdateEclipseClasspath app. -->
+        <classpathentry path="src/test/scala" kind="src"/><classpathentry path="src/main/resources" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-macro-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1-unparser" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
+***********
+*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
+*********** Utility and should not be modified by hand or using the Eclipse
+*********** BuildPath... GUI dialog.
+***********
+--><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.11/scala-parser-combinators_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.11/scala-xml_2.11-1.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-3.1.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.8.8-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.0.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
+            
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.12.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.12.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.12.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.8.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.8.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.8.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.14-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.14.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.14-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-51.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-51.1.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-51.1-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.11/scalacheck_2.11-1.13.4-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.11.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.11-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.11/scallop_2.11-0.9.5.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.11/scallop_2.11-0.9.5-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.10.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.10.0.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.10.0-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
+            <attributes>
+                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+                </attributes>
+          </classpathentry>
+      </classpath>


### PR DESCRIPTION
In the recent changes to simplify sbt tasks so that specialized tasks
aren't needed for the cli except for testing it, the src/test directory
was renamed src/it.

This change adjusts the eclipse project setup to match.
DAFFODIL-1914