### PR TITLE
Ignore minLength when lengthKind=explicit

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -367,9 +367,9 @@ trait ElementRuntimeValuedPropertiesMixin
         case (Implicit, Binary, HexBinary) => (LengthUnits.Bytes, maxLengthLong) // fixed length
         case (Implicit, Text, String) => (lengthUnits, maxLengthLong) // fixed length
         case (Implicit, Text, AnySimpleType) => (lengthUnits, textOutputMinLength) // fixed length
-        case (Explicit, Text, String) => (lengthUnits, minLengthLong)
-        case (Explicit, Binary, HexBinary) => (LengthUnits.Bytes, minLengthLong)
-        case (Explicit, Text, AnySimpleType) => (lengthUnits, textOutputMinLength)
+        case (Explicit, Text, String) => (lengthUnits, 0L)
+        case (Explicit, Binary, HexBinary) => (LengthUnits.Bytes, 0L)
+        case (Explicit, Text, AnySimpleType) => (lengthUnits, 0L)
         case (Prefixed, _, String) => (lengthUnits, minLengthLong)
         case (Prefixed, Text, _) => (lengthUnits, textOutputMinLength)
         case (Pattern, _, String) => (lengthUnits, minLengthLong)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -1361,7 +1361,7 @@ trait ElementBaseGrammarMixin
       val len = optLengthConstant.get
       val maxLengthLong = maxLength.longValueExact
       val minLengthLong = minLength.longValueExact
-      def warn(m: String, value: Long) = SDW(WarnID.FacetExplicitLengthOutOfRange, "Explicit dfdl:length of %s is out of range for facet %sLength='%s'.", len, "max", value)
+      def warn(m: String, value: Long) = SDW(WarnID.FacetExplicitLengthOutOfRange, "Explicit dfdl:length of %s is out of range for facet %sLength='%s'.", len, m, value)
       if (maxLengthLong != -1 && len > maxLengthLong) warn("max", maxLengthLong)
       Assert.invariant(minLengthLong >= 0)
       if (minLengthLong > 0 && len < minLengthLong) warn("min", minLengthLong)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testUnparserGeneral.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testUnparserGeneral.tdml
@@ -638,6 +638,29 @@
         </xs:complexType>
       </xs:element>
 
+      <xs:element name="e4">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="length" type="xs:int" dfdl:textNumberJustification="center" dfdl:lengthKind="explicit" dfdl:textOutputMinLength="4" dfdl:length="1" dfdl:outputValueCalc="{ dfdl:valueLength(../ex:payload, 'bits') }" />
+            <xs:element name="payload">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="sublength" type="xs:unsignedInt" dfdl:representation="binary"
+                              dfdl:alignment="1" dfdl:alignmentUnits="bits"
+                              dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bits" />
+                  <xs:element name="subfield1" type="xs:unsignedInt" dfdl:representation="binary"
+                              dfdl:alignment="1" dfdl:alignmentUnits="bits"
+                              dfdl:lengthKind="explicit" dfdl:length="{ ../ex:sublength }" dfdl:lengthUnits="bits" />
+                  <xs:element name="subfield2" type="xs:unsignedInt" dfdl:representation="binary"
+                              dfdl:alignment="8" dfdl:alignmentUnits="bits"
+                              dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bits" />
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
   </tdml:defineSchema>
 
   <!--
@@ -719,6 +742,27 @@
         </ex:e3>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:unparserTestCase>
+
+<!--
+      Test Name: alignmentPaddingOVC4
+      Schema: delimitedStrings
+      Purpose: This test demonstrates an SDE when explicit length is less than textOutputMinLength
+-->
+  <tdml:unparserTestCase name="alignmentPaddingOVC4" model="alignmentPaddingOVC" root="e4">
+    <tdml:document>
+      <tdml:documentPart type="text">x20x</tdml:documentPart><!-- length of below fields in bits -->
+      <tdml:documentPart type="bits">0101</tdml:documentPart><!-- subfield1 length -->
+      <tdml:documentPart type="bits">10101</tdml:documentPart><!-- subfield1 -->
+      <tdml:documentPart type="bits">0000000</tdml:documentPart><!-- alignment skip -->
+      <tdml:documentPart type="bits">1010</tdml:documentPart><!-- subfield1 -->
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Explicit dfdl:length</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>textOutputMinLength</tdml:error>
+    </tdml:errors>
   </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -394,11 +394,10 @@
       Test Name: unparseDelimitedPaddedString09
       Schema: delimitedStringsPadding
       Purpose: This test demonstrates unparsing a string with padding
