### PR TITLE
Only output milliseconds in infoset when necessary

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/calendar/DFDLCalendar.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/calendar/DFDLCalendar.scala
@@ -223,7 +223,13 @@ case class DFDLTime(calendar: Calendar, parsedTZ: Boolean)
     new DFDLTime(cal, expectsTZ)
   }
 
-  @transient override lazy val tlFormatter = if (this.hasTimeZone) TextCalendarConstants.tlTimeInfosetFormatter else TextCalendarConstants.tlTimeNoTZInfosetFormatter
+  @transient override lazy val tlFormatter = (this.hasTimeZone, this.hasFractionalSeconds) match {
+    case (true, true) => TextCalendarConstants.tlTimeInfosetFormatter
+    case (false, true) => TextCalendarConstants.tlTimeNoTZInfosetFormatter
+    case (true, false) => TextCalendarConstants.tlTimeNoFractSecInfosetFormatter
+    case (false, false) => TextCalendarConstants.tlTimeNoTZNoFractSecInfosetFormatter
+  }
+
 
   override def equals(other: Any): Boolean = other match {
     case that: DFDLTime => this.toDateTimeWithReference equals that.toDateTimeWithReference
@@ -273,7 +279,12 @@ case class DFDLDateTime(calendar: Calendar, parsedTZ: Boolean)
     new DFDLDateTime(cal, expectsTZ)
   }
 
-  @transient override lazy val tlFormatter = if (this.hasTimeZone) TextCalendarConstants.tlDateTimeInfosetFormatter else TextCalendarConstants.tlDateTimeNoTZInfosetFormatter
+  @transient override lazy val tlFormatter = (this.hasTimeZone, this.hasFractionalSeconds) match {
+    case (true, true) => TextCalendarConstants.tlDateTimeInfosetFormatter
+    case (false, true) => TextCalendarConstants.tlDateTimeNoTZInfosetFormatter
+    case (true, false) => TextCalendarConstants.tlDateTimeNoFractSecInfosetFormatter
+    case (false, false) => TextCalendarConstants.tlDateTimeNoTZNoFractSecInfosetFormatter
+  }
 
   override def equals(other: Any) = other match {
     case that: DFDLDateTime => dateTimeEqual(this, that)
@@ -424,6 +435,8 @@ abstract class DFDLCalendar(containsTZ: Boolean)
     //
     containsTZ
   }
