### PR TITLE
Change val and lazy val to def - multi-threading bug due to state?

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
@@ -373,7 +373,7 @@ trait SchemaAwareLoaderMixin {
 
   protected def doValidation: Boolean
 
-  lazy val resolver = DFDLCatalogResolver.get
+  def resolver = DFDLCatalogResolver.get
 
   override lazy val parser: SAXParser = {
 
@@ -501,7 +501,7 @@ class DaffodilXMLLoader(val errorHandler: org.xml.sax.ErrorHandler) {
 
   def this() = this(RethrowSchemaErrorHandler)
 
-  val xercesAdapter = new DFDLXercesAdapter(errorHandler)
+  def xercesAdapter = new DFDLXercesAdapter(errorHandler)
 
   //
   // Controls whether we setup Xerces for validation or not.


### PR DESCRIPTION
These two one-liner changes *may* have to do with the threading bug.

It's hard to tell of course. The xml loader's xerces adapter is stateful and in theory cannot be shared across threads.  So while this may not be fixing "the" bug, it is fixing "some" bug. 

Changing these two lines eliminates that incorrect sharing at the cost of just allocating objects. But this is per file loaded, so the overhead is not expected to be significant. 

DAFFODIL-1908