### PR TITLE
Explicitly use the Xerces factories that use our custom catalog resolver

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesXMLValidator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesXMLValidator.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.externalvars
 
 import javax.xml.transform.stream.StreamSource
-import javax.xml.validation.SchemaFactory
 import org.xml.sax.SAXException
 import java.io.File
 
@@ -31,8 +30,7 @@ object ExternalVariablesValidator {
 
   def validate(xmlFile: File): Either[java.lang.Throwable, _] = {
     try {
-      val schemaLang = "http://www.w3.org/2001/XMLSchema"
-      val factory = SchemaFactory.newInstance(schemaLang)
+      val factory = new org.apache.xerces.jaxp.validation.XMLSchemaFactory()
       val schema = factory.newSchema(new StreamSource(extVarXsd))
       val validator = schema.newValidator()
       validator.validate(new StreamSource(xmlFile))

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Validator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Validator.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.util
 
 import javax.xml.transform.stream.StreamSource
 import javax.xml.XMLConstants
-import javax.xml.validation.SchemaFactory
 import scala.xml.parsing.NoBindingFactoryAdapter
 import java.io.StringReader
 import java.net.URI
@@ -62,9 +61,7 @@ object Validator extends NoBindingFactoryAdapter {
             }
           }
 
-          val schemaLang = "http://www.w3.org/2001/XMLSchema"
-          val factory = SchemaFactory.newInstance(schemaLang)
-          //          val hdlr = new ContentHandler()
+          val factory = new org.apache.xerces.jaxp.validation.XMLSchemaFactory()
           factory.setErrorHandler(errHandler)
           val resolver = DFDLCatalogResolver.get
           factory.setResourceResolver(resolver)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
@@ -43,8 +43,6 @@ import org.apache.daffodil.util.Logging
 import org.apache.daffodil.util.Misc
 import org.apache.daffodil.api.DaffodilSchemaSource
 import javax.xml.XMLConstants
-import javax.xml.parsers.SAXParserFactory
-import javax.xml.validation.SchemaFactory
 import java.io.InputStream
 import java.io.BufferedInputStream
 import java.io.Reader
@@ -376,10 +374,7 @@ trait SchemaAwareLoaderMixin {
   def resolver = DFDLCatalogResolver.get
 
   override lazy val parser: SAXParser = {
-
-    // val x = new com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
-
-    val f = SAXParserFactory.newInstance()
+    val f = new org.apache.xerces.jaxp.SAXParserFactoryImpl()
     f.setNamespaceAware(true)
     f.setFeature("http://xml.org/sax/features/namespace-prefixes", true)
 
@@ -427,7 +422,7 @@ trait SchemaAwareLoaderMixin {
    * using the below SchemaFactory and SchemaFactory.newSchema calls.  The
    * newSchema call is what forces schema validation to take place.
    */
-  protected val sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+  protected val sf = new org.apache.xerces.jaxp.validation.XMLSchemaFactory()
   sf.setResourceResolver(resolver)
   sf.setErrorHandler(errorHandler)
 


### PR DESCRIPTION
The DFDLCatalogResolver is a custom resolver that extends the Xerces
EntityResolver. This means that the SAXParserFactory's and
SchemaFactory's that use this resolver must also be the Xerces versions
since only they know how to use the Xerces EntityResolver correctly.

This changes all SchemaFactory and SAXParserFactory instances that use
our custom resolver to explicitly specify that the Xerces instance
should be created by using the overloaded newInstance(...) method.

DFDL-1924