### PR TITLE
Fix performance regression in layering feature

### DIFF
--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/ByteBufferDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/ByteBufferDataInputStream.scala
@@ -23,6 +23,7 @@ import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import java.nio.charset.CodingErrorAction
+import org.apache.commons.io.IOUtils
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import org.apache.daffodil.exceptions.Assert
@@ -90,13 +91,7 @@ object ByteBufferDataInputStream {
       case _ => {
         // copy the contents of the stream into an array of bytes
         val bos = new ByteArrayOutputStream
-        var b: Int = 0
-        while ({
-          b = in.read()
-          b != -1
-        }) {
-          bos.write(b)
-        }
+        IOUtils.copy(in, bos)
         bos.flush()
         bos.close()
         in.close()


### PR DESCRIPTION
Commit 1ea2290f28 changed how the input data was copied to a
ByteArrayOutputStream by coping byte-by-byte rather than use
IOUtils.copy(). The byte-by-byte change was useful for debugging, but
caused a noticeable performance hit since IOUtils.copy() can copy in
chunks. Revert the change to bring back the performance.

DAFFODIL-1933