### PR TITLE
Check for available data before trying to parse binarySeconds or binaryMilliseconds

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
@@ -184,6 +184,12 @@ case class ConvertBinaryCalendarSecMilliParser(
   def parse(start: PState): Unit = {
 
     val dis = start.dataInputStream
+
+    if (!dis.isDefinedForLength(lengthInBits)) {
+      PENotEnoughBits(start, lengthInBits, dis.remainingBits)
+      return
+    }
+
     val slong: Long = dis.getSignedLong(lengthInBits, start)
     val cal = epochCal.clone.asInstanceOf[Calendar]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -237,12 +237,12 @@ abstract class OrderedSequenceParserBase(
                   case t: Throwable => {
                     if (pstate.isInUse(priorState)) {
                       markLeakCausedByException = true
+                      pstate.discard(priorState)
                       if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException]) {
                         val stackTrace = new StringWriter()
                         t.printStackTrace(new PrintWriter(stackTrace))
                         Assert.invariantFailed("Exception thrown with mark not returned: " + t + "\nStackTrace:\n" + stackTrace)
                       }
-                      pstate.discard(priorState)
                     }
                     throw t
                   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -2407,6 +2407,36 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase name="dateTimeBin21" root="dateTimeBin"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0000000 00000000 00000000 00111110</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Insufficient bits</tdml:error>
+      <tdml:error>Needed 32</tdml:error>
+      <tdml:error>31 available</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBin22" root="dateTimeBin5"
+    model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
+    roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">0000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Insufficient bits</tdml:error>
+      <tdml:error>Needed 64</tdml:error>
+      <tdml:error>63 available</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
   <tdml:parserTestCase name="dateBinBCD" root="dateBinBCD"
     model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
     roundTrip="true">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -191,6 +191,8 @@ class TestSimpleTypes {
   @Test def test_dateTimeBin18() { runner.runOneTest("dateTimeBin18") }
   @Test def test_dateTimeBin19() { runner.runOneTest("dateTimeBin19") }
   @Test def test_dateTimeBin20() { runner.runOneTest("dateTimeBin20") }
+  @Test def test_dateTimeBin21() { runner.runOneTest("dateTimeBin21") }
+  @Test def test_dateTimeBin22() { runner.runOneTest("dateTimeBin22") }
   @Test def test_dateBinBCD() { runner.runOneTest("dateBinBCD") }
   @Test def test_dateBinBCD2() { runner.runOneTest("dateBinBCD2") }
   @Test def test_dateBinBCD3() { runner.runOneTest("dateBinBCD3") }


### PR DESCRIPTION
If we do not check for available data, a NotEnoughData exception is
thrown when trying to get the binary long, which ends up leaking.
Instead, we should just check for enough data first.
    
Also, when exceptions are accidentally leaked, ensure that we discard
marks before throwing an assertion about the leak. Otherwise the mark is
never returned and we get an error about leaked marks instead of the
actual root issue of a leaked assertion.

DAFFODIL-2010
