### PR TITLE
TDMLRunner explicit roundTrip="twoPass" feature.

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -73,7 +73,7 @@
       <attribute name="suiteName" type="xs:token" use="optional"/>
       <attribute name="ID" type="xs:token" use="optional"/>
       <attribute name="description" type="xs:string" use="optional"/>
-      <attribute name="defaultRoundTrip" type="xs:boolean" use="optional"/>
+      <attribute name="defaultRoundTrip" type="tns:roundTripType" use="optional"/>
       <attribute name="defaultValidation" type="tns:validationType" use="optional"/>
       <attribute name="defaultConfig" type="xs:string" use="optional"/>
     </complexType>
@@ -151,12 +151,22 @@
     <attribute name="root" type="xs:NCName" use="optional"/> <!-- only needed when there is no infoset. -->
     <attribute name="model" type="xs:string" use="optional"/> <!-- is there a type for a path/uri? -->
     <attribute name="config" type="xs:string" use="optional"/> <!-- is there a type for a path/uri? -->
-    <attribute name="roundTrip" type="xs:boolean" use="optional"/>
+    <attribute name="roundTrip" type="tns:roundTripType" use="optional"/>
     <attribute name="description" type="xs:string" use="optional"/>
     <attribute name="unsupported" type="xs:boolean" use="optional" default="false"/>
     <attribute name="validation" type="tns:validationType" use="optional"/>
   </attributeGroup>
 
+  <simpleType name="roundTripType">
+    <restriction base="xs:token">
+      <enumeration value="false"/> <!-- means same as none -->
+      <enumeration value="none"/>
+      <enumeration value="true"/> <!-- means same as onePass -->
+      <enumeration value="onePass"/> <!--  parse, compare infoset, unparse - compare data -->
+      <enumeration value="twoPass"/> <!-- parse, unparse, reparse - compare infoset -->
+    </restriction>
+  </simpleType>
+  
   <simpleType name="elementFormDefaultType">
     <restriction base="xs:token">
       <enumeration value="qualified"/>

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
@@ -411,13 +411,17 @@ object Misc {
    */
   def remapCodepointToVisibleGlyph(codepoint: Int): Int = {
     if (codepoint > 255 || codepoint < -128) return codepoint
-    val b = Bits.asSignedByte(codepoint)
+    val b = codepoint.toByte
     val r = remapOneByteToVisibleGlyph(b)
     if (r == -1) codepoint else r
   }
 
   def remapStringToVisibleGlyphs(s: String) = {
     s.map { c => remapCodepointToVisibleGlyph(c.toInt).toChar }
+  }
+
+  def remapBytesToStringOfVisibleGlyphs(ba: Array[Byte]): String = {
+    ba.map { b => remapCodepointToVisibleGlyph(b.toInt).toChar }.mkString
   }
 
   def remapByteToVisibleGlyph(b: Byte): Int = {
@@ -429,6 +433,9 @@ object Misc {
   }
 
   /**
+   * Remaps a byte to a unicode codepoint for a visible picture, or -1 if
+   * no remapping is needed.
+   *
    * A difficulty is that there do not seem to be generally available Unicode fonts
    * which are truly monospaced for every Unicode character. So since we are
    * trying to produce data dumps that are monospaced, the tabular layout is off a bit.
@@ -439,7 +446,6 @@ object Misc {
    * in this remap stuff. But not for the "double wide" Kanji or other wide oriental
    * characters.
    */
-
   private def remapOneByteToVisibleGlyph(b: Byte): Int = {
     Bits.asUnsignedByte(b) match {
       //

--- a/daffodil-tdml/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -41,7 +41,7 @@ object Runner {
     validateTDMLFile: Boolean = true,
     validateDFDLSchemas: Boolean = true,
     compileAllTopLevel: Boolean = false,
-    defaultRoundTripDefault: Boolean = defaultRoundTripDefaultDefault,
+    defaultRoundTripDefault: RoundTrip = defaultRoundTripDefaultDefault,
     defaultValidationDefault: String = defaultValidationDefaultDefault): Runner =
     new Runner(null, dir, file, validateTDMLFile, validateDFDLSchemas, compileAllTopLevel,
       defaultRoundTripDefault, defaultValidationDefault)
@@ -56,7 +56,7 @@ object Runner {
   // defaultRoundTripDefault - on runner aka test suite factory
   // defaultRoundTripDefaultDefault - on runner factory
   //
-  def defaultRoundTripDefaultDefault = false
+  def defaultRoundTripDefaultDefault: RoundTrip = NoRoundTrip
   def defaultValidationDefaultDefault = "off"
 }
 
@@ -70,8 +70,9 @@ class Runner private (elem: scala.xml.Elem, dir: String, file: String,
   validateTDMLFile: Boolean = true,
   validateDFDLSchemas: Boolean = true,
   compileAllTopLevel: Boolean = false,
-  defaultRoundTripDefault: Boolean = Runner.defaultRoundTripDefaultDefault,
+  defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
   defaultValidationDefault: String = Runner.defaultValidationDefaultDefault) {
+
 
   if (elem ne null)
     Assert.usage((dir eq null) && (file eq null))

--- a/daffodil-tdml/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.tdml
+
+import org.apache.daffodil.xml.XMLUtils
+import junit.framework.Assert._
+import org.junit.Test
+import org.apache.daffodil.Implicits._
+
+class TestTDMLRoundTrips {
+
+  val tdml = XMLUtils.TDML_NAMESPACE
+  val dfdl = XMLUtils.DFDL_NAMESPACE
+  val xsi = XMLUtils.XSI_NAMESPACE
+  val xsd = XMLUtils.XSD_NAMESPACE
+  val example = XMLUtils.EXAMPLE_NAMESPACE
+  val tns = example
+  val fn = XMLUtils.XPATH_FUNCTION_NAMESPACE
+
+  @Test def testOnePassPass1() {
+
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="r" dfdl:lengthKind="implicit">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator=",">
+                              <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                              <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="r" model="s" roundTrip="onePass">
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:r>
+                              <foo>foo</foo>
+                              <bar>bar</bar>
+                            </ex:r>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                        <ts:document>foo,bar</ts:document>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    ts.runOneTest("test1")
+  }
+
+  /**
+   * A test defined to show that we need two-pass, because the canonical separator
+   * is a ";", but "," is also accepted and that's what is in the original data.
+   *
+   * The output from the one pass unparse will have the semicolon, and so will fail
+   * to match the original input.
+   */
+  @Test def testOnePassFail1() {
+
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="r" dfdl:lengthKind="implicit">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator="; ,">
+                              <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                              <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="r" model="s" roundTrip="onePass">
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:r>
+                              <foo>foo</foo>
+                              <bar>bar</bar>
+                            </ex:r>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                        <ts:document>foo,bar</ts:document>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[TDMLException] {
+      ts.runOneTest("test1")
+    }
+    val m = e.getMessage()
+    assertTrue(m.toLowerCase.contains("unparsed data differs"))
+  }
+
+  /**
+   * A test defined to show that we need two-passes, so that we re-parse
+   * the canonical data from the unparse and then get a matching infoset.
+   */
+  @Test def testTwoPass1() {
+
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="r" dfdl:lengthKind="implicit">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator="; ,">
+                              <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                              <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="r" model="s" roundTrip="twoPass">
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:r>
+                              <foo>foo</foo>
+                              <bar>bar</bar>
+                            </ex:r>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                        <ts:document>foo,bar</ts:document>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    ts.runOneTest("test1")
+  }
+
+  /**
+   * A test defined to show that when we say we need two passes, if the
+   * unparse data in fact matches the original (i.e., we didn't really need two passes)
+   * that is detected and reported.
+   *
+   * This means test authors have to know if the test is parse-only, one pass parse/unparse round trip,
+   * or two-pass, and label the test accordingly.
+   */
+  @Test def testTwoPassNotNeeded1() {
+
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="r" dfdl:lengthKind="implicit">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator=",">
+                              <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                              <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="r" model="s" roundTrip="twoPass">
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:r>
+                              <foo>foo</foo>
+                              <bar>bar</bar>
+                            </ex:r>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                        <ts:document>foo,bar</ts:document>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val e = intercept[TDMLException] {
+      ts.runOneTest("test1")
+    }
+    val m = e.getMessage()
+    assertTrue(m.toLowerCase.contains("should this really be a two-pass test"))
+  }
+
+  /**
+   * A test defined to show that we need three-passes, so that we re-parse
+   * the canonical data from the unparse and then still do not get a matching infoset,
+   * but unparsing that infoset finally does give us matching unparsed data.
+   */
+  /*
+  @Test def testThreePass1() {
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:xsi={ xsi } xmlns:fn={ fn } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s" elementFormDefault="unqualified">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="r" dfdl:lengthKind="implicit">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator=",">
+                              <xs:element name="foo" nillable="true" type="xs:string" dfdl:lengthKind="delimited" dfdl:useNilForDefault="yes" dfdl:nilKind="literalValue" dfdl:nilValue="%ES; nil" dfdl:outputValueCalc="{ ../bar }"/>
+                              <xs:element name="bar" type="xs:string" dfdl:inputValueCalc="{ if (fn:nilled(../foo)) then '' else 'foo' }"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="r" model="s" roundTrip="threePass">
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:r>
+                              <foo>foo</foo>
+                              <bar/>
+                            </ex:r>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                        <ts:document></ts:document>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    ts.runOneTest("test1")
+  }
+  */
+}

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext1.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext1.tdml
@@ -500,6 +500,7 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 
 
 <parserTestCase name="alignment_bytes_12_03" root="Fixed_text_multi_sequence3"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpaflsaln101_01.dfdl.xsd"
 		description="Section 12 Framing - Alignment with trailingSkip">
 
@@ -599,6 +600,7 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 	</parserTestCase>
     
      <parserTestCase name="delimiter_12_02" root="Fixed_string_with_Pads_10_1"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - ignore case">
 
 		<document>IAAAAAAAAAAT</document>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
@@ -56,6 +56,7 @@
 		maxlength 3, field 3 has minlength 3.  no padding/triming on field 1.
 	-->
 	<parserTestCase name="simple_type_properties_pad_trim_13_03" root="groupElem"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpadelonetrm_01.dfdl.xsd" validation="on"
 		 description="Section 13.2 trimming on text fields in a delimited sequence, left justified">
 		<document>A:a~B:bb*~C:ccc</document>
@@ -274,6 +275,7 @@
 	
 <!-- @ Terminator inherited at both parent element and group from default format -->	
 	<parserTestCase name="simple_type_properties_text_calendar_13_02" root="calendar_group"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpacaltxt_43.dfdl.xsd" 
 		 description="Section 13.10 Properties for calendar text  - implicit patterns for date, time, and dateTime ">
 		<document>2010-12-30*04:05:06+01:00*2010-12-30T04:05:06@@</document>
@@ -289,6 +291,7 @@
 	</parserTestCase>
 		
 	<parserTestCase name="simple_type_properties_text_calendar_13_03" root="myDateTime"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpacaltxt_43.dfdl.xsd" 
 		 description="Section 13.10 Properties for calendar text  - calendarStrictChecking (56th week  is ok if lax)">
 		<document>xxxx2011040506MON56@</document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext1.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext1.tdml
@@ -505,7 +505,8 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 
 <parserTestCase name="alignment_bytes_12_03" root="Fixed_text_multi_sequence3"
 		model="./fvt/ext/dpa/dpaflsaln101_01.dfdl.xsd"
-		description="Section 12 Framing - Alignment with trailingSkip">
+		description="Section 12 Framing - Alignment with trailingSkip"
+        roundTrip="twoPass">
 
 			<document>AAAeeeeeBB</document>
 
@@ -603,7 +604,8 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 	</parserTestCase>
     
      <parserTestCase name="delimiter_12_02" root="Fixed_string_with_Pads_10_1"
-		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - ignore case">
+		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - ignore case"
+        roundTrip="twoPass">
 
 		<document>IAAAAAAAAAAT</document>
 		<infoset>
@@ -615,7 +617,8 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 	</parserTestCase>
 
     <parserTestCase name="delimiter_12_03" root="Fixed_string_with_Pads_10_2"
-		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - space separated list - DFDL-12-032R">
+		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - space separated list - DFDL-12-032R"
+		roundTrip="twoPass">
 
 		<document>:AAAAAAAAAAterminator</document>
 		<infoset>
@@ -627,7 +630,8 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
 	</parserTestCase>
 	
 	<parserTestCase name="delimiter_12_04" root="Fixed_text_sequence"
-		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - NL entity - DFDL-12-032R">
+		model="./fvt/ext/dpa/delimiter_12.dfdl.xsd" description="Section 12.2 simple initiator and terminator - NL entity - DFDL-12-032R"
+		roundTrip="twoPass">
 		<document><documentPart type="byte">0A61620A</documentPart></document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -819,7 +823,8 @@ entity NL and also use of UTF-16 encoding - DFDL-6-045R"
  
  <parserTestCase name="multiple_delimiters2"
  model="./fvt/ext/dpa/dpaextdeltxt101.dfdl.xsd" description="Section 14 Sequence groups with delimiters, a whitespace separated list for separator - DFDL-14-008R"
- root="myStringSeq4">
+ root="myStringSeq4"
+ roundTrip="twoPass">
  <document>abcde|fghij|klmno::pqrst|uvwzy|z]</document>
  <infoset>
   <dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext2.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext2.tdml
@@ -56,6 +56,7 @@
 		maxlength 3, field 3 has minlength 3.  no padding/triming on field 1.
 	-->
 	<parserTestCase name="simple_type_properties_pad_trim_13_03" root="groupElem"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpadelonetrm_01.dfdl.xsd" validation="on"
 		 description="Section 13.2 trimming on text fields in a delimited sequence, left justified">
 		<document>A:a~B:bb*~C:ccc</document>
@@ -271,9 +272,10 @@
 	
 <!-- @ Terminator inherited at both parent element and group from default format -->	
 	<parserTestCase name="simple_type_properties_text_calendar_13_02" root="calendar_group"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpacaltxt_43.dfdl.xsd" 
 		 description="Section 13.10 Properties for calendar text  - implicit patterns for date, time, and dateTime ">
-		<document>2010-12-30*04:05:06+01:00*2010-12-30T04:05:06@@</document>
+		<document>2010-12-30*04:05:06+01:00*2010-12-30T04:05:06</document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 			  <calendar_group>
@@ -286,6 +288,7 @@
 	</parserTestCase>
 		
 	<parserTestCase name="simple_type_properties_text_calendar_13_03" root="myDateTime"
+        roundTrip="twoPass"
 		model="./fvt/ext/dpa/dpacaltxt_43.dfdl.xsd" 
 		 description="Section 13.10 Properties for calendar text  - calendarStrictChecking (56th week  is ok if lax)">
 		<document>xxxx2011040506MON56@</document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -887,7 +887,8 @@
 --> 
   <tdml:parserTestCase name="checkTotalDigits_Fail_off"
     root="e4_1" model="TestFacets" description="Section 21 - Validation Detection - External Switch - DFDL-21-002R"
-    validation="off">
+    validation="off"
+    roundTrip="twoPass">
 
     <tdml:document>123456</tdml:document>
 		<tdml:infoset>
@@ -905,7 +906,8 @@
                Validation = LIMITED.
 --> 
   <tdml:parserTestCase name="checkTotalDigits_Fail_limited"
-    root="e4_1" model="TestFacets" validation="limited">
+    root="e4_1" model="TestFacets" validation="limited"
+    roundTrip="twoPass">
 
     <tdml:document>123456</tdml:document>
 		<tdml:infoset>
@@ -930,7 +932,8 @@
                Validation = ON.
 --> 
   <tdml:parserTestCase name="checkTotalDigits_Fail_on"
-    root="e4_1" model="TestFacets" validation="on">
+    root="e4_1" model="TestFacets" validation="on"
+    roundTrip="twoPass">
 
     <tdml:document>123456</tdml:document>
 		<tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/Facets.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/Facets.tdml
@@ -4379,7 +4379,8 @@
       Purpose: This test demonstrates the use of validation for the totalDigits facet.
   -->
   <tdml:parserTestCase name="checkTotalDigits_Pass"
-    root="e4_1" model="TestFacets">
+    root="e4_1" model="TestFacets"
+    roundTrip="twoPass">
 
     <tdml:document>12345</tdml:document>
     <tdml:infoset>
@@ -4502,7 +4503,8 @@
       Purpose: This test demonstrates the use of validation for the fractionDigits and totalDigits facet.
   -->
   <tdml:parserTestCase name="checkTotalDigitsFractionDigits_Pass2"
-    root="e4_1_2" model="TestFacets">
+    root="e4_1_2" model="TestFacets"
+    roundTrip="twoPass">
 
     <tdml:document>123.010</tdml:document>
     <tdml:infoset>
@@ -6146,7 +6148,8 @@
   -->
 
   <tdml:parserTestCase name="minMaxInExdateTime01" root="mImE_e13"
-    model="minMaxInExSchema" description="Section 5 - Facets - min/max In/Exclusive - DFDL-5-055R">
+    model="minMaxInExSchema" description="Section 5 - Facets - min/max In/Exclusive - DFDL-5-055R"
+    roundTrip="twoPass">
     <tdml:document>Today is the 16th day of March, year 2012</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/AK.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/AK.tdml
@@ -22,7 +22,8 @@
   defaultRoundTrip="true">
 
   <parserTestCase name="AK000" root="list" model="AK.dfdl.xsd"
-    description="Simple Binary with signed and usigned types - DFDL-5-020R">
+    description="Simple Binary with signed and usigned types - DFDL-5-020R"
+    roundTrip="twoPass">
     <document>
       <documentPart type="byte">ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff</documentPart>
     </document>
@@ -43,7 +44,8 @@
   </parserTestCase>
 
   <parserTestCase name="AK001" root="list" model="AK.dfdl.xsd"
-    description="Simple Binary with signed and usigned types - DFDL-5-020R">
+    description="Simple Binary with signed and usigned types - DFDL-5-020R"
+    roundTrip="twoPass">
     <document>
       <documentPart type="byte">7f7f7fff7fffffff7fffffff7fffffff7fffffffffffffff7fffffffffffffff</documentPart>
     </document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Boolean.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Boolean.tdml
@@ -259,7 +259,8 @@
   </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="binaryBoolean_1" root="binaryList2" model="boolean"
-    description="Binary boolean">
+    description="Binary boolean"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte"><![CDATA[00 00 00 01 00 00 00 00 00 00 00 1b 00 10 00 0c]]></tdml:documentPart>
     </tdml:document>
@@ -354,7 +355,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="textBoolean_0" root="textList" model="boolean"
-    description="Text boolean">
+    description="Text boolean"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[1,Y,yes,0,no,N;2,a,2,b,2,c;]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -400,7 +402,8 @@
   </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="textBoolean_IgnoreCase" root="textListIgnoreCase" model="boolean"
-    description="Text boolean">
+    description="Text boolean"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[1,y,YES,0,NO,n;2,A,2,B,2,C;]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/RuntimeCalendarLanguage.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/RuntimeCalendarLanguage.tdml
@@ -45,7 +45,8 @@
        Purpose: This test demonstrates setting the calendarLanguage property at runtime to German.
 -->
   <tdml:parserTestCase name="runtimeCalendarLanguage1" root="r" model="s1" 
-  description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
+  description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
+  roundTrip="twoPass">
 
     <tdml:document><![CDATA[de1996Freitag März 2013]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -964,7 +964,8 @@
 
   <tdml:parserTestCase name="whiteSpaceBeforeValidShort"
     root="s_1" model="SimpleTypes-Embedded.dfdl.xsd"
-    description="Test parsing when encountering a whitespace character before a valid short - DFDL-5-014R">
+    description="Test parsing when encountering a whitespace character before a valid short - DFDL-5-014R"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[ 9999]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -1945,7 +1946,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="dateText" root="dateText"
-    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R">
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[Wednesday, July 10, '96]]></tdml:document>
     <tdml:infoset>
@@ -2455,7 +2457,8 @@
   -->
   
   <tdml:parserTestCase name="double_binary_04" root="d_01"
-      model="SimpleTypes-binary" description="Section 5 Schema types-double - DFDL-5-009R">
+      model="SimpleTypes-binary" description="Section 5 Schema types-double - DFDL-5-009R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="bits">1111111111111111111111111111111111111111111111111111111111111111</tdml:documentPart>
     </tdml:document>
@@ -2717,7 +2720,7 @@
 
   <tdml:parserTestCase name="double_text4" root="doubleText3"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-double - DFDL-5-009R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[123.45678901234567899]]></tdml:document>
     <tdml:infoset>
@@ -2762,7 +2765,7 @@
 
   <tdml:parserTestCase name="float_text3" root="floatText2"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Simple type-float - DFDL-5-008R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[123456789012345678901]]></tdml:document>
     <tdml:infoset>
@@ -2835,7 +2838,8 @@
   -->
 
   <tdml:parserTestCase name="float_binary_03" root="float_01"
-      model="SimpleTypes-binary" description="Section 5 Simple types-float - DFDL-5-008R">
+      model="SimpleTypes-binary" description="Section 5 Simple types-float - DFDL-5-008R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="bits">11111111111111111111111111111111</tdml:documentPart>
     </tdml:document>
@@ -3465,7 +3469,8 @@
   -->
 
   <tdml:parserTestCase name="literalChar_padding2" root="string2"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[remove padding pleaseXXXXXXXX]]></tdml:documentPart>
     </tdml:document>
@@ -3483,7 +3488,8 @@
   -->
 
   <tdml:parserTestCase name="charEntity_padding1" root="string3"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte"><![CDATA[72 65 6D 6F 76 65 20 70 61 64 64 69 6E 67 20 70 6C 65 61 73 65 15 15 15 15 15]]></tdml:documentPart>
     </tdml:document>
@@ -3501,7 +3507,8 @@
   -->
 
   <tdml:parserTestCase name="charEntity_padding2" root="string4"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte"><![CDATA[72 65 6D 6F 76 65 20 70 61 64 64 69 6E 67 20 70 6C 65 61 73 65 09 09 09 09]]></tdml:documentPart>
     </tdml:document>
@@ -3539,7 +3546,8 @@
   -->
 
   <tdml:parserTestCase name="literalChar_padding3" root="string5"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[---------first---------/________second________]]></tdml:documentPart>
     </tdml:document>
@@ -3561,7 +3569,8 @@
   -->
 
   <tdml:parserTestCase name="literalChar_padding4" root="string6"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[_______________first-second________]]></tdml:documentPart>
     </tdml:document>
@@ -3619,7 +3628,7 @@
 
   <tdml:parserTestCase name="number_padding" root="int1"
       model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R"
-    roundTrip="true">
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[12345##]]></tdml:documentPart>
     </tdml:document>
@@ -3637,7 +3646,8 @@
   -->
 
   <tdml:parserTestCase name="number_padding2" root="int2"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[12345############################]]></tdml:documentPart>
     </tdml:document>
@@ -3655,7 +3665,8 @@
   -->
 
   <tdml:parserTestCase name="number_padding3" root="intseq"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[123====.456-----]]></tdml:documentPart>
     </tdml:document>
@@ -3676,7 +3687,8 @@
   -->
 
   <tdml:parserTestCase name="number_padding4" root="numseq"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[......55~-----6800-----~49.......]]></tdml:documentPart>
     </tdml:document>
@@ -3698,7 +3710,8 @@
   -->
 
   <tdml:parserTestCase name="number_padding5" root="int6"
-      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R">
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textNumberPadCharacter DFDL-13-047R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[______5]]></tdml:documentPart>
     </tdml:document>
