### PR TITLE
Reduce memory usage regressions in commit 07ee2434bb

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -18,8 +18,6 @@
 package org.apache.daffodil.processors.parsers
 
 import java.nio.channels.Channels
-import java.nio.CharBuffer
-import java.nio.LongBuffer
 
 import scala.Right
 import scala.collection.mutable
@@ -322,9 +320,7 @@ final class PState private (
     }
   }
 
-  // TODO: this should come from a thread safe pool or something so that we do not allocate it for every parse
-  override lazy val regexMatchBuffer = CharBuffer.allocate(tunable.maximumRegexMatchLengthInCharacters)
-  override lazy val regexMatchBitPositionBuffer = LongBuffer.allocate(tunable.maximumRegexMatchLengthInCharacters)
+  override lazy val (regexMatchBuffer, regexMatchBitPositionBuffer) = dataProcArg.regexMatchState.get
 }
 
 object PState {


### PR DESCRIPTION
The modifications to the IO layer to support streaming made changes
that substantially increased memory usage. This makes the following
changes to minimize that:

- No longer save the char iterator state. Saving this state required
  duplication a LongBuffer and CharBuffer, which are two non-trivial
  allocations/copies for every point of uncertainty. This really adds up
  for some file types. Instead, never save the char iterator state. When
  the bit position changes due to resetting a mark, we will just clear
  the char iterator state and decode data again. This does mean some
  data might be decoded twice if we backtrack, but that should be
  relatively quick, and means we only take a hit when we backtrack
  instead of every time there is a point of uncertainty.
- The regexMatch buffers are intentionally large to match long patterns.
  Unfortunately, the PState was changed so that every PState allocated
  its own regex buffers, which resulted in a lot of large allocations.
  Instead, modify the DataProcessor to store ThreadLocal state for the
  regex buffers, and the PState access that state when necessary. So we
  will no only have large regex buffers for each Thread rather than each
  call to parse.
- For every file parsed in the CLI performance command, we allocated a
  new InputSourceDataInputStream before doing any performance testing.
  So if you wanted to do a performance test of 500,000 files, we would
  allocate 500,000 InputSourceDataInputStreams immediately. This class
  isn't huge, but it can add up pretty quick and use a lot of memory.
  Instead, just allocate the InputSourceDataInputStream right before the
  call to parse so that it can be garbage collected when the parse ends.

DAFFODIL-1966