### PR TITLE
Configure the Travis CI build environment for more memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,12 @@ scala:
   - 2.11.8
 jdk:
   - oraclejdk8
-sudo: false
+sudo: required
+dist: trusty
 before_script:
   - unset _JAVA_OPTIONS
 script:
-  - sbt -J-Xms4g -J-Xmx4g ++$TRAVIS_SCALA_VERSION
+  - sbt -J-Xms7g -J-Xmx7g ++$TRAVIS_SCALA_VERSION
     compile
     test:compile
     it:compile


### PR DESCRIPTION
The default Travis CI build environment (sudo: false, dist: trusty) is
container based on only provides a max of 4GB of memory. This is near
the limit Daffodil requires to run all the tests and create artifacts,
which sometimes results in a kill -9 when it runs out of memory and the
build fails. This configures Travis CI to use a virtual machine based
environment (sudo: true, dist: trust). This takes longer to start up
(20-50 seconds vs 1-6 seconds) and we don't actually need the sudo
functionality, but it provides 7.5GB of memory. Daffodil already takes
20+ minutes to run all the tests on Travis CI--an extra minute of
startup time won't even be noticed. Allows configuring SBT to use 7GB
instead of 4GB when run in the Travsi CI environment.

DAFFODIL-1962