@@ -3716,7 +3729,8 @@
   -->
 
   <tdml:parserTestCase name="padding_escape" root="string10"
-      model="SimpleTypes-padding" description="Section 7 - On parsing, the escape scheme is applied after padding characters are trimmed DFDL-7-089R">
+      model="SimpleTypes-padding" description="Section 7 - On parsing, the escape scheme is applied after padding characters are trimmed DFDL-7-089R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text">\\\word/\\\</tdml:documentPart>
     </tdml:document>
@@ -3754,7 +3768,8 @@
 
   <tdml:parserTestCase name="padding_nil2" root="nil2"
       model="SimpleTypes-padding" description="Spec errata - On parsing the element value is nil if
-      the trimmed data matches one of the literal strings in the list">
+      the trimmed data matches one of the literal strings in the list"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text">///o///</tdml:documentPart>
     </tdml:document>
@@ -3791,7 +3806,8 @@
   -->
 
   <tdml:parserTestCase name="justification_1" root="seq"
-      model="SimpleTypes-padding" description="Section 5 - Simple Types - textStringJustification DFDL-13-041R">
+      model="SimpleTypes-padding" description="Section 5 - Simple Types - textStringJustification DFDL-13-041R"
+      roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text">oregano.oregano.oregano</tdml:documentPart>
     </tdml:document>
@@ -4119,7 +4135,7 @@
   
   <tdml:parserTestCase name="timeImplicitPattern" root="timeImp"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[12:43:20+00:00]]></tdml:document>
     <tdml:infoset>
@@ -4554,7 +4570,8 @@
 -->
   
   <tdml:parserTestCase name="datePatternChoice" root="date21"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[It is day 25 of March, 2013]]></tdml:document>
     <tdml:infoset>
