### PR TITLE
Eliminates backpointers from RuntimeData structures.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -248,11 +248,6 @@ abstract class ChoiceTermBase( final override val xml: Node,
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -150,8 +150,8 @@ final class DFDLSchemaFile(val sset: SchemaSet,
         ldr.validateSchema(schemaSource) // validate as XSD (catches UPA errors for example)
       } catch {
         case _: org.xml.sax.SAXParseException =>
-          // ok to absorb this. We have captured fatal exceptions in the
-          // error handler. 
+        // ok to absorb this. We have captured fatal exceptions in the
+        // error handler.
         case e: Exception =>
           Assert.invariantFailed("Unexpected exception type " + e)
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -478,34 +478,11 @@ trait ElementBase
   }.value
 
   protected def computeElementRuntimeData(): ElementRuntimeData = {
-    val ee = enclosingElement
-    //
-    // Must be lazy below, because we are defining the elementRuntimeData in terms of
-    // the elementRuntimeData of its enclosing element. This backpointer must be
-    // constructed lazily so that we first connect up all the erds to their children,
-    // and only subsequently ask for these parents to be elaborated.
-    //
-    lazy val parent = ee.map { enc =>
-      Assert.invariant(this != enc)
-      enc.elementRuntimeData
-    }
-    lazy val parentTerm = this.enclosingTerm.map { enc =>
-      Assert.invariant(this != enc)
-      enc.termRuntimeData
-    }
-
-    //
-    // I got sick of initialization time problems, so this mutual recursion
-    // defines the tree of ERDs.
-    //
-    // This works because of deferred arguments and lazy evaluation
-    //
+    
     lazy val childrenERDs: Seq[ElementRuntimeData] =
       elementChildren.map { _.elementRuntimeData }
 
     val newERD: ElementRuntimeData = new ElementRuntimeData(
-      parent,
-      parentTerm,
       childrenERDs,
       schemaSet.variableMap,
       nextElementResolver,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -24,7 +24,6 @@ import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.processors.RuntimeData
-import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.xml.ResolvesQNames
@@ -91,8 +90,6 @@ trait SchemaComponent
       diagnosticDebugName,
       path,
       namespaces,
-      enclosingElement.map { _.erd },
-      Maybe.toMaybe(enclosingTerm.map { _.termRuntimeData }),
       tunable)
   }.value
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -31,7 +31,6 @@ import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 import org.apache.daffodil.schema.annotation.props.gen.SequenceKind
 import org.apache.daffodil.Implicits.ns2String
 import org.apache.daffodil.grammar.SequenceGrammarMixin
-import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.schema.annotation.props.Found
 import org.apache.daffodil.schema.annotation.props.PropertyLookupResult
@@ -230,11 +229,6 @@ abstract class SequenceTermBase(
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementKindUnparsers.scala
@@ -87,17 +87,7 @@ class SequenceCombinatorUnparser(ctxt: ModelGroupRuntimeData, childUnparsers: Ar
                 doUnparser = true
               }
             } else if (ev.isEnd && ev.isComplex) {
-              val c = ev.asComplex
-              //ok. We've peeked ahead and found the end of the complex element
-              //that this sequence is the model group of.
-              val optParentRD = ctxt.immediateEnclosingElementRuntimeData
-              optParentRD match {
-                case Some(e: ElementRuntimeData) =>
-                  Assert.invariant(c.runtimeData.namedQName =:= e.namedQName)
-                case _ =>
-                  Assert.invariantFailed("Not end element for this sequence's containing element. Event %s, optParentRD %s.".format(
-                    ev, optParentRD))
-              }
+                // ok. Expected case. Do nothing.
             } else {
               Assert.invariantFailed("Not a start event: " + ev)
             }


### PR DESCRIPTION
This cleanup is a step toward eliminating the double-linked non-sharing behavior
in the schema compiler, because maintaining these double-linked pointers
for the runtime was forcing them to exist in the schema compiler also. 

Turns out the runtime didn't need them except to check an Assert in one unparser. That check is removed, and all the backpointers can go away from RuntimeData and friends.

DAFFODIL-1444