### PR TITLE
Adding value of 'bcd' to binaryCalendarRep

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertBinaryCalendarUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertBinaryCalendarUnparser.scala
@@ -17,16 +17,29 @@
 
 package org.apache.daffodil.processors.unparsers
 
+import java.lang.{ Long => JLong }
+import java.math.{ BigDecimal => JBigDecimal }
+import java.math.{ BigInteger => JBigInteger }
+
 import org.apache.daffodil.calendar.DFDLCalendar
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.io.DataOutputStream
 import org.apache.daffodil.io.FormatInfo
+import org.apache.daffodil.processors.CalendarEv
+import org.apache.daffodil.processors.CalendarLanguageEv
 import org.apache.daffodil.processors.ElementRuntimeData
+import org.apache.daffodil.processors.Evaluatable
+import org.apache.daffodil.processors.parsers.ConvertTextCalendarProcessorBase
+import org.apache.daffodil.processors.parsers.HasKnownLengthInBits
+import org.apache.daffodil.processors.parsers.HasRuntimeExplicitLength
 import org.apache.daffodil.schema.annotation.props.gen.BinaryCalendarRep
+import org.apache.daffodil.schema.annotation.props.gen.LengthUnits
+import org.apache.daffodil.util.DecimalUtils
 import org.apache.daffodil.util.Maybe.One
 import org.apache.daffodil.util.Misc
 
 import com.ibm.icu.util.Calendar
+import com.ibm.icu.util.ULocale
 
 case class ConvertBinaryCalendarSecMilliUnparser(
   override val context: ElementRuntimeData,
@@ -51,7 +64,7 @@ case class ConvertBinaryCalendarSecMilliUnparser(
 
     val calValue = node.dataValue match {
       case dc: DFDLCalendar => dc.calendar
-      case x => Assert.invariantFailed("ConvertTextCalendar received unsupported type. %s of type %s.".format(x, Misc.getNameFromClass(x)))
+      case x => Assert.invariantFailed("ConvertBinaryCalendar received unsupported type. %s of type %s.".format(x, Misc.getNameFromClass(x)))
     }
 
     // Adjust the time based on time zone - if a time zone wasn't specified, Calendar will assume the default
@@ -81,4 +94,111 @@ case class ConvertBinaryCalendarSecMilliUnparser(
         context.dpathElementCompileInfo.namedQName.toPrettyString, lengthInBits, dos.maybeRelBitLimit0b.get)
     }
   }