@@ -4614,7 +4631,8 @@
 -->
   
   <tdml:parserTestCase name="dateCalendarLanguage" root="date24"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[Freitag März 2013]]></tdml:document>
     <tdml:infoset>
@@ -4632,7 +4650,8 @@
 -->
   
   <tdml:parserTestCase name="dateCalendarLanguage2" root="date25"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[Lunes Noviembre 2013]]></tdml:document>
     <tdml:infoset>
@@ -4650,7 +4669,8 @@
 -->
   
   <tdml:parserTestCase name="dateCalendarLanguage3" root="date26"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[Monday November 2013]]></tdml:document>
     <tdml:infoset>
@@ -4789,7 +4809,7 @@
   
   <tdml:parserTestCase name="dateTimePattern01" root="dateTime01"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[It is 11:53AM on the 1st of April, year 2013]]></tdml:document>
     <tdml:infoset>
@@ -4808,7 +4828,7 @@
   
   <tdml:parserTestCase name="timeLaxCheckPolicy01" root="time01"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[05:62:30+00:00]]></tdml:document>
     <tdml:infoset>
@@ -4827,7 +4847,7 @@
   
   <tdml:parserTestCase name="timeLaxCheckPolicy02" root="time01"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[28:62:30-00:00]]></tdml:document>
     <tdml:infoset>
@@ -4846,7 +4866,7 @@
   
   <tdml:parserTestCase name="timeLaxCheckPolicy03" root="time01"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[28:62:90+00:00]]></tdml:document>
     <tdml:infoset>
@@ -4864,7 +4884,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeLaxCheckPolicy01" root="dateTime02"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2013-01-31T23:62:30]]></tdml:document>
     <tdml:infoset>
@@ -4882,7 +4903,8 @@
 -->
   
   <tdml:parserTestCase name="dateLaxCheckPolicy01" root="date02"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2000-12-45]]></tdml:document>
     <tdml:infoset>
@@ -4902,7 +4924,7 @@
   
   <tdml:parserTestCase name="dateLaxCheckPolicy02" root="date03"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2000-01-366]]></tdml:document>
     <tdml:infoset>
@@ -4922,7 +4944,7 @@
   
   <tdml:parserTestCase name="dateLaxCheckPolicy03" root="date03"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2001-01-366]]></tdml:document>
     <tdml:infoset>
@@ -4960,7 +4982,8 @@
 -->
   
   <tdml:parserTestCase name="dateLaxCheckPolicy05" root="date02"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2001-02-29]]></tdml:document>
     <tdml:infoset>
@@ -5113,7 +5136,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats" root="time04"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.EST]]></tdml:document>
     <tdml:infoset>
@@ -5132,7 +5155,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats2" root="time04b"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.Eastern Standard Time]]></tdml:document>
     <tdml:infoset>
@@ -5151,7 +5174,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats3" root="time05"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.PT]]></tdml:document>
     <tdml:infoset>
@@ -5188,7 +5211,8 @@
 -->
   
   <tdml:parserTestCase name="timeFormatting2" root="time17"
-    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R">
+    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[03:43PM]]></tdml:document>
     <tdml:infoset>
@@ -5207,7 +5231,8 @@
 -->
   
   <tdml:parserTestCase name="timeFormatting2c" root="time17"
-    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R">
+    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[23:43AM]]></tdml:document>
     <tdml:infoset>
@@ -5313,7 +5338,8 @@
 -->
   
   <tdml:parserTestCase name="timeFormatting7" root="time19"
-    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R">
+    model="dateTimeSchema" description="Section 13 Simple Types - pattern derived from ICU SimpleDatetimeFormat - DFDL-13-147R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[00:43]]></tdml:document>
     <tdml:infoset>
@@ -5332,7 +5358,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats4" root="time05b"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.Pacific Standard Time]]></tdml:document>
     <tdml:infoset>
@@ -5351,7 +5377,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats5" root="time06"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.Los Angeles Time]]></tdml:document>
     <tdml:infoset>
@@ -5389,7 +5415,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats7" root="time05b"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.Eastern Standard Time]]></tdml:document>
     <tdml:infoset>
@@ -5427,7 +5453,7 @@
   
   <tdml:parserTestCase name="timeZoneFormats9" root="time27"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarPattern - DFDL-13-146R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.GMT+00:00]]></tdml:document>
     <tdml:infoset>
@@ -5482,7 +5508,7 @@
   
   <tdml:parserTestCase name="timeCalendarTimeZone3" root="time28"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarTimeZone - DFDL-13-140R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43.EST]]></tdml:document>
     <tdml:infoset>
@@ -5501,7 +5527,7 @@
   
   <tdml:parserTestCase name="timeFractionalSeconds01" root="time03"
     model="dateTimeSchema" description="Section 13 Simple Types - fractional seconds - DFDL-13-150R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[08:43:30.9678]]></tdml:document>
     <tdml:infoset>
@@ -5555,7 +5581,8 @@
 -->
   
   <tdml:parserTestCase name="dateTrim01" root="date09"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[....2013-03-24....]]></tdml:document>
     <tdml:infoset>
@@ -5573,7 +5600,8 @@
 -->
   
   <tdml:parserTestCase name="dateTrim02" root="date10"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2013-03-24xxxx]]></tdml:document>
     <tdml:infoset>
@@ -5591,7 +5619,8 @@
 -->
   
   <tdml:parserTestCase name="dateTrim03" root="date11"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[dddddddddddddddddddddddddddddd2013-03-24]]></tdml:document>
     <tdml:infoset>
@@ -5611,7 +5640,8 @@
 -->
   
   <tdml:parserTestCase name="timeTrim01" root="time10"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[....12:30:30....]]></tdml:document>
     <tdml:infoset>
@@ -5629,7 +5659,8 @@
 -->
   
   <tdml:parserTestCase name="timeTrim02" root="time11"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[::::::12:30:30]]></tdml:document>
     <tdml:infoset>
@@ -5648,7 +5679,7 @@
   
   <tdml:parserTestCase name="millisecondAccuracy" root="time12"
     model="dateTimeSchema" description="Section 13 Simple Types - at least millisecond accuracy - DFDL-13-152R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[3:30:38.001]]></tdml:document>
     <tdml:infoset>
@@ -5667,7 +5698,7 @@
   
   <tdml:parserTestCase name="millisecondAccuracy2" root="time13"
     model="dateTimeSchema" description="Section 13 Simple Types - at least millisecond accuracy - DFDL-13-152R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[3:30:38.001435]]></tdml:document>
     <tdml:infoset>
@@ -5718,7 +5749,7 @@
   
   <tdml:parserTestCase name="millisecondAccuracy5" root="time29"
     model="dateTimeSchema" description="Section 13 Simple Types - at least millisecond accuracy - DFDL-13-152R"
-    roundTrip="true">
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[3:30:38.002345276]]></tdml:document>
     <tdml:infoset>
@@ -5966,7 +5997,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimePattern02" root="dateTime03"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[Twas a sunny Wednesday at 11 O'clock. The year was 2008, and it was the hottest December we had ever experienced.]]></tdml:document>
     <tdml:infoset>
@@ -5986,7 +6018,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimePattern03" root="dateTime04"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[27:30:30 February-29-2012]]></tdml:document>
     <tdml:infoset>
@@ -6130,7 +6163,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeTrim01" root="dateTime09"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[.....03.04.1999 04:31:44PM.....]]></tdml:document>
     <tdml:infoset>
@@ -6148,7 +6182,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeTrim02" root="dateTime10"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[03.04.1999 04:31:44PM:::::::::::::::::::::::::::::::::::::::::]]></tdml:document>
     <tdml:infoset>
@@ -6168,7 +6203,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeTrim03" root="dateTime11"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte"><![CDATA[09 09 09 09 30 33 2e 30 34 2e 31 39 39 39 20 30 34 3a 33 31 3a 34 34 50 4d 09 09 09 09]]></tdml:documentPart>
@@ -6190,7 +6226,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeTrim04" root="dateTime12"
-    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R">
+    model="dateTimeSchema" description="Section 13 Simple Types - textCalendarJustification - DFDL-13-165R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte"><![CDATA[09 09 09 09 30 33 2e 30 34 2e 31 39 39 39 20 30 34 3a 36 31 3a 34 34 50 4d]]></tdml:documentPart>
@@ -6393,7 +6430,7 @@
 
   <tdml:parserTestCase name="hexBinary_Delimited_01"
     root="hb_root01" model="HexBinary"
-    description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="true">
+    description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="twoPass">
     <tdml:document>
         <tdml:documentPart type="bits"><![CDATA[01010111011001010010000001100011011000010110111000100111011101000010000001100010011001010010000001100011011011110110111001]]></tdml:documentPart>
       <tdml:documentPart type="bits"><![CDATA[11001101110101011011010110010101100100001000000110001001111001001000000110111101110101011100100010000001110000011001010111]]></tdml:documentPart>
@@ -6766,7 +6803,8 @@
                implementation works.
   -->
   <tdml:parserTestCase name="NonNegativeInteger" root="Date"
-    model="nonNegativeInteger.dfdl.xsd" description="nonNegativeInteger test">
+    model="nonNegativeInteger.dfdl.xsd" description="nonNegativeInteger test"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[Date: 20
 ]]></tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/WhiteSpace.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/WhiteSpace.tdml
@@ -58,7 +58,8 @@
 
   <tdml:parserTestCase name="whiteSpaceDuringLax"
     root="uS_02" model="Lax.dfdl.xsd"
-    description="Test parsing when encountering a whitespace character during a valid unsigned short - DFDL-5-019R">
+    description="Test parsing when encountering a whitespace character during a valid unsigned short - DFDL-5-019R"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[9 99]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
@@ -668,7 +668,8 @@ is multiple bytes in UTF-8 encoding that is used"
   
   <tdml:parserTestCase name="whitespace_02"
     description="Section 6.3 DFDL Character Entities - DFDL-6-036R"
-    model="EscapesSchema" root="e2">
+    model="EscapesSchema" root="e2"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text">[ start ]hello[ end ]</tdml:documentPart>
     </tdml:document>
@@ -709,7 +710,8 @@ is multiple bytes in UTF-8 encoding that is used"
   
   <tdml:parserTestCase name="whitespace_04"
     description="Section 6.3 DFDL Character Entities - DFDL-6-036R"
-    model="EscapesSchema" root="e4">
+    model="EscapesSchema" root="e4"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"> h e l l o</tdml:documentPart>
     </tdml:document>
@@ -791,7 +793,8 @@ is multiple bytes in UTF-8 encoding that is used"
   
   <tdml:parserTestCase name="whitespace_08"
     description="Section 6.3 DFDL Character Entities - DFDL-6-036R"
-    model="whitespaceSchema" root="spacePad2">
+    model="whitespaceSchema" root="spacePad2"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[      hello      ]]></tdml:documentPart>
     </tdml:document>
@@ -830,7 +833,8 @@ is multiple bytes in UTF-8 encoding that is used"
   
   <tdml:parserTestCase name="whitespace_10"
     description="Section 6.3 DFDL Character Entities - DFDL-6-036R"
-    model="whitespaceSchema" root="spacePad4">
+    model="whitespaceSchema" root="spacePad4"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[      123      ]]></tdml:documentPart>
     </tdml:document>
@@ -887,7 +891,8 @@ is multiple bytes in UTF-8 encoding that is used"
   -->
 
   <tdml:parserTestCase name="doubleNLterminator" root="seq" model="NLSchema"
-    description="">
+    description=""
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte">74 65 78 74 0d 0a 0d 0a</tdml:documentPart>
       <tdml:documentPart type="byte">74 65 78 74 0d 0a 0d 0a</tdml:documentPart>
@@ -910,7 +915,8 @@ is multiple bytes in UTF-8 encoding that is used"
   -->
 
   <tdml:parserTestCase name="doubleNLseparator" root="seq2" model="NLSchema"
-    description="">
+    description=""
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte">74 65 78 74 0d 0a 0d 0a</tdml:documentPart>
       <tdml:documentPart type="byte">74 65 78 74</tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.tdml
@@ -62,7 +62,8 @@
   </parserTestCase>
 
   <parserTestCase name="CarriageReturn" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="text"><![CDATA[0,1,2,3,45,6,7,8,910,11,12,13,14]]></documentPart>
@@ -100,7 +101,8 @@
   </parserTestCase>
 
   <parserTestCase name="LineSeparator" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="text"><![CDATA[0,1,2,3,4 5,6,7,8 10,11,12,13,14]]></documentPart>
@@ -137,7 +139,8 @@
   </parserTestCase>
 
   <parserTestCase name="NextLine" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="text"><![CDATA[0,1,2,3,45,6,7,8,910,11]]></documentPart>
@@ -211,7 +214,8 @@
   </parserTestCase>
 
   <parserTestCase name="CarriageReturn_byte" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="byte">302C312C322C332C340d352C362C372C382C390d31302C31312C31322C31332C3134</documentPart>
