### PR TITLE
Daffodil 1942 binary calendar rep packed

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -713,7 +713,7 @@ trait ElementBaseGrammarMixin
     ibm4690PackedDateDelimitedLength | ibm4690PackedTimeDelimitedLength | ibm4690PackedDateTimeDelimitedLength
   }
 
-    // ibm4690Packed calendar with known length
+  // ibm4690Packed calendar with known length
   private lazy val ibm4690PackedDateKnownLength = prod("ibm4690PackedDateKnownLength", primType == PrimType.Date) {
     ConvertZonedCombinator(this, new IBM4690PackedIntegerKnownLength(this, false, binaryNumberKnownLengthInBits), ConvertTextDatePrim(this))
   }
@@ -744,6 +744,49 @@ trait ElementBaseGrammarMixin
   }
   private lazy val ibm4690PackedTimeDelimitedLength = prod("ibm4690PackedTimeDelimitedLength", primType == PrimType.Time) {
     ConvertZonedCombinator(this, new IBM4690PackedIntegerDelimitedEndOfData(this, false), ConvertTextTimePrim(this))
+  }
+
+  private lazy val packedKnownLengthCalendar = prod("packedKnownLengthCalendar", binaryCalendarRep == BinaryCalendarRep.Packed) {
+    packedDateKnownLength | packedTimeKnownLength | packedDateTimeKnownLength
+  }
+  private lazy val packedRuntimeLengthCalendar = prod("packedRuntimeLengthCalendar", binaryCalendarRep == BinaryCalendarRep.Packed) {
+    packedDateRuntimeLength | packedTimeRuntimeLength | packedDateTimeRuntimeLength
+  }
+  private lazy val packedDelimitedLengthCalendar = prod("packedDelimitedLengthCalendar", binaryCalendarRep == BinaryCalendarRep.Packed) {
+    packedDateDelimitedLength | packedTimeDelimitedLength | packedDateTimeDelimitedLength
+  }
+
+  // Packed calendar with known length
+  private lazy val packedDateKnownLength = prod("packedDateKnownLength", primType == PrimType.Date) {
+    ConvertZonedCombinator(this, new PackedIntegerKnownLength(this, false, packedSignCodes, binaryNumberKnownLengthInBits), ConvertTextDatePrim(this))
+  }
+  private lazy val packedDateTimeKnownLength = prod("packedDateTimeKnownLength", primType == PrimType.DateTime) {
+    ConvertZonedCombinator(this, new PackedIntegerKnownLength(this, false, packedSignCodes, binaryNumberKnownLengthInBits), ConvertTextDateTimePrim(this))
+  }
+  private lazy val packedTimeKnownLength = prod("packedTimeKnownLength", primType == PrimType.Time) {
+    ConvertZonedCombinator(this, new PackedIntegerKnownLength(this, false, packedSignCodes, binaryNumberKnownLengthInBits), ConvertTextTimePrim(this))
+  }
+
+  // Packed calendar with runtime length
+  private lazy val packedDateRuntimeLength = prod("packedDateRuntimeLength", primType == PrimType.Date) {
+    ConvertZonedCombinator(this, new PackedIntegerRuntimeLength(this, false, packedSignCodes), ConvertTextDatePrim(this))
+  }
+  private lazy val packedDateTimeRuntimeLength = prod("packedDateTimeRuntimeLength", primType == PrimType.DateTime) {
+    ConvertZonedCombinator(this, new PackedIntegerRuntimeLength(this, false, packedSignCodes), ConvertTextDateTimePrim(this))
+  }
+  private lazy val packedTimeRuntimeLength = prod("packedTimeRuntimeLength", primType == PrimType.Time) {
+    ConvertZonedCombinator(this, new PackedIntegerRuntimeLength(this, false, packedSignCodes), ConvertTextTimePrim(this))
+  }
+
+  // Packed calendar with delimited length
+  private lazy val packedDateDelimitedLength = prod("packedDateDelimitedLength", primType == PrimType.Date) {
+    ConvertZonedCombinator(this, new PackedIntegerDelimitedEndOfData(this, false, packedSignCodes), ConvertTextDatePrim(this))
+  }
+  private lazy val packedDateTimeDelimitedLength = prod("packedDateTimeDelimitedLength", primType == PrimType.DateTime) {
+    ConvertZonedCombinator(this, new PackedIntegerDelimitedEndOfData(this, false, packedSignCodes), ConvertTextDateTimePrim(this))
+  }
+  private lazy val packedTimeDelimitedLength = prod("packedTimeDelimitedLength", primType == PrimType.Time) {
+    ConvertZonedCombinator(this, new PackedIntegerDelimitedEndOfData(this, false, packedSignCodes), ConvertTextTimePrim(this))
   }
 
   private lazy val textDouble = prod("textDouble", impliedRepresentation == Representation.Text) {
@@ -942,6 +985,13 @@ trait ElementBaseGrammarMixin
                   case (LengthKind.Delimited, -1) => ibm4690PackedDelimitedLengthCalendar
                   case (_, -1) => ibm4690PackedRuntimeLengthCalendar
                   case (_, _) => ibm4690PackedKnownLengthCalendar
+                }
+              }
+              case (BinaryCalendarRep.Packed) => {
+                (lengthKind, binaryNumberKnownLengthInBits) match {
+                  case (LengthKind.Delimited, -1) => packedDelimitedLengthCalendar
+                  case (_, -1) => packedRuntimeLengthCalendar
+                  case (_, _) => packedKnownLengthCalendar
                 }
               }
               case _ =>  notYetImplemented("Type %s when representation='binary' and binaryCalendarRep=%s", primType.name, binaryCalendarRep.toString)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -360,6 +360,51 @@
     <xs:element name="timeBinIBM4690Packed2" type="xs:time" dfdl:calendarPatternKind="implicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 5 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed"/>
 