+
+  def hasFractionalSeconds: Boolean = (calendar.isSet(Calendar.MILLISECOND) && (calendar.get(Calendar.MILLISECOND) != 0))
 
   final def toJBigDecimal: JBigDecimal = new JBigDecimal(calendar.getTimeInMillis())
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
@@ -154,12 +154,22 @@ object TextCalendarConstants {
   final val maxFractionalSeconds = 9
 
   // before being used, setCalendar must be called on the SimpleDateFormat
+  //
+  // The reason for the various NoTZ and NoFractSec variations are because
+  // we need to keep track of whether the data had timezone or millisecond
+  // information initially, otherwise we end up assuming a timezone, such
+  // as UTC, and .000000 milliseconds when the data did not specify this
+  // information.
   final val tlDateTimeNoTZInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-dd'T'HH:mm:ss.SSSSSS")
   final val tlDateTimeInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-dd'T'HH:mm:ss.SSSSSSxxxxx")
+  final val tlDateTimeNoTZNoFractSecInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-dd'T'HH:mm:ss")
+  final val tlDateTimeNoFractSecInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-dd'T'HH:mm:ssxxxxx")
   final val tlDateNoTZInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-dd")
   final val tlDateInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("uuuu-MM-ddxxxxx")
   final val tlTimeNoTZInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("HH:mm:ss.SSSSSS")
   final val tlTimeInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("HH:mm:ss.SSSSSSxxxxx")
+  final val tlTimeNoTZNoFractSecInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("HH:mm:ss")
+  final val tlTimeNoFractSecInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("HH:mm:ssxxxxx")
   final val tlTzInfosetFormatter: ThreadLocal[SimpleDateFormat] = createTLInfosetFormatter("xxx") // -08:00 The ISO8601 extended format with hours and minutes fields.
 
   private def createTLInfosetFormatter(pattern: String) = new ThreadLocal[SimpleDateFormat] {

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
@@ -267,7 +267,7 @@
 		<document>xxxx2011040506MON01@</document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			  <myDateTime xsi:type="xs:dateTime">2010-12-27T04:05:06.000000+00:00</myDateTime>
+			  <myDateTime xsi:type="xs:dateTime">2010-12-27T04:05:06+00:00</myDateTime>
 			</dfdlInfoset>
 
 		</infoset>
@@ -283,8 +283,8 @@
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 			  <calendar_group>
 			    <date1 xsi:type="xs:date">2010-12-30+00:00</date1>
-			    <time1 xsi:type="xs:time">04:05:06.000000+01:00</time1>
-			    <datetime1 xsi:type="xs:dateTime">2010-12-30T04:05:06.000000+00:00</datetime1>
+			    <time1 xsi:type="xs:time">04:05:06+01:00</time1>
+			    <datetime1 xsi:type="xs:dateTime">2010-12-30T04:05:06+00:00</datetime1>
 			  </calendar_group>
 			</dfdlInfoset>
 		</infoset>
@@ -297,7 +297,7 @@
 		<document>xxxx2011040506MON56@</document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			  <myDateTime xsi:type="xs:dateTime">2012-01-16T04:05:06.000000+00:00</myDateTime>
+			  <myDateTime xsi:type="xs:dateTime">2012-01-16T04:05:06+00:00</myDateTime>
 			</dfdlInfoset>
 		</infoset>
 	</parserTestCase>	
@@ -308,7 +308,7 @@
 		<document>101230040506@</document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			  <myDateTime4 xsi:type="xs:dateTime">2010-12-30T04:05:06.000000-05:00</myDateTime4>
+			  <myDateTime4 xsi:type="xs:dateTime">2010-12-30T04:05:06-05:00</myDateTime4>
 			</dfdlInfoset>
 		</infoset>
 	</parserTestCase>
@@ -319,7 +319,7 @@
 		<document><documentPart type="byte">0000003C</documentPart></document>
 		<infoset>
 			<dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			  <testBinarySeconds xsi:type="xs:dateTime">1970-01-01T00:01:00.000000+00:00</testBinarySeconds>
+			  <testBinarySeconds xsi:type="xs:dateTime">1970-01-01T00:01:00+00:00</testBinarySeconds>
 			</dfdlInfoset>
 		</infoset>
 	</parserTestCase>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV000.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV000.tdml
@@ -81,7 +81,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-08-06:00</repdate>
-              <reptime xsi:type="xs:time">00:53:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">00:53:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-04-07-06:00</startDate>
               <endDate xsi:type="xs:date">2008-04-07-06:00</endDate>
             </metadata>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV001.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV001.tdml
@@ -79,7 +79,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-10-06:00</repdate>
-              <reptime xsi:type="xs:time">04:38:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">04:38:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-03-31-06:00</startDate>
               <endDate xsi:type="xs:date">2008-03-31-06:00</endDate>
             </metadata>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV002.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV002.tdml
@@ -104,7 +104,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-10-06:00</repdate>
-              <reptime xsi:type="xs:time">04:37:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">04:37:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-03-30-06:00</startDate>
               <endDate xsi:type="xs:date">2008-03-30-06:00</endDate>
             </metadata>
@@ -305,7 +305,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-10-06:00</repdate>
-              <reptime xsi:type="xs:time">04:37:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">04:37:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-03-30-06:00</startDate>
               <endDate xsi:type="xs:date">2008-03-30-06:00</endDate>
             </metadata>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV003.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AV003.tdml
@@ -97,7 +97,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-10-06:00</repdate>
-              <reptime xsi:type="xs:time">04:36:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">04:36:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-03-23-06:00</startDate>
               <endDate xsi:type="xs:date">2008-03-23-06:00</endDate>
             </metadata>
@@ -294,7 +294,7 @@
           <table>
             <metadata>
               <repdate xsi:type="xs:date">2008-04-10-06:00</repdate>
-              <reptime xsi:type="xs:time">04:36:00.000000-06:00</reptime>
+              <reptime xsi:type="xs:time">04:36:00-06:00</reptime>
               <startDate xsi:type="xs:date">2008-03-23-06:00</startDate>
               <endDate xsi:type="xs:date">2008-03-23-06:00</endDate>
             </metadata>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -693,7 +693,7 @@
     <tdml:document><![CDATA[2014-03-24T03:45:30]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeImp>2014-03-24T03:45:30.000000</dateTimeImp>
+        <dateTimeImp>2014-03-24T03:45:30</dateTimeImp>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:validationErrors>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/Facets.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/Facets.tdml
@@ -4808,7 +4808,7 @@
     <tdml:document><![CDATA[2013-03-24T03:45:30]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeImp>2013-03-24T03:45:30.000000</dateTimeImp>
+        <dateTimeImp>2013-03-24T03:45:30</dateTimeImp>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6202,7 +6202,7 @@
     <tdml:document>11:00:00</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <mImE_e14>11:00:00.000000</mImE_e14>
+        <mImE_e14>11:00:00</mImE_e14>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -2115,7 +2115,7 @@
     <tdml:document><![CDATA[12:08 PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeText>12:08:00.000000</timeText>
+        <timeText>12:08:00</timeText>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2127,7 +2127,7 @@
     <tdml:document><![CDATA[1996.07.10 AD at 15:08:56 GMT-05:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeText>1996-07-10T15:08:56.000000-05:00</dateTimeText>
+        <dateTimeText>1996-07-10T15:08:56-05:00</dateTimeText>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2142,7 +2142,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin>1977-01-01T00:01:09.000000</dateTimeBin>
+        <dateTimeBin>1977-01-01T00:01:09</dateTimeBin>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2179,7 +2179,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin4>1869-12-31T00:05:00.000000+00:00</dateTimeBin4>
+        <dateTimeBin4>1869-12-31T00:05:00+00:00</dateTimeBin4>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2223,7 +2223,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin7>1869-12-31T00:05:00.000000</dateTimeBin7>
+        <dateTimeBin7>1869-12-31T00:05:00</dateTimeBin7>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2238,7 +2238,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin6>11000-06-15T03:25:19.000000</dateTimeBin6>
+        <dateTimeBin6>11000-06-15T03:25:19</dateTimeBin6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2268,7 +2268,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin6>10000-01-01T00:00:00.000000</dateTimeBin6>
+        <dateTimeBin6>10000-01-01T00:00:00</dateTimeBin6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2297,7 +2297,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin6>5828963-12-20T00:00:00.000000</dateTimeBin6>
+        <dateTimeBin6>5828963-12-20T00:00:00</dateTimeBin6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2327,7 +2327,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin6>-5838269-09-20T00:00:00.000000</dateTimeBin6>
+        <dateTimeBin6>-5838269-09-20T00:00:00</dateTimeBin6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2355,7 +2355,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin8>2018-01-01T09:13:43.000000+09:00</dateTimeBin8>
+        <dateTimeBin8>2018-01-01T09:13:43+09:00</dateTimeBin8>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2561,7 +2561,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeBinBCD>18:56:03.000000</timeBinBCD>
+        <timeBinBCD>18:56:03</timeBinBCD>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2613,7 +2613,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeBinBCD5>18:56:03.000000</timeBinBCD5>
+        <timeBinBCD5>18:56:03</timeBinBCD5>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2629,7 +2629,7 @@
       <tdml:dfdlInfoset>
         <timeBinBCD6>
           <length>3</length>
-          <time>18:56:03.000000</time>
+          <time>18:56:03</time>
         </timeBinBCD6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -2644,7 +2644,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBinBCD>2004-06-14T18:56:03.000000</dateTimeBinBCD>
+        <dateTimeBinBCD>2004-06-14T18:56:03</dateTimeBinBCD>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2670,7 +2670,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBinBCD3>2004-06-14T18:56:03.000000</dateTimeBinBCD3>
+        <dateTimeBinBCD3>2004-06-14T18:56:03</dateTimeBinBCD3>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2686,7 +2686,7 @@
       <tdml:dfdlInfoset>
         <dateTimeBinBCD4>
           <num1>3</num1>
-          <datetime>2004-06-14T18:56:03.000000</datetime>
+          <datetime>2004-06-14T18:56:03</datetime>
           <num2>19</num2>
         </dateTimeBinBCD4>
       </tdml:dfdlInfoset>
@@ -2743,7 +2743,7 @@
       <tdml:dfdlInfoset>
         <dateTimeBinIBM4690Packed>
           <length>6</length>
-          <datetime>2007-11-30T04:15:08.000000</datetime>
+          <datetime>2007-11-30T04:15:08</datetime>
         </dateTimeBinIBM4690Packed>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -2758,7 +2758,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBinIBM4690Packed2>1856-03-20T09:51:38.000000</dateTimeBinIBM4690Packed2>
+        <dateTimeBinIBM4690Packed2>1856-03-20T09:51:38</dateTimeBinIBM4690Packed2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2786,7 +2786,7 @@
       <tdml:dfdlInfoset>
         <timeBinIBM4690Packed>
           <num1>27</num1>
-          <time>10:32:49.000000</time>
+          <time>10:32:49</time>
           <num2>19</num2>
         </timeBinIBM4690Packed>
       </tdml:dfdlInfoset>
@@ -2872,7 +2872,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeBinPacked>06:13:27.000000</timeBinPacked>
+        <timeBinPacked>06:13:27</timeBinPacked>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2888,7 +2888,7 @@
       <tdml:dfdlInfoset>
         <timeBinPacked2>
           <length>4</length>
-          <time>04:15:08.000000</time>
+          <time>04:15:08</time>
         </timeBinPacked2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -2903,7 +2903,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBinPacked>1645-12-25T19:36:50.000000</dateTimeBinPacked>
+        <dateTimeBinPacked>1645-12-25T19:36:50</dateTimeBinPacked>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2930,7 +2930,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBinPacked2>3931-04-15T06:20:45.000000-05:00</dateTimeBinPacked2>
+        <dateTimeBinPacked2>3931-04-15T06:20:45-05:00</dateTimeBinPacked2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -4744,7 +4744,7 @@
     <tdml:document><![CDATA[1995-03-24 01:30:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime14><dateTime>1995-03-24T01:30:00.000000</dateTime></dateTime14>
+        <dateTime14><dateTime>1995-03-24T01:30:00</dateTime></dateTime14>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -4765,7 +4765,7 @@
     <tdml:document><![CDATA[1995-03-24 01:30:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime15><dateTime>1995-03-24T01:30:00.000000-05:00</dateTime></dateTime15>
+        <dateTime15><dateTime>1995-03-24T01:30:00-05:00</dateTime></dateTime15>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -4823,7 +4823,7 @@
     <tdml:document><![CDATA[12:43:20+00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeImp>12:43:20.000000+00:00</timeImp>
+        <timeImp>12:43:20+00:00</timeImp>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -4861,7 +4861,7 @@
     <tdml:document><![CDATA[2013-03-24T03:45:30]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeImp>2013-03-24T03:45:30.000000</dateTimeImp>
+        <dateTimeImp>2013-03-24T03:45:30</dateTimeImp>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5496,7 +5496,7 @@
     <tdml:document><![CDATA[It is 11:53AM on the 1st of April, year 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime01>2013-04-01T11:53:00.000000</dateTime01>
+        <dateTime01>2013-04-01T11:53:00</dateTime01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5515,7 +5515,7 @@
     <tdml:document><![CDATA[05:62:30+00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time01>06:02:30.000000+00:00</time01>
+        <time01>06:02:30+00:00</time01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5534,7 +5534,7 @@
     <tdml:document><![CDATA[28:62:30-00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time01>05:02:30.000000+00:00</time01>
+        <time01>05:02:30+00:00</time01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5553,7 +5553,7 @@
     <tdml:document><![CDATA[28:62:90+00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time01>05:03:30.000000+00:00</time01>
+        <time01>05:03:30+00:00</time01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5572,7 +5572,7 @@
     <tdml:document><![CDATA[2013-01-31T23:62:30]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime02>2013-02-01T00:02:30.000000</dateTime02>
+        <dateTime02>2013-02-01T00:02:30</dateTime02>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5823,7 +5823,7 @@
     <tdml:document><![CDATA[08:43.EST]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time04>08:43:00.000000-05:00</time04>
+        <time04>08:43:00-05:00</time04>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5842,7 +5842,7 @@
     <tdml:document><![CDATA[08:43.Eastern Standard Time]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time04b>08:43:00.000000-05:00</time04b>
+        <time04b>08:43:00-05:00</time04b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5861,7 +5861,7 @@
     <tdml:document><![CDATA[08:43.PT]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time05>08:43:00.000000-08:00</time05>
+        <time05>08:43:00-08:00</time05>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5879,7 +5879,7 @@
     <tdml:document><![CDATA[22:43]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time16>22:43:00.000000</time16>
+        <time16>22:43:00</time16>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5899,7 +5899,7 @@
     <tdml:document><![CDATA[03:43PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time17>12:43:00.000000</time17>
+        <time17>12:43:00</time17>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5919,7 +5919,7 @@
     <tdml:document><![CDATA[23:43AM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time17>00:43:00.000000</time17>
+        <time17>00:43:00</time17>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5937,7 +5937,7 @@
     <tdml:document><![CDATA[03:43AM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time17b>03:43:00.000000</time17b>
+        <time17b>03:43:00</time17b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5955,7 +5955,7 @@
     <tdml:document><![CDATA[03:43PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time17b>15:43:00.000000</time17b>
+        <time17b>15:43:00</time17b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -5973,7 +5973,7 @@
     <tdml:document><![CDATA[00:43PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time18>12:43:00.000000</time18>
+        <time18>12:43:00</time18>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6026,7 +6026,7 @@
     <tdml:document><![CDATA[00:43]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time19>00:43:00.000000</time19>
+        <time19>00:43:00</time19>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6045,7 +6045,7 @@
     <tdml:document><![CDATA[08:43.Pacific Standard Time]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time05b>08:43:00.000000-08:00</time05b>
+        <time05b>08:43:00-08:00</time05b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6064,7 +6064,7 @@
     <tdml:document><![CDATA[08:43.Los Angeles Time]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time06>08:43:00.000000-08:00</time06>
+        <time06>08:43:00-08:00</time06>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6083,7 +6083,7 @@
     <tdml:document><![CDATA[08:43.uslax]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time07>08:43:00.000000-08:00</time07>
+        <time07>08:43:00-08:00</time07>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6102,7 +6102,7 @@
     <tdml:document><![CDATA[08:43.Eastern Standard Time]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time05b>08:43:00.000000-05:00</time05b>
+        <time05b>08:43:00-05:00</time05b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6121,7 +6121,7 @@
     <tdml:document><![CDATA[08:43.-0800]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time27>08:43:00.000000-08:00</time27>
+        <time27>08:43:00-08:00</time27>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6140,7 +6140,7 @@
     <tdml:document><![CDATA[08:43.GMT+00:00]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time27>08:43:00.000000+00:00</time27>
+        <time27>08:43:00+00:00</time27>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6158,7 +6158,7 @@
     <tdml:document><![CDATA[08:43:40]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time08>08:43:40.000000+01:00</time08>
+        <time08>08:43:40+01:00</time08>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6176,7 +6176,7 @@
     <tdml:document><![CDATA[08:43:40]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time09>08:43:40.000000+01:30</time09>
+        <time09>08:43:40+01:30</time09>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6195,7 +6195,7 @@
     <tdml:document><![CDATA[08:43.EST]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time28>08:43:00.000000-05:00</time28>
+        <time28>08:43:00-05:00</time28>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6232,7 +6232,7 @@
     <tdml:document><![CDATA[Mon, 01 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time03>08:43:31.000000</time03>
+        <time03>08:43:31</time03>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6328,7 +6328,7 @@
     <tdml:document><![CDATA[....12:30:30....]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time10>12:30:30.000000</time10>
+        <time10>12:30:30</time10>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6347,7 +6347,7 @@
     <tdml:document><![CDATA[::::::12:30:30]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time11>12:30:30.000000</time11>
+        <time11>12:30:30</time11>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6477,7 +6477,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <time31>
-          <time>12:49:00.000000</time>
+          <time>12:49:00</time>
         </time31>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -6502,7 +6502,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <time32>
-          <time>12:49:00.000000-05:00</time>
+          <time>12:49:00-05:00</time>
         </time32>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -6588,7 +6588,7 @@
     <tdml:document><![CDATA[03@54$%^&*()5]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time20>03:54:05.000000</time20>
+        <time20>03:54:05</time20>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6607,7 +6607,7 @@
     <tdml:document><![CDATA[03@54$%^!@#.,/.'}{}{*()5]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time21>03:54:05.000000</time21>
+        <time21>03:54:05</time21>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6626,7 +6626,7 @@
     <tdml:document><![CDATA[28]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time22>00:28:00.000000</time22>
+        <time22>00:28:00</time22>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6645,7 +6645,7 @@
     <tdml:document><![CDATA[]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time23>00:00:00.000000</time23>
+        <time23>00:00:00</time23>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6664,7 +6664,7 @@
     <tdml:document><![CDATA[.]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time24>00:00:00.000000</time24>
+        <time24>00:00:00</time24>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6685,7 +6685,7 @@
     <tdml:document><![CDATA[Twas a sunny Wednesday at 11 O'clock. The year was 2008, and it was the hottest December we had ever experienced.]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime03>2008-12-03T11:00:00.000000+00:00</dateTime03>
+        <dateTime03>2008-12-03T11:00:00+00:00</dateTime03>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6706,7 +6706,7 @@
     <tdml:document><![CDATA[27:30:30 February-29-2012]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime04>2012-03-01T03:30:30.000000</dateTime04>
+        <dateTime04>2012-03-01T03:30:30</dateTime04>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6727,7 +6727,7 @@
     <tdml:document><![CDATA[01 02 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime05>2013-02-05T00:00:00.000000</dateTime05>
+        <dateTime05>2013-02-05T00:00:00</dateTime05>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6748,7 +6748,7 @@
     <tdml:document><![CDATA[01 02 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime06>2013-02-07T00:00:00.000000</dateTime06>
+        <dateTime06>2013-02-07T00:00:00</dateTime06>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6769,7 +6769,7 @@
     <tdml:document><![CDATA[01 02 2013]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime07>2013-01-31T00:00:00.000000</dateTime07>
+        <dateTime07>2013-01-31T00:00:00</dateTime07>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6790,7 +6790,7 @@
     <tdml:document><![CDATA[01 02 2013 12:43:30PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime08>2013-02-03T12:43:30.000000</dateTime08>
+        <dateTime08>2013-02-03T12:43:30</dateTime08>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6811,7 +6811,7 @@
     <tdml:document><![CDATA[01 01 2013 12:43:30PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime08>2013-01-06T12:43:30.000000</dateTime08>
+        <dateTime08>2013-01-06T12:43:30</dateTime08>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6832,7 +6832,7 @@
     <tdml:document><![CDATA[02 01 2013 12:43:30PM]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime08>2013-01-13T12:43:30.000000</dateTime08>
+        <dateTime08>2013-01-13T12:43:30</dateTime08>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6851,7 +6851,7 @@
     <tdml:document><![CDATA[.....03.04.1999 04:31:44PM.....]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime09>1999-03-04T16:31:44.000000</dateTime09>
+        <dateTime09>1999-03-04T16:31:44</dateTime09>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6870,7 +6870,7 @@
     <tdml:document><![CDATA[03.04.1999 04:31:44PM:::::::::::::::::::::::::::::::::::::::::]]></tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime10>1999-03-04T16:31:44.000000</dateTime10>
+        <dateTime10>1999-03-04T16:31:44</dateTime10>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6893,7 +6893,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime11>1999-03-04T16:31:44.000000</dateTime11>
+        <dateTime11>1999-03-04T16:31:44</dateTime11>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -6916,7 +6916,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTime12>1999-03-04T17:01:44.000000</dateTime12>
+        <dateTime12>1999-03-04T17:01:44</dateTime12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -1601,7 +1601,7 @@
 
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <timeT>04:09:23.000000</timeT>
+        <timeT>04:09:23</timeT>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 
@@ -1625,7 +1625,7 @@
 
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeT>2013-05-03T03:30:30.000000</dateTimeT>
+        <dateTimeT>2013-05-03T03:30:30</dateTimeT>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -5593,8 +5593,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e37>
-          <dateTime1>1988-03-24T04:55:23.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:24.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:23</dateTime1>
+          <dateTime2>1988-03-24T04:55:24</dateTime2>
           <lessThanEqualTo>true</lessThanEqualTo>
         </e37>
       </tdml:dfdlInfoset>
@@ -5615,8 +5615,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e38>
-          <dateTime1>1988-03-24T04:55:24.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:23.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:24</dateTime1>
+          <dateTime2>1988-03-24T04:55:23</dateTime2>
           <greaterThanEqualTo>true</greaterThanEqualTo>
         </e38>
       </tdml:dfdlInfoset>
@@ -5637,8 +5637,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e18>
-          <dateTime1>1988-03-24T04:55:24.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:23.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:24</dateTime1>
+          <dateTime2>1988-03-24T04:55:23</dateTime2>
           <oneGTtwo>true</oneGTtwo>
         </e18>
       </tdml:dfdlInfoset>
@@ -5659,8 +5659,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e19>
-          <dateTime1>1988-03-24T04:55:23.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:24.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:23</dateTime1>
+          <dateTime2>1988-03-24T04:55:24</dateTime2>
           <oneLTtwo>true</oneLTtwo>
         </e19>
       </tdml:dfdlInfoset>
@@ -5681,8 +5681,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e20>
-          <dateTime1>1988-03-24T04:55:23.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:24.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:23</dateTime1>
+          <dateTime2>1988-03-24T04:55:24</dateTime2>
           <notEqual>true</notEqual>
         </e20>
       </tdml:dfdlInfoset>
@@ -5703,8 +5703,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e21>
-          <dateTime1>1988-03-24T04:55:23.000000</dateTime1>
-          <dateTime2>1988-03-24T04:55:23.000000</dateTime2>
+          <dateTime1>1988-03-24T04:55:23</dateTime1>
+          <dateTime2>1988-03-24T04:55:23</dateTime2>
           <same>true</same>
         </e21>
       </tdml:dfdlInfoset>
@@ -5857,8 +5857,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e28>
-          <time1>04:55:23.000000</time1>
-          <time2>04:55:24.000000</time2>
+          <time1>04:55:23</time1>
+          <time2>04:55:24</time2>
           <lessThanEqualTo>true</lessThanEqualTo>
         </e28>
       </tdml:dfdlInfoset>
@@ -5879,8 +5879,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e29>
-          <time1>04:55:24.000000</time1>
-          <time2>04:55:23.000000</time2>
+          <time1>04:55:24</time1>
+          <time2>04:55:23</time2>
           <greaterThanEqualTo>true</greaterThanEqualTo>
         </e29>
       </tdml:dfdlInfoset>
@@ -5901,8 +5901,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e30>
-          <time1>04:55:24.000000</time1>
-          <time2>04:55:23.000000</time2>
+          <time1>04:55:24</time1>
+          <time2>04:55:23</time2>
           <oneGTtwo>true</oneGTtwo>
         </e30>
       </tdml:dfdlInfoset>
@@ -5923,8 +5923,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e31>
-          <time1>04:55:23.000000</time1>
-          <time2>04:55:24.000000</time2>
+          <time1>04:55:23</time1>
+          <time2>04:55:24</time2>
           <oneLTtwo>true</oneLTtwo>
         </e31>
       </tdml:dfdlInfoset>
@@ -5945,8 +5945,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e32>
-          <time1>04:55:23.000000</time1>
-          <time2>04:55:24.000000</time2>
+          <time1>04:55:23</time1>
+          <time2>04:55:24</time2>
           <notEqual>true</notEqual>
         </e32>
       </tdml:dfdlInfoset>
@@ -5967,8 +5967,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e33>
-          <time1>04:55:23.000000</time1>
-          <time2>04:55:23.000000</time2>
+          <time1>04:55:23</time1>
+          <time2>04:55:23</time2>
           <same>true</same>
         </e33>
       </tdml:dfdlInfoset>
@@ -5990,8 +5990,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e34>
-          <dateTime1>2000-01-15T00:00:00.000000</dateTime1>
-          <dateTime2>2000-02-15T00:00:00.000000</dateTime2>
+          <dateTime1>2000-01-15T00:00:00</dateTime1>
+          <dateTime2>2000-02-15T00:00:00</dateTime2>
           <oneLTtwo>true</oneLTtwo>
         </e34>
       </tdml:dfdlInfoset>
@@ -6014,8 +6014,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e35>
-          <dateTime1>2000-01-01T12:00:00.000000+00:00</dateTime1>
-          <dateTime2>1999-12-31T23:00:00.000000+00:00</dateTime2>
+          <dateTime1>2000-01-01T12:00:00+00:00</dateTime1>
+          <dateTime2>1999-12-31T23:00:00+00:00</dateTime2>
           <oneLTtwo>false</oneLTtwo>
         </e35>
       </tdml:dfdlInfoset>
@@ -6030,8 +6030,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e35a>
-          <dateTime1>2000-01-01T12:00:00.000000</dateTime1>
-          <dateTime2>1999-12-31T23:00:00.000000+00:00</dateTime2>
+          <dateTime1>2000-01-01T12:00:00</dateTime1>
+          <dateTime2>1999-12-31T23:00:00+00:00</dateTime2>
           <oneLTtwo>true</oneLTtwo>
         </e35a>
       </tdml:dfdlInfoset>
@@ -6054,8 +6054,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2002-04-02T12:00:00.000000-01:00</dateTime1>
-          <dateTime2>2002-04-02T17:00:00.000000+04:00</dateTime2>
+          <dateTime1>2002-04-02T12:00:00-01:00</dateTime1>
+          <dateTime2>2002-04-02T17:00:00+04:00</dateTime2>
           <same>true</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6077,8 +6077,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2002-04-02T12:00:00.000000-05:00</dateTime1>
-          <dateTime2>2002-04-02T23:00:00.000000+06:00</dateTime2>
+          <dateTime1>2002-04-02T12:00:00-05:00</dateTime1>
+          <dateTime2>2002-04-02T23:00:00+06:00</dateTime2>
           <same>true</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6100,8 +6100,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2002-04-02T12:00:00.000000-05:00</dateTime1>
-          <dateTime2>2002-04-02T17:00:00.000000-05:00</dateTime2>
+          <dateTime1>2002-04-02T12:00:00-05:00</dateTime1>
+          <dateTime2>2002-04-02T17:00:00-05:00</dateTime2>
           <same>false</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6123,8 +6123,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2002-04-02T12:00:00.000000-05:00</dateTime1>
-          <dateTime2>2002-04-02T12:00:00.000000-05:00</dateTime2>
+          <dateTime1>2002-04-02T12:00:00-05:00</dateTime1>
+          <dateTime2>2002-04-02T12:00:00-05:00</dateTime2>
           <same>true</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6146,8 +6146,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2002-04-02T23:00:00.000000-04:00</dateTime1>
-          <dateTime2>2002-04-03T02:00:00.000000-01:00</dateTime2>
+          <dateTime1>2002-04-02T23:00:00-04:00</dateTime1>
+          <dateTime2>2002-04-03T02:00:00-01:00</dateTime2>
           <same>true</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6173,8 +6173,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2000-01-01T00:00:00.000000-05:00</dateTime1>
-          <dateTime2>2000-01-01T00:00:00.000000-05:00</dateTime2>
+          <dateTime1>2000-01-01T00:00:00-05:00</dateTime1>
+          <dateTime2>2000-01-01T00:00:00-05:00</dateTime2>
           <same>true</same>
         </e36>
       </tdml:dfdlInfoset>
@@ -6197,8 +6197,8 @@ c]]></value>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e36>
-          <dateTime1>2005-04-05T00:00:00.000000-05:00</dateTime1>
-          <dateTime2>2005-04-04T00:00:00.000000-05:00</dateTime2>
+          <dateTime1>2005-04-05T00:00:00-05:00</dateTime1>
+          <dateTime2>2005-04-04T00:00:00-05:00</dateTime2>
           <same>false</same>
         </e36>
       </tdml:dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/functions.tdml
@@ -113,7 +113,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <dtFunctions>
-          <bulkDateTime>1988-03-24T04:55:23.000000</bulkDateTime>
+          <bulkDateTime>1988-03-24T04:55:23</bulkDateTime>
           <year>1988</year>
           <month>3</month>
           <day>24</day>
@@ -140,7 +140,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <dtFunctions>
-          <bulkDateTime>1988-04-05T04:55:23.000000</bulkDateTime>
+          <bulkDateTime>1988-04-05T04:55:23</bulkDateTime>
           <year>1988</year>
           <month>4</month>
           <day>5</day>
@@ -214,7 +214,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <tFunctions>
-          <bulkTime>12:44:56.000000+00:00</bulkTime>
+          <bulkTime>12:44:56+00:00</bulkTime>
           <hours>12</hours>
           <minutes>44</minutes>
           <seconds>56</seconds>
@@ -238,7 +238,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <tFunctions>
-          <bulkTime>13:02:56.000000+00:00</bulkTime>
+          <bulkTime>13:02:56+00:00</bulkTime>
           <hours>13</hours>
           <minutes>2</minutes>
           <seconds>56</seconds>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -996,8 +996,8 @@
       <tdml:dfdlInfoset>
         <e_concat3>
           <one>-5000.0</one>
-          <two>2004-04-12T13:20:00.000000</two>
-          <concat>-5000.02004-04-12T13:20:00.000000</concat>
+          <two>2004-04-12T13:20:00</two>
+          <concat>-5000.02004-04-12T13:20:00</concat>
         </e_concat3>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -2157,7 +2157,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_yearfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <year>2034</year>
         </e_yearfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2178,7 +2178,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_yearfromdatetime2>
-          <date>0000-01-01T23:00:00.000000</date>
+          <date>0000-01-01T23:00:00</date>
           <year>0</year>
         </e_yearfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2217,7 +2217,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_monthfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <month>12</month>
         </e_monthfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2256,7 +2256,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_dayfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <day>31</day>
         </e_dayfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2295,7 +2295,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_hoursfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <hours>23</hours>
         </e_hoursfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2334,7 +2334,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_minutesfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <minutes>0</minutes>
         </e_minutesfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2373,7 +2373,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_secondsfromdatetime2>
-          <date>2034-12-31T23:00:00.000000</date>
+          <date>2034-12-31T23:00:00</date>
           <seconds>0</seconds>
         </e_secondsfromdatetime2>
       </tdml:dfdlInfoset>
@@ -2415,7 +2415,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromdatetime1>
-          <date>2013-04-01T11:53:06.000000</date>
+          <date>2013-04-01T11:53:06</date>
           <year>2013</year>
           <month>4</month>
           <day>1</day>
@@ -2443,7 +2443,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromdatetime2>
-          <date>2014-01-01T00:02:30.000000</date>
+          <date>2014-01-01T00:02:30</date>
           <year>2014</year>
           <month>1</month>
           <day>1</day>
@@ -2471,7 +2471,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromdatetime2>
-          <date>0101-01-13T00:12:39.000000</date>
+          <date>0101-01-13T00:12:39</date>
           <year>101</year>
           <month>1</month>
           <day>13</day>
@@ -2498,7 +2498,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromdatetime3>
-          <date>-1234-01-30T10:01:02.000000-08:00</date>
+          <date>-1234-01-30T10:01:02-08:00</date>
           <year>-1234</year>
           <month>1</month>
           <day>30</day>
@@ -2758,7 +2758,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_hoursfromtime2>
-          <time>23:00:00.000000+00:00</time>
+          <time>23:00:00+00:00</time>
           <hours>23</hours>
         </e_hoursfromtime2>
       </tdml:dfdlInfoset>
@@ -2798,7 +2798,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_minutesfromtime2>
-          <time>23:59:00.000000+00:00</time>
+          <time>23:59:00+00:00</time>
           <minutes>59</minutes>
         </e_minutesfromtime2>
       </tdml:dfdlInfoset>
@@ -2838,7 +2838,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_secondsfromtime2>
-          <time>23:00:48.000000+00:00</time>
+          <time>23:00:48+00:00</time>
           <seconds>48</seconds>
         </e_secondsfromtime2>
       </tdml:dfdlInfoset>
@@ -2860,7 +2860,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromtime1>
-          <time>00:00:00.000000+00:00</time>
+          <time>00:00:00+00:00</time>
           <hours>0</hours>
           <minutes>0</minutes>
           <seconds>0</seconds>
@@ -2910,7 +2910,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_xfromtime1>
-          <time>12:13:14.000000+00:00</time>
+          <time>12:13:14+00:00</time>
           <hours>12</hours>
           <minutes>13</minutes>
           <seconds>14</seconds>
@@ -6860,8 +6860,8 @@
       <tdml:dfdlInfoset>
         <dateTime01>
           <date>1996-03-31</date>
-          <time>04:55:30.000000</time>
-          <dateTime>1996-03-31T04:55:30.000000</dateTime>
+          <time>04:55:30</time>
+          <dateTime>1996-03-31T04:55:30</dateTime>
         </dateTime01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -6885,8 +6885,8 @@
       <tdml:dfdlInfoset>
         <dateTime01>
           <date>1996-01-31</date>
-          <time>04:55:30.000000</time>
-          <dateTime>1996-01-31T04:55:30.000000</dateTime>
+          <time>04:55:30</time>
+          <dateTime>1996-01-31T04:55:30</dateTime>
         </dateTime01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -6929,8 +6929,8 @@
       <tdml:dfdlInfoset>
           <dateTime03>
             <date>1996-03-31-08:00</date>
-            <time>04:55:30.000000-08:00</time>
-            <dateTime>1996-03-31T04:55:30.000000-08:00</dateTime>
+            <time>04:55:30-08:00</time>
+            <dateTime>1996-03-31T04:55:30-08:00</dateTime>
           </dateTime03>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -6983,8 +6983,8 @@
       <tdml:dfdlInfoset>
         <dateTime10>
           <date>1996-03-31</date>
-          <time>04:55:30.000000</time>
-          <dateTime>1996-03-31T04:55:30.000000</dateTime>
+          <time>04:55:30</time>
+          <dateTime>1996-03-31T04:55:30</dateTime>
         </dateTime10>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -7010,8 +7010,8 @@
       <tdml:dfdlInfoset>
         <dateTime11>
           <date>1996-03-31-05:00</date>
-          <time>04:55:30.000000-05:00</time>
-          <dateTime>1996-03-31T04:55:30.000000-05:00</dateTime>
+          <time>04:55:30-05:00</time>
+          <dateTime>1996-03-31T04:55:30-05:00</dateTime>
         </dateTime11>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -7037,8 +7037,8 @@
       <tdml:dfdlInfoset>
         <dateTime12>
           <date>1996-03-31-09:00</date>
-          <time>04:55:30.000000</time>
-          <dateTime>1996-03-31T04:55:30.000000-09:00</dateTime>
+          <time>04:55:30</time>
+          <dateTime>1996-03-31T04:55:30-09:00</dateTime>
         </dateTime12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -7064,8 +7064,8 @@
       <tdml:dfdlInfoset>
         <dateTime13>
           <date>1996-03-31</date>
-          <time>04:55:30.000000+11:00</time>
-          <dateTime>1996-03-31T04:55:30.000000+11:00</dateTime>
+          <time>04:55:30+11:00</time>
+          <dateTime>1996-03-31T04:55:30+11:00</dateTime>
         </dateTime13>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -8031,7 +8031,7 @@
       <tdml:dfdlInfoset>
         <dateTime04>
           <string>1996-02-04T12:30:34</string>
-          <dateTime>1996-02-04T12:30:34.000000</dateTime>
+          <dateTime>1996-02-04T12:30:34</dateTime>
         </dateTime04>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -8183,7 +8183,7 @@
     </tdml:document>
     <tdml:infoset>
     	<tdml:dfdlInfoset>
-    		<dateTime07>2014-10-23T00:00:00.000000</dateTime07>
+    		<dateTime07>2014-10-23T00:00:00</dateTime07>
     	</tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -8204,7 +8204,7 @@
     </tdml:document>
     <tdml:infoset>
     	<tdml:dfdlInfoset>
-    		<dateTime08>2014-10-23T04:55:30.000000</dateTime08>
+    		<dateTime08>2014-10-23T04:55:30</dateTime08>
     	</tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -8248,7 +8248,7 @@
       <tdml:dfdlInfoset>
         <time01>
           <string>12:49:00</string>
-          <time>12:49:00.000000</time>
+          <time>12:49:00</time>
         </time01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -8332,7 +8332,7 @@
       <tdml:dfdlInfoset>
         <time02>
           <string>12:49:00</string>
-          <time>12:49:00.000000</time>
+          <time>12:49:00</time>
         </time02>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -8374,7 +8374,7 @@
     </tdml:document>
     <tdml:infoset>
     	<tdml:dfdlInfoset>
-    		<dfdl:time04>08:00:00.000000</dfdl:time04>
+    		<dfdl:time04>08:00:00</dfdl:time04>
     	</tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -8395,7 +8395,7 @@
     </tdml:document>
     <tdml:infoset>
     	<tdml:dfdlInfoset>
-    		<tdml:time05>08:00:00.000000</tdml:time05>
+    		<tdml:time05>08:00:00</tdml:time05>
     	</tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -8416,7 +8416,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <time06>05:37:21.000000-05:00</time06>
+        <time06>05:37:21-05:00</time06>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -13273,7 +13273,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_timezonefromtime3>
-          <time>04:17:09.000000+07:00</time>
+          <time>04:17:09+07:00</time>
           <timeZone>+07:00</timeZone>
         </e_timezonefromtime3>
       </tdml:dfdlInfoset>

--- a/tutorials/src/main/resources/bugReportTemplate.tdml
+++ b/tutorials/src/main/resources/bugReportTemplate.tdml
@@ -74,7 +74,7 @@
 
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:myTestRoot>2013-04-02T14:00:56.000000-05:00</ex:myTestRoot>
+        <ex:myTestRoot>2013-04-02T14:00:56-05:00</ex:myTestRoot>
       </tdml:dfdlInfoset>
     </tdml:infoset>
      
@@ -85,7 +85,7 @@
 
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:myTestRoot>2013-04-02T14:00:56.000000-05:00</ex:myTestRoot>
+        <ex:myTestRoot>2013-04-02T14:00:56-05:00</ex:myTestRoot>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 

--- a/tutorials/src/main/resources/tdmlTutorial.tdml.xml
+++ b/tutorials/src/main/resources/tdmlTutorial.tdml.xml
@@ -169,7 +169,7 @@ For this example we'll just look at a simple textual data document.
          Here is our actual expected result, where the date and time
          is now in XML's cannonical representation for these.
         -->
-        <ex:myTestRoot>2013-04-02T14:00:56.000000-05:00</ex:myTestRoot>
+        <ex:myTestRoot>2013-04-02T14:00:56-05:00</ex:myTestRoot>
       </tdml:dfdlInfoset>
     </tdml:infoset>
      
@@ -201,7 +201,7 @@ second. The order doesn't actually matter.
 </p></tdml:tutorial>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:myTestRoot>2013-04-02T14:00:56.000000-05:00</ex:myTestRoot>
+        <ex:myTestRoot>2013-04-02T14:00:56-05:00</ex:myTestRoot>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 


### PR DESCRIPTION
Most Time/DateTime elements are parsed without millisecond precision, so
we should only show milliseconds in the infoset when they are used,
instead of outputting 12:00:00.000000

DAFFODIL-2005