### PR TITLE
Daffodil 1444 runtime backpointers

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -248,11 +248,6 @@ abstract class ChoiceTermBase( final override val xml: Node,
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -150,8 +150,8 @@ final class DFDLSchemaFile(val sset: SchemaSet,
         ldr.validateSchema(schemaSource) // validate as XSD (catches UPA errors for example)
       } catch {
         case _: org.xml.sax.SAXParseException =>
-          // ok to absorb this. We have captured fatal exceptions in the
-          // error handler. 
+        // ok to absorb this. We have captured fatal exceptions in the
+        // error handler.
         case e: Exception =>
           Assert.invariantFailed("Unexpected exception type " + e)
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -478,34 +478,11 @@ trait ElementBase
   }.value
 
   protected def computeElementRuntimeData(): ElementRuntimeData = {
-    val ee = enclosingElement
-    //
-    // Must be lazy below, because we are defining the elementRuntimeData in terms of
-    // the elementRuntimeData of its enclosing element. This backpointer must be
-    // constructed lazily so that we first connect up all the erds to their children,
-    // and only subsequently ask for these parents to be elaborated.
-    //
-    lazy val parent = ee.map { enc =>
-      Assert.invariant(this != enc)
-      enc.elementRuntimeData
-    }
-    lazy val parentTerm = this.enclosingTerm.map { enc =>
-      Assert.invariant(this != enc)
-      enc.termRuntimeData
-    }
-
-    //
-    // I got sick of initialization time problems, so this mutual recursion
-    // defines the tree of ERDs.
-    //
-    // This works because of deferred arguments and lazy evaluation
-    //
+    
     lazy val childrenERDs: Seq[ElementRuntimeData] =
       elementChildren.map { _.elementRuntimeData }
 
     val newERD: ElementRuntimeData = new ElementRuntimeData(
-      parent,
-      parentTerm,
       childrenERDs,
       schemaSet.variableMap,
       nextElementResolver,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -24,7 +24,6 @@ import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.processors.RuntimeData
-import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.xml.ResolvesQNames
@@ -91,8 +90,6 @@ trait SchemaComponent
       diagnosticDebugName,
       path,
       namespaces,
-      enclosingElement.map { _.erd },
-      Maybe.toMaybe(enclosingTerm.map { _.termRuntimeData }),
       tunable)
   }.value
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -31,7 +31,6 @@ import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 import org.apache.daffodil.schema.annotation.props.gen.SequenceKind
 import org.apache.daffodil.Implicits.ns2String
 import org.apache.daffodil.grammar.SequenceGrammarMixin
-import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.schema.annotation.props.Found
 import org.apache.daffodil.schema.annotation.props.PropertyLookupResult
@@ -230,11 +229,6 @@ abstract class SequenceTermBase(
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Grammar.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Grammar.scala
@@ -180,8 +180,13 @@ abstract class NamedGram(context: SchemaComponent) extends Gram(context) {
   // Note: keep the toString really simple.
   // It causes much grief if toString uses complicated things that can fail or
   // that end up needing the name of this NamedGram again.
-  override def toString = name // + "(" + context.scPath.last + ")" //+ (if (isEmpty) "(Empty)" else "")
 
+  override def name = context match {
+    case nm: NamedMixin => nm.name
+    case _ => super.name
+  }
+
+  override def toString = "<" + name + ">" + super.name + "</" + name + ">"
 }
 
 /**
@@ -192,9 +197,9 @@ abstract class Terminal(contextArg: SchemaComponent, guard: Boolean)
 
   override def isEmpty = !guard
 
-  private lazy val realSC = context.asInstanceOf[SchemaComponent]
-  final override lazy val path = realSC.path + "@@" + diagnosticDebugName
-
-  override def toString = path // dangerous. What if realSC.path fails?
+  //  private lazy val realSC = context.asInstanceOf[SchemaComponent]
+  //  final override lazy val path = realSC.path + "@@" + diagnosticDebugName
+  //
+  //  override def toString = path // dangerous. What if realSC.path fails?
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Production.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Production.scala
@@ -48,6 +48,8 @@ final class Prod(nameArg: String, val sc: SchemaComponent, guard: Boolean, gramA
 
   final override def name = nameArg
 
+  override def toString() = "<" + name + ">" + gram.toString + "</" + name + ">"
+
   final override lazy val path = sc.path + "@@Prod(" + diagnosticDebugName + ")"
 
   final override lazy val gram: Gram = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
@@ -76,6 +76,8 @@ class ElementCombinator(context: ElementBase,
   extends NamedGram(context)
   with Padded {
 
+  override def toString = subComb.toString() // parse centric view of the world. Unparser doesn't use subComb at all.
+
   private lazy val subComb = {
     if (context.isParentUnorderedSequence) {
       new ChoiceElementCombinator(context, eBeforeContent,
@@ -406,6 +408,8 @@ class ChoiceElementCombinator(context: ElementBase, eGramBefore: Gram, eGram: Gr
 
 abstract class ElementCombinatorBase(context: ElementBase, eGramBefore: Gram, eGram: Gram, eGramAfter: Gram)
   extends NamedGram(context) {
+
+  override def toString() = "<element name='" + name + "'>" + eGram.toString() + "</element>"
 
   // The order of things matters in some cases, so to be consistent we'll always use the
   // same order even when it doesn't matter

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesElementKinds.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesElementKinds.scala
@@ -45,6 +45,7 @@ import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.util.Maybe._
 import org.apache.daffodil.cookers.ChoiceBranchKeyCooker
 import org.apache.daffodil.api.WarnID
+import org.apache.daffodil.util.Misc
 
 object ENoWarn3 { EqualitySuppressUnusedImportWarning() }
 
@@ -81,7 +82,14 @@ case class DelimiterStackCombinatorElement(e: ElementBase, body: Gram) extends T
   lazy val uInit = if (e.initiatorParseEv.isKnownNonEmpty) One(e.initiatorUnparseEv) else Nope
   lazy val uTerm = if (e.terminatorParseEv.isKnownNonEmpty) One(e.terminatorUnparseEv) else Nope
 
-  lazy val parser: DaffodilParser = new DelimiterStackParser((pInit.toList ++ pTerm.toList).toArray, e.termRuntimeData, body.parser)
+  lazy val delims = (pInit.toList ++ pTerm.toList)
+
+  override def toString() =
+    "<" + Misc.getNameFromClass(this) + " delims='" + delims.mkString(" ") + "'>" +
+      body.toString() +
+      "</" + Misc.getNameFromClass(this) + ">"
+
+  lazy val parser: DaffodilParser = new DelimiterStackParser(delims.toArray, e.termRuntimeData, body.parser)
 
   override lazy val unparser: DaffodilUnparser = new DelimiterStackUnparser(uInit, None, uTerm, e.termRuntimeData, body.unparser)
 }
@@ -103,6 +111,11 @@ case class ComplexTypeCombinator(ct: ComplexTypeBase, body: Gram) extends Termin
 
   override def isEmpty = body.isEmpty
 
+  override def toString() =
+    "<" + Misc.getNameFromClass(this) + ">" +
+      body.toString() +
+      "</" + Misc.getNameFromClass(this) + ">"
+
   lazy val parser: DaffodilParser = new ComplexTypeParser(ct.runtimeData, body.parser)
 
   override lazy val unparser: DaffodilUnparser =
@@ -111,8 +124,12 @@ case class ComplexTypeCombinator(ct: ComplexTypeBase, body: Gram) extends Termin
 
 case class SequenceCombinator(sq: SequenceTermBase, rawTerms: Seq[Gram])
   extends Terminal(sq, true) {
+  override def toString() =
+    "<" + Misc.getNameFromClass(this) + ">" +
+      terms.map { _.toString() }.mkString +
+      "</" + Misc.getNameFromClass(this) + ">"
 
-  lazy val terms = rawTerms.filterNot{ _.isEmpty }
+  lazy val terms = rawTerms.filterNot { _.isEmpty }
 
   override lazy val isEmpty = terms.isEmpty
 
@@ -138,6 +155,7 @@ case class UnorderedSequenceCombinator(s: Sequence, terms: Seq[Gram])
 }
 
 case class ArrayCombinator(e: ElementBase, body: Gram) extends Terminal(e, !body.isEmpty) {
+  override def toString() = "<Array>" + body.toString + "</Array>"
 
   lazy val parser: DaffodilParser = new ArrayCombinatorParser(e.elementRuntimeData, body.parser)
   override lazy val unparser: Unparser = new ArrayCombinatorUnparser(e.elementRuntimeData, body.unparser)
@@ -145,6 +163,7 @@ case class ArrayCombinator(e: ElementBase, body: Gram) extends Terminal(e, !body
 
 case class OptionalCombinator(e: ElementBase, body: Gram) extends Terminal(e, !body.isEmpty) {
 
+  override def toString() = "<Optional>" + body.toString + "</Optional>"
   lazy val parser: DaffodilParser = new OptionalCombinatorParser(e.elementRuntimeData, body.parser)
   override lazy val unparser: Unparser = new OptionalCombinatorUnparser(e.elementRuntimeData, body.unparser)
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
@@ -85,17 +85,7 @@ class SequenceCombinatorUnparser(ctxt: ModelGroupRuntimeData, childUnparsers: Ar
                 doUnparser = true
               }
             } else if (ev.isEnd && ev.isComplex) {
-              val c = ev.asComplex
-              //ok. We've peeked ahead and found the end of the complex element
-              //that this sequence is the model group of.
-              val optParentRD = ctxt.immediateEnclosingElementRuntimeData
-              optParentRD match {
-                case Some(e: ElementRuntimeData) =>
-                  Assert.invariant(c.runtimeData.namedQName =:= e.namedQName)
-                case _ =>
-                  Assert.invariantFailed("Not end element for this sequence's containing element. Event %s, optParentRD %s.".format(
-                    ev, optParentRD))
-              }
+                // ok. Expected case. Do nothing.
             } else {
               Assert.invariantFailed("Not a start event: " + ev)
             }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
@@ -63,11 +63,9 @@ class SequenceCombinatorUnparser(ctxt: ModelGroupRuntimeData, childUnparsers: Ar
 
   def unparse(start: UState): Unit = {
 
-
     var index = 0
     var doUnparser = false
     val limit = childUnparsers.length
-
     start.groupIndexStack.push(1L) // one-based indexing
 
     while (index < limit) {

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section13/packed/TestPacked.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section13/packed/TestPacked.scala
@@ -21,7 +21,7 @@ import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
-object TestPacked {
+object TestPacked2 {
   val testDir = "/org/apache/daffodil/section13/packed/"
   lazy val runner = Runner(testDir, "packed.tdml")
 
@@ -31,7 +31,7 @@ object TestPacked {
 
 }
 
-class TestPacked {
+class TestPacked2 {
   import TestPacked._
 
   @Test def testDelimitedIBM4690IntOptSeq02(): Unit = { runner.runOneTest("DelimitedIBM4690IntOptSeq02") } // Needs proper trailing suppression - DAFFODIL-1919


### PR DESCRIPTION
Removes backpointers from the RuntimeData.

This is a cleanup, but also part of preparing for improvements to the schema compiler, which was being forced to maintain backpointers due to the runtime needing runtime backpointers. 

Turns out, the runtime never used these backpointers, except to check one Assert in unparser.