### PR TITLE
Add new tunable (errorOnUnsupportedJavaVersion) to allow running with older versions of Java

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/util/CheckJavaVersion.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/util/CheckJavaVersion.scala
@@ -17,24 +17,27 @@
 
 package org.apache.daffodil.util
 
-import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.processors.charset.CharsetUtils
 
 class InvalidJavaVersionException(msg: String, cause: Throwable = null) extends Exception(msg, cause)
 
 object CheckJavaVersion {
 
-  def checkJavaVersion(context: ThrowsSDE) = {
+  def checkJavaVersion(): Option[String] = {
     val jVersion = scala.util.Properties.javaVersion
-    if (!scala.util.Properties.isJavaAtLeast("1.8")) {
-      throw new InvalidJavaVersionException("Daffodil requires Java 8 (1.8) or higher. You are currently running %s".format(jVersion))
-    }
-    //
-    // Test specifically for this particular decoder bug
-    // 
-    if (CharsetUtils.hasJava7DecoderBug) {
-      throw new InvalidJavaVersionException("This Java JVM has the Java 7 Decoder Bug. Daffodil requires Java 8 or higher.")
-    }
+    val errorStringOpt =
+      if (!scala.util.Properties.isJavaAtLeast("1.8")) {
+        Some("Daffodil requires Java 8 (1.8) or higher. You are currently running %s.".format(jVersion))
+      } else if (CharsetUtils.hasJava7DecoderBug) {
+        Some("This Java JVM has the Java 7 Decoder Bug. Daffodil requires Java 8 or higher.")
+      } else {
+        None
+      }
+    errorStringOpt
   }
 
+  val allowUnsupportedJavaMessage =
+    "Due to the tunable value of errorOnUnsupportedJavaVersion, " +
+    "processing will continue with the understanding that this is not " +
+    "fully tested and may have unexpected behavior in some circumstances."
 }


### PR DESCRIPTION
Currently we intentionally throw an exception if Daffodil is not run
with Java 8 due to bugs in how Java 7 handles decoding errors. However,
there are some cases where a user has no choice except to run under Java
7. This patch adds a new tunable "errorOnUnsupportedJavaVersion" that causes
Java 8 check failures to be logged as a warning rather than thrown as an
exception. This allows the above use case to be possible, with the explicit
understanding that it is not fully tested and is know to have unexpected
behavior in some circumstances.

DAFFODIL-1921