### PR TITLE
Added max/minValidYear tunable

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
@@ -138,7 +138,15 @@ case class DaffodilTunables(
 
   val maximumSimpleElementSizeInCharacters: Int = 1024 * 1024,
   val initialRegexMatchLimitInCharacters: Int = 64,
-  val maximumRegexMatchLengthInCharacters: Int = 1024 * 1024)
+  val maximumRegexMatchLengthInCharacters: Int = 1024 * 1024,
+
+  /* Due to differences in the DFDL spec and ICU4J SimpleDateFormat, we must have SimpleDateFormat
+   * parse in lenient mode, which allows the year value to overflow with very large years
+   * into possibly negative years. These tunables simply make sure that value we get back
+   * from SimpleDateFormat are reasonable
+   */
+  val minValidYear: Int = 0,
+  val maxValidYear: Int = 9999)
 
   extends Serializable
   with Logging {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PrimitivesDateTime1.scala
@@ -30,6 +30,7 @@ import org.apache.daffodil.processors.CalendarLanguageEv
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Processor
 import org.apache.daffodil.schema.annotation.props.gen.BinaryCalendarRep
+import org.apache.daffodil.dsom.TunableLimitExceededError
 
 abstract class ConvertTextCalendarProcessorBase(
   override val context: ElementRuntimeData,
@@ -131,6 +132,10 @@ case class ConvertTextCalendarParser(
     // exception to be thrown if a Calendar is not valid.
     try {
       cal.getTime
+      if ((cal.get(Calendar.YEAR) > start.tunable.maxValidYear) || (cal.get(Calendar.YEAR) < start.tunable.minValidYear))
+        throw new TunableLimitExceededError(erd.schemaFileLocation,
+          "Year value of %s is not within the limits of the tunables minValidYear (%s) and maxValidYear (%s)",
+          cal.get(Calendar.YEAR), start.tunable.minValidYear, start.tunable.maxValidYear)
     } catch {
       case e: IllegalArgumentException => {
         PE(start, "Convert to %s (for xs:%s): Failed to parse '%s': %s.", prettyType, xsdType, str, e.getMessage())
@@ -212,6 +217,10 @@ case class ConvertBinaryCalendarSecMilliParser(
     val newTime = cal.getTimeInMillis + millisToAdd
     try {
       cal.setTimeInMillis(newTime)
+      if ((cal.get(Calendar.YEAR) > start.tunable.maxValidYear) || (cal.get(Calendar.YEAR) < start.tunable.minValidYear))
+        throw new TunableLimitExceededError(context.schemaFileLocation,
+          "Year value of %s is not within the limits of the tunables minValidYear (%s) and maxValidYear (%s)",
+          cal.get(Calendar.YEAR), start.tunable.minValidYear, start.tunable.maxValidYear)
     } catch {
       case e: IllegalArgumentException => {
         PE(start, "%s milliseconds from the binaryCalendarEpoch is out of range of valid values: %s.",

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -2236,11 +2236,12 @@
     <tdml:document>
       <tdml:documentPart type="bits">00000000 00000001 00000010 01001110 11010001 10100111 00001000 00000000</tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <dateTimeBin6>11000-06-15T03:25:19</dateTimeBin6>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Tunable Limit Exceeded Error</tdml:error>
+      <tdml:error>not within the limits of</tdml:error>
+      <tdml:error>minValidYear</tdml:error>
+      <tdml:error>maxValidYear</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binaryMillieconds' -->
@@ -2264,11 +2265,11 @@
     roundTrip="true">
 
     <tdml:document>
-      <tdml:documentPart type="bits">00000000 00000000 11100101 10011000 00001111 10110100 10001110 11101000</tdml:documentPart>
+      <tdml:documentPart type="bits">00000000 00000000 11100101 10011000 00001111 10101000 11010110 11101000</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <dateTimeBin6>10000-01-01T00:00:00</dateTimeBin6>
+        <dateTimeBin6>9999-12-31T23:47:12</dateTimeBin6>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2287,7 +2288,7 @@
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binaryMillieconds' with expected result equal
-    to the maximum date allowed -->
+    to the maximum date allowed, but still out of bounds for maxValidYear tunable  -->
   <tdml:parserTestCase name="dateTimeBin12" root="dateTimeBin6"
     model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
     roundTrip="true">
@@ -2295,11 +2296,12 @@
     <tdml:document>
       <tdml:documentPart type="bits">00000010 10001101 01000110 11111011 11111100 10101110 01100010 11101000</tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <dateTimeBin6>5828963-12-20T00:00:00</dateTimeBin6>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Tunable Limit Exceeded Error:</tdml:error>
+      <tdml:error>not within the limits of</tdml:error>
+      <tdml:error>minValidYear</tdml:error>
+      <tdml:error>maxValidYear</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binaryMillieconds' - expecting an error for being 1 milisecond
@@ -2317,7 +2319,7 @@
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binaryMillieconds' with expected result equal
-    to the minimum date allowed -->
+    to the minimum date allowed, but still out of bounds for minValidYear tunable -->
   <tdml:parserTestCase name="dateTimeBin14" root="dateTimeBin6"
     model="SimpleTypes-binary" description="Section 5 Schema types-dateTime - DFDL-5-016R"
     roundTrip="true">
@@ -2325,11 +2327,12 @@
     <tdml:document>
       <tdml:documentPart type="bits">11111101 01110001 00110111 10110011 11111100 10101110 01100010 11101000</tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <dateTimeBin6>-5838269-09-20T00:00:00</dateTimeBin6>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Tunable Limit Exceeded Error:</tdml:error>
+      <tdml:error>not within the limits of</tdml:error>
+      <tdml:error>minValidYear</tdml:error>
+      <tdml:error>maxValidYear</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binaryMillieconds' - expecting an error for being 1 milisecond
@@ -4952,10 +4955,32 @@
 
     <tdml:document><![CDATA[99999999-03-24T03:45:30]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Parse Error:</tdml:error>
-      <tdml:error>Placeholder for error message</tdml:error>
+      <tdml:error>Tunable Limit Exceeded Error:</tdml:error>
+      <tdml:error>not within the limits of</tdml:error>
+      <tdml:error>minValidYear</tdml:error>
+      <tdml:error>maxValidYear</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+<!--
+     Test Name: dateTimeImplicitPatternFail6
+        Schema: dateTimeSchema
+          Root: dateTimeImp
+       Purpose: This test demonstrates a dateTime data type with a year that is out of range.
+-->
+
+  <tdml:parserTestCase name="dateTimeImplicitPatternFail6" root="dateTimeImp"
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarPatternKind - DFDL-13-138R">
+
+    <tdml:document><![CDATA[10000-03-24T03:45:30]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Tunable Limit Exceeded Error:</tdml:error>
+      <tdml:error>not within the limits of</tdml:error>
+      <tdml:error>minValidYear</tdml:error>
+      <tdml:error>maxValidYear</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 
 <!--
      Test Name: datePattern01

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section05/simple_types/TestSimpleTypesDebug.scala
@@ -105,7 +105,4 @@ class TestSimpleTypesDebug {
 
   @Test def test_dateCalendarFirstDayOfWeek03() { runner.runOneTest("dateCalendarFirstDayOfWeek03") }
   @Test def test_dateCalendarFirstDayOfWeek04() { runner.runOneTest("dateCalendarFirstDayOfWeek04") }
-
-  // DAFFODIL-1946
-  @Test def test_dateTimeImplicitPatternFail5() { runner.runOneTest("dateTimeImplicitPatternFail5") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -239,7 +239,8 @@ class TestSimpleTypes {
   @Test def test_dateTimeImplicitPatternFail2() { runner.runOneTest("dateTimeImplicitPatternFail2") }
   @Test def test_dateTimeImplicitPatternFail3() { runner.runOneTest("dateTimeImplicitPatternFail3") }
   @Test def test_dateTimeImplicitPatternFail4() { runner.runOneTest("dateTimeImplicitPatternFail4") }
-  //@Test def test_dateTimeImplicitPatternFail5() { runner.runOneTest("dateTimeImplicitPatternFail5") }
+  @Test def test_dateTimeImplicitPatternFail5() { runner.runOneTest("dateTimeImplicitPatternFail5") }
+  @Test def test_dateTimeImplicitPatternFail6() { runner.runOneTest("dateTimeImplicitPatternFail6") }
 
   @Test def test_datePattern01() { runner.runOneTest("datePattern01") }
   //  @Test def test_datePattern01b() { runner.runOneTest("datePattern01b") }


### PR DESCRIPTION
Due to differences in the DFDL spec and ICU4J SimpleDateFormat, we must
have SimpleDateFormat parse in lenient mode which allows the year value
to overflow with very large years into possibly negative years.

To combat this overflowing of years the max/minValidYear tunable has
been added with default values of "9999" and "0" respectively.

DAFFODIL-1946