### PR TITLE
Add default value for binaryCalendarEpoch

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
@@ -29,6 +29,7 @@
           alignmentUnits="bytes"
           binaryFloatRep="ieee"
           binaryNumberRep="binary"
+          binaryCalendarEpoch="1970-01-01T00:00:00"
           bitOrder="mostSignificantBitFirst"
           byteOrder="bigEndian"
           calendarCenturyStart="53"


### PR DESCRIPTION
Default value in DFDLGeneralFormat.dfdl.xsd is set to the Unix Epoch

DAFFODIL-2006