### PR TITLE
Remove Java 10 from TravisCI build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jdk:
   - oraclejdk7
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
 sudo: required
 dist: trusty


### PR DESCRIPTION
Using Java 10 results in a deprecation error and causes the build to
fail. Since Java 10 is deprecated, let's just remove it from the build
matrix.

DAFFODIL-2016