+    <xs:element name="dateBinPacked" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed"
+      dfdl:binaryPackedSignCodes="C D F C" dfdl:binaryNumberCheckPolicy="strict" dfdl:calendarTimeZone=""/>
+    <xs:element name="dateBinPacked2" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed" />
+    <xs:element name="dateBinPacked3" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed" dfdl:binaryPackedSignCodes="C D F C" />
+    <xs:element name="dateBinPacked4">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="num1" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="packed"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0" dfdl:binaryPackedSignCodes="C D F C"
+            dfdl:binaryNumberCheckPolicy="strict" />
+          <xs:element name="date" type="xs:date" dfdl:calendarPattern="MMddyyyy" dfdl:encoding="ISO-8859-1"
+            dfdl:calendarPatternKind="explicit" dfdl:binaryCalendarRep="packed" dfdl:lengthKind="delimited" dfdl:terminator=";"
+            dfdl:binaryPackedSignCodes="C D F C" dfdl:binaryNumberCheckPolicy="strict" dfdl:calendarTimeZone="" />
+          <xs:element name="num2" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="packed"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0" dfdl:binaryPackedSignCodes="C D F C"
+            dfdl:binaryNumberCheckPolicy="strict" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="timeBinPacked" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed"
+      dfdl:binaryPackedSignCodes="C D F C" dfdl:binaryNumberCheckPolicy="strict" dfdl:calendarTimeZone=""/>
+    <xs:element name="timeBinPacked2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="length" type="xs:int" dfdl:representation="binary"
+            dfdl:lengthKind="explicit" dfdl:length="{ 1 }" dfdl:lengthUnits="bytes" />
+          <xs:element name="time" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:calendarPatternKind="explicit"
+            dfdl:lengthKind="explicit" dfdl:length="{ ../ex:length }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed"
+            dfdl:binaryPackedSignCodes="C D F C"  dfdl:binaryNumberCheckPolicy="strict" dfdl:calendarTimeZone="" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="dateTimeBinPacked" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyHHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 8 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed"
+      dfdl:binaryPackedSignCodes="C D F C" dfdl:binaryNumberCheckPolicy="strict"/>
+    <xs:element name="dateTimeBinPacked2" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyHHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="packed"
+      dfdl:binaryPackedSignCodes="C D F C" dfdl:binaryNumberCheckPolicy="lax" dfdl:calendarTimeZone="UTC-05:00"/>
+
     <xs:element name="dateBinInvalid" type="xs:date" dfdl:calendarPattern="yyyy.MM.dd" dfdl:calendarPatternKind="explicit" dfdl:lengthKind="explicit"
       dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1970-01-01T00:00:00+00:00"/>
 
