### PR TITLE
Daffodil 1923 - Allow use of the same character for escapeBlockEnd and escapeEscapeCharacter

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
@@ -603,5 +603,47 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
- 
+
+  <!--
+       Test Name: escBlkMultipleEEC
+          Schema: eBlkMultipleEEC
+            Root: record
+         Purpose: This test demonstrates that escapeSheme with escapeBlock where the escapeBlockEnd is the same as 2 escapeEscapeCharacters (DAFFODIL-1923).
+  -->
+  <defineSchema name="eBlkMultipleEEC">
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" />
+
+    <dfdl:defineEscapeScheme name="eBlkMultipleEEC">
+      <dfdl:escapeScheme escapeBlockStart="&quot;"
+        escapeBlockEnd="&quot;&quote;" escapeKind="escapeBlock"
+        escapeEscapeCharacter="&quot;"  extraEscapedCharacters="" generateEscapeBlock="whenNeeded"/>
+    </dfdl:defineEscapeScheme>
+
+    <xs:element name="record">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="," >
+          <xs:element name="item" type="xs:string" maxOccurs="unbounded"
+	    dfdl:escapeSchemeRef="tns:eBlkMultipleEEC" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </defineSchema>
+
+  <parserTestCase name="escBlkMultipleEEC" model="eBlkMultipleEEC"
+    description="Section 7 defineEscapeScheme - DFDL-7-079R" root="record" roundTrip="true">
+    <document>1,"Column """Number""" Two"",3,4,5</document>
+    <infoset>
+      <dfdlInfoset>
+    	<tns:record>
+    	  <tns:item>1</tns:item>
+    	  <tns:item>Column &quot;Number&quot; Two</tns:item>
+    	  <tns:item>3</tns:item>
+    	  <tns:item>4</tns:item>
+    	  <tns:item>5</tns:item>
+  	</tns:record>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+
 </testSuite>

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeDebug.scala
@@ -49,9 +49,5 @@ class TestEscapeSchemeDebug {
   //DFDL-961
   @Test def test_scenario3_11_postfix() { runner2.runOneTest("scenario3_11_postfix") }
 
-
-  //DAFFODIL-1923
-  @Test def test_escBlkAllQuotes() { runner.runOneTest("escBlkAllQuotes") }
-  @Test def test_escBlkEndSame() { runner.runOneTest("escBlkEndSame") }
-
+  @Test def test_escBlkMultipleEEC() { runner.runOneTest("escBlkMultipleEEC") } // DAFFODIL-1972
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
@@ -140,4 +140,7 @@ class TestEscapeScheme {
   @Test def test_scenario4_12_req_term() { runner2.runOneTest("scenario4_12_req_term") }
 
   @Test def test_scenario5_1() { runner2.runOneTest("scenario5_1") }
+
+  @Test def test_escBlkAllQuotes() { runner.runOneTest("escBlkAllQuotes") }
+  @Test def test_escBlkEndSame() { runner.runOneTest("escBlkEndSame") }
 }


### PR DESCRIPTION
This commit allows the same character(s) to be used for the escapeBlockEnd and escapeEscapeCharacter.

Prior to this the code would first check for the escapeBlockEnd without checking to see if it was also the escapeEscapeCharacter, and would think that it hit the end of the escapeBlock when it was just the escapeEscapeCharacter.