### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -238,8 +238,8 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   This product bundles 'Scala', including the following files:
-    - lib/org.scala-lang.modules.scala-parser-combinators_2.12-1.0.4.jar
-    - lib/org.scala-lang.modules.scala-xml_2.12-1.0.6.jar
+    - lib/org.scala-lang.modules.scala-parser-combinators_2.12-1.1.1.jar
+    - lib/org.scala-lang.modules.scala-xml_2.12-1.1.0.jar
     - lib/org.scala-lang.scala-library-2.12.6.jar
     - org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-2.1.0.jar
   These files are available under the BSD-3-Clause licnese:
@@ -321,36 +321,424 @@ subcomponents is subject to the terms and conditions of the following licenses.
     copyright holders.
 
   This product bundles 'ICU4J', including the following files:
-    - lib/com.ibm.icu.icu4j-51.1.jar
-  These files are available under the ICU License. For details, see
-  https://ssl.icu-project.org/repos/icu/icu4j/tags/release-51-2/main/shared/licenses/license.html
+    - lib/com.ibm.icu.icu4j-62.1.jar
+  These files are available under the Unicode License. For details, see
+  https://ssl.icu-project.org/repos/icu/tags/release-62-1/icu4j/main/shared/licenses/LICENSE
 
-    Copyright (c) 1995-2013 International Business Machines Corporation and others
+    COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
 
+    Copyright © 1991-2018 Unicode, Inc. All rights reserved.
+    Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of the Unicode data files and any associated documentation
+    (the "Data Files") or Unicode software and any associated documentation
+    (the "Software") to deal in the Data Files or Software
+    without restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, and/or sell copies of
+    the Data Files or Software, and to permit persons to whom the Data Files
+    or Software are furnished to do so, provided that either
+    (a) this copyright and permission notice appear with all copies
+    of the Data Files or Software, or
+    (b) this copyright and permission notice appear in associated
+    Documentation.
+
+    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+    NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+    DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+    DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in these Data Files or Software without prior
+    written authorization of the copyright holder.
+
+    ---------------------
+
+    Third-Party Software Licenses
+
+    This section contains third-party software notices and/or additional
+    terms for licensed third-party software components included within ICU
+    libraries.
+
+    1. ICU License - ICU 1.8.1 to ICU 57.1
+
+    COPYRIGHT AND PERMISSION NOTICE
+
+    Copyright (c) 1995-2016 International Business Machines Corporation and others
     All rights reserved.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"),
-    to deal in the Software without restriction, including without limitation
-    the rights to use, copy, modify, merge, publish, distribute, and/or sell
-    copies of the Software, and to permit persons
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, and/or sell copies of the Software, and to permit persons
     to whom the Software is furnished to do so, provided that the above
-    copyright notice(s) and this permission notice appear in all copies
-    of the Software and that both the above copyright notice(s) and this
+    copyright notice(s) and this permission notice appear in all copies of
+    the Software and that both the above copyright notice(s) and this
     permission notice appear in supporting documentation.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-    PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL
-    THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM,
-    OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
-    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
-    NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
-    USE OR PERFORMANCE OF THIS SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+    OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+    HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+    SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+    CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-    Except as contained in this notice, the name of a copyright holder shall not be
-    used in advertising or otherwise to promote the sale, use or other dealings in
-    this Software without prior written authorization of the copyright holder.
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale, use
+    or other dealings in this Software without prior written authorization
+    of the copyright holder.
+
+    All trademarks and registered trademarks mentioned herein are the
+    property of their respective owners.
+
+    2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+
+     #     The Google Chrome software developed by Google is licensed under
+     # the BSD license. Other software included in this distribution is
+     # provided under other licenses, as set forth below.
+     #
+     #  The BSD License
+     #  http://opensource.org/licenses/bsd-license.php
+     #  Copyright (C) 2006-2008, Google Inc.
+     #
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     # modification, are permitted provided that the following conditions are met:
+     #
+     #  Redistributions of source code must retain the above copyright notice,
+     # this list of conditions and the following disclaimer.
+     #  Redistributions in binary form must reproduce the above
+     # copyright notice, this list of conditions and the following
+     # disclaimer in the documentation and/or other materials provided with
+     # the distribution.
+     #  Neither the name of  Google Inc. nor the names of its
+     # contributors may be used to endorse or promote products derived from
+     # this software without specific prior written permission.
+     #
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     # CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+     # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+     # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     #
+     #
+     #  The word list in cjdict.txt are generated by combining three word lists
+     # listed below with further processing for compound word breaking. The
+     # frequency is generated with an iterative training against Google web
+     # corpora.
+     #
+     #  * Libtabe (Chinese)
+     #    - https://sourceforge.net/project/?group_id=1519
+     #    - Its license terms and conditions are shown below.
+     #
+     #  * IPADIC (Japanese)
+     #    - http://chasen.aist-nara.ac.jp/chasen/distribution.html
+     #    - Its license terms and conditions are shown below.
+     #
+     #  ---------COPYING.libtabe ---- BEGIN--------------------
+     #
+     #  /*
+     #   * Copyright (c) 1999 TaBE Project.
+     #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
+     #   * All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the TaBE Project nor the names of its
+     #   *   contributors may be used to endorse or promote products derived
+     #   *   from this software without specific prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  /*
+     #   * Copyright (c) 1999 Computer Systems and Communication Lab,
+     #   *                    Institute of Information Science, Academia
+     #       *                    Sinica. All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the Computer Systems and Communication Lab
+     #   *   nor the names of its contributors may be used to endorse or
+     #   *   promote products derived from this software without specific
+     #   *   prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
+     #      University of Illinois
+     #  c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
+     #
+     #  ---------------COPYING.libtabe-----END--------------------------------
+     #
+     #
+     #  ---------------COPYING.ipadic-----BEGIN-------------------------------
+     #
+     #  Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+     #  and Technology.  All Rights Reserved.
+     #
+     #  Use, reproduction, and distribution of this software is permitted.
+     #  Any copy of this software, whether in its original form or modified,
+     #  must include both the above copyright notice and the following
+     #  paragraphs.
+     #
+     #  Nara Institute of Science and Technology (NAIST),
+     #  the copyright holders, disclaims all warranties with regard to this
+     #  software, including all implied warranties of merchantability and
+     #  fitness, in no event shall NAIST be liable for
+     #  any special, indirect or consequential damages or any damages
+     #  whatsoever resulting from loss of use, data or profits, whether in an
+     #  action of contract, negligence or other tortuous action, arising out
+     #  of or in connection with the use or performance of this software.
+     #
+     #  A large portion of the dictionary entries
+     #  originate from ICOT Free Software.  The following conditions for ICOT
+     #  Free Software applies to the current dictionary as well.
+     #
+     #  Each User may also freely distribute the Program, whether in its
+     #  original form or modified, to any third party or parties, PROVIDED
+     #  that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+     #  on, or be attached to, the Program, which is distributed substantially
+     #  in the same form as set out herein and that such intended
+     #  distribution, if actually made, will neither violate or otherwise
+     #  contravene any of the laws and regulations of the countries having
+     #  jurisdiction over the User or the intended distribution itself.
+     #
+     #  NO WARRANTY
+     #
+     #  The program was produced on an experimental basis in the course of the
+     #  research and development conducted during the project and is provided
+     #  to users as so produced on an experimental basis.  Accordingly, the
+     #  program is provided without any warranty whatsoever, whether express,
+     #  implied, statutory or otherwise.  The term "warranty" used herein
+     #  includes, but is not limited to, any warranty of the quality,
+     #  performance, merchantability and fitness for a particular purpose of
+     #  the program and the nonexistence of any infringement or violation of
+     #  any right of any third party.
+     #
+     #  Each user of the program will agree and understand, and be deemed to
+     #  have agreed and understood, that there is no warranty whatsoever for
+     #  the program and, accordingly, the entire risk arising from or
+     #  otherwise connected with the program is assumed by the user.
+     #
+     #  Therefore, neither ICOT, the copyright holder, or any other
+     #  organization that participated in or was otherwise related to the
+     #  development of the program and their respective officials, directors,
+     #  officers and other employees shall be held liable for any and all
+     #  damages, including, without limitation, general, special, incidental
+     #  and consequential damages, arising out of or otherwise in connection
+     #  with the use or inability to use the program or any product, material
+     #  or result produced or otherwise obtained by using the program,
+     #  regardless of whether they have been advised of, or otherwise had
+     #  knowledge of, the possibility of such damages at any time during the
+     #  project or thereafter.  Each user will be deemed to have agreed to the
+     #  foregoing by his or her commencement of use of the program.  The term
+     #  "use" as used herein includes, but is not limited to, the use,
+     #  modification, copying and distribution of the program and the
+     #  production of secondary products from the program.
+     #
+     #  In the case where the program, whether in its original form or
+     #  modified, was distributed or delivered to or received by a user from
+     #  any person, organization or entity other than ICOT, unless it makes or
+     #  grants independently of ICOT any specific warranty to the user in
+     #  writing, such person, organization or entity, will also be exempted
+     #  from and not be held liable to the user for any such damages as noted
+     #  above as far as the program is concerned.
+     #
+     #  ---------------COPYING.ipadic-----END----------------------------------
+
+    3. Lao Word Break Dictionary Data (laodict.txt)
+
+     #  Copyright (c) 2013 International Business Machines Corporation
+     #  and others. All Rights Reserved.
+     #
+     # Project: http://code.google.com/p/lao-dictionary/
+     # Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt
+     # License: http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt
+     #              (copied below)
+     #
+     #  This file is derived from the above dictionary, with slight
+     #  modifications.
+     #  ----------------------------------------------------------------------
+     #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification,
+     #  are permitted provided that the following conditions are met:
+     #
+     #
+     # Redistributions of source code must retain the above copyright notice, this
+     #  list of conditions and the following disclaimer. Redistributions in
+     #  binary form must reproduce the above copyright notice, this list of
+     #  conditions and the following disclaimer in the documentation and/or
+     #  other materials provided with the distribution.
+     #
+     #
+     # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+     # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     # OF THE POSSIBILITY OF SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    4. Burmese Word Break Dictionary Data (burmesedict.txt)
+
+     #  Copyright (c) 2014 International Business Machines Corporation
+     #  and others. All Rights Reserved.
+     #
+     #  This list is part of a project hosted at:
+     #    github.com/kanyawtech/myanmar-karen-word-lists
+     #
+     #  --------------------------------------------------------------------------
+     #  Copyright (c) 2013, LeRoy Benjamin Sharon
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification, are permitted provided that the following conditions
+     #  are met: Redistributions of source code must retain the above
+     #  copyright notice, this list of conditions and the following
+     #  disclaimer.  Redistributions in binary form must reproduce the
+     #  above copyright notice, this list of conditions and the following
+     #  disclaimer in the documentation and/or other materials provided
+     #  with the distribution.
+     #
+     #    Neither the name Myanmar Karen Word Lists, nor the names of its
+     #    contributors may be used to endorse or promote products derived
+     #    from this software without specific prior written permission.
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     #  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     #  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+     #  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+     #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     #  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     #  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+     #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+     #  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+     #  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     #  SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    5. Time Zone Database
+
+      ICU uses the public domain data and code derived from Time Zone
+    Database for its time zone support. The ownership of the TZ database
+    is explained in BCP 175: Procedure for Maintaining the Time Zone
+    Database section 7.
+
+     # 7.  Database Ownership
+     #
+     #    The TZ database itself is not an IETF Contribution or an IETF
+     #    document.  Rather it is a pre-existing and regularly updated work
+     #    that is in the public domain, and is intended to remain in the
+     #    public domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do
+     #    not apply to the TZ Database or contributions that individuals make
+     #    to it.  Should any claims be made and substantiated against the TZ
+     #    Database, the organization that is providing the IANA
+     #    Considerations defined in this RFC, under the memorandum of
+     #    understanding with the IETF, currently ICANN, may act in accordance
+     #    with all competent court orders.  No ownership claims will be made
+     #    by ICANN or the IETF Trust on the database or the code.  Any person
+     #    making a contribution to the database or code waives all rights to
+     #    future claims in that contribution or in the TZ Database.
+
+    6. Google double-conversion
+
+    Copyright 2006-2011, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+      * Neither the name of Google Inc. nor the names of its
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   This product bundles 'JDOM2', including the following files:
     - lib/org.jdom.jdom2-2.0.6.jar
@@ -406,7 +794,7 @@ subcomponents is subject to the terms and conditions of the following licenses.
     on the JDOM Project, please see <http://www.jdom.org/>. 
 
   This product bundles 'JLine', including the following files:
-    - lib/jline.jline-2.12.1.jar
+    - lib/jline.jline-2.14.6.jar
   These files are available under a BSD-3-Clause license. For details, see
   https://github.com/jline/jline2/blob/master/LICENSE.txt
 
@@ -446,7 +834,7 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OF THE POSSIBILITY OF SUCH DAMAGE.
 
   This product bundles 'Scallop', including the following files:
-    - lib/org.rogach.scallop_2.12-3.1.2.jar
+    - lib/org.rogach.scallop_2.12-3.1.3.jar
   These files are available under under an MIT License. For details, see
   https://github.com/scallop/scallop/blob/develop/license.txt
 
@@ -471,7 +859,7 @@ subcomponents is subject to the terms and conditions of the following licenses.
     SOFTWARE.
 
   This product product bundles 'Stax 2 API', including the following files:
-    - lib/org.codehaus.woodstox.stax2-api-3.1.4.jar
+    - lib/org.codehaus.woodstox.stax2-api-4.1.jar
   These files are available under the BSD-2-Clause license:
 
     Copyright 2010- FasterXML.com

--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -11,7 +11,7 @@ Based on source code originally developed by
 
 The following NOTICE information applies to binary components distributed with this project:
 