@@ -250,7 +254,8 @@
   </parserTestCase>
 
   <parserTestCase name="CRLF_byte" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="byte">302C312C322C332C340d0a352C362C372C382C390d0a31302C31312C31322C31332C3134</documentPart>
@@ -289,7 +294,8 @@
   </parserTestCase>
 
   <parserTestCase name="LineSeparator_byte" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="byte">302C312C322C332C34e280a8352C362C372C382C39e280a831302C31312C31322C31332C3134</documentPart>
@@ -328,7 +334,8 @@
   </parserTestCase>
 
   <parserTestCase name="NextLine_byte" root="matrix"
-    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R">
+    model="charClassEntities.dfdl.xsd" description="CSV-style tests and use of %NL; - DFDL-6-045R"
+    roundTrip="twoPass">
 
     <document>
       <documentPart type="byte">302C312C322C332C34c285352C362C372C382C39c28531302C31312C31322C31332C3134</documentPart>
@@ -449,7 +456,8 @@ jonesington,david,frederick,1986-02-19
 
   <parserTestCase name="doubleNL2" root="TopLevel"
     model="TopLevel.dfdl.xsd"
-    description="">
+    description=""
+    roundTrip="twoPass">
     <document>
       <documentPart type="file">02nine_headers.txt</documentPart>
     </document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/entities_01.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/entities_01.tdml
@@ -67,7 +67,8 @@
 
   <tdml:parserTestCase name="entity_fail_02" root="root" model="sch2" 
     description="Initiator cannot contain ES.  %ES; is used only in nilValue - DFDL-6-046R
-    Note: Revised - DFDL Spec. now allows ES for Initiators as long as it is not the only entry in the list.">
+    Note: Revised - DFDL Spec. now allows ES for Initiators as long as it is not the only entry in the list."
+    roundTrip="twoPass">
     <tdml:document>0,1</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
@@ -161,7 +161,8 @@
   -->
 
   <tdml:parserTestCase name="ibm_format_compat_02"
-    root="ABC" model="ABC_IBM.dfdl.xsd" description="">
+    root="ABC" model="ABC_IBM.dfdl.xsd" description=""
+    roundTrip="twoPass">
     <tdml:document><![CDATA[a
 ]]></tdml:document>
     <tdml:infoset>
@@ -364,7 +365,8 @@
   -->
 
   <tdml:parserTestCase name="multifile_choice_03"
-    root="choice01" model="multi_base_01.dfdl.xsd" description="import a schema - DFDL-6-007R">
+    root="choice01" model="multi_base_01.dfdl.xsd" description="import a schema - DFDL-6-007R"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[remote03:5555]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -572,7 +574,8 @@
   -->
 
   <tdml:parserTestCase name="long_chain_01" root="rabbitHole"
-    model="multi_base_03.dfdl.xsd" description="import a schema - DFDL-6-007R">
+    model="multi_base_03.dfdl.xsd" description="import a schema - DFDL-6-007R"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[f:....53....(e)|f:..41..(e)]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -1744,7 +1747,8 @@
   -->
 
   <tdml:parserTestCase name="nonsense_namespace_01"
-    root="ABC" model="ABC_invalid.dfdl.xsd" description="">
+    root="ABC" model="ABC_invalid.dfdl.xsd" description=""
+    roundTrip="twoPass">
     <tdml:document><![CDATA[a
 ]]></tdml:document>
     <tdml:infoset>
