### PR TITLE
Change occursCountKind to 'implicit' in general format.

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
@@ -53,7 +53,7 @@
           leadingSkip="0"
           lengthKind="implicit"
           lengthUnits="bytes"
-          occursCountKind="parsed"
+          occursCountKind="implicit"
           outputNewLine="%LF;"
           representation="text"
           separator=""

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested_group_ref.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested_group_ref.tdml
@@ -23,8 +23,9 @@
 	xmlns:ex="http://example.com" xmlns="http://example.com"
 	xsi:schemaLocation="http://www.ibm.com/xmlns/dfdl/testData xsd/tdml.xsd">
 
-	<tdml:defineSchema name="nestedGroupRefs">
-		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+	<tdml:defineSchema name="nestedGroupRefs1">
+		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
+          occursCountKind="parsed" />
 
 		<xs:element name="root">
 			<xs:complexType>
@@ -59,8 +60,8 @@
 
 	</tdml:defineSchema>
 
-	<tdml:parserTestCase name="nestedGroupRefs" root="root"
-		model="nestedGroupRefs" description="Simple type defined in terms of primitive int.">
+	<tdml:parserTestCase name="nestedGroupRefs1" root="root"
+		model="nestedGroupRefs1" description="Simple type defined in terms of primitive int.">
 
 		<tdml:document><![CDATA[A,B,C|D,E,F|G,H,I
 A,B,C|D,E,F|G,H,I

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -137,7 +137,7 @@ class TresysTests {
   // @Test def test_t3() { runnerMB.runOneTest("t3") }
   // @Test def test_encodingErrorPolicy_error() { runnerMB.runOneTest("encodingErrorPolicy_error") }
 
-  @Test def test_nested_group_refs() { runnerNG.runOneTest("nestedGroupRefs") }
+  @Test def test_nested_group_refs1() { runnerNG.runOneTest("nestedGroupRefs1") }
 
   @Test def test_AF000() { runnerAF.runOneTest("AF000") }
   @Test def test_AF001() { runnerAF.runOneTest("AF001") }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScheme.tdml
@@ -277,7 +277,8 @@
   </parserTestCase>
   
   <defineSchema name="escapeSchemeExpressions">
-    <dfdl:format ref="tns:GeneralFormat" separatorPosition="infix" lengthKind="delimited"/> 
+    <dfdl:format ref="tns:GeneralFormat" separatorPosition="infix" lengthKind="delimited"
+      occursCountKind='parsed'/> 
 
     <dfdl:defineEscapeScheme name="fromData">
       <dfdl:escapeScheme escapeCharacter="{ /tns:e1/tns:escapeChar }"

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -55,7 +55,8 @@
   
   <tdml:defineSchema name="alignmentSchema">
     
-    <dfdl:format ref="ex:GeneralFormat" representation="binary" encoding="utf-8" alignmentUnits="bits" alignment="4" leadingSkip="0"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary" encoding="utf-8" alignmentUnits="bits" alignment="4" leadingSkip="0"
+      occursCountKind='parsed'/>
     
     <xs:element name="string32be" dfdl:representation="text" type="xs:string" dfdl:encoding="utf-32be" dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bytes"
       dfdl:alignment="2" dfdl:alignmentUnits="bits" dfdl:leadingSkip="0"/>
@@ -2023,7 +2024,7 @@
         Schema: alignmentSchema
           Root: e10
        Purpose: This test demonstrates that optional elements cannot have alignment properties different from the items
-                that follow them, or a SDE will be thrown.
+                that follow them, or a SDW will be issued.
   -->
 
   <tdml:parserTestCase name="alignmentOptionalElem" root="e10"
@@ -2049,7 +2050,7 @@
         Schema: alignmentSchema
           Root: e10a
        Purpose: This test demonstrates that optional elements cannot have alignment properties different from the items
-                that follow them, or a SDE will be thrown.
+                that follow them, or a SDW will be issued..
   -->
 
   <tdml:parserTestCase name="alignmentOptionalElem02" root="e10a"
@@ -2074,7 +2075,7 @@
         Schema: alignmentSchema
           Root: e10b
        Purpose: This test demonstrates that optional elements cannot have alignment properties different from the items
-                that follow them, or a SDE will be thrown.
+                that follow them, or a SDW will be issued.
   -->
 
   <tdml:parserTestCase name="alignmentOptionalElem03" root="e10b"
@@ -2098,7 +2099,7 @@
         Schema: alignmentSchema
           Root: e10c
        Purpose: This test demonstrates that optional elements cannot have alignment properties different from the items
-                that follow them, or a SDE will be thrown.
+                that follow them, or a SDW will be issued.
   -->
 
   <tdml:parserTestCase name="alignmentOptionalElem04" root="e10c"

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -983,7 +983,8 @@ more ignored input
   </tdml:parserTestCase>
 
 	<tdml:defineSchema name="nestedGroupRefs">
-		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
+          occursCountKind='parsed'/>
 
 		<xs:element name="root">
 			<xs:complexType>
@@ -1086,7 +1087,8 @@ A,B,C|D,E,F|G,H,I]]></tdml:document>
   </tdml:parserTestCase>
 
 	<tdml:defineSchema name="nestedGroupRefs2">
-		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" 
+          occursCountKind='parsed'/>
 
 		<xs:element name="root">
 			<xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupInitiatedContent.tdml
@@ -22,7 +22,8 @@
   xmlns:ex="http://example.com" xmlns:ct="http://w3.ibm.com/xmlns/dfdl/ctInfoset">
 
   <tdml:defineSchema name="s1">
-    <dfdl:format ref="ex:GeneralFormat" />
+    <dfdl:format ref="ex:GeneralFormat" 
+      occursCountKind='parsed'/>
 
     <xs:element name="e1" dfdl:lengthKind="implicit">
       <xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -228,7 +228,8 @@
 
 
   <tdml:defineSchema name="hiddenElem">
-    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
+      occursCountKind='parsed'/>
     
     <xs:group name="hiddenData">
       <xs:sequence dfdl:separator="|">


### PR DESCRIPTION
Fixed test regressions that were depending on 'parsed' behavior.

Also fixed some comments about SDE that is now an SDW (DAFFODIL-991)

DAFFODIL-1948, DAFFODIL-991