### PR TITLE
Use --binary flag when generating release checksums

### DIFF
--- a/scripts/release-candidate.sh
+++ b/scripts/release-candidate.sh
@@ -100,8 +100,8 @@ do
     pushd $DAFFODIL_RELEASE_DIR/$i > /dev/null
     for file in *
     do
-       sha256sum $file > $file.sha256
-       sha512sum $file > $file.sha512
+       sha256sum --binary $file > $file.sha256
+       sha512sum --binary $file > $file.sha512
        gpg --default-key $PGP_SIGNING_KEY_ID --detach-sign --armor --output $file.asc $file
     done
     popd > /dev/null


### PR DESCRIPTION
The sha*sum programs default to --text mode when generating checksums.
On GNU systems this isn't a problem since --text and --binary are the
same. But that isn't the case on Windows systems, which can result in
failed checksum validations. This change specifies the --binary option
when generating checksums to ensure compatability with Windows and
similar systems.

DAFFODIL-2009