@@ -1759,7 +1763,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="nonsense_namespace_02"
-    root="ABC" model="ABC_invalid.dfdl.xsd" description="">
+    root="ABC" model="ABC_invalid.dfdl.xsd" description=""
+    roundTrip="twoPass">
     <tdml:document><![CDATA[d
 ]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScenarios.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScenarios.tdml
@@ -83,7 +83,8 @@
   </parserTestCase>
 
   <parserTestCase name="scenario1_2" model="es1"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo/bar</document>
     <infoset>
       <dfdlInfoset>
@@ -120,7 +121,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario1_5" model="es1"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo///bar</document>
     <infoset>
       <dfdlInfoset>
@@ -259,7 +261,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario1_12" model="es1"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo/</document>
     <infoset>
       <dfdlInfoset>
@@ -279,7 +282,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario1_13" model="es1"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo///</document>
     <infoset>
       <dfdlInfoset>
@@ -398,7 +402,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario2_5" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo//$;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -410,7 +415,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario2_6" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo//////////bar</document>
     <infoset>
       <dfdlInfoset>
@@ -435,7 +441,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario2_8" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$//;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -640,7 +647,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_2" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$/;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -677,7 +685,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_5" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo///;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -715,7 +724,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_8" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$////;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -728,7 +738,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_9" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$///////;bar</document>
     <infoset>
       <dfdlInfoset>
@@ -765,7 +776,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_11" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$/;</document>
     <infoset>
       <dfdlInfoset>
@@ -835,7 +847,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario3_14" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo$/$/$/;</document>
     <infoset>
       <dfdlInfoset>
@@ -1059,7 +1072,8 @@
   </parserTestCase>
   
   <parserTestCase name="scenario4_10" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
+    roundTrip="twoPass">
     <document>foo///</document>
     <infoset>
       <dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
@@ -251,7 +251,8 @@
   -->
 
   <parserTestCase name="escapeSchemeNonEmpty" model="emptyRef"
-    description="Section 13 defineEscapeScheme - DFDL-13-022R" root="esc">
+    description="Section 13 defineEscapeScheme - DFDL-13-022R" root="esc"
+    roundTrip="twoPass">
     <document><![CDATA[;/../a]]></document>
     <infoset>
       <dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section11/content_framing_properties/ContentFramingProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section11/content_framing_properties/ContentFramingProps.tdml
@@ -771,7 +771,7 @@
   -->
 
   <tdml:parserTestCase name="alignmentPacked7BitASCII_04" root="e9"
-    model="packed7BitASCII" roundTrip="true">
+    model="packed7BitASCII" roundTrip="twoPass">
     <tdml:document bitOrder="LSBFirst">
       <tdml:documentPart type="bits" byteOrder="RTL"><![CDATA[ 0110100 0110010 11]]></tdml:documentPart>
     </tdml:document>
@@ -894,7 +894,8 @@
         results in the insertion of the Unicode Replacement Character (U+FFFD) as the replacement for that error.
   -->
   <tdml:parserTestCase name="encodingErrorReplace2" root="ee2"
-    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R">
+    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">64f0908767</tdml:documentPart>
@@ -915,7 +916,8 @@
         results in the insertion of the Unicode Replacement Character (U+FFFD) as the replacement for that error.
   -->
   <tdml:parserTestCase name="encodingErrorReplace3" root="ee2"
-    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R">
+    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">64c2ff67</tdml:documentPart>
@@ -936,7 +938,8 @@
         results in the insertion of the Unicode Replacement Character (U+FFFD) as the replacement for that error.
   -->
   <tdml:parserTestCase name="encodingErrorReplace4" root="ee2"
-    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R">
+    model="ContentFramingProperties-Embedded.dfdl.xsd" description="Section 11 encoding - DFDL-11-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">648067</tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -594,7 +594,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentHexBinary" root="hB"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - hexBinary - DFDL-12-029R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - hexBinary - DFDL-12-029R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0101</tdml:documentPart> <!-- leadingSkip -->
@@ -616,7 +617,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentHexBinary2" root="hB2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - hexBinary - DFDL-12-029R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - hexBinary - DFDL-12-029R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">ab 43 82 b3</tdml:documentPart> <!-- leadingSkip -->
@@ -637,7 +639,8 @@
   -->
   
   <tdml:parserTestCase name="alignment01" root="e"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0010 00000100</tdml:documentPart>
@@ -657,7 +660,8 @@
   -->
   
   <tdml:parserTestCase name="alignment02" root="e3"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">00 00</tdml:documentPart> <!-- leadingSkip -->
@@ -687,7 +691,8 @@
   -->
   
   <tdml:parserTestCase name="alignment03" root="e4"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - DFDL-12-002R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">00 00</tdml:documentPart> <!-- leadingSkip -->
@@ -717,7 +722,8 @@
   -->
 
   <tdml:parserTestCase name="leadingSkip1" root="e"
-    model="s1" description="Section 12.1 Aligned Data - DFDL-12-005R">
+    model="s1" description="Section 12.1 Aligned Data - DFDL-12-005R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">aabbcc</tdml:documentPart>
@@ -760,7 +766,8 @@
    -->
 
   <tdml:parserTestCase name="implicitAlignmentString1" root="string"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - String - DFDL-12-014R - DFDL-13-006R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - String - DFDL-12-014R - DFDL-13-006R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0110 0111</tdml:documentPart> <!-- leadingSkip and buffer to fulfill alignment -->
@@ -784,7 +791,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentString2" root="string2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - String - DFDL-12-014R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - String - DFDL-12-014R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01100111 01101111</tdml:documentPart> <!-- leadingSkip -->
@@ -807,7 +815,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedInt" root="uInt"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (binary) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (binary) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1 0000000 00000000 00000000 00000000</tdml:documentPart> <!-- leadingSkip and buffer to fulfill alignment -->
@@ -830,7 +839,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedShort" root="uShort"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (binary) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (binary) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1 0000000 00000000</tdml:documentPart> <!-- leadingSkip and buffer to fulfill alignment -->
@@ -853,7 +863,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentInt" root="int"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (binary) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (binary) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">a4 b4</tdml:documentPart> <!-- leadingSkip -->
@@ -878,7 +889,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentInt2" root="int"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (binary) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (binary) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">a4 b4</tdml:documentPart> <!-- leadingSkip -->
@@ -902,7 +914,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentShort" root="short"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (binary) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (binary) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">100100</tdml:documentPart> <!-- leadingSkip (6 bits) -->
@@ -927,7 +940,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentShort2" root="short"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (binary) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (binary) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">100100</tdml:documentPart> <!-- leadingSkip (6 bits) -->
@@ -951,7 +965,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentLong" root="long"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (binary) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (binary) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11010101 10101010 1101</tdml:documentPart> <!-- leadingSkip (20 bits) -->
@@ -975,7 +990,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentLongT" root="longT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (text) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (text) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">00 b3 b3 b3</tdml:documentPart> <!-- leadingSkip (4 bytes) -->
@@ -998,7 +1014,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentLongTBits" root="longTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (text) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - long (text) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0101</tdml:documentPart> <!-- leadingSkip (4 bits) -->
@@ -1022,7 +1039,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentByte" root="byte"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (binary) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (binary) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11</tdml:documentPart> <!-- leadingSkip (2 bits) -->
@@ -1047,7 +1065,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentByte2" root="byte"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (binary) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (binary) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11</tdml:documentPart> <!-- leadingSkip (2 bits) -->
@@ -1071,7 +1090,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedByte" root="uByte"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (binary) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (binary) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11</tdml:documentPart> <!-- leadingSkip (2 bits) -->
@@ -1095,7 +1115,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedByte2" root="uByte"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (binary) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (binary) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11</tdml:documentPart> <!-- leadingSkip (2 bits) -->
@@ -1120,7 +1141,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedIntT" root="uIntT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3</tdml:documentPart> <!-- leadingSkip -->
@@ -1168,7 +1190,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedIntT2b" root="uIntT2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">00</tdml:documentPart> <!-- leadingSkip -->
@@ -1192,7 +1215,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedIntTBits" root="uIntTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedInt (text) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -1217,7 +1241,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedShortT2b" root="uShortT2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (text) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (text) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">00</tdml:documentPart> <!-- leadingSkip -->
@@ -1241,7 +1266,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedShortTBits" root="uShortTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (text) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedShort (text) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0</tdml:documentPart> <!-- leadingSkip -->
@@ -1265,7 +1291,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedLong" root="uLong"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - uLong (binary) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - uLong (binary) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">11010</tdml:documentPart> <!-- leadingSkip (5 bits) -->
@@ -1290,7 +1317,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedLongT" root="uLongT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">32 32 32 32 32</tdml:documentPart> <!-- leadingSkip plus 3 filler bits for alignment (8 bits) -->
@@ -1314,7 +1342,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedLongT2" root="uLongT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10101111 10001010</tdml:documentPart> <!-- 2 bytes of leadingSkip (in bits) -->
@@ -1338,7 +1367,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedLongTBits" root="uLongTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedLong (text) - DFDL-12-018R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">0101</tdml:documentPart> <!-- leadingSkip (4 bits) -->
@@ -1363,7 +1393,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentIntT" root="intT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (text) - DFDL-12-019R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - int (text) - DFDL-12-019R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01 101001</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1387,7 +1418,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentShortT" root="shortT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (text) - DFDL-12-020R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - short (text) - DFDL-12-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">011010 01</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1411,7 +1443,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentByteT" root="byteT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (text) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (text) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01 111111</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1435,7 +1468,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentByteT2" root="byteT2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (text) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - byte (text) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10 111111</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1484,7 +1518,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentUnsignedByteT2" root="uByteT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (text) - DFDL-12-021R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - unsignedByte (text) - DFDL-12-021R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10 111111</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1508,7 +1543,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDateT" root="dateT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - date (text) - DFDL-12-024R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - date (text) - DFDL-12-024R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">junk!31 03 2013</tdml:documentPart> <!-- leadingSkip (junk!) and dateT -->
@@ -1531,7 +1567,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDateT2" root="dateT2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - date (text) - DFDL-12-024R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - date (text) - DFDL-12-024R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">Bleak Monday in May - 2013</tdml:documentPart> <!-- leadingSkip (Bleak) and dateT -->
@@ -1554,7 +1591,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentTimeT" root="timeT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - time (text) - DFDL-12-026R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - time (text) - DFDL-12-026R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">time: 04:09:23</tdml:documentPart> <!-- leadingSkip (time:) and timeT -->
@@ -1577,7 +1615,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDateTimeT" root="dateTimeT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - dateTime (text) - DFDL-12-022R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - dateTime (text) - DFDL-12-022R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">look: Friday 05 2013 - 03:30:30</tdml:documentPart> <!-- leadingSkip (look:) and dateTimeT -->
@@ -1600,7 +1639,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentFloatT" root="floatT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (text) - DFDL-12-015R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (text) - DFDL-12-015R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1623,7 +1663,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentFloatT2" root="floatT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (text) - DFDL-12-015R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (text) - DFDL-12-015R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10</tdml:documentPart> <!-- leadingSkip -->
@@ -1671,7 +1712,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentFloat" root="float"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (binary) - DFDL-12-015R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (binary) - DFDL-12-015R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">2A 00 90 0D</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1694,7 +1736,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentFloat2" root="float"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (binary) - DFDL-12-015R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - float (binary) - DFDL-12-015R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01010101 01010101</tdml:documentPart> <!-- leadingSkip -->
@@ -1718,7 +1761,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDouble" root="double"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (binary) - DFDL-12-016R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (binary) - DFDL-12-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">2A 00 90 0D 2A 45 9F 9E</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1741,7 +1785,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDouble2" root="double2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (binary) - DFDL-12-016R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (binary) - DFDL-12-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01010101 01010101 01010101 01010101 01010101 01010101 01010101 01010101</tdml:documentPart> <!-- leadingSkip and padding for alignment -->
@@ -1790,7 +1835,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDoubleT2" root="doubleTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (text) - DFDL-12-016R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - double (text) - DFDL-12-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -1865,7 +1911,8 @@
   -->
 
   <tdml:parserTestCase name="explicitAlignmentNoSkips02" root="e6"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">011 00000 010011000 001 0</tdml:documentPart>
@@ -1893,7 +1940,8 @@
   -->
 
   <tdml:parserTestCase name="explicitAlignmentNoSkips03" root="e7"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">011100 0001001100 000 10100 000100001111</tdml:documentPart>
@@ -1921,7 +1969,8 @@
   -->
 
   <tdml:parserTestCase name="explicitAlignmentNoSkips04" root="e8"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">00000001 11111111 00001100 00010100 00000000 00000000</tdml:documentPart>
@@ -1949,7 +1998,8 @@
   -->
 
   <tdml:parserTestCase name="explicitAlignmentNoSkips05" root="e9"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - alignmentUnits - DFDL-12-010R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">00000001 00001100 00010100 00000000 10000000 00000000 00000001</tdml:documentPart>
@@ -1978,7 +2028,8 @@
 
   <tdml:parserTestCase name="alignmentOptionalElem" root="e10"
     model="alignmentSchema"
-    description="Section 12.1 Aligned Data - Avoid Ambiguity when parsing - DFDL-12-011R">
+    description="Section 12.1 Aligned Data - Avoid Ambiguity when parsing - DFDL-12-011R"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="bits">1 0 11 101 </tdml:documentPart>
     </tdml:document>
@@ -2002,7 +2053,8 @@
   -->
 
   <tdml:parserTestCase name="alignmentOptionalElem02" root="e10a"
-    model="alignmentSchema" description="Section 12.1 Aligned Data - Avoid Ambiguity when parsing - DFDL-12-011R">
+    model="alignmentSchema" description="Section 12.1 Aligned Data - Avoid Ambiguity when parsing - DFDL-12-011R"
+    roundTrip="twoPass">
 
   <tdml:document>
     <tdml:documentPart type="bits">0 1 1 1 101</tdml:documentPart>
@@ -2143,7 +2195,8 @@
   -->
 
   <tdml:parserTestCase name="leftFraming01" root="e13"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">a</tdml:documentPart>
@@ -2165,7 +2218,8 @@
   -->
 
   <tdml:parserTestCase name="rightFraming01" root="e14"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">strng:a</tdml:documentPart>
@@ -2186,7 +2240,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFraming01" root="e15"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">a:strnggnrts:a</tdml:documentPart>
@@ -2210,7 +2265,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFraming02" root="e16"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">gnrts:aa:strng</tdml:documentPart>
@@ -2234,7 +2290,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingNested01" root="e17"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">skip</tdml:documentPart> <!-- 2 byte (2 char) leadingSkip and 2 byte (2 char) padding to fulfill alignment -->
@@ -2260,7 +2317,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingNested02" root="e18"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">skip</tdml:documentPart> <!-- e18 - 2 byte leadingSkip and 2 byte padding to fulfill alignment -->
@@ -2316,7 +2374,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingNested03" root="e19"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">skip</tdml:documentPart> <!-- 2 byte (2 char) leadingSkip and 2 byte (2 char) padding to fulfill alignment -->
@@ -2342,7 +2401,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingNested04" root="e20"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">skip</tdml:documentPart> <!-- 2 byte (2 char) leadingSkip and 2 byte padding to fulfill alignment -->
@@ -2377,7 +2437,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingNested05" root="e21"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">skip</tdml:documentPart> <!-- 2 byte (2 char) leadingSkip and 2 byte (2 char) padding to fulfill alignment -->
@@ -2447,7 +2508,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentNonNegativeInteger" root="nonNeg"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">01110101 11010010</tdml:documentPart> <!-- leadingSkip -->
@@ -2468,7 +2530,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentNonNegativeInteger2" root="nonNeg"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">01 01</tdml:documentPart> <!-- leadingSkip -->
@@ -2489,7 +2552,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentNonNegativeInteger3" root="nonNeg2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2511,7 +2575,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentInteger1" root="integer2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2533,7 +2598,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentInteger2" root="integer"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R"
+    roundTrip="twoPass">
     
     <tdml:document>
       <tdml:documentPart type="byte">01 01</tdml:documentPart> <!-- leadingSkip -->
@@ -2554,7 +2620,8 @@
   -->
   
   <tdml:parserTestCase name="impAlignmentInteger3" root="integer"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer - DFDL-12-017R"
+    roundTrip="twoPass">
     
     <tdml:document>
       <tdml:documentPart type="byte">01 01</tdml:documentPart> <!-- leadingSkip -->
@@ -2575,7 +2642,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentNonNegativeIntegerT" root="nonNegativeIntegerT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3</tdml:documentPart> <!-- leadingSkip -->
@@ -2598,7 +2666,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentNonNegativeIntegerT2" root="nonNegativeIntegerT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10101010</tdml:documentPart> <!-- leadingSkip -->
@@ -2621,7 +2690,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentNonNegativeIntegerT3" root="nonNegativeIntegerTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - nonNegativeInteger (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2669,7 +2739,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentIntegerT" root="integerT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3</tdml:documentPart> <!-- leadingSkip -->
@@ -2692,7 +2763,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentIntegerT2" root="integerTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - integer (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2740,7 +2812,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDecimalT" root="decimalT"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3</tdml:documentPart> <!-- leadingSkip -->
@@ -2763,7 +2836,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDecimalT2" root="decimalTBits"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal (text) - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal (text) - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2811,7 +2885,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDecimal" root="decimal"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal  - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal  - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">09 01</tdml:documentPart> <!-- leadingSkip -->
@@ -2834,7 +2909,8 @@
   -->
 
   <tdml:parserTestCase name="implicitAlignmentDecimal2" root="decimal2"
-    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal  - DFDL-12-017R">
+    model="implicitAlignmentSchema" description="Section 12.1 Aligned Data - Implicit Alignment - decimal  - DFDL-12-017R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">1</tdml:documentPart> <!-- leadingSkip -->
@@ -2858,7 +2934,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice01" root="e22"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart> <!-- e22 leadingSkip and padding to fulfill alignment-->
@@ -2885,7 +2962,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice02" root="e22"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart> <!-- e22 leadingSkip and padding to fulfill alignment-->
@@ -2911,7 +2989,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice03" root="e23"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart> <!-- e23 leadingSkip and padding to fulfill alignment-->
@@ -2950,7 +3029,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice04" root="e23"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart> <!-- e23 leadingSkip and padding to fulfill alignment-->
@@ -2989,7 +3069,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice05" root="e24"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart>                       <!-- e24 leadingSkip (2B) and padding to fulfill alignment -->
@@ -3037,7 +3118,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice06" root="e24"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart>                       <!-- e24 leadingSkip (2B) and padding to fulfill alignment -->
@@ -3098,7 +3180,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingChoice07" root="e24"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-016R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">BA 19 00 00</tdml:documentPart>                       <!-- e24 leadingSkip (2B) and padding to fulfill alignment -->
@@ -3178,7 +3261,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingArray02" root="e26"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-020R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">aabb</tdml:documentPart>               <!-- leadingSkip (2B) and padding to fulfill alignment -->
@@ -3248,7 +3332,8 @@
   -->
 
   <tdml:parserTestCase name="leftAndRightFramingArray03" root="e27"
-    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-020R">
+    model="alignmentSchema" description="Section 9 Framing - Aligned Data - DFDL-09-020R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">-=</tdml:documentPart>                 <!-- outer[1] leadingSkip and alignment padding --> 
@@ -3308,7 +3393,8 @@
   -->
 
   <tdml:parserTestCase name="trailingSkipDelimited01" root="e28"
-    model="alignmentSchema" description="Section 12 - Aligned Data - DFDL-12-006R">
+    model="alignmentSchema" description="Section 12 - Aligned Data - DFDL-12-006R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">test:a</tdml:documentPart>
@@ -3351,7 +3437,8 @@
   -->
 
   <tdml:parserTestCase name="trailingSkipDelimited03" root="e30"
-    model="alignmentSchema" description="Section 12 - Aligned Data - DFDL-12-006R">
+    model="alignmentSchema" description="Section 12 - Aligned Data - DFDL-12-006R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">test1:test2:]a)</tdml:documentPart>
@@ -3441,7 +3528,8 @@
 
   <tdml:parserTestCase name="alignmentArray" root="e32"
     model="alignmentSchema"
-    description="Section 12.1 Aligned Data">
+    description="Section 12.1 Aligned Data"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="bits">101 1 000 1 111</tdml:documentPart>
     </tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
@@ -150,7 +150,8 @@
   <tdml:parserTestCase name="DelimProp_01"
     model="DelimiterProperties-Embedded.dfdl.xsd"
     description="Section 12 property delimiters, a whitespace separated list of initiators and terminators - DFDL-12-032R"
-    root="DP_01">
+    root="DP_01"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[+1,+2,+3,+4:-5.-6.-7.-8${{9;10;11;12]]::13|14|15|16]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -187,7 +188,8 @@
 
   <tdml:parserTestCase name="DelimProp_02" root="DP_02"
     model="DelimiterProperties-Embedded.dfdl.xsd"
-    description="Section 12 property delimiters -each element terminated by a different terminator - DFDL-12-033R">
+    description="Section 12 property delimiters -each element terminated by a different terminator - DFDL-12-033R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[1]2)3}]]></tdml:document>
     <tdml:infoset>
@@ -214,7 +216,8 @@
 
   <tdml:parserTestCase name="DelimProp_04" root="DP_02"
     model="DelimiterProperties-Embedded.dfdl.xsd"
-    description="Section 12 property delimiters -each element terminated by a different terminator - DFDL-12-033R">
+    description="Section 12 property delimiters -each element terminated by a different terminator - DFDL-12-033R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[1]02)3}]]></tdml:document>
     <tdml:infoset>
@@ -231,7 +234,8 @@
 
   <tdml:parserTestCase name="DelimProp_05" root="DP_03"
     model="DelimiterProperties-Embedded.dfdl.xsd"
-    description="Section 14 Sequence groups with delimiters -each element terminated by a different terminator - DFDL-12-033R">
+    description="Section 14 Sequence groups with delimiters -each element terminated by a different terminator - DFDL-12-033R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[.00300]-02.75)3.9900}]]></tdml:document>
     <tdml:infoset>
@@ -293,7 +297,8 @@
 
   <tdml:parserTestCase name="DelimProp_10_01" root="DP_04_01"
     model="DelimiterProperties-Embedded.dfdl.xsd"
-    description="Section 12 property delimiters -use of %WSP+; as terminator - DFDL-12-033R Should pass">
+    description="Section 12 property delimiters -use of %WSP+; as terminator - DFDL-12-033R Should pass"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[.00300 -02.75
       3.9900 7.33
@@ -313,7 +318,8 @@
 
   <tdml:parserTestCase name="OptionalWSPTermWithExplicitLength" root="e1"
     model="DelimiterProperties-Embedded2.dfdl.xsd"
-    description="Section 14 Sequence groups with delimiters -use of %WSP*; as terminator - DFDL-12-033R should pass">
+    description="Section 14 Sequence groups with delimiters -use of %WSP*; as terminator - DFDL-12-033R should pass"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[12 45 78  
 257 1 9  4]]></tdml:document>
     <tdml:infoset>
@@ -490,7 +496,8 @@
 
   <tdml:parserTestCase name="DelimProp_07" model="initiatedContentSchema"
     description="Section 12 property delimiters, a whitespace separated list of initiators and terminators - DFDL-12-032R"
-    root="DP_07">
+    root="DP_07"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[+1,+2,+3,+4:-5.-6.-7.-8${{9;10;11;12]]::13|14|15|16]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -724,7 +731,8 @@
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="delims_ignorecase_01" root="e1"
-    model="ignoreCase" description="delimiters with ignore case">
+    model="ignoreCase" description="delimiters with ignore case"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[iixxaa1bbssaa2bbssaa3bbyytt]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/AI.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/AI.tdml
@@ -49,7 +49,8 @@
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="AI000" root="list"
-    model="AI.dfdl.xsd" description="AI - length kind pattern test - DFDL-12-038R">
+    model="AI.dfdl.xsd" description="AI - length kind pattern test - DFDL-12-038R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/DelimitedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/DelimitedTests.tdml
@@ -447,7 +447,8 @@ C</MessageHeaders>
 
   <tdml:parserTestCase name="Lesson4_delimited_fixed_length"
     root="address1" model="lengthKindDelimited-Embedded.dfdl.xsd"
-    description="delimited fixed length elements - DFDL-12-053R">
+    description="delimited fixed length elements - DFDL-12-053R"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[000118*Ridgewood Circle    *Rochester           *NY]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -489,7 +490,8 @@ C</MessageHeaders>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="NumSeq_00a" root="NS_00a"
-    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-048R">
+    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-048R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[1aab]]></tdml:document>
     <tdml:infoset>
