### PR TITLE
Eliminates backpointers from RuntimeData structures.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -253,11 +253,6 @@ abstract class ChoiceTermBase(
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -479,34 +479,11 @@ trait ElementBase
   }.value
 
   protected def computeElementRuntimeData(): ElementRuntimeData = {
-    val ee = enclosingElement
-    //
-    // Must be lazy below, because we are defining the elementRuntimeData in terms of
-    // the elementRuntimeData of its enclosing element. This backpointer must be
-    // constructed lazily so that we first connect up all the erds to their children,
-    // and only subsequently ask for these parents to be elaborated.
-    //
-    lazy val parent = ee.map { enc =>
-      Assert.invariant(this != enc)
-      enc.elementRuntimeData
-    }
-    lazy val parentTerm = this.enclosingTerm.map { enc =>
-      Assert.invariant(this != enc)
-      enc.termRuntimeData
-    }
-
-    //
-    // I got sick of initialization time problems, so this mutual recursion
-    // defines the tree of ERDs.
-    //
-    // This works because of deferred arguments and lazy evaluation
-    //
+    
     lazy val childrenERDs: Seq[ElementRuntimeData] =
       elementChildren.map { _.elementRuntimeData }
 
     val newERD: ElementRuntimeData = new ElementRuntimeData(
-      parent,
-      parentTerm,
       childrenERDs,
       schemaSet.variableMap,
       nextElementResolver,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -24,7 +24,6 @@ import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.processors.RuntimeData
-import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.xml.ResolvesQNames
@@ -91,8 +90,6 @@ trait SchemaComponent
       diagnosticDebugName,
       path,
       namespaces,
-      enclosingElement.map { _.erd },
-      Maybe.toMaybe(enclosingTerm.map { _.termRuntimeData }),
       tunable)
   }.value
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -27,7 +27,6 @@ import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 import org.apache.daffodil.schema.annotation.props.gen.SequenceKind
 import org.apache.daffodil.Implicits.ns2String
 import org.apache.daffodil.grammar.SequenceGrammarMixin
-import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.schema.annotation.props.Found
 import org.apache.daffodil.schema.annotation.props.PropertyLookupResult
@@ -39,6 +38,7 @@ import org.apache.daffodil.processors.SeparatorParseEv
 import org.apache.daffodil.processors.ModelGroupRuntimeData
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.processors.SeparatorUnparseEv
+import org.apache.daffodil.exceptions.Assert
 
 /**
  * Base for anything sequence-like.
@@ -228,11 +228,6 @@ abstract class SequenceGroupTermBase(
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,
@@ -377,7 +372,6 @@ final class ChoiceBranchImpliedSequence(rawGM: Term)
     new SequenceRuntimeData(
       schemaSet.variableMap,
       encodingInfo,
-      // elementChildren.map { _.elementRuntimeData.dpathElementCompileInfo },
       schemaFileLocation,
       dpathCompileInfo,
       diagnosticDebugName,
@@ -385,11 +379,6 @@ final class ChoiceBranchImpliedSequence(rawGM: Term)
       namespaces,
       defaultBitOrder,
       groupMembersRuntimeData,
-      enclosingElement.map { _.elementRuntimeData }.getOrElse(
-        Assert.invariantFailed("model group with no surrounding element.")),
-      enclosingTerm.map { _.termRuntimeData }.getOrElse {
-        Assert.invariantFailed("model group with no surrounding term.")
-      },
       isRepresented,
       couldHaveText,
       alignmentValueInBits,

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
@@ -169,16 +169,14 @@ abstract class RepeatingChildUnparser(
                 // System.err.println("Stopping occurrences(1) of %s due to event %s".format(erd.namedQName, ev))
                 false // event not a start for this element
               }
-            } else if (ev.isEnd && ev.isComplex) {
-              //ok. We've peeked ahead and found the end of a complex element.
+            } else {
+              Assert.invariant(ev.isEnd)
+              // could be end of simple elemnet - we handle on the start event. Nothing to do.
+              // or could be end of complex event, i.e., we've peeked ahead and found the end of a complex element.
               // It has to be the complex element that ultimately encloses this sequence.
               // Though that's not a unique element given that this sequence could be inside
               // a global group definition that is reused in muliple places.
-              //that this sequence is the model group of.
-              false
-            } else {
-              // end of simple element. We shouldUnparse on the start event.
-              // System.err.println("Stopping occurrences(3) of %s due to event %s".format(erd.namedQName, ev))
+              // Nothing to do for complex type either.
               false
             }
           } else {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
@@ -170,23 +170,12 @@ abstract class RepeatingChildUnparser(
                 false // event not a start for this element
               }
             } else if (ev.isEnd && ev.isComplex) {
-              val c = ev.asComplex
-              //ok. We've peeked ahead and found the end of the complex element
+              //ok. We've peeked ahead and found the end of a complex element.
+              // It has to be the complex element that ultimately encloses this sequence.
+              // Though that's not a unique element given that this sequence could be inside
+              // a global group definition that is reused in muliple places.
               //that this sequence is the model group of.
-              val optParentRD = srd.immediateEnclosingElementRuntimeData
-              // FIXME: there's no reason to walk backpointer to immediateEnclosingElementRuntimeData
-              // as we just want that element's name, and we could precompute that and
-              // include it on the SequenceChildUnparser for this
-              optParentRD match {
-                case Some(e: ElementRuntimeData) => {
-                  Assert.invariant(c.runtimeData.namedQName =:= e.namedQName)
-                  // System.err.println("Stopping occurrences(2) of %s due to event %s".format(erd.namedQName, ev))
-                  false
-                }
-                case _ =>
-                  Assert.invariantFailed("Not end element for this sequence's containing element. Event %s, optParentRD %s.".format(
-                    ev, optParentRD))
-              }
+              false
             } else {
               // end of simple element. We shouldUnparse on the start event.
               // System.err.println("Stopping occurrences(3) of %s due to event %s".format(erd.namedQName, ev))


### PR DESCRIPTION
This is a step toward eliminating the double-linked non-sharing behavior
in the schema compiler, because maintaining these double-linked pointers
for the runtime was forcing them to exist in the schema compiler also.

DAFFODIL-1444