### PR TITLE
Update sbt and sbt-native-packager plugin to make jar hashes consistent

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-sbt.version=1.0.4
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 
 addSbtPlugin("org.musigma" % "sbt-rat" % "0.6.0")
 
@@ -28,5 +28,5 @@ addSbtPlugin("org.musigma" % "sbt-rat" % "0.6.0")
 // dependencies to the latest versions and removes the warning.
 dependencyOverrides ++= Seq(
   "org.codehaus.plexus" % "plexus-utils" % "3.0.17",
-  "com.google.guava" % "guava" % "18.0"
+  "com.google.guava" % "guava" % "20.0"
 )


### PR DESCRIPTION
It looks like some combination of old versions of sbt and the sbt native
packager plugin caused generated jars in the zip/tar/rpms to have
different hashes. The only difference appeared to be the timestamp of
the file, but this makes it difficult to ensure that all files are the
same. Updating sbt and the sbt-native-packager plugin to the latest
version seems to correct this issue. So all jars, no matter if in a zip,
tar, rpm, or maven, should all have the exact same hash.

DAFFODIL-1938