@@ -635,7 +637,8 @@ C</MessageHeaders>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="NumSeq_07" root="NS_07"
-    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-043R">
+    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-043R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[.639,pqrs,27.44,vxyz,3.78,abcd,73,-289,-8476,-749]]></tdml:document>
     <tdml:infoset>
@@ -661,7 +664,8 @@ C</MessageHeaders>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="NumSeq_08" root="NS_07"
-    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-043R">
+    model="lengthKindDelimited-Embedded.dfdl.xsd" description="Section 12 lengthKind-delimited - DFDL-12-043R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[.639,pqrs,27.44,vxyz,3.78,abcd,73,-289,-5.89,hijk,-23,-8476,-749]]></tdml:document>
     <tdml:infoset>
@@ -712,7 +716,8 @@ C</MessageHeaders>
 
   <tdml:parserTestCase name="lengthKindDelimited_01"
     root="delim_01" model="lengthKindDelimited-Embedded.dfdl.xsd"
-    description="Section 12 lengthKind-delimited - use space character (0x20) as %WSP; - DFDL-12-048R">
+    description="Section 12 lengthKind-delimited - use space character (0x20) as %WSP; - DFDL-12-048R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[abcd  +
 		  efg]]></tdml:document>
@@ -729,7 +734,8 @@ C</MessageHeaders>
 
   <tdml:parserTestCase name="lengthKindDelimited_02"
     root="delim_01" model="lengthKindDelimited-Embedded.dfdl.xsd"
-    description="Section 12 lengthKind-delimited - use tab character (0x09) as %WSP; - DFDL-12-048R">
+    description="Section 12 lengthKind-delimited - use tab character (0x09) as %WSP; - DFDL-12-048R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[abcd		+
 				efg]]></tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -49,7 +49,8 @@
 	</tdml:defineSchema>
 
 	<tdml:parserTestCase name="Lesson1_lengthKind_explicit"
-		root="address" model="lengthKind_explicit" description="lengthKind='explicit' - DFDL-12-039R">
+		root="address" model="lengthKind_explicit" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document><![CDATA[000118Ridgewood Circle    Rochester           NY]]></tdml:document>
 		<tdml:infoset>
 			<tdml:dfdlInfoset>
@@ -129,7 +130,8 @@
 -->
 
 	<tdml:parserTestCase name="ExplicitLengthBitsNotFixed"
-		root="notFixed" model="test_ExplicitLengthBits" description="lengthKind='explicit' - DFDL-12-039R">
+		root="notFixed" model="test_ExplicitLengthBits" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="byte">00000180
 			</tdml:documentPart>
@@ -158,7 +160,8 @@
 -->
 
 	<tdml:parserTestCase name="ExplicitLengthBitsFixed"
-		root="fixed" model="test_ExplicitLengthBits" description="lengthKind='explicit' - DFDL-12-039R">
+		root="fixed" model="test_ExplicitLengthBits" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
 		</tdml:document>
@@ -256,7 +259,8 @@
 
 	<tdml:parserTestCase name="test_ExplicitLengthChildLengthLessParent_Chars"
 		root="fixed1" model="test_ExplicitLengthChildLengthLessParent"
-		description="lengthKind='explicit' - DFDL-12-039R">
+		description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="text"><![CDATA[123456789012345678901234567890]]></tdml:documentPart>
 		</tdml:document>
@@ -288,7 +292,8 @@
 
 	<tdml:parserTestCase name="test_ExplicitLengthChildLengthLessParent_Bytes"
 		root="fixed2" model="test_ExplicitLengthChildLengthLessParent"
-		description="lengthKind='explicit' - DFDL-12-039R">
+		description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="byte">00 0F 00 0F 00 0F 00 0F
 			</tdml:documentPart>
@@ -468,7 +473,8 @@
 	</tdml:defineSchema>
 
 	<tdml:parserTestCase name="test_ExplicitLengthBytesNotFixed"
-		root="notFixed" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R">
+		root="notFixed" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="byte">00000030
 			</tdml:documentPart>
@@ -490,7 +496,8 @@
 	</tdml:parserTestCase>
 
 	<tdml:parserTestCase name="test_ExplicitLengthBytesFixed"
-		root="fixed" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R">
+		root="fixed" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
 		</tdml:document>
@@ -518,7 +525,8 @@
 -->
 
   <tdml:parserTestCase name="ExplicitLengthBytesFixed50"
-    root="fixed_50" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R">
+    root="fixed_50" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NYXX000118Ridgewood Circle    Rochester           NYXX]]></tdml:documentPart>
     </tdml:document>
@@ -554,7 +562,8 @@
 	</tdml:parserTestCase>
 
 	<tdml:parserTestCase name="test_ExplicitLengthBytesChoiceRef"
-		root="choiceRef" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R">
+		root="choiceRef" model="test_ExplicitLengthBytes" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="byte">00000033
 			</tdml:documentPart>
@@ -684,7 +693,8 @@
 -->
 
 	<tdml:parserTestCase name="ExplicitLengthCharsNotFixed"
-		root="notFixed" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+		root="notFixed" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="byte">00000030
 			</tdml:documentPart>
@@ -713,7 +723,8 @@
 -->
 
 	<tdml:parserTestCase name="ExplicitLengthCharsFixed"
-		root="fixed" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+		root="fixed" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R"
+		roundTrip="twoPass">
 		<tdml:document>
 			<tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
 		</tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PatternTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PatternTests.tdml
@@ -603,7 +603,8 @@
   -->
   <tdml:parserTestCase name="LengthPatternIllegalBits_02_EncodingErrorPolicy_Replace"
     root="def_04" model="DFDL-207-Embedded.dfdl.xsd"
-    description="Section 12 lengthKind-pattern -c2c2 is an invalid code point in utf-8 - DFDL-12-088R">
+    description="Section 12 lengthKind-pattern -c2c2 is an invalid code point in utf-8 - DFDL-12-088R"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="byte">2121c2c22121</tdml:documentPart>
     </tdml:document>
@@ -700,7 +701,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="nested_patterns" root="list_04"
-    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R">
+    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[cat,dog,house.]]></tdml:document>
     <tdml:infoset>
@@ -717,7 +719,8 @@
 
   <tdml:parserTestCase name="nested_patterns_01"
     root="list_04" model="lengthKindPattern-Embedded.dfdl.xsd"
-    description="Section 12 lengthKind-pattern - DFDL-12-087R">
+    description="Section 12 lengthKind-pattern - DFDL-12-087R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">6361742C646F670D0A2C686F7573652E</tdml:documentPart>
@@ -735,7 +738,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="nested_patterns_02" root="list_05"
-    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R">
+    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[cat,dog,house,1.]]></tdml:document>
     <tdml:infoset>
@@ -752,7 +756,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="nested_patterns_03" root="list_05"
-    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R">
+    model="lengthKindPattern-Embedded.dfdl.xsd" description="Section 12 lengthKind-pattern - DFDL-12-087R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[cat,dog,house,b.]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-character-nils.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-character-nils.tdml
@@ -91,7 +91,8 @@
 
   <tdml:parserTestCase name="text_01ic" root="docIC"
     model="text_01"
-    description="Text_01 Two nilValues one length 1, other length 2, with ignorecase">
+    description="Text_01 Two nilValues one length 1, other length 2, with ignorecase"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0XxX]]></tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils.tdml
@@ -70,7 +70,8 @@
 
   <tdml:parserTestCase name="text_03" root="doc"
     model="text_03"
-    description="Text_03 Two nilValues one a regular value the other a CharEntity - DFDL-13-235R">
+    description="Text_03 Two nilValues one a regular value the other a CharEntity - DFDL-13-235R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,nil,;]]></tdml:documentPart>
@@ -90,7 +91,8 @@
 
   <tdml:parserTestCase name="text_03ic" root="docIC"
     model="text_03"
-    description="Text_03 nil values with ignore case - DFDL-13-235R">
+    description="Text_03 nil values with ignore case - DFDL-13-235R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[NIL,Nil,niL;]]></tdml:documentPart>
@@ -133,7 +135,8 @@
 
   <tdml:parserTestCase name="text_04" root="doc"
     model="text_04"
-    description="Text_04 Two nilValues one a regular value the other a WSP CharEntity - DFDL-13-235R">
+    description="Text_04 Two nilValues one a regular value the other a WSP CharEntity - DFDL-13-235R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,nil, ;]]></tdml:documentPart>
@@ -176,7 +179,8 @@
 
   <tdml:parserTestCase name="text_05" root="doc"
     model="text_05"
-    description="Text_05 Two nilValues one a regular value the other a CharEntity - DFDL-13-235R">
+    description="Text_05 Two nilValues one a regular value the other a CharEntity - DFDL-13-235R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,nil, ;]]></tdml:documentPart>
@@ -219,7 +223,8 @@
 
   <tdml:parserTestCase name="text_06" root="doc"
     model="text_06"
-    description="Text_06 Two nilValues one a regular value the other a WSP+ CharEntity - DFDL-13-235R">
+    description="Text_06 Two nilValues one a regular value the other a WSP+ CharEntity - DFDL-13-235R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,nil, 	 ;]]></tdml:documentPart>
@@ -313,7 +318,8 @@
   
     <tdml:parserTestCase name="test_padded_nils" root="doc"
     model="PaddedNils"
-    description="Verify that padding and nils work correctly">
+    description="Verify that padding and nils work correctly"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0PPP,PPPnil,PPP   PPP;]]></tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/nillable.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/nillable.tdml
@@ -169,7 +169,8 @@
 
   <tdml:parserTestCase name="litNil2" root="doc"
     model="s1"
-    description="literal nil is a DFDL character class entity %ES; - DFDL-13-234R">
+    description="literal nil is a DFDL character class entity %ES; - DFDL-13-234R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,;]]></tdml:documentPart>
@@ -187,7 +188,8 @@
 
   <tdml:parserTestCase name="litNil3" root="doc_01"
     model="s1"
