### PR TITLE
Add SDE for missing closing tag

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -127,6 +127,7 @@ final class DFDLSchemaFile(val sset: SchemaSet,
     } catch {
       case e: java.io.IOException => die(e)
       case e: SAXException => die(e)
+      case e: scala.xml.parsing.FatalError => die(e)
     }
     node
   }.value

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/MissingClosingTag.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/MissingClosingTag.dfdl.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://www.example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat" lengthKind="delimited" separator="."
+      lengthUnits="bytes" encoding="UTF-8" initiator=""
+      terminator="" occursCountKind="parsed" ignoreCase="no"
+      textNumberRep="standard" representation="text">
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="e1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="inty" type="blah" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -191,4 +191,25 @@
 
   </tdml:parserTestCase>
 
+<!--
+    Test Name: missing_closing_tag
+       Schema: MissingClosingTag.dfdl.xsd
+         Root: e1
+      Purpose: This test demonstrates that an SDE will be displayed in the event of a missing
+               closing tag in the schema file.
+-->
+
+  <tdml:parserTestCase name="missing_closing_tag" root="e1"
+    model="MissingClosingTag.dfdl.xsd"
+    description="">
+    <tdml:document />
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>expected closing tag</tdml:error>
+      <tdml:error>dfdl:format</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -42,4 +42,5 @@ class TestSDE {
 
   @Test def test_schema_line_number() { runner.runOneTest("schema_line_number") }
   @Test def test_schema_warning() { runner.runOneTest("schema_warning") }
+  @Test def test_missing_closing_tag() { runner.runOneTest("missing_closing_tag") }
 }


### PR DESCRIPTION
Previously a missing closing tag would case a fatal Scala xml parsing
error. Now it will have an SDE specifying the missing tag.

DAFFODIL-1955