### PR TITLE
Fix comparison of calendars that do not have timezones

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -6029,11 +6029,11 @@ c]]></value>
     <tdml:document><![CDATA[2000-01-01T12:00:00,1999-12-31T23:00:00+00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e35>
-          <dateTime1>2000-01-01T12:00:00.000000+00:00</dateTime1>
+        <e35a>
+          <dateTime1>2000-01-01T12:00:00.000000</dateTime1>
           <dateTime2>1999-12-31T23:00:00.000000+00:00</dateTime2>
-          <oneLTtwo>false</oneLTtwo>
-        </e35>
+          <oneLTtwo>true</oneLTtwo>
+        </e35a>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
@@ -58,9 +58,6 @@ class TestDFDLExpressionsDebug {
 
   import TestDFDLExpressionsDebug._
 
-  // DAFFODIL-1986
-  @Test def test_comparison_operators_46a() { runner.runOneTest("comparison_operators_46a") }
-
   //DFDL-1287
   @Test def test_internal_space_preserved4() { runner.runOneTest("internal_space_preserved4") }
   @Test def test_internal_space_not_preserved2() { runner.runOneTest("internal_space_not_preserved2") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -157,9 +157,7 @@ class TestDFDLExpressions {
   @Test def test_comparison_operators_44() { runner.runOneTest("comparison_operators_44") }
   @Test def test_comparison_operators_45() { runner.runOneTest("comparison_operators_45") }
   @Test def test_comparison_operators_46() { runner.runOneTest("comparison_operators_46") }
-
-  // DAFFODIL-1986
-  // @Test def test_comparison_operators_46a() { runner.runOneTest("comparison_operators_46a") }
+  @Test def test_comparison_operators_46a() { runner.runOneTest("comparison_operators_46a") }
 
   // from XPath Spec Sec 10.4.6.1 Examples
   @Test def test_comparison_operators_47() { runner.runOneTest("comparison_operators_47") }


### PR DESCRIPTION
The assertions was just incorrect. It is perfectly valid to call the
orderIgnoreTimeZone function where one calendar has a timezone and the
other does not, as long as they have been normalized/modified according
to the W3C spec before being called. Remove this invarient, and add a
couple extra just to make sure we are modifying calendar appropriately.
And move test out of scala debug.

DAFFODIL-1986