-    description="literal nil is a DFDL character class entity %ES; - DFDL-13-234R">
+    description="literal nil is a DFDL character class entity %ES; - DFDL-13-234R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,:;]]></tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/packed/packed.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/packed/packed.tdml
@@ -696,7 +696,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="DelimitedPackedIntSeq" root="packedIntSeq" model="s14"
-    description="Parsing a delimited sequence of the various packed formats">
+    description="Parsing a delimited sequence of the various packed formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">003C 2A 123D 3B</tdml:documentPart>
@@ -712,7 +713,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="DelimitedPackedDecSeq" root="packedDecSeq" model="s14"
-    description="Parsing a delimited sequence of the various packed formats">
+    description="Parsing a delimited sequence of the various packed formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">003C 2A 123D 3B</tdml:documentPart>
@@ -763,7 +765,8 @@
   </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="DelimitedBCDIntSeq" root="bcdIntSeq" model="s14"
-    description="Parsing a delimited sequence of the various bcd formats">
+    description="Parsing a delimited sequence of the various bcd formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">0003 2C 0123 3B</tdml:documentPart>
@@ -779,7 +782,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="DelimitedBCDDecSeq" root="bcdDecSeq" model="s14"
-    description="Parsing a delimited sequence of the various bcd formats">
+    description="Parsing a delimited sequence of the various bcd formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">0003 2C 0123 3B</tdml:documentPart>
@@ -830,7 +834,8 @@
 
 
   <tdml:parserTestCase name="DelimitedIBM4690IntSeq" root="ibmIntSeq" model="s14"
-    description="Parsing a delimited sequence of the various ibm formats">
+    description="Parsing a delimited sequence of the various ibm formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">FFF3 2C D123 3B</tdml:documentPart>
@@ -846,7 +851,8 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="DelimitedIBM4690DecSeq" root="ibmDecSeq" model="s14"
-    description="Parsing a delimited sequence of the various ibm formats">
+    description="Parsing a delimited sequence of the various ibm formats"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">FFF3 2C D123 3B</tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -499,7 +499,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberPattern_negativeIgnored04" root="tnp09" model="textNumberPattern"
-    description="Section 13.6 - Number properties with Text Representation - DFDL-13-073R">
+    description="Section 13.6 - Number properties with Text Representation - DFDL-13-073R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">******$123456 is negative!</tdml:documentPart>
@@ -543,7 +544,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberPattern_negativeIgnored06" root="tnp30" model="textNumberPattern"
-    description="Section 13.6 - Number properties with Text Representation - DFDL-13-073R">
+    description="Section 13.6 - Number properties with Text Representation - DFDL-13-073R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">(0.43E3)</tdml:documentPart>
@@ -564,7 +566,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberPattern_exponent01" root="tnp05" model="textNumberPattern"
-    description="Section 13.6 - Number properties with Text Representation - DFDL-13-067.1R">
+    description="Section 13.6 - Number properties with Text Representation - DFDL-13-067.1R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">006.54E9</tdml:documentPart>
@@ -781,7 +784,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax02" root="tnp10" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[           0052    ]]></tdml:documentPart>
@@ -803,7 +807,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax03" root="tnp10" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[        000052    ]]></tdml:documentPart>
@@ -868,7 +873,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax06" root="tnp31" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[    00003352    ]]></tdml:documentPart>
@@ -890,7 +896,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax07" root="tnp32" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[00003352    ]]></tdml:documentPart>
@@ -912,7 +919,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax08" root="tnp33" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[00003352]]></tdml:documentPart>
@@ -934,7 +942,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax09" root="tnp34" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[03]]></tdml:documentPart>
@@ -1110,7 +1119,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax17" root="tnp36" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[          3352]]></tdml:documentPart>
@@ -1156,7 +1166,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_strict02" root="tnp11" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[    52    ]]></tdml:documentPart>
@@ -1179,7 +1190,8 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_strict03" root="tnp13" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[052]]></tdml:documentPart>
@@ -1223,7 +1235,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_strict05" root="tnp13" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[000000000005]]></tdml:documentPart>
@@ -2220,7 +2233,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding01" root="tnp54" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-092R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-092R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx5,000</tdml:documentPart>
@@ -2300,7 +2314,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding05" root="tnp56" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-092R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-092R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">                 12 o'clock</tdml:documentPart>
@@ -2320,7 +2335,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding06" root="tnp57" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-096R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-096R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">data:                           4,999</tdml:documentPart>
@@ -2340,7 +2356,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding07" root="tnp57" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-096R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-096R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">(data:                           4,999)</tdml:documentPart>
@@ -2360,7 +2377,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding08" root="tnp58" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-096R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-096R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">4>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> right</tdml:documentPart>
@@ -2380,7 +2398,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding09" root="tnp59" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-096R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-096R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">8 Items$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$</tdml:documentPart>
@@ -2420,7 +2439,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding11" root="tnp61" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-097R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-097R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">******9</tdml:documentPart>
@@ -2440,7 +2460,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_padding12" root="tnp62" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-097R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-097R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">######2</tdml:documentPart>
@@ -2481,7 +2502,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo01" root="tnp64" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">********++++5</tdml:documentPart>
@@ -2502,7 +2524,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo02" root="tnp65" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****5*****</tdml:documentPart>
@@ -2523,7 +2546,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo03" root="tnp66" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end****</tdml:documentPart>
@@ -2544,7 +2568,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo04" root="tnp67" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">***********************************************************************************************************************************************************************************3</tdml:documentPart>
@@ -2565,7 +2590,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo05" root="tnp68" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">-500</tdml:documentPart>
@@ -2586,7 +2612,8 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_paddingCombo06" root="tnp68" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">----500</tdml:documentPart>
@@ -2606,7 +2633,8 @@
   -->
 
   <tdml:parserTestCase name="decimalPadding01" root="decimalPad" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end****</tdml:documentPart>
@@ -2647,7 +2675,8 @@
   -->
 
   <tdml:parserTestCase name="decimalPadding03" root="intPad" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end****</tdml:documentPart>
@@ -2668,7 +2697,8 @@
   -->
 
   <tdml:parserTestCase name="decimalPadding04" root="decimalPad2" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****4****</tdml:documentPart>
@@ -2689,7 +2719,8 @@
   -->
 
   <tdml:parserTestCase name="decimalPadding05" root="decimalPad3" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end</tdml:documentPart>
@@ -2729,7 +2760,8 @@
   -->
 
   <tdml:parserTestCase name="nonNegIntPadding01" root="nonNegIntPad" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end****</tdml:documentPart>
@@ -2770,7 +2802,8 @@
   -->
 
   <tdml:parserTestCase name="nonNegIntPadding03" root="nonNegIntPad2" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****4****</tdml:documentPart>
@@ -2791,7 +2824,8 @@
   -->
 
   <tdml:parserTestCase name="nonNegIntPadding04" root="nonNegIntPad3" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">****begin: 4 :end</tdml:documentPart>
@@ -2975,7 +3009,8 @@
    -->
 
   <tdml:parserTestCase name="standardZeroRep02" root="tnp78" model="textNumberPattern"
-    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R">
+    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">NAUGHT</tdml:documentPart>
@@ -2996,7 +3031,8 @@
   -->
 
   <tdml:parserTestCase name="standardZeroRep03" root="tnp79" model="textNumberPattern"
-    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R">
+    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">ZERO</tdml:documentPart>
@@ -3017,7 +3053,8 @@
   -->
 
   <tdml:parserTestCase name="standardZeroRep04" root="tnp80" model="textNumberPattern"
-    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R">
+    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">*****nil</tdml:documentPart>
@@ -3076,7 +3113,8 @@
   -->
 
   <tdml:parserTestCase name="standardZeroRep06" root="tnp81" model="textNumberPattern"
-    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R">
+    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="byte">7F</tdml:documentPart>
@@ -3154,7 +3192,8 @@
   -->
 
   <tdml:parserTestCase name="standardZeroRep10" root="tnp85" model="textNumberPattern"
-    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R">
+    description="Section 13.6 - textStandardZeroRep - DFDL-13-058R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">nil</tdml:documentPart>
@@ -4068,7 +4107,8 @@
 
   <tdml:parserTestCase name="zero" root="zero"
     model="textprops"
-    description="Test zero repreentations">
+    description="Test zero repreentations"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[NIL|ZILCH|ZERO|5|0]]]></tdml:documentPart>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -492,7 +492,7 @@
   </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="parse_int_01" root="e1"
-    model="pattern" description="" roundTrip="true">
+    model="pattern" description="" roundTrip="twoPass">
 
     <tdml:document><![CDATA[1576]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -469,7 +469,8 @@
   -->
 
   <tdml:parserTestCase name="hiddenGroupChoice2" root="e"
-    model="hiddenGroupChoice" description="Section 14 - Hidden Groups - DFDL-14-042R">
+    model="hiddenGroupChoice" description="Section 14 - Hidden Groups - DFDL-14-042R"
+    roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[stringy,2]]></tdml:documentPart>
     </tdml:document>
@@ -887,7 +888,8 @@ Date: Mon Feb 23 15:20:47 CST 2009
   </tdml:defineSchema>
   
   <tdml:parserTestCase name="AD000" root="list" model="AD-Embedded"
-    description="occursCount with expressions">
+    description="occursCount with expressions"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[3
 first x
 second x
@@ -1138,7 +1140,8 @@ A,B,C|D,E,F|G,H,I]]></tdml:document>
   </tdml:defineSchema>
 
 	<tdml:parserTestCase name="nestedGroupRefs2" root="root"
-		model="nestedGroupRefs2" description="Verify that nested hidden groups and choices work correctly - DFDL-14-039R">
+		model="nestedGroupRefs2" description="Verify that nested hidden groups and choices work correctly - DFDL-14-039R"
+		roundTrip="twoPass">
 
 		<tdml:document><![CDATA[A,B,C,1,x|D,E,F,2,y|G,H,I,3,z
 A,B,C,x,1|D,E,F,y,2|G,H,I,z,3

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupDelimiters.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupDelimiters.tdml
@@ -112,7 +112,8 @@
   <tdml:parserTestCase name="SeqGrp_01"
     model="SequenceGroupDelimiters-Embedded.dfdl.xsd"
     description="Section 14 Sequence groups with delimiters, a whitespace separated list for separator - DFDL-14-008R"
-    root="SG_01">
+    root="SG_01"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[1,2,3,4:5.6.7.8$9;10;11;12::13|14|15|16]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -159,7 +160,8 @@
 
   <tdml:parserTestCase name="SeqGrp_03" root="SG_03"
     model="SequenceGroupDelimiters-Embedded.dfdl.xsd"
-    description="Section 14 Sequence groups with delimiters -multiple separators - DFDL-14-008R">
+    description="Section 14 Sequence groups with delimiters -multiple separators - DFDL-14-008R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[1,,2,,,3,4]]></tdml:document>
     <tdml:infoset>
@@ -500,7 +502,8 @@
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="lastElts" root="testLastElts" 
-    model="lastElts" description="test for last optional element contains the separator, but is not escaped.">
+    model="lastElts" description="test for last optional element contains the separator, but is not escaped."
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[G2  R1

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
@@ -309,7 +309,8 @@
 
   <tdml:parserTestCase name="initiatedContentChoice6"
     description="initiatedContent with delimited elements - - DFDL-15-003R"
-    model="s1" root="e3">
+    model="s1" root="e3"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[[1789 (3.25]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -327,7 +328,8 @@
 
   <tdml:parserTestCase name="initiatedContentChoice7"
     description="same as initiatedConten6 except initiatedContent='no' - - DFDL-15-003R"
-    model="s1" root="e4">
+    model="s1" root="e4"
+    roundTrip="twoPass">
     <tdml:document><![CDATA[[1789 [3.25]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/ArrayOptionalElem.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/ArrayOptionalElem.tdml
@@ -191,7 +191,8 @@
   
   <tdml:parserTestCase name="Lesson6_fixed_array"
     description="occursCountKind 'fixed' - DFDL-16-002R"
-    model="arrays_optional_elements.dfdl.xsd" root="address1">
+    model="arrays_optional_elements.dfdl.xsd" root="address1"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[000118Ridgewood Circle    Main Street         Rochester           NYUSA                 ]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -3045,7 +3045,8 @@ c]]></value>
   -->
   
   <tdml:parserTestCase name="expressionRules05" root="e_05"
-    model="expressionRules" description="Section 6 - DFDL Expressions - DFDL-06-078R">
+    model="expressionRules" description="Section 6 - DFDL Expressions - DFDL-06-078R"
+    roundTrip="twoPass">
 
     <tdml:document>123{456{{789[123</tdml:document>
     <tdml:infoset>
@@ -3240,7 +3241,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="whitespace_expression2" root="ws_expr2"
-    model="expressions-Embedded.dfdl.xsd" description="Section 6 - DFDL Expressions - DFDL-06-078R">
+    model="expressions-Embedded.dfdl.xsd" description="Section 6 - DFDL Expressions - DFDL-06-078R"
+    roundTrip="twoPass">
 
     <tdml:document>3]4=5]</tdml:document>
     <tdml:infoset>
@@ -3401,7 +3403,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="comparison_operators_08" root="e5"
-    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1">
+    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1"
+    roundTrip="twoPass">
 
     <tdml:document>7.509,7.510</tdml:document>
     <tdml:infoset>
@@ -4489,7 +4492,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="sequential_and_or_02" root="e6"
-    model="and_or_schema" description="Section 23 - DFDL Expressions - DFDL-23-067R">
+    model="and_or_schema" description="Section 23 - DFDL Expressions - DFDL-23-067R"
+    roundTrip="twoPass">
 
     <tdml:document>abc,abc,1.0,5</tdml:document>
     <tdml:infoset>
@@ -5990,7 +5994,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="comparison_operators_46" root="e35"
-    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1">
+    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2000-01-01T12:00:00,1999-12-31T23:00:00+00:00]]></tdml:document>
     <tdml:infoset>
@@ -6131,7 +6136,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="comparison_operators_52" root="e36"
-    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1">
+    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[1999-12-31T24:00:00-05:00,2000-01-01T00:00:00-05:00]]></tdml:document>
     <tdml:infoset>
@@ -6154,7 +6160,8 @@ c]]></value>
   -->
 
   <tdml:parserTestCase name="comparison_operators_53" root="e36"
-    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1">
+    model="comparisonOperators" description="Section 23 - DFDL Expressions - DFDL-23-068R1"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[2005-04-04T24:00:00-05:00,2005-04-04T00:00:00-05:00]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/functions.tdml
@@ -133,7 +133,8 @@
 -->
   
   <tdml:parserTestCase name="dateTimeFunctions02" root="dtFunctions"
-    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R">
+    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[03-36-1988 04:55:23]]></tdml:document>
     <tdml:infoset>
@@ -182,7 +183,8 @@
 -->
   
   <tdml:parserTestCase name="dateFunctions02" root="dFunctions"
-    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R">
+    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[02-30-2012]]></tdml:document>
     <tdml:infoset>
@@ -205,7 +207,8 @@
 -->
   
   <tdml:parserTestCase name="timeFunctions01" root="tFunctions"
-    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R">
+    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[12:44:56GMT]]></tdml:document>
     <tdml:infoset>
