### PR TITLE
Fix modulus problem with ULong

### DIFF
--- a/daffodil-lib/src/main/scala/passera/unsigned/ULong.scala
+++ b/daffodil-lib/src/main/scala/passera/unsigned/ULong.scala
@@ -146,14 +146,19 @@ case class ULong(override val longValue: Long) extends AnyVal with Unsigned[ULon
     val n = rep
     val d = x.rep
 
-    val t = d >> 63
-    val n1 = n & ~t
-    val a = n1 >>> 1
-    val b = a / d
-    val q0 = b << 1
-    val r = n - q0 * d
-    // val q = q0 + (if (ULong(r) >= ULong(d)) 1 else 0)
-    ULong(r.toLong)
+    if (d < 0) {
+      if (this < x)
+        ULong(n)
+      else
+        ULong(n - d)
+    } else {
+      val q = ((n >>> 1) / d) << 1
+      val r = n - q * d
+      if (ULong(r) >= x)
+        ULong(r - d)
+      else
+        ULong(r)
+    }
   }
 
   override def toString =

--- a/daffodil-lib/src/test/scala/passera/test/TestULong.scala
+++ b/daffodil-lib/src/test/scala/passera/test/TestULong.scala
@@ -38,5 +38,28 @@ class TestULong {
     assertEquals(ULong.MaxValueAsBigInt, mm1.toBigInt)
     assertEquals(BigInt(Long.MinValue).abs.toString, mm1.toString)
   }
+
+  // DAFFODIL-1714
+  @Test def testULongModulus1 {
+    for (i <- 0 to 16 ) {
+      val numerator = ULong(i)
+      val denominator = ULong(8)
+      val remainder = numerator % denominator
+      assertEquals(ULong(i%8), remainder)
+    }
+  }
+
+  @Test def testULongModulus2 {
+    val mm1 = ULong(-1L)
+    val remainder = mm1 % ULong(65536)
+    assertEquals(ULong(0x0000FFFF), remainder)
+  }
+  
+  @Test def testULongModulus3 {
+    val mm1 = ULong(-1L)
+    val mm2 = ULong(-2L)
+    val remainder = mm1 % mm2
+    assertEquals(ULong(1), remainder)
+  }
   
 }


### PR DESCRIPTION
The ULong code incurrectly calculates the modulus (remainder) of values
and x%y can have values in the range 0<=val<2y instead of 0<=val<y, due
to the way unsigned arithmetic is performed using signed primitives.

This commit fixes the underlying problem and adds test cases to check
the behaviour is correct with both small (<2^63) and large (>=2^63)
unsigned longs.

DAFFODIL-1714