### PR TITLE
Show different error message for OOM

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -1355,6 +1355,20 @@ object Main extends Logging {
         log(LogLevel.Error, "%s", e.getMessage())
         1
       }
+      case e: OutOfMemoryError => {
+        System.err.println("""|
+                            |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                            |!!             Daffodil ran out of memory!              !!
+                            |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                            |
+                            | Try increasing the amount of memory by changing or
+                            | setting the DAFFODIL_JAVA_OPTS environment variable.
+                            | "DAFFODIL_JAVA_OPTS=-Xmx5G" for 5GB.
+                            |
+                            |""".stripMargin)
+        e.printStackTrace
+        1
+      }
       case e: Exception => {
         bugFound(e)
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
@@ -271,7 +271,7 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Vector[Parser])
       case t: Throwable => {
         if (pBefore != null) {
           markLeakCausedByException = true
-          if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException]) {
+          if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException] && !t.isInstanceOf[java.lang.Error]) {
             val stackTrace = new StringWriter()
             t.printStackTrace(new PrintWriter(stackTrace))
             Assert.invariantFailed("Exception thrown with mark not returned: " + t + "\nStackTrace:\n" + stackTrace)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -238,7 +238,7 @@ abstract class OrderedSequenceParserBase(
                     if (pstate.isInUse(priorState)) {
                       markLeakCausedByException = true
                       pstate.discard(priorState)
-                      if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException]) {
+                      if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException] && !t.isInstanceOf[java.lang.Error]) {
                         val stackTrace = new StringWriter()
                         t.printStackTrace(new PrintWriter(stackTrace))
                         Assert.invariantFailed("Exception thrown with mark not returned: " + t + "\nStackTrace:\n" + stackTrace)


### PR DESCRIPTION
Instead of showing a generic error message, we should suggest
increasing memory when we crash due to an OutOfMemoryError.

DAFFODIL-1953