@@ -2717,6 +2762,136 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>calendarPatternKind must be 'explicit' when binaryCalendarRep='ibm4690Packed'</tdml:error>
     </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinPacked" root="dateBinPacked"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 21 42 3C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinPacked>2023-12-14</dateBinPacked>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinPacked2" root="dateBinPacked2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 21 42 3C</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Property binaryPackedSignCodes is not defined</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinPacked3" root="dateBinPacked3"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 21 42 3C</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Property binaryNumberCheckPolicy is not defined</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinPacked4" root="dateBinPacked4"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 4D 3B 10 11 97 8C 3B 06 7C 3B</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinPacked4>
+          <num1>-14</num1>
+          <date>1978-01-01</date>
+          <num2>67</num2>
+        </dateBinPacked4>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinPacked" root="timeBinPacked"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">00 61 32 7C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinPacked>06:13:27.000000</timeBinPacked>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinPacked2" root="timeBinPacked2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">04 00 41 50 8C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinPacked2>
+          <length>4</length>
+          <time>04:15:08.000000</time>
+        </timeBinPacked2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinPacked" root="dateTimeBinPacked"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 22 51 64 51 93 65 0C</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinPacked>1645-12-25T19:36:50.000000+00:00</dateTimeBinPacked>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinPacked2" root="dateTimeBinPacked"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 22 51 64 51 93 65 0D</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Expected unsigned data but parsed a negative number</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinPacked3" root="dateTimeBinPacked2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">41 53 93 10 62 04 5A</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinPacked2>3931-04-15T06:20:45.000000-05:00</dateTimeBinPacked2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="dateBinInvalid" root="dateBinInvalid"

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -323,6 +323,43 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="dateBinIBM4690Packed" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed" />
+    <xs:element name="dateBinIBM4690Packed2" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 18 }" dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="ibm4690Packed"/>
+
+    <xs:element name="dateTimeBinIBM4690Packed">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="length" type="xs:int" dfdl:representation="binary"
+            dfdl:lengthKind="explicit" dfdl:length="{ 1 }" dfdl:lengthUnits="bytes" />
+          <xs:element name="datetime" type="xs:dateTime" dfdl:calendarPattern="MMddyyHHmmss" dfdl:calendarPatternKind="explicit"
+            dfdl:lengthKind="explicit" dfdl:length="{ ../ex:length }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="dateTimeBinIBM4690Packed2" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyHHmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 56 }" dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="ibm4690Packed" />
+    <xs:element name="dateTimeBinIBM4690Packed3" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyhhmmss" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed"/>
+
+    <xs:element name="timeBinIBM4690Packed">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="num1" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="ibm4690Packed"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0"/>
+          <xs:element name="time" type="xs:time" dfdl:calendarPattern="HHmmss" dfdl:encoding="ISO-8859-1"
+            dfdl:calendarPatternKind="explicit" dfdl:binaryCalendarRep="ibm4690Packed" dfdl:lengthKind="delimited" dfdl:terminator=";"/>
+          <xs:element name="num2" type="xs:decimal" dfdl:encoding="ISO-8859-1" dfdl:representation="binary" dfdl:binaryNumberRep="ibm4690Packed"
+            dfdl:lengthKind="delimited" dfdl:terminator=";" dfdl:binaryDecimalVirtualPoint="0"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="timeBinIBM4690Packed2" type="xs:time" dfdl:calendarPatternKind="implicit"
+      dfdl:lengthKind="explicit" dfdl:length="{ 5 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed"/>
+
     <xs:element name="dateBinInvalid" type="xs:date" dfdl:calendarPattern="yyyy.MM.dd" dfdl:calendarPatternKind="explicit" dfdl:lengthKind="explicit"
       dfdl:length="{ 4 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1970-01-01T00:00:00+00:00"/>
 