+}
+
+abstract class BinaryCalendarBCDUnparser (
+  override val context: ElementRuntimeData,
+  pattern: String,
+  localeEv: CalendarLanguageEv,
+  calendarEv: CalendarEv)
+  extends ConvertTextCalendarProcessorBase {
+
+  protected def fromBigInteger(bigInt: JBigInteger, nBits: Int): Array[Byte] = DecimalUtils.bcdFromBigInteger(bigInt, nBits)
+
+  protected def putNumber(dos: DataOutputStream, bigDec: JBigDecimal, nBits: Int, finfo: FormatInfo): Boolean = {
+    val packedNum = fromBigInteger(bigDec.unscaledValue, nBits)
+    dos.putByteArray(packedNum, packedNum.length * 8, finfo)
+  }
+
+  def doUnparse(state: UState, bitLength: Int): Unit = {
+
+    val locale: ULocale = localeEv.evaluate(state)
+    val calendar: Calendar = calendarEv.evaluate(state)
+
+    calendar.clear()
+
+    val df = tlDataFormatter(locale, calendar)
+    df.setCalendar(calendar)
+
+    val node = state.currentInfosetNode.asSimple
+
+    val calValue = node.dataValue match {
+      case dc: DFDLCalendar => dc.calendar
+      case x => Assert.invariantFailed("ConvertBinaryCalendar received unsupported type. %s of type %s.".format(x, Misc.getNameFromClass(x)))
+    }
+
+    val str: String = df.format(calValue)
+
+    val strAsBigDec: JBigDecimal = DecimalUtils.bcdToBigDecimal(DecimalUtils.bcdFromBigInteger(new JBigInteger(str), 0), 0)
+
+    val dos = state.dataOutputStream
+    val res = putNumber(dos, strAsBigDec, bitLength, state)
+
+    if (!res) {
+      Assert.invariant(dos.maybeRelBitLimit0b.isDefined)
+      UnparseError(One(state.schemaFileLocation), One(state.currentLocation), "Insufficient space to unparse element %s, required %s bits, but only %s were available.",
+        context.dpathElementCompileInfo.namedQName.toPrettyString, bitLength, dos.maybeRelBitLimit0b.get)
+    }
+  }
+}
+
+case class BinaryCalendarBCDKnownLengthUnparser(
+  override val context: ElementRuntimeData,
+  lengthInBits: Int,
+  pattern: String,
+  localeEv: CalendarLanguageEv,
+  calendarEv: CalendarEv)
+  extends BinaryCalendarBCDUnparser(context, pattern, localeEv, calendarEv)
+  with PrimUnparser
+  with HasKnownLengthInBits {
+
+  /**
+   * Primitive unparsers must override runtimeDependencies
+   */
+  override lazy val runtimeDependencies = Seq(localeEv, calendarEv)
+
+  def unparse(state: UState): Unit = {
+    doUnparse(state, lengthInBits)
+  }
+}
+
+case class BinaryCalendarBCDRuntimeLengthUnparser(
+  override val e: ElementRuntimeData,
+  pattern: String,
+  localeEv: CalendarLanguageEv,
+  calendarEv: CalendarEv,
+  val lengthEv: Evaluatable[JLong],
+  val lUnits: LengthUnits)
+  extends BinaryCalendarBCDUnparser(e, pattern, localeEv, calendarEv)
+  with PrimUnparser
+  with HasRuntimeExplicitLength {
+
+  /**
+   * Primitive unparsers must override runtimeDependencies
+   */
+  override lazy val runtimeDependencies = Seq(localeEv, calendarEv, lengthEv)
+
+  def unparse(state: UState): Unit = {
+    doUnparse(state, getBitLength(state))
+  }
+
+}
+
+case class BinaryCalendarBCDDelimitedLengthUnparser(
+  val e: ElementRuntimeData,
+  pattern: String,
+  localeEv: CalendarLanguageEv,
+  calendarEv: CalendarEv)
+  extends BinaryCalendarBCDUnparser(e, pattern, localeEv, calendarEv)
+  with PrimUnparser {
+
+  /**
+   * Primitive unparsers must override runtimeDependencies
+   */
+  override lazy val runtimeDependencies = Seq(localeEv, calendarEv)
+
+  def unparse(state: UState): Unit = {
+    doUnparse(state, 0)
+  }
+
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextCalendarUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextCalendarUnparser.scala
@@ -28,11 +28,11 @@ import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.util.Misc
 import org.apache.daffodil.processors.parsers.ConvertTextCalendarProcessorBase
 
-case class ConvertTextCalendarUnparser(erd: ElementRuntimeData,
+case class ConvertTextCalendarUnparser(context: ElementRuntimeData,
   pattern: String,
   localeEv: CalendarLanguageEv,
   calendarEv: CalendarEv)
-  extends ConvertTextCalendarProcessorBase(erd, pattern)
+  extends ConvertTextCalendarProcessorBase
   with TextPrimUnparser {
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/PackedBinaryTraits.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/PackedBinaryTraits.scala
@@ -169,7 +169,7 @@ abstract class PackedBinaryDecimalDelimitedBaseParser(
       } else {
         try {
           val num = toBigDecimal(fieldBytes, binaryDecimalVirtualPoint)
-          state.simpleElement.setDataValue(num)
+          writeResult(state, num)
         } catch {
           case n: NumberFormatException => PE(state, "Error in packed data: \n%s", n.getMessage())
         }
@@ -178,5 +178,9 @@ abstract class PackedBinaryDecimalDelimitedBaseParser(
       }
       return
     }
+  }
+
+  def writeResult(state: PState, num: BigDecimal) {
+    state.simpleElement.setDataValue(num)
   }
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -263,9 +263,62 @@
       dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="2000-1-1T00:00"/>
     <xs:element name="dateTimeBin11" type="xs:dateTime" dfdl:lengthKind="implicit" dfdl:lengthUnits="bytes"
       dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="01-01-2000T00:00:00"/>
+    <xs:element name="dateTimeBin12" type="xs:dateTime" dfdl:lengthKind="delimited" dfdl:terminator=";"
+      dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1977-01-01T00:00:07"/>
 
-    <xs:element name="dateBin2" type="xs:date" dfdl:lengthKind="explicit" dfdl:length="{ 4 }"
-      dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1970-01-01T00:00:00+00:00"/>
+    <xs:element name="dateBinBCD" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="dateBinBCD2" type="xs:date" dfdl:calendarPattern="MMddyyyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="dateBinBCD3" type="xs:date" dfdl:calendarPattern="MM-dd-yy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="dateBinBCD4" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="bcd"/>
+
+    <xs:element name="timeBinBCD" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="timeBinBCD2" type="xs:time" dfdl:calendarPattern="HHmmssSSSS" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 5 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="timeBinBCD3" type="xs:time" dfdl:calendarPatternKind="implicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 5 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="timeBinBCD4" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="timeBinBCD5" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryCalendarRep="bcd" dfdl:encoding="ISO-8859-1"/>
+
+    <xs:element name="timeBinBCD6">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="length" type="xs:int" dfdl:representation="binary"
+            dfdl:lengthKind="explicit" dfdl:length="{ 1 }" dfdl:lengthUnits="bytes" />
+          <xs:element name="time" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+            dfdl:lengthKind="explicit" dfdl:length="{ ../ex:length }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="dateTimeBinBCD" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyHHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="dateTimeBinBCD2" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyhhmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+    <xs:element name="dateTimeBinBCD3" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyhhmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+
+    <xs:element name="dateTimeBinBCD4">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="num1" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="bcd"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0"/>
+          <xs:element name="datetime" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyHHmmss" dfdl:encoding="ISO-8859-1"
+            dfdl:calendarPatternKind="explicit" dfdl:binaryCalendarRep="bcd" dfdl:lengthKind="delimited" dfdl:terminator=";"/>
+          <xs:element name="num2" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="bcd"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="dateBinInvalid" type="xs:date" dfdl:calendarPattern="yyyy.MM.dd" dfdl:calendarPatternKind="explicit" dfdl:lengthKind="explicit"
+      dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1970-01-01T00:00:00+00:00"/>
 
   </tdml:defineSchema>
   
@@ -2251,7 +2304,244 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="dateBin2" root="dateBin2"
+  <tdml:parserTestCase name="dateTimeBin20" root="dateTimeBin12"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00000000 00000000 00000000 00111101</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error: Subset lengthKind='delimited' only supported for packed binary formats.</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD" root="dateBinBCD"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">12 14 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinBCD>2023-12-14</dateBinBCD>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD2" root="dateBinBCD2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">12 14 20 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinBCD2>2023-12-14</dateBinBCD2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD3" root="dateBinBCD"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">12 0F 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Invalid low nibble</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD4" root="dateBinBCD3"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">08 17 48</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Character '-' not allowed in dfdl:calendarPattern for xs:date with a binaryCalendarRep of 'bcd'</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD5" root="dateBinBCD4"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>The given length (7 bits) must be a multiple of 4 when using binaryCalendarRep='bcd'</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinBCD6" root="dateBinBCD"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0001 0010 0010 0111 1001 1001</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinBCD>1999-12-27</dateBinBCD>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD" root="timeBinBCD"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">18 56 03</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinBCD>18:56:03.000000</timeBinBCD>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD2" root="timeBinBCD2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 45 00 99 87</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinBCD2>01:45:00.998000</timeBinBCD2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD3" root="timeBinBCD3"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 45 00 99 87</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>calendarPatternKind must be 'explicit' when binaryCalendarRep='bcd'</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD4" root="timeBinBCD4"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">18 56 03</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Size of binary data 'Time' cannot be determined implicitly</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD5" root="timeBinBCD5"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">18 56 03 3B</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinBCD5>18:56:03.000000</timeBinBCD5>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinBCD6" root="timeBinBCD6"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">03 18 56 03</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinBCD6>
+          <length>3</length>
+          <time>18:56:03.000000</time>
+        </timeBinBCD6>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinBCD" root="dateTimeBinBCD"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">06 14 20 04 18 56 03</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinBCD>2004-06-14T18:56:03.000000</dateTimeBinBCD>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinBCD2" root="dateTimeBinBCD2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 45 00 99 87</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Size of binary data 'DateTime' with binaryCalendarRep='bcd' cannot be determined implicitly</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinBCD3" root="dateTimeBinBCD3"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">06 14 20 04 18 56 03</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinBCD3>2004-06-14T18:56:03.000000</dateTimeBinBCD3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinBCD4" root="dateTimeBinBCD4"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">03 3B 06 14 20 04 18 56 03 3B 19 3B</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinBCD4>
+          <num1>3</num1>
+          <datetime>2004-06-14T18:56:03.000000</datetime>
+          <num2>19</num2>
+        </dateTimeBinBCD4>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinInvalid" root="dateBinInvalid"
     model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
     roundTrip="false">
 

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
@@ -117,4 +117,6 @@ class TestSimpleTypesDebug {
 
   // DAFFODIL-1946
   @Test def test_dateTimeImplicitPatternFail5() { runner.runOneTest("dateTimeImplicitPatternFail5") }
+
+  @Test def test_dateTimeBinBCD3() { runner.runOneTest("dateTimeBinBCD3") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -189,7 +189,24 @@ class TestSimpleTypes {
   @Test def test_dateTimeBin17() { runner.runOneTest("dateTimeBin17") }
   @Test def test_dateTimeBin18() { runner.runOneTest("dateTimeBin18") }
   @Test def test_dateTimeBin19() { runner.runOneTest("dateTimeBin19") }
-  @Test def test_dateBin2() { runner.runOneTest("dateBin2") }
+  @Test def test_dateTimeBin20() { runner.runOneTest("dateTimeBin20") }
+  @Test def test_dateBinBCD() { runner.runOneTest("dateBinBCD") }
+  @Test def test_dateBinBCD2() { runner.runOneTest("dateBinBCD2") }
+  @Test def test_dateBinBCD3() { runner.runOneTest("dateBinBCD3") }
+  @Test def test_dateBinBCD4() { runner.runOneTest("dateBinBCD4") }
+  @Test def test_dateBinBCD5() { runner.runOneTest("dateBinBCD5") }
+  @Test def test_dateBinBCD6() { runner.runOneTest("dateBinBCD6") }
+  @Test def test_timeBinBCD() { runner.runOneTest("timeBinBCD") }
+  @Test def test_timeBinBCD2() { runner.runOneTest("timeBinBCD2") }
+  @Test def test_timeBinBCD3() { runner.runOneTest("timeBinBCD3") }
+  @Test def test_timeBinBCD4() { runner.runOneTest("timeBinBCD4") }
+  @Test def test_timeBinBCD5() { runner.runOneTest("timeBinBCD5") }
+  @Test def test_timeBinBCD6() { runner.runOneTest("timeBinBCD6") }
+  @Test def test_dateTimeBinBCD() { runner.runOneTest("dateTimeBinBCD") }
+  @Test def test_dateTimeBinBCD2() { runner.runOneTest("dateTimeBinBCD2") }
+  //@Test def test_dateTimeBinBCD3() { runner.runOneTest("dateTimeBinBCD3") }
+  @Test def test_dateTimeBinBCD4() { runner.runOneTest("dateTimeBinBCD4") }
+  @Test def test_dateBinInvalid() { runner.runOneTest("dateBinInvalid") }
 
   @Test def test_dateTimeImplicitPattern() { runner.runOneTest("dateTimeImplicitPattern") }
   @Test def test_dateTimeImplicitPatternFail() { runner.runOneTest("dateTimeImplicitPatternFail") }


### PR DESCRIPTION
Adds parsing and unparsing capability for binary representation of
xs:date, xs:time, and xs:dateTime with a binaryCalendarRep of 'bcd',
including known, runtime determined, and delimited lengths of data.

DAFFODIL-1941