-               In this case, lengthKind is explicit and NOT an expression, so the value is padded to the length 
-               given by the max of the expression and the minimum length.
-               or the minimum length, whichever is greater. 
-               (See JIRA DFDL-1584 however, as this behavior needs clarification)
-      Round trip - no. See description of unparsePaddedString10.
+               In this case, lengthKind is explicit and an expression, so the value is padded to the length given by dfdl:length.
+               Because the facet minLength (and maxLength) is 10, but the length expression is only 2
+               when we unparse, we'll show a Schema Definition Warning and only pad to dfdl:length,
+               as is described in DFDL Erratum 5.18
 -->
   <tdml:unparserTestCase name="unparseDelimitedPaddedString09" model="delimitedStringsPadding" root="e11"
     roundTrip="false">
@@ -407,19 +406,23 @@
         <ex:e11 xmlns:ex="http://example.com">O</ex:e11>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:document>O#########</tdml:document>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Explicit dfdl:length</tdml:warning>
+      <tdml:warning>out of range</tdml:warning>
+      <tdml:warning>facet minLength</tdml:warning>
+    </tdml:warnings>
+    <tdml:document>O#</tdml:document>
   </tdml:unparserTestCase>
 
 <!--
       Test Name: unparsePaddedString10
       Schema: delimitedStringsPadding
       Purpose: This test demonstrates unparsing a string with padding
-               In this case, lengthKind is explicit and an expression, so the value is padded to the length given by the max
-               of the expression and the minimum length, which for a string is given by minLength facet.
-               Because the facet minLength (and maxLength) is 10, but the length expression
-               when we unparse, we'll pad to the minLength, and get 10 characters, 
-               and that won't re-parse. So this test cannot round trip.
-      (See JIRA DFDL-1584 however, as this behavior needs clarification)
+               In this case, lengthKind is explicit and an expression, so the value is padded to the length given by dfdl:length.
+               Because the facet minLength (and maxLength) is 10, but the length expression is only 2
+               when we unparse, we'll show a Schema Definition Warning and only pad to dfdl:length,
+               as is described in DFDL Erratum 5.18
 -->
   <tdml:unparserTestCase name="unparsePaddedString10" model="delimitedStringsPadding" root="e12"
    roundTrip="false">
@@ -428,7 +431,13 @@
         <ex:e12 xmlns:ex="http://example.com">O</ex:e12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:document>O#########</tdml:document>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Explicit dfdl:length</tdml:warning>
+      <tdml:warning>out of range</tdml:warning>
+      <tdml:warning>facet minLength</tdml:warning>
+    </tdml:warnings>
+    <tdml:document>O#</tdml:document>
   </tdml:unparserTestCase>
 
 <!--

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
@@ -70,5 +70,6 @@ class TestUnparserGeneral {
   @Test def test_alignmentPaddingOVC1() { runner.runOneTest("alignmentPaddingOVC1") }
   @Test def test_alignmentPaddingOVC2() { runner.runOneTest("alignmentPaddingOVC2") }
   @Test def test_alignmentPaddingOVC3() { runner.runOneTest("alignmentPaddingOVC3") }
+  @Test def test_alignmentPaddingOVC4() { runner.runOneTest("alignmentPaddingOVC4") }
 
 }


### PR DESCRIPTION
According to DFDL Erratum 5.18 if dfdl:lengthKind='explicit' the facet
minLength is not used to determin the target length.

Although we are ignoring minLength, it is a schema definition wraning if
the explicit length specified is out of range of minLength and it is an
error if it is out of range of textOutputMinLength.

Also fixed a small error in the range check warning.

DFDL-1989