@@ -228,7 +231,8 @@
 -->
   
   <tdml:parserTestCase name="timeFunctions02" root="tFunctions"
-    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R">
+    model="dateTimeSchema" description="Section 23 Expressions - Date, Time functions - DFDL-23-109R"
+    roundTrip="twoPass">
 
     <tdml:document><![CDATA[12:62:56GMT]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -22,7 +22,7 @@
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:math="http://www.w3.org/2005/xpath-functions/math"
   xmlns:ex="http://example.com"
-  defaultRoundTrip="true">
+  defaultRoundTrip="onePass">
     
   <tdml:defineSchema name="Functions.dfdl.xsd">
     <dfdl:format ref="ex:GeneralFormat" initiator=""
@@ -2436,7 +2436,8 @@
 -->
 
   <tdml:parserTestCase name="xfromdatetime_02" root="e_xfromdatetime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-dateTime - DFDL-23-109R, fn:month-from-dateTime - DFDL-23-110R, fn:day-from-dateTime - DFDL-23-111R, fn:hours-from-dateTime - DFDL-23-112R, fn:minutes-from-dateTime - DFDL-23-113R, fn:seconds-from-dateTime - DFDL-23-114R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-dateTime - DFDL-23-109R, fn:month-from-dateTime - DFDL-23-110R, fn:day-from-dateTime - DFDL-23-111R, fn:hours-from-dateTime - DFDL-23-112R, fn:minutes-from-dateTime - DFDL-23-113R, fn:seconds-from-dateTime - DFDL-23-114R"
+    roundTrip="twoPass">
 
     <tdml:document>2013-12-31T23:62:30</tdml:document>
     <tdml:infoset>
@@ -2463,7 +2464,8 @@
 -->
 
   <tdml:parserTestCase name="xfromdatetime_03" root="e_xfromdatetime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-dateTime - DFDL-23-109R, fn:month-from-dateTime - DFDL-23-110R, fn:day-from-dateTime - DFDL-23-111R, fn:hours-from-dateTime - DFDL-23-112R, fn:minutes-from-dateTime - DFDL-23-113R, fn:seconds-from-dateTime - DFDL-23-114R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-dateTime - DFDL-23-109R, fn:month-from-dateTime - DFDL-23-110R, fn:day-from-dateTime - DFDL-23-111R, fn:hours-from-dateTime - DFDL-23-112R, fn:minutes-from-dateTime - DFDL-23-113R, fn:seconds-from-dateTime - DFDL-23-114R"
+    roundTrip="twoPass">
 
     <tdml:document>0100-13-12T24:11:99</tdml:document>
     <tdml:infoset>
@@ -2681,7 +2683,8 @@
 -->
 
   <tdml:parserTestCase name="xfromdate_02" root="e_xfromdate2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-date - DFDL-23-115R, fn:month-from-date - DFDL-23-116R, fn:day-from-date - DFDL-23-117R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-date - DFDL-23-115R, fn:month-from-date - DFDL-23-116R, fn:day-from-date - DFDL-23-117R"
+    roundTrip="twoPass">
 
     <tdml:document>2008-09-31</tdml:document>
     <tdml:infoset>
@@ -2705,7 +2708,8 @@
 -->
 
   <tdml:parserTestCase name="xfromdate_03" root="e_xfromdate1"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-date - DFDL-23-115R, fn:month-from-date - DFDL-23-116R, fn:day-from-date - DFDL-23-117R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:year-from-date - DFDL-23-115R, fn:month-from-date - DFDL-23-116R, fn:day-from-date - DFDL-23-117R"
+    roundTrip="twoPass">
 
     <tdml:document>-0020-01-99</tdml:document>
     <tdml:infoset>
@@ -2747,7 +2751,8 @@
 -->
 
   <tdml:parserTestCase name="hoursfromtime_02" root="e_hoursfromtime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R"
+    roundTrip="twoPass">
 
     <tdml:document>23:00:00+00:00</tdml:document>
     <tdml:infoset>
@@ -2786,7 +2791,8 @@
 -->
 
   <tdml:parserTestCase name="minutesfromtime_02" root="e_minutesfromtime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:minutes-from-time - DFDL-23-119R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:minutes-from-time - DFDL-23-119R"
+    roundTrip="twoPass">
 
     <tdml:document>23:59:00+00:00</tdml:document>
     <tdml:infoset>
@@ -2825,7 +2831,8 @@
 -->
 
   <tdml:parserTestCase name="secondsfromtime_02" root="e_secondsfromtime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:seconds-from-time - DFDL-23-120R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:seconds-from-time - DFDL-23-120R"
+    roundTrip="twoPass">
 
     <tdml:document>23:00:48+00:00</tdml:document>
     <tdml:infoset>
@@ -2846,7 +2853,8 @@
 -->
 
   <tdml:parserTestCase name="xfromtime_01" root="e_xfromtime1"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R"
+    roundTrip="twoPass">
 
     <tdml:document>24:00:00+00:00</tdml:document>
     <tdml:infoset>
@@ -2870,7 +2878,8 @@
 -->
 
   <tdml:parserTestCase name="xfromtime_02" root="e_xfromtime2"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R"
+    roundTrip="twoPass">
 
     <tdml:document>01:75:18.743-04:00</tdml:document>
     <tdml:infoset>
@@ -2894,7 +2903,8 @@
 -->
 
   <tdml:parserTestCase name="xfromtime_03" root="e_xfromtime1"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:hours-from-time - DFDL-23-118R, fn:minutes-from-time - DFDL-23-119R, fn:seconds-from-time - DFDL-23-120R"
+    roundTrip="twoPass">
 
     <tdml:document>12:13:14+00:00</tdml:document>
     <tdml:infoset>
@@ -3666,7 +3676,8 @@
 -->
 
   <tdml:parserTestCase name="valueLength_0" root="valueLength"
-    model="Functions.dfdl.xsd" description="Section 23 ">
+    model="Functions.dfdl.xsd" description="Section 23 "
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[////test////]]></tdml:documentPart>
@@ -3690,7 +3701,8 @@
 -->
 
   <tdml:parserTestCase name="valueLength_1" root="valueLength2"
-    model="Functions.dfdl.xsd" description="Section 23 ">
+    model="Functions.dfdl.xsd" description="Section 23 "
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[////test////]]></tdml:documentPart>
@@ -3744,7 +3756,8 @@
 -->
 
   <tdml:parserTestCase name="valueLength_3" root="valueLength4"
-    model="Functions.dfdl.xsd" description="Section 23 ">
+    model="Functions.dfdl.xsd" description="Section 23 "
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[/te*,st!*;]]></tdml:documentPart>
@@ -4018,7 +4031,8 @@
 -->
 
   <tdml:parserTestCase name="valueContentLength1" root="valueContentLength1"
-    model="Functions-binary.dfdl.xsd" description="dfdl:valueLength and dfdl:contentLength functions.">
+    model="Functions-binary.dfdl.xsd" description="dfdl:valueLength and dfdl:contentLength functions."
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10101000 01010100 110011</tdml:documentPart>
@@ -4053,7 +4067,8 @@
 -->
 
   <tdml:parserTestCase name="valueContentLength2" root="valueContentLength2"
-    model="Functions-binary.dfdl.xsd" description="dfdl:outputValueCalc and dfdl:valueLength during parse.">
+    model="Functions-binary.dfdl.xsd" description="dfdl:outputValueCalc and dfdl:valueLength during parse."
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="bits">10101000 01010100 110011</tdml:documentPart>
@@ -5882,7 +5897,8 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_02" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3.455,2</tdml:documentPart>
@@ -5908,7 +5924,8 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_03" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3.00865,4</tdml:documentPart>
@@ -5933,7 +5950,8 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_04" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3.00065,4</tdml:documentPart>
@@ -5958,7 +5976,8 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_05" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
+    roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">3.000065,5</tdml:documentPart>
@@ -13247,7 +13266,8 @@
 -->
 
   <tdml:parserTestCase name="timezonefromtime_03" root="e_timezonefromtime3"
-    model="Functions.dfdl.xsd" description="Section 23 - Functions - dfdl:timeZoneFromTime - DFDL-23-109R">
+    model="Functions.dfdl.xsd" description="Section 23 - Functions - dfdl:timeZoneFromTime - DFDL-23-109R"
+    roundTrip="twoPass">
 
     <tdml:document>04:17:09+07:00</tdml:document>
     <tdml:infoset>

--- a/tutorials/src/main/resources/tdmlTutorial.tdml.xml
+++ b/tutorials/src/main/resources/tdmlTutorial.tdml.xml
@@ -125,10 +125,18 @@ community by IBM. (It is built into the Daffodil software.)
  test case will actually test parsing and unparsing, but as it is a parser
  test case, it begins with parsing the data to an infoset, then unparses it
  and checks that it gets back the original data. 
+ <br />
+ Except, that it won't get back the exact original data. The Time Zone notation won't 
+ be reproduced exactly. What is unparsed is equivalent to the original, but not identical.
+ So this pass requires that we do a second parse pass, and
+ verify that we get the infoset back that we expected. That is, what was unparsed
+ can be reparsed back to the same infoset. So this test specifies the roundTrip="twoPass"
+ attribute which overrides the default behavior of the suite.
  </p></tdml:tutorial>
 
   <tdml:parserTestCase name="dateTimeTest" root="myTestRoot" model="s1" 
-    description="Test of date/time. Runs round trip (parse and unparse) because that is the default for this test suite.">
+    description="Test of date/time. Runs round trip (parse and unparse) because that is the default for this test suite."
+    roundTrip="twoPass">
 
     <tdml:tutorial xml:space="preserve"><p>
 The data for your test is given by the tdml:document element, which optionally 


### PR DESCRIPTION
Added feature where tests are explicit about number of roundTrip tries.

I needed this feature to help with debugging the 100+ test failures I was getting in debugging the new separator/suppression implementation. But I did this change on a separate branch. 

This changes the TDML runner so that tests now must be explicit about how many passes.

This applies only to positive parse test cases. No changes for unparser tests or negative tests.

The roundTrip (and defaultRoundTrip) attributes now take these values:

"none" or "false" - no round trip

"simple" or "true" - parse - infoset must match, unparse - data must match original data exactly. This is the default behavior unless overridden with defaultRoundTrip property of test suite. 

"twoPass" - parse - infoset must match, unparse - data must NOT match original, parse - infoset must match. 

320+ tests required change from simple to twoPass.

DAFFODIL-1961