### PR TITLE
Fix bugs associated with truncateSpecifiedLengthString="yes"

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/Padded.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/Padded.scala
@@ -70,9 +70,7 @@ trait PaddingInfoMixin {
       else eBase.textStringJustification match {
         case TextStringJustification.Left => TextTruncationType.Left
         case TextStringJustification.Right => TextTruncationType.Right
-        case TextStringJustification.Center => {
-          eBase.SDE("Properties dfdl:truncateSpecifiedLengthString 'yes' and dfdl:textStringJustification 'center' are incompatible.")
-        }
+        case TextStringJustification.Center => TextTruncationType.ErrorIfNeeded
       }
     res
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TextJustification.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TextJustification.scala
@@ -31,5 +31,6 @@ object TextTruncationType extends Enum {
   sealed abstract trait Type extends EnumValueType
   case object Left extends Type
   case object Right extends Type
+  case object ErrorIfNeeded extends Type
   case object None extends Type
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -258,7 +258,7 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Unparse Error</tdml:error>
       <tdml:error>textStringJustification</tdml:error>
       <tdml:error>center</tdml:error>
       <tdml:error>truncateSpecifiedLengthString</tdml:error>
@@ -296,6 +296,53 @@
     </tdml:infoset>
     <tdml:document>6789100000</tdml:document>
   </tdml:unparserTestCase>
+
+<!--
+      Test Name: unparsePaddedStringTruncate04
+      Schema: delimitedStringsPadding
+      Purpose: This test demonstrates unparsing a string with padding, where truncateSpecifiedLengthString is set to "yes"
+               In this case, the string does not need to be truncated, and should be output with centered justification.
+-->
+  <tdml:unparserTestCase name="unparsePaddedStringTruncate04" model="delimitedStringsPadding" root="e6">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e6 xmlns:ex="http://example.com">123456</ex:e6>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>__123456__</tdml:document>
+  </tdml:unparserTestCase>
+
+<!--
+      Test Name: unparsePaddedStringTruncate05
+      Schema: delimitedStringsPadding
+      Purpose: This test demonstrates unparsing a string with padding, where truncateSpecifiedLengthString is set to "yes"
+               In this case, the string does not need to be truncated and the justification is "left", so the data is output justified to the left.
+-->
+  <tdml:unparserTestCase name="unparsePaddedStringTruncate05" model="delimitedStringsPadding" root="e7">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e7 xmlns:ex="http://example.com">123456</ex:e7>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>123456____</tdml:document>
+  </tdml:unparserTestCase>
+
+
+<!--
+      Test Name: unparsePaddedStringTruncate06
+      Schema: delimitedStringsPadding
+      Purpose: This test demonstrates unparsing a string with padding, where truncateSpecifiedLengthString is set to "yes"
+               In this case, the string does not need to be truncated and the justification is "right", is output right justified.
+-->
+  <tdml:unparserTestCase name="unparsePaddedStringTruncate06" model="delimitedStringsPadding" root="e8">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e8 xmlns:ex="http://example.com">123456</ex:e8>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>____123456</tdml:document>
+  </tdml:unparserTestCase>
+
 
 <!--
       Test Name: unparseDelimitedPaddedString06

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
@@ -53,6 +53,9 @@ class TestTextNumberPropsUnparse {
   @Test def test_unparsePaddedStringTruncate01() { runner.runOneTest("unparsePaddedStringTruncate01") }
   @Test def test_unparsePaddedStringTruncate02() { runner.runOneTest("unparsePaddedStringTruncate02") }
   @Test def test_unparsePaddedStringTruncate03() { runner.runOneTest("unparsePaddedStringTruncate03") }
+  @Test def test_unparsePaddedStringTruncate04() { runner.runOneTest("unparsePaddedStringTruncate04") }
+  @Test def test_unparsePaddedStringTruncate05() { runner.runOneTest("unparsePaddedStringTruncate05") }
+  @Test def test_unparsePaddedStringTruncate06() { runner.runOneTest("unparsePaddedStringTruncate06") }
 
   @Test def test_parseDelimitedPaddedString01() { runner.runOneTest("parseDelimitedPaddedString01") }
 


### PR DESCRIPTION
- Check to make sure an explicit length string actually needs to be
  truncated before trying to truncate it, otherwise it results in an
  StringIndexOutOfBoundsException. We have the check for character
  lengths, but were missing it for bit/byte lenghts.
- Allow truncateSpecifiedLengthString="yes" when
  textStringJustification="center". This is legal according to the spec,
  but should result in a processing error in cases where truncation is
  needed.

DAFFODIL-1969