@@ -2568,6 +2605,118 @@
         </dateTimeBinBCD4>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinIBM4690Packed" root="dateBinIBM4690Packed"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">12 14 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinIBM4690Packed>2023-12-14</dateBinIBM4690Packed>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinIBM4690Packed2" root="dateBinIBM4690Packed2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R" >
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0000 0000 00000 0000 00</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>The given length (18 bits) must be a multiple of 4 when using binaryCalendarRep='ibm4690Packed'</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinIBM4690Packed3" root="dateBinIBM4690Packed"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">D2 14 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Expected unsigned data but parsed a negative number</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinIBM4690Packed" root="dateTimeBinIBM4690Packed"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">06 11 30 07 04 15 08</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinIBM4690Packed>
+          <length>6</length>
+          <datetime>2007-11-30T04:15:08.000000</datetime>
+        </dateTimeBinIBM4690Packed>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinIBM4690Packed2" root="dateTimeBinIBM4690Packed2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">03 20 18 56 09 51 38</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBinIBM4690Packed2>1856-03-20T09:51:38.000000</dateTimeBinIBM4690Packed2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBinIBM4690Packed3" root="dateTimeBinIBM4690Packed3"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R" >
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 45 00 99 87</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Length of binary data 'DateTime' with binaryCalendarRep='ibm4690Packed' cannot be determined implicitly</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinIBM4690Packed" root="timeBinIBM4690Packed"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">27 3B 10 32 49 3B 19 3B</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <timeBinIBM4690Packed>
+          <num1>27</num1>
+          <time>10:32:49.000000</time>
+          <num2>19</num2>
+        </timeBinIBM4690Packed>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="timeBinIBM4690Packed2" root="timeBinIBM4690Packed2"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R" >
+
+    <tdml:document>
+      <tdml:documentPart type="byte">01 45 00 99 87</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>calendarPatternKind must be 'explicit' when binaryCalendarRep='ibm4690Packed'</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="dateBinInvalid" root="dateBinInvalid"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -219,6 +219,16 @@ class TestSimpleTypes {
   @Test def test_timeBinIBM4690Packed() { runner.runOneTest("timeBinIBM4690Packed") }
   @Test def test_timeBinIBM4690Packed2() { runner.runOneTest("timeBinIBM4690Packed2") }
 
+  @Test def test_dateBinPacked() { runner.runOneTest("dateBinPacked") }
+  @Test def test_dateBinPacked2() { runner.runOneTest("dateBinPacked2") }
+  @Test def test_dateBinPacked3() { runner.runOneTest("dateBinPacked3") }
+  @Test def test_dateBinPacked4() { runner.runOneTest("dateBinPacked4") }
+  @Test def test_timeBinPacked() { runner.runOneTest("timeBinPacked") }
+  @Test def test_timeBinPacked2() { runner.runOneTest("timeBinPacked2") }
+  @Test def test_dateTimeBinPacked() { runner.runOneTest("dateTimeBinPacked") }
+  @Test def test_dateTimeBinPacked2() { runner.runOneTest("dateTimeBinPacked2") }
+  @Test def test_dateTimeBinPacked3() { runner.runOneTest("dateTimeBinPacked3") }
+
   @Test def test_dateBinInvalid() { runner.runOneTest("dateBinInvalid") }
 
   @Test def test_dateTimeImplicitPattern() { runner.runOneTest("dateTimeImplicitPattern") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -209,6 +209,16 @@ class TestSimpleTypes {
   @Test def test_dateTimeBinBCD2() { runner.runOneTest("dateTimeBinBCD2") }
   @Test def test_dateTimeBinBCD3() { runner.runOneTest("dateTimeBinBCD3") }
   @Test def test_dateTimeBinBCD4() { runner.runOneTest("dateTimeBinBCD4") }
+
+  @Test def test_dateBinIBM4690Packed() { runner.runOneTest("dateBinIBM4690Packed") }
+  @Test def test_dateBinIBM4690Packed2() { runner.runOneTest("dateBinIBM4690Packed2") }
+  @Test def test_dateBinIBM4690Packed3() { runner.runOneTest("dateBinIBM4690Packed3") }
+  @Test def test_dateTimeBinIBM4690Packed() { runner.runOneTest("dateTimeBinIBM4690Packed") }
+  @Test def test_dateTimeBinIBM4690Packed2() { runner.runOneTest("dateTimeBinIBM4690Packed2") }
+  @Test def test_dateTimeBinIBM4690Packed3() { runner.runOneTest("dateTimeBinIBM4690Packed3") }
+  @Test def test_timeBinIBM4690Packed() { runner.runOneTest("timeBinIBM4690Packed") }
+  @Test def test_timeBinIBM4690Packed2() { runner.runOneTest("timeBinIBM4690Packed2") }
+
   @Test def test_dateBinInvalid() { runner.runOneTest("dateBinInvalid") }
 
   @Test def test_dateTimeImplicitPattern() { runner.runOneTest("dateTimeImplicitPattern") }


### PR DESCRIPTION
This is showing 2 commits because I branched this off of the branch for DAFFODIL-1943 as some of the changes were needed. I'm not sure if there's a way to only show the newest changes but it should be easy to tell which is which. This review is for binaryCalendarRep="packed".