### PR TITLE
Enable tests that roundtrip with new ICU version

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext1.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/ibm-tests/dpaext1.tdml
@@ -58,12 +58,10 @@ the sample schemas given in the specification are used (made into complete schem
 the basic demonstration of DFDL with binary and text number formats  -->
 
 	<!-- example from  Simple Example 1.2  -->
-	<!-- See DFDL-1501 to make this round trip -->
 	<parserTestCase name="introduction_1_01"
 	    root="root"
 		model="./fvt/ext/dpa/dpaspc121_01.dfdl.xsd"
-		description="Section 1.2 General number example,  What is DFDL - binary numbers"
-		roundTrip="false">
+		description="Section 1.2 General number example,  What is DFDL - binary numbers">
 
 		<document><documentPart type="byte">0000000500779e8c169a54dd0a1b4a3fce2946f6</documentPart></document>
 
@@ -80,11 +78,9 @@ the basic demonstration of DFDL with binary and text number formats  -->
 	</parserTestCase>
 
 	<!--  Second example from  Simple Example 1.2 -->
-	<!-- See DFDL-1501 to make this round trip -->
 	<parserTestCase name="introduction_1_02" root="root"
 		model="./fvt/ext/dpa/dpaspc121_02.dfdl.xsd"
-		description="Section 12 lengthKind-delimited - DFDL-12-043R"
-		roundTrip="false">
+		description="Section 12 lengthKind-delimited - DFDL-12-043R">
 
 		<document>5,7839372,8.6E-200,-7.1E8</document>
 


### PR DESCRIPTION
The new version ICU fixed a bug related to unparsing very small
BigDecimals, allowing these tests to correctly trip.

DAFFODIL-1736