-Apache Xerces Java (lib/xerces.xercesImpl-2.10.0.jar)
+Apache Xerces Java (lib/xerces.xercesImpl-2.12.0.jar)
   Apache Xerces Java
   Copyright 1999-2010 The Apache Software Foundation
 
@@ -56,11 +56,11 @@ JDOM2 (lib/org.jdom.jdom2-2.0.6.jar)
   This product includes software developed by the
   JDOM Project (http://www.jdom.org/).
 
-Jansi (lib/org.fusesource.jansi.jansi-1.14.jar)
+Jansi (lib/org.fusesource.jansi.jansi-1.17.1.jar)
   Copyright (C) 2009, Progress Software Corporation and/or its
   subsidiaries or affiliates.  All rights reserved.
 
-Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-2.8.8.jar)
+Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-2.9.6.jar)
   # Jackson JSON processor
 
   Jackson is a high-performance, Free/Open Source JSON processing library.
@@ -82,7 +82,7 @@ Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-2.8.8.jar)
   in some artifacts (usually source distributions); but is always available
   from the source code management (SCM) system project uses.
 
-Woodstox (lib/com.fasterxml.woodstox.woodstox-core-5.0.3.jar)
+Woodstox (lib/com.fasterxml.woodstox.woodstox-core-5.1.0.jar)
   This product currently only contains code developed by authors
   of specific components, as identified by the source code files.
 

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/debugger/CLIDebuggerRunner.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/debugger/CLIDebuggerRunner.scala
@@ -45,7 +45,7 @@ class CLIDebuggerRunner(cmdsIter: Iterator[String]) extends InteractiveDebuggerR
   }
 
   def fini(): Unit = {
-    reader.map { _.shutdown }
+    reader.map { _.close }
     reader = None
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
@@ -72,6 +72,10 @@ abstract class ConvertTextNumberPrim[S](e: ElementBase)
     val (pattern, patternStripped) = {
       val p = e.textNumberPattern
 
+      if (p.startsWith(";")) {
+        e.SDE("Invalid textNumberPattern: The postive number pattern is mandatory")
+      }
+
       val noEscapedTicksRegex = """''""".r
       val patternNoEscapedTicks = noEscapedTicksRegex.replaceAllIn(p, "")
       val noQuotedRegex = """'[^']+'""".r

--- a/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
@@ -73,7 +73,7 @@ class TestXMLLoaderWithLocation {
       val node = (new DaffodilXMLLoader(eh)).load(res)
       assertTrue(eh.hasError)
       val msgs = eh.diagnostics.map { _.getMessage() }.mkString("\n")
-      assertTrue(msgs.contains("xs:illegal"))
+      assertTrue(msgs.contains(":illegal"))
       assertTrue(node.toString.toLowerCase.contains("dafint:file"))
     } finally {
       val t = new java.io.File(tmpXMLFileName)

--- a/daffodil-lib/src/main/resources/edu/illinois/ncsa/daffodil/xsd/built-in-formats.xsd
+++ b/daffodil-lib/src/main/resources/edu/illinois/ncsa/daffodil/xsd/built-in-formats.xsd
@@ -47,7 +47,7 @@
 					textStandardGroupingSeparator="," textStandardExponentRep="E"
 					textStandardZeroRep="0" textStandardInfinityRep="Inf"
 					textStandardNaNRep="NaN" textNumberPattern="#,##0.###;-#,##0.###"
-					textNumberRounding="explicit" textNumberRoundingMode="roundUnnecessary"
+					textNumberRounding="explicit" textNumberRoundingMode="roundHalfEven"
 					textNumberRoundingIncrement="0" decimalSigned="yes"
                      />
 			</dfdl:defineFormat>

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
@@ -72,7 +72,7 @@
           textNumberRep="standard"
           textNumberRounding="explicit"
           textNumberRoundingIncrement="0"
-          textNumberRoundingMode="roundUnnecessary"
+          textNumberRoundingMode="roundHalfEven"
           textOutputMinLength="0"
           textPadKind="none"
           textStandardBase="10"

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
@@ -180,12 +180,12 @@ case class UnsignedLongConverter() extends ConvertTo[BigInt] {
       if (l >= 0L) new BigInt(java.math.BigInteger.valueOf(l))
       else throw new Exception("parsed as negative value")
     }
-    case bi: java.math.BigInteger => {
-      val ul = new BigInt(bi)
+    case icubd: com.ibm.icu.math.BigDecimal => {
+      val ul = new BigInt(icubd.toBigIntegerExact)
       if (ul > maxUnsignedLong) throw new Exception("too big for unsignedLong")
       if (ul < 0) throw new Exception("parsed as negative value")
       ul
     }
-    case _ => throw new Exception("not a valid unsignedLong")
+    case other => throw new Exception("not a valid unsignedLong: " + other + " : " + other.getClass.getName)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetOutputter.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.infoset
 
 import org.apache.daffodil.util.MStackOfBoolean
 import org.apache.daffodil.util.Indentable
-import com.fasterxml.jackson.core.io.JsonStringEncoder
+import com.fasterxml.jackson.core.util.BufferRecyclers
 import org.apache.daffodil.dpath.NodeInfo
 
 class JsonInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
@@ -33,7 +33,7 @@ class JsonInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
   // is false).
   private val isFirstChildStack = MStackOfBoolean()
 
-  private val stringEncoder = JsonStringEncoder.getInstance() // thread-safe instance of a string encoder
+  private val stringEncoder = BufferRecyclers.getJsonStringEncoder() // thread-safe instance of a string encoder
 
   override def reset(): Unit = {
     isFirstChildStack.clear()

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -355,15 +355,8 @@
 		<tdml:validationErrors>
 
 			<tdml:error>data</tdml:error>
-			<tdml:error>occurred</tdml:error>
-			<!-- <tdml:error>'9'</tdml:error> -->
-			<tdml:error>expected</tdml:error>
-			<tdml:error>minimum of '2'</tdml:error>
-			<tdml:error>maximum of '5'</tdml:error>
-
-
-			<tdml:error>'ex:data'</tdml:error>
 			<tdml:error>occur</tdml:error>
+			<tdml:error>expected</tdml:error>
 			<tdml:error>maximum of '5'</tdml:error>
 			<tdml:error>exceeded</tdml:error>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/RuntimeCalendarLanguage.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/RuntimeCalendarLanguage.tdml
@@ -45,8 +45,7 @@
        Purpose: This test demonstrates setting the calendarLanguage property at runtime to German.
 -->
   <tdml:parserTestCase name="runtimeCalendarLanguage1" root="r" model="s1" 
-  description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
-  roundTrip="twoPass">
+  description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
 
     <tdml:document><![CDATA[de1996Freitag März 2013]]></tdml:document>
     <tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -507,13 +507,15 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="Long2" root="l_2"
+  <tdml:parserTestCase name="Long2" root="l_2" roundTrip="twoPass"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-long - DFDL-5-012R">
 
     <tdml:document><![CDATA[1         ]]></tdml:document>
-    <tdml:errors>
-      <tdml:error />
-    </tdml:errors>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <l_2>1</l_2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="Long3" root="l_3"
@@ -631,7 +633,8 @@
     description="Test parsing when encountering a whitespace character during a invalid unsigned int - DFDL-5-018R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -643,7 +646,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidUnsignedInt"
-    root="uI_03" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="uI_03" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid unsigned int - DFDL-5-018R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
@@ -721,7 +724,8 @@
     description="Test parsing when encountering a whitespace character during a invalid int - DFDL-5-013R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -733,7 +737,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidInt"
-    root="int05" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="int05" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid int - DFDL-5-013R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
@@ -811,7 +815,8 @@
     description="Test parsing when encountering a whitespace character during a invalid integer - DFDL-5-011R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -823,7 +828,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidInteger"
-    root="integer02" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="integer02" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid integer - DFDL-5-011R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
@@ -902,7 +907,8 @@
     description="Test parsing when encountering a whitespace character during an invalid long - DFDL-5-012R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -914,12 +920,12 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidLong"
-    root="l_4" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="l_4" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid long - DFDL-5-012R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-       <integer02>999</integer02>
+       <l_4>999</l_4>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -1004,7 +1010,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidShort"
-    root="s_1" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="s_1" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid short - DFDL-5-014R">
     <tdml:document><![CDATA[9999 ]]></tdml:document>
     <tdml:infoset>
@@ -1046,6 +1052,7 @@
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1083,7 +1090,8 @@
     description="Test parsing when encountering a whitespace character during an invalid byte - DFDL-5-015R">
     <tdml:document><![CDATA[00 12]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '00 1' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1095,7 +1103,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidByte"
-    root="b_01" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="b_01" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid byte - DFDL-5-015R">
     <tdml:document><![CDATA[127 ]]></tdml:document>
     <tdml:infoset>
@@ -1189,7 +1197,8 @@
     description="Test parsing when encountering a whitespace character during a invalid unsigned long - DFDL-5-017R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1201,7 +1210,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidUnsignedLong"
-    root="uL_04" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="uL_04" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid unsigned long - DFDL-5-017R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
@@ -1295,7 +1304,8 @@
     description="Test parsing when encountering a whitespace character during a invalid unsigned short - DFDL-5-019R">
     <tdml:document><![CDATA[99 99]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '99 9' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1307,7 +1317,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidUnsignedShort"
-    root="uS_02" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="uS_02" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid unsigned short - DFDL-5-019R">
     <tdml:document><![CDATA[999 ]]></tdml:document>
     <tdml:infoset>
@@ -1401,7 +1411,8 @@
     description="Test parsing when encountering a whitespace character during a valid unsigned byte - DFDL-5-020R">
     <tdml:document><![CDATA[1 27]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Left over data</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse '1 2' (using up all characters).</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1413,7 +1424,7 @@
 -->
 
   <tdml:parserTestCase name="whiteSpaceAfterValidUnsignedByte"
-    root="uB_01" model="SimpleTypes-Embedded.dfdl.xsd"
+    root="uB_01" model="SimpleTypes-Embedded.dfdl.xsd" roundTrip="twoPass"
     description="Test parsing when encountering a whitespace character after a valid Unsigned byte - DFDL-5-020R">
     <tdml:document><![CDATA[99 ]]></tdml:document>
     <tdml:infoset>
@@ -4949,8 +4960,7 @@
 -->
   
   <tdml:parserTestCase name="dateCalendarLanguage" root="date24"
-    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R"
-    roundTrip="twoPass">
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
 
     <tdml:document><![CDATA[Freitag März 2013]]></tdml:document>
     <tdml:infoset>
@@ -5008,7 +5018,7 @@
   <tdml:parserTestCase name="dateCalendarLanguage4" root="date32"
     model="dateTimeSchema" description="Section 13 Simple Types - calendarLanguage - DFDL-13-145R">
 
-    <tdml:document><![CDATA[пятница марта 2013]]></tdml:document>
+    <tdml:document><![CDATA[пятница мар. 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <date32>2013-03-01+00:00</date32>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -1050,7 +1050,6 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Unable to parse expression</tdml:error>
-      <tdml:error>but `/' found</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -762,7 +762,7 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax01" root="tnp28" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">1234</tdml:documentPart>
@@ -830,14 +830,14 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax04" root="tnp12" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[    0052    ]]></tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <tnp10>52</tnp10>
+        <tnp12>52</tnp12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 
@@ -852,7 +852,7 @@
 -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax05" root="tnp29" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[1234]]></tdml:documentPart>
@@ -965,7 +965,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax10" root="tnp34" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[  03  ]]></tdml:documentPart>
@@ -987,7 +987,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax11" root="tnp34" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[  3  ]]></tdml:documentPart>
@@ -1009,14 +1009,14 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax12" root="tnp35" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[  3  ]]></tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <tnp34>3</tnp34>
+        <tnp35>3</tnp35>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 
@@ -1031,7 +1031,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax13" root="tnp33" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[   3352     ]]></tdml:documentPart>
@@ -1053,7 +1053,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax14" root="tnp33" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[   03352     ]]></tdml:documentPart>
@@ -1075,7 +1075,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax15" root="tnp32" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[    3352    ]]></tdml:documentPart>
@@ -1097,7 +1097,7 @@
   -->
 
   <tdml:parserTestCase name="textNumberCheckPolicy_lax16" root="tnp36" model="textNumberPattern"
-    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R">
+    description="Section 13.6 - textNumberCheckPolicy - DFDL-13-052R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[    3352    ]]></tdml:documentPart>
@@ -1638,7 +1638,8 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardDecimalSeparator cannot contain</tdml:error>
+      <tdml:error>Byte Entity</tdml:error>
+      <tdml:error>%#r2E;</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -1914,7 +1915,8 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardGroupingSeparator cannot contain</tdml:error>
+      <tdml:error>Byte Entity</tdml:error>
+      <tdml:error>%#r5B;</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2106,14 +2108,16 @@
   -->
 
   <tdml:parserTestCase name="textNumberPattern_scientificNotation02" root="tnp50" model="textNumberPattern"
-    description="Section 13 - Text number pattern - Scientific Notation - DFDL-13-087R">
+    description="Section 13 - Text number pattern - Scientific Notation - DFDL-13-087R" roundTrip="twoPass">
 
     <tdml:document>
       <tdml:documentPart type="text">1.234E3</tdml:documentPart>
     </tdml:document>
-    <tdml:errors>
-      <tdml:error>Parse Error</tdml:error>
-    </tdml:errors>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:tnp50 xmlns:ex="http://example.com">1234.0</ex:tnp50>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
   
   <!--
@@ -2221,7 +2225,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Invalid textNumberPattern</tdml:error>
-      <tdml:error>Grouping separator in exponential in pattern "##,###.##E0"</tdml:error>
+      <tdml:error>Cannot have grouping separator in scientific notation</tdml:error>
+      <tdml:error>##,###.##E0</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2302,7 +2307,7 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Invalid textNumberPattern</tdml:error>
-      <tdml:error>Multiple pad specifiers in pattern</tdml:error>
+      <tdml:error>multiple pad specifiers</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2427,7 +2432,7 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Invalid textNumberPattern</tdml:error>
-      <tdml:error>Multiple pad specifiers in pattern</tdml:error>
+      <tdml:error>multiple pad specifiers</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2489,7 +2494,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Invalid textNumberPattern</tdml:error>
-      <tdml:error>Invalid pad specifier in pattern "#*"</tdml:error>
+      <tdml:error>Malformed pattern</tdml:error>
+      <tdml:error>"#*"</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -3141,6 +3147,8 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Byte Entity</tdml:error>
+      <tdml:error>%#r3E;</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -3301,11 +3309,11 @@
     <tdml:document>
       <tdml:documentPart type="text">-123</tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <tnp89>123</tnp89>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Convert to Unsigned Short (for xs:unsignedShort)</tdml:error>
+      <tdml:error>Out of Range: '-123' converted to -123, is not in range for the type</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
   
   <!--
@@ -4145,7 +4153,8 @@
     </tdml:document>
 	
 	<tdml:errors>
-		<tdml:error>Invalid textNumberPattern: Unquoted special character</tdml:error>
+		<tdml:error>Invalid textNumberPattern</tdml:error>
+    <tdml:error>unquoted special character</tdml:error>
 	</tdml:errors>
 
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -524,6 +524,7 @@
     <xs:element name="tnp02" type="xs:decimal" dfdl:textNumberRep="standard" dfdl:textNumberPattern="00.000;" />
     <xs:element name="tnp03" type="xs:decimal" dfdl:textNumberRep="standard" dfdl:textNumberPattern="##.##;" />
     <xs:element name="tnp04" type="xs:decimal" dfdl:textNumberRep="standard" dfdl:textNumberPattern="#.####;" />
+    <xs:element name="tnp05" type="xs:decimal" dfdl:textNumberRep="standard" dfdl:textNumberPattern="##.##;" dfdl:textNumberRoundingMode="roundUnnecessary" />
 
   </tdml:defineSchema>
   
@@ -625,6 +626,46 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:document><![CDATA[0.1]]></tdml:document>
+  </tdml:unparserTestCase>
+
+<!--
+     Test Name: unparse_tnp_05a
+        Schema: pattern
+          Root: tnp05
+       Purpose: This test demonstrates that it is a processing error if rounding is required with roundingMode of roundUnnecessary
+-->
+
+  <tdml:unparserTestCase name="unparse_tnp_05a" root="tnp05"
+    model="pattern" description="DFDL-13-080R" roundTrip="false">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:tnp05>0.125</ex:tnp05>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>rounding</tdml:error>
+    </tdml:errors>
+    <tdml:document><![CDATA[0.12]]></tdml:document>
+  </tdml:unparserTestCase>
+
+<!--
+     Test Name: unparse_tnp_05b
+        Schema: pattern
+          Root: tnp05
+       Purpose: This test demonstrates that it unparse succeeds if rounding is not required with roundingMode of roundUnnecessary
+-->
+
+  <tdml:unparserTestCase name="unparse_tnp_05b" root="tnp05"
+    model="pattern" description="DFDL-13-080R">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:tnp05>0.12</ex:tnp05>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document><![CDATA[0.12]]></tdml:document>
   </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc2.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc2.tdml
@@ -369,7 +369,7 @@
 
           <xs:element name="x" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../xi }" dfdl:outputValueCalc="{ fn:concat('2017-8-',dfdl:valueLength(../y, 'bytes')) }" dfdl:calendarPatternKind="explicit" />
           <xs:element name="y" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../yi }" dfdl:outputValueCalc="{ fn:concat('1986-6-',dfdl:valueLength(../z, 'bytes')) }" dfdl:calendarPatternKind="explicit" />
-          <xs:element name="z" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMM yyyy" dfdl:calendarLanguage="{ ../zi }" dfdl:calendarPatternKind="explicit" dfdl:encoding="UTF-8" />
+          <xs:element name="z" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../zi }" dfdl:calendarPatternKind="explicit" dfdl:encoding="UTF-8" />
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -490,7 +490,7 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:document>
-      <tdml:documentPart type="text">XYZ5X038.0Y41.23Z008</tdml:documentPart>
+      <tdml:documentPart type="text">XYZ5.0X038.0Y41.23Z008</tdml:documentPart>
     </tdml:document>
   </tdml:unparserTestCase>
 

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
@@ -67,15 +67,6 @@ class TestSimpleTypesDebug {
   @Test def test_dateCalendarCenturyStart2() { runner.runOneTest("dateCalendarCenturyStart2") }
 
   //////////////////////// DFDL-845 ////////////////////////////
-  @Test def test_whiteSpaceAfterValidInt() { runner.runOneTest("whiteSpaceAfterValidInt") }
-  @Test def test_whiteSpaceAfterValidLong() { runner.runOneTest("whiteSpaceAfterValidLong") }
-  @Test def test_whiteSpaceAfterValidShort() { runner.runOneTest("whiteSpaceAfterValidShort") }
-  @Test def test_whiteSpaceAfterValidUnsignedInt() { runner.runOneTest("whiteSpaceAfterValidUnsignedInt") }
-  @Test def test_whiteSpaceAfterValidUnsignedShort() { runner.runOneTest("whiteSpaceAfterValidUnsignedShort") }
-  @Test def test_whiteSpaceAfterValidUnsignedByte() { runner.runOneTest("whiteSpaceAfterValidUnsignedByte") }
-  @Test def test_whiteSpaceAfterValidByte() { runner.runOneTest("whiteSpaceAfterValidByte") }
-  @Test def test_whiteSpaceAfterValidUnsignedLong() { runner.runOneTest("whiteSpaceAfterValidUnsignedLong") }
-  @Test def test_whiteSpaceAfterValidInteger() { runner.runOneTest("whiteSpaceAfterValidInteger") }
 
   @Test def test_whiteSpaceDuringValidShort() { runner.runOneTest("whiteSpaceDuringValidShort") }
   @Test def test_whiteSpaceDuringValidInteger() { runner.runOneTest("whiteSpaceDuringValidInteger") }

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsDebug.scala
@@ -34,34 +34,19 @@ class TestTextNumberPropsDebug {
 
   import TestTextNumberPropsDebug._
 
-  // DFDL-845
-  @Test def test_textNumberCheckPolicy_lax01() { runner.runOneTest("textNumberCheckPolicy_lax01") }
-  @Test def test_textNumberCheckPolicy_lax05() { runner.runOneTest("textNumberCheckPolicy_lax05") }
-  @Test def test_textNumberCheckPolicy_lax04() { runner.runOneTest("textNumberCheckPolicy_lax04") }
-  @Test def test_textNumberCheckPolicy_lax10() { runner.runOneTest("textNumberCheckPolicy_lax10") }
-  @Test def test_textNumberCheckPolicy_lax11() { runner.runOneTest("textNumberCheckPolicy_lax11") }
-  @Test def test_textNumberCheckPolicy_lax12() { runner.runOneTest("textNumberCheckPolicy_lax12") }
-  @Test def test_textNumberCheckPolicy_lax13() { runner.runOneTest("textNumberCheckPolicy_lax13") }
-  @Test def test_textNumberCheckPolicy_lax14() { runner.runOneTest("textNumberCheckPolicy_lax14") }
-  @Test def test_textNumberCheckPolicy_lax15() { runner.runOneTest("textNumberCheckPolicy_lax15") }
-  @Test def test_textNumberCheckPolicy_lax16() { runner.runOneTest("textNumberCheckPolicy_lax16") }
-
   // DFDL-847
   @Test def test_textStandardDecimalSeparator10() { runner.runOneTest("textStandardDecimalSeparator10") }
   @Test def test_textStandardDecimalSeparator11() { runner.runOneTest("textStandardDecimalSeparator11") }
-
-  // DFDL-851
-  @Test def test_textStandardGroupingSeparator12() { runner.runOneTest("textStandardGroupingSeparator12") }
-  @Test def test_textStandardDecimalSeparator17() { runner.runOneTest("textStandardDecimalSeparator17") }
-  @Test def test_standardZeroRep07() { runner.runOneTest("standardZeroRep07") }
 
   // DFDL-853
   @Test def test_textNumberPattern_pSymbol01() { runner.runOneTest("textNumberPattern_pSymbol01") }
   @Test def test_textNumberPattern_pSymbol02() { runner.runOneTest("textNumberPattern_pSymbol02") }
 
-  @Test def test_textNumberPattern_scientificNotation02() { runner.runOneTest("textNumberPattern_scientificNotation02") }
-
-  //DFDL-191
+  // DFDL-861
   @Test def test_infnanCaseInsensitive() { runner.runOneTest("infnanCaseInsensitive") }
   @Test def test_expCaseSensitive() { runner.runOneTest("expCaseSensitive") }
+
+  // DAFFODIL-1981
+  @Test def test_expEmptyString() { runner.runOneTest("expEmptyString") }
+  @Test def test_expEmptyString2() { runner.runOneTest("expEmptyString2") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -283,15 +283,15 @@ class TestSimpleTypes {
   //@Test def test_whiteSpaceDuringValidLong() { runner.runOneTest("whiteSpaceDuringValidLong") }
   //@Test def test_whiteSpaceDuringValidByte() { runner.runOneTest("whiteSpaceDuringValidByte") }
 
-  //@Test def test_whiteSpaceAfterValidInt() { runner.runOneTest("whiteSpaceAfterValidInt") }
-  //@Test def test_whiteSpaceAfterValidLong() { runner.runOneTest("whiteSpaceAfterValidLong") }
-  //@Test def test_whiteSpaceAfterValidShort() { runner.runOneTest("whiteSpaceAfterValidShort") }
-  //@Test def test_whiteSpaceAfterValidUnsignedInt() { runner.runOneTest("whiteSpaceAfterValidUnsignedInt") }
-  //@Test def test_whiteSpaceAfterValidUnsignedShort() { runner.runOneTest("whiteSpaceAfterValidUnsignedShort") }
-  //@Test def test_whiteSpaceAfterValidUnsignedByte() { runner.runOneTest("whiteSpaceAfterValidUnsignedByte") }
-  //@Test def test_whiteSpaceAfterValidByte() { runner.runOneTest("whiteSpaceAfterValidByte") }
-  //@Test def test_whiteSpaceAfterValidUnsignedLong() { runner.runOneTest("whiteSpaceAfterValidUnsignedLong") }
-  //@Test def test_whiteSpaceAfterValidInteger() { runner.runOneTest("whiteSpaceAfterValidInteger") }
+  @Test def test_whiteSpaceAfterValidInt() { runner.runOneTest("whiteSpaceAfterValidInt") }
+  @Test def test_whiteSpaceAfterValidLong() { runner.runOneTest("whiteSpaceAfterValidLong") }
+  @Test def test_whiteSpaceAfterValidShort() { runner.runOneTest("whiteSpaceAfterValidShort") }
+  @Test def test_whiteSpaceAfterValidUnsignedInt() { runner.runOneTest("whiteSpaceAfterValidUnsignedInt") }
+  @Test def test_whiteSpaceAfterValidUnsignedShort() { runner.runOneTest("whiteSpaceAfterValidUnsignedShort") }
+  @Test def test_whiteSpaceAfterValidUnsignedByte() { runner.runOneTest("whiteSpaceAfterValidUnsignedByte") }
+  @Test def test_whiteSpaceAfterValidByte() { runner.runOneTest("whiteSpaceAfterValidByte") }
+  @Test def test_whiteSpaceAfterValidUnsignedLong() { runner.runOneTest("whiteSpaceAfterValidUnsignedLong") }
+  @Test def test_whiteSpaceAfterValidInteger() { runner.runOneTest("whiteSpaceAfterValidInteger") }
 
   @Test def test_characterDuringValidInt() { runner.runOneTest("characterDuringValidInt") }
   @Test def test_whiteSpaceAfterLengthExceededInt() { runner.runOneTest("whiteSpaceAfterLengthExceededInt") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -63,24 +63,18 @@ class TestTextNumberProps {
 
   @Test def test_standardZeroRep01() { runner.runOneTest("standardZeroRep01") }
   @Test def test_standardZeroRep02() { runner.runOneTest("standardZeroRep02") }
+  @Test def test_standardZeroRep03() { runner.runOneTest("standardZeroRep03") }
+  @Test def test_standardZeroRep04() { runner.runOneTest("standardZeroRep04") }
+  @Test def test_standardZeroRep04b() { runner.runOneTest("standardZeroRep04b") }
   @Test def test_standardZeroRep05() { runner.runOneTest("standardZeroRep05") }
   @Test def test_standardZeroRep06() { runner.runOneTest("standardZeroRep06") }
+  @Test def test_standardZeroRep07() { runner.runOneTest("standardZeroRep07") }
   @Test def test_standardZeroRep08() { runner.runOneTest("standardZeroRep08") }
+  @Test def test_standardZeroRep09() { runner.runOneTest("standardZeroRep09") }
   @Test def test_standardZeroRep10() { runner.runOneTest("standardZeroRep10") }
   @Test def test_standardZeroRep11() { runner.runOneTest("standardZeroRep11") }
 
   @Test def test_textNumberPattern_noNegative() { runner.runOneTest("textNumberPattern_noNegative") }
-
-  // DFDL-861
-  //  @Test def test_standardZeroRep03() { runner.runOneTest("standardZeroRep03") }
-
-  // DFDL-851
-  //  @Test def test_standardZeroRep07() { runner.runOneTest("standardZeroRep07") }
-
-  @Test def test_standardZeroRep09() { runner.runOneTest("standardZeroRep09") }
-
-  @Test def test_standardZeroRep04() { runner.runOneTest("standardZeroRep04") }
-  @Test def test_standardZeroRep04b() { runner.runOneTest("standardZeroRep04b") }
 
   @Test def test_lengthDeterminedFirst01() { runner.runOneTest("lengthDeterminedFirst01") }
   @Test def test_lengthDeterminedFirst02() { runner.runOneTest("lengthDeterminedFirst02") }
@@ -93,6 +87,8 @@ class TestTextNumberProps {
   @Test def test_dynamicExp_neg() { runner.runOneTest("dynamicExpNeg") }
   @Test def test_dynamicExpInvalid() { runner.runOneTest("dynamicExpInvalid") }
   @Test def test_expCaseInsensitive() { runner.runOneTest("expCaseInsensitive") }
+  // DAFFODIL-861
+  //@Test def test_expCaseSensitive() { runner.runOneTest("expCaseSensitive") }
   @Test def test_expRawByteInvalid() { runner.runOneTest("expRawByteInvalid") }
   @Test def test_expRawByteNotAllowed() { runner.runOneTest("expRawByteNotAllowed") }
   @Test def test_expCharClasses() { runner.runOneTest("expCharClasses") }
@@ -100,8 +96,9 @@ class TestTextNumberProps {
   @Test def test_expCharEntities2() { runner.runOneTest("expCharEntities2") }
   @Test def test_noStandardExpRep() { runner.runOneTest("noStandardExpRep") }
   @Test def test_noStandardExpRep2() { runner.runOneTest("noStandardExpRep2") }
-  @Test def test_expEmptyString() { runner.runOneTest("expEmptyString") }
-  @Test def test_expEmptyString2() { runner.runOneTest("expEmptyString2") }
+  // DAFFODIL-1981
+  //@Test def test_expEmptyString() { runner.runOneTest("expEmptyString") }
+  //@Test def test_expEmptyString2() { runner.runOneTest("expEmptyString2") }
 
   @Test def test_zero() { runner.runOneTest("zero") }
   @Test def test_pattern_neg1() { runner.runOneTest("pattern_neg1") }
@@ -118,25 +115,25 @@ class TestTextNumberProps {
   @Test def test_nanCharEntities() { runner.runOneTest("nanCharEntities") }
   @Test def test_infCharClasses() { runner.runOneTest("infCharClasses") }
   @Test def test_infCharEntities() { runner.runOneTest("infCharEntities") }
+  // DAFFODIL-861
+  //@Test def test_infnanCaseInsensitive() { runner.runOneTest("infnanCaseInsensitive") }
 
-  // DFDL-845
-  //  @Test def test_textNumberCheckPolicy_lax01() { runner.runOneTest("textNumberCheckPolicy_lax01") }
-  //  @Test def test_textNumberCheckPolicy_lax05() { runner.runOneTest("textNumberCheckPolicy_lax05") }
-  //  @Test def test_textNumberCheckPolicy_lax04() { runner.runOneTest("textNumberCheckPolicy_lax04") }
-  //  @Test def test_textNumberCheckPolicy_lax10() { runner.runOneTest("textNumberCheckPolicy_lax10") }
-  //  @Test def test_textNumberCheckPolicy_lax11() { runner.runOneTest("textNumberCheckPolicy_lax11") }
-  //  @Test def test_textNumberCheckPolicy_lax12() { runner.runOneTest("textNumberCheckPolicy_lax12") }
-  //  @Test def test_textNumberCheckPolicy_lax13() { runner.runOneTest("textNumberCheckPolicy_lax13") }
-  //  @Test def test_textNumberCheckPolicy_lax14() { runner.runOneTest("textNumberCheckPolicy_lax14") }
-  //  @Test def test_textNumberCheckPolicy_lax15() { runner.runOneTest("textNumberCheckPolicy_lax15") }
-  //  @Test def test_textNumberCheckPolicy_lax16() { runner.runOneTest("textNumberCheckPolicy_lax16") }
-
+  @Test def test_textNumberCheckPolicy_lax01() { runner.runOneTest("textNumberCheckPolicy_lax01") }
   @Test def test_textNumberCheckPolicy_lax02() { runner.runOneTest("textNumberCheckPolicy_lax02") }
   @Test def test_textNumberCheckPolicy_lax03() { runner.runOneTest("textNumberCheckPolicy_lax03") }
+  @Test def test_textNumberCheckPolicy_lax04() { runner.runOneTest("textNumberCheckPolicy_lax04") }
+  @Test def test_textNumberCheckPolicy_lax05() { runner.runOneTest("textNumberCheckPolicy_lax05") }
   @Test def test_textNumberCheckPolicy_lax06() { runner.runOneTest("textNumberCheckPolicy_lax06") }
   @Test def test_textNumberCheckPolicy_lax07() { runner.runOneTest("textNumberCheckPolicy_lax07") }
   @Test def test_textNumberCheckPolicy_lax08() { runner.runOneTest("textNumberCheckPolicy_lax08") }
   @Test def test_textNumberCheckPolicy_lax09() { runner.runOneTest("textNumberCheckPolicy_lax09") }
+  @Test def test_textNumberCheckPolicy_lax10() { runner.runOneTest("textNumberCheckPolicy_lax10") }
+  @Test def test_textNumberCheckPolicy_lax11() { runner.runOneTest("textNumberCheckPolicy_lax11") }
+  @Test def test_textNumberCheckPolicy_lax12() { runner.runOneTest("textNumberCheckPolicy_lax12") }
+  @Test def test_textNumberCheckPolicy_lax13() { runner.runOneTest("textNumberCheckPolicy_lax13") }
+  @Test def test_textNumberCheckPolicy_lax14() { runner.runOneTest("textNumberCheckPolicy_lax14") }
+  @Test def test_textNumberCheckPolicy_lax15() { runner.runOneTest("textNumberCheckPolicy_lax15") }
+  @Test def test_textNumberCheckPolicy_lax16() { runner.runOneTest("textNumberCheckPolicy_lax16") }
   @Test def test_textNumberCheckPolicy_lax17() { runner.runOneTest("textNumberCheckPolicy_lax17") }
 
   @Test def test_textNumberCheckPolicy_strict01() { runner.runOneTest("textNumberCheckPolicy_strict01") }
@@ -161,6 +158,7 @@ class TestTextNumberProps {
   @Test def test_textStandardDecimalSeparator14() { runner.runOneTest("textStandardDecimalSeparator14") }
   @Test def test_textStandardDecimalSeparator15() { runner.runOneTest("textStandardDecimalSeparator15") }
   @Test def test_textStandardDecimalSeparator16() { runner.runOneTest("textStandardDecimalSeparator16") }
+  @Test def test_textStandardDecimalSeparator17() { runner.runOneTest("textStandardDecimalSeparator17") }
 
   // DFDL-847
   //  @Test def test_textStandardDecimalSeparator10() { runner.runOneTest("textStandardDecimalSeparator10") }
@@ -177,22 +175,19 @@ class TestTextNumberProps {
   @Test def test_textStandardGroupingSeparator09() { runner.runOneTest("textStandardGroupingSeparator09") }
   @Test def test_textStandardGroupingSeparator10() { runner.runOneTest("textStandardGroupingSeparator10") }
   @Test def test_textStandardGroupingSeparator11() { runner.runOneTest("textStandardGroupingSeparator11") }
+  @Test def test_textStandardGroupingSeparator12() { runner.runOneTest("textStandardGroupingSeparator12") }
   @Test def test_textStandardGroupingSeparator13() { runner.runOneTest("textStandardGroupingSeparator13") }
   @Test def test_textStandardGroupingSeparator14() { runner.runOneTest("textStandardGroupingSeparator14") }
   @Test def test_textStandardGroupingSeparator15() { runner.runOneTest("textStandardGroupingSeparator15") }
   @Test def test_textStandardGroupingSeparator16() { runner.runOneTest("textStandardGroupingSeparator16") }
   @Test def test_textStandardGroupingSeparator17() { runner.runOneTest("textStandardGroupingSeparator17") }
 
-  // DFDL-851
-  //  @Test def test_textStandardGroupingSeparator12() { runner.runOneTest("textStandardGroupingSeparator12") }
-  //  @Test def test_textStandardDecimalSeparator17() { runner.runOneTest("textStandardDecimalSeparator17") }
-
   // DFDL-853
   //  @Test def test_textNumberPattern_pSymbol01() { runner.runOneTest("textNumberPattern_pSymbol01") }
   //  @Test def test_textNumberPattern_pSymbol02() { runner.runOneTest("textNumberPattern_pSymbol02") }
 
   @Test def test_textNumberPattern_scientificNotation01() { runner.runOneTest("textNumberPattern_scientificNotation01") }
-  //  @Test def test_textNumberPattern_scientificNotation02() { runner.runOneTest("textNumberPattern_scientificNotation02") }
+  @Test def test_textNumberPattern_scientificNotation02() { runner.runOneTest("textNumberPattern_scientificNotation02") }
   @Test def test_textNumberPattern_scientificNotation03() { runner.runOneTest("textNumberPattern_scientificNotation03") }
   @Test def test_textNumberPattern_scientificNotation04() { runner.runOneTest("textNumberPattern_scientificNotation04") }
   @Test def test_textNumberPattern_scientificNotation05() { runner.runOneTest("textNumberPattern_scientificNotation05") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
@@ -66,4 +66,6 @@ class TestTextNumberPropsUnparse {
   @Test def test_unparse_tnp_02() { runner.runOneTest("unparse_tnp_02") }
   @Test def test_unparse_tnp_03() { runner.runOneTest("unparse_tnp_03") }
   @Test def test_unparse_tnp_04() { runner.runOneTest("unparse_tnp_04") }
+  @Test def test_unparse_tnp_05a() { runner.runOneTest("unparse_tnp_05a") }
+  @Test def test_unparse_tnp_05b() { runner.runOneTest("unparse_tnp_05b") }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,30 +22,30 @@ object Dependencies {
   lazy val common = core ++ infoset ++ test
 
   lazy val core = Seq(
-    "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-    "com.ibm.icu" % "icu4j" % "51.1", // new versions avail. 58.1 requires code changes
-    "xerces" % "xercesImpl" % "2.10.0",
+    "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+    "com.ibm.icu" % "icu4j" % "62.1",
+    "xerces" % "xercesImpl" % "2.12.0",
     "xml-resolver" % "xml-resolver" % "1.2",
-    "commons-io" % "commons-io" % "2.5",
-    "jline" % "jline" % "2.12.1", // newer versions avail. 3.0.0-M1 requires code changes
+    "commons-io" % "commons-io" % "2.6",
+    "jline" % "jline" % "2.14.6",
   )
 
   lazy val infoset = Seq(
     "org.jdom" % "jdom2" % "2.0.6",
-    "com.fasterxml.woodstox" % "woodstox-core" % "5.0.3",
-    "com.fasterxml.jackson.core" % "jackson-core" % "2.8.8"
+    "com.fasterxml.woodstox" % "woodstox-core" % "5.1.0",
+    "com.fasterxml.jackson.core" % "jackson-core" % "2.9.6"
   )
    
   lazy val cli = Seq( 
-    "org.fusesource.jansi" % "jansi" % "1.14",
-    "org.rogach" %% "scallop" % "3.1.2",
-    "net.sf.expectit" % "expectit-core" % "0.8.1" % "it,test"
+    "org.fusesource.jansi" % "jansi" % "1.17.1",
+    "org.rogach" %% "scallop" % "3.1.3",
+    "net.sf.expectit" % "expectit-core" % "0.9.0" % "it,test"
   )
 
   lazy val test = Seq(
-    "junit" % "junit" % "4.11" % "it,test",
+    "junit" % "junit" % "4.12" % "it,test",
     "com.novocode" % "junit-interface" % "0.11" % "it,test",
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "it,test"
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % "it,test"
   )
 }


### PR DESCRIPTION
Updates that required changes:

- ICU4J
  - License has switched to the Unicode license, LICENSE and NOTICE
    updated.
  - No longer requires that a positive number pattern exists. That is
    required by the DFDL specification, so the check is done manually
    (i.e. the pattern cannot start with a semi-colon)
  - ICU now correctly checks roundUnnecsssary and throws an exception
    if rounding is needed on unparsing--before it would just round with
    roundHalfEven. We now catch this exception and return an
    UnparseError. To maintain backwards compatibility, the
    textNumberRoundingMode property in built-in-formats.xsd and
    DFDLGeneralFormat.dfdl.xsd is changed from roundUnnecessary to
    roundHalfEven.
  - ICU's DecimalFormat.parse() method now returns an ICU BigDecimal
    instead of a Java BigInt/BigDecimal.
  - There is a bug in ICU that if a text number pattern uses scientific
    notation but the number is +Inf, -Inf, or NaN, ICU will add the
    exponent (e.g. INFx10^0). This is wrong, so this now manually
    detects if the number is one of those values and outputs the
    appropriate inf/nanRep along with pattern prefix/suffix instead of
    using the DecimalFormat.format method.
  - Lax number parsing no longer trims whitespace, so we now manually
    perform the trim if dfdl:checkPolicy is lax.
  - Various tests are changed or moved out of scala-debug due to ICU bug
    fixes. For example ICU now handles MMM (abbreviated month) for a
    Russian calendar language. Some tests are changed just due to
    different error messages. Some just need to use twoPass round trip.
  - A few tests now fail due to new bugs in ICU. The failing features are:
      1) ICU no longer trims padding characters after a suffix,
         resulting in failures when trying to parse such numbers leading
         to ParseErrors. Padding before prefix, after prefix, and
         before suffix still work as expected.
      2) ICU Fails to parse scientific numbers where the exponent rep
         is the empty string, e.g. 12.34+2 is now invalid.
    Tests (total of 3) that require these features are disabled and
    moved to scala-debug.

- Xerces
  - Some error messages changed to now expand namespace prefixes or
    display slightly different information, requiring updates to some
    tests.

- JLine
  - Deprecated shutdown() in favor of close()

- Jackson
  - Deprecated JsonStringReader.getInstance() replaced with
    BufferRecyclers.getJsonStringEncoder()

DAFFODIL-1973, DAFFODIL-851, DAFFODIL-845