### PR TITLE
Changing to ignore attributeFormDefault

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
@@ -118,11 +118,12 @@ final class XMLSchemaDocument(xmlArg: Node,
     val hasSchemaLocation = (xml \ "@schemaLocation").text != ""
     val hasBlockDefault = (xml \ "@blockDefault").text != ""
     val hasFinalDefault = (xml \ "@finalDefault").text != ""
+    val hasAttributeFormDefault = (xml \ "@attributeFormDefault").text != ""
     schemaDefinitionWarningUnless(WarnID.UnsupportedAttributeSchemaLocation, !hasSchemaLocation, "schemaLocation is ignored.")
     schemaDefinitionWarningUnless(WarnID.UnsupportedAttributeBlockDefault, !hasBlockDefault, "blockDefault is ignored")
     schemaDefinitionWarningUnless(WarnID.UnsupportedAttributeFinalDefault, !hasFinalDefault, "finalDefault is ignored")
-    schemaDefinitionUnless(attributeFormDefault == "unqualified", "attributeFormDefault='qualified' is not yet implemented.")
-    val res = hasSchemaLocation | hasBlockDefault | hasFinalDefault
+    schemaDefinitionWarningUnless(WarnID.UnsupportedAttributeFormDefault, !hasAttributeFormDefault, "attributeFormDefault is not part of DFDL and will be ignored")
+    val res = hasSchemaLocation | hasBlockDefault | hasFinalDefault | hasAttributeFormDefault
     res
   }.value
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
@@ -78,6 +78,7 @@ object WarnID extends PropsEnum[WarnID] {
   case object UnsupportedAttributeBlockDefault extends WarnID; forceConstruction(UnsupportedAttributeBlockDefault)
   case object UnsupportedAttributeFinalDefault extends WarnID; forceConstruction(UnsupportedAttributeFinalDefault)
   case object UnsupportedAttributeSchemaLocation extends WarnID; forceConstruction(UnsupportedAttributeSchemaLocation)
+  case object UnsupportedAttributeFormDefault extends WarnID; forceConstruction(UnsupportedAttributeFormDefault)
 
   override def apply(name: String, context: ThrowsSDE) = Assert.usageError("not to be called. Call find(name) method instead.")
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
@@ -91,7 +91,7 @@ object SchemaUtils {
     scope = XMLUtils.combineScopes("ex", targetNamespace, scope)
 
     val schemaNode =
-      <xs:schema elementFormDefault={ elementFormDefault } attributeFormDefault="unqualified">
+      <xs:schema elementFormDefault={ elementFormDefault } >
         <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
         <xs:annotation>
           <xs:appinfo source={ XMLUtils.dfdlAppinfoSource }>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -145,6 +145,7 @@
                  <xsd:enumeration value="regexPatternZeroLength" />
                  <xsd:enumeration value="unsupportedAttributeBlockDefault" />
                  <xsd:enumeration value="unsupportedAttributeFinalDefault" />
+                 <xsd:enumeration value="unsupportedAttributeFormDefault" />
                  <xsd:enumeration value="unsupportedAttributeSchemaLocation" />
                </xsd:restriction>
              </xsd:simpleType>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc81_01.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc81_01.dfdl.xsd
@@ -36,7 +36,7 @@
 			<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" 
 				truncateSpecifiedLengthString="no"  separator=""  
 				textBidi="no" floating="no" encodingErrorPolicy="replace"
-				encodingErrorPolicy="replace" encoding="ASCII" representation="text"
+				encoding="ASCII" representation="text" textOutputMinLength="0"
 				byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" alignment="1" alignmentUnits="bytes" fillByte="f"
 				occursCountKind="implicit" initiatedContent="no" sequenceKind="ordered"
 				ignoreCase="no" textPadKind="none" textTrimKind="none"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc82_01.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaspc82_01.dfdl.xsd
@@ -31,7 +31,7 @@
 			<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" 
 				truncateSpecifiedLengthString="no"  separator=""  
 				textBidi="no" floating="no" encodingErrorPolicy="replace"   
-				encodingErrorPolicy="replace" encoding="ASCII" representation="text"
+				encoding="ASCII" representation="text" textOutputMinLength="0"
 				byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" 
 				alignment="1" alignmentUnits="bytes" fillByte="f"
 				occursCountKind="implicit" initiatedContent="no" sequenceKind="ordered"
@@ -51,7 +51,7 @@
 	<xs:annotation>
 		<xs:appinfo source="http://www.ogf.org/dfdl/">
 			<dfdl:defineFormat name="myFormat">
-				<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" truncateSpecifiedLengthString="no"  separator=""  textBidi="no" floating="no"  encodingErrorPolicy="replace"  encodingErrorPolicy="replace" encoding="ASCII" />
+				<dfdl:format initiator="" terminator="" leadingSkip="0" trailingSkip="0" truncateSpecifiedLengthString="no"  separator=""  textBidi="no" floating="no"  encodingErrorPolicy="replace"  encoding="ASCII" />
 			</dfdl:defineFormat>
 		</xs:appinfo>
 	</xs:annotation>

--- a/daffodil-test-ibm1/src/test/scala-debug/org/apache/daffodil/IBMTests2.scala
+++ b/daffodil-test-ibm1/src/test/scala-debug/org/apache/daffodil/IBMTests2.scala
@@ -44,11 +44,6 @@ class IBMTestsThatThrow {
   lazy val runner1 = new DFDLTestSuite(Misc.getRequiredResource(tdml1))
   lazy val runner2 = new DFDLTestSuite(Misc.getRequiredResource(tdml2))
 
-  @Test def test_scoping_define_format_8_04() { runner1.runOneTest("scoping_define_format_8_04") } //DFDL-565 - attributeFormDefault='qualified'
-
-  @Test def test_scoping_default_format_8_01() { runner1.runOneTest("scoping_default_format_8_01") } // DFDL-565 attributeFormDefault='qualified'
-  @Test def test_scoping_define_format_8_01() { runner1.runOneTest("scoping_define_format_8_01") } // DFDL-565 attributeFormDefault='qualified'
-
   @Test def test_alignment_bytes_12_05() { runner1.runOneTest("alignment_bytes_12_05") } //DFDL-99 binary dateTime
 
   @Test def test_length_implicit_12_02() { runner1.runOneTest("length_implicit_12_02") } // implicit length string - bug in IBM test (doesn't have minLength - both are required)

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
@@ -57,10 +57,11 @@ class IBMTestsThatPass {
 
   @Test def test_property_syntax_7_04() { runner1.runOneTest("property_syntax_7_04") }
 
-  // Used to work, but now we get NYI for attributeFormDefault='qualified'
-  // @Test def test_scoping_default_format_8_01() { runner1.runOneTest("scoping_default_format_8_01") }
+  @Test def test_scoping_default_format_8_01() { runner1.runOneTest("scoping_default_format_8_01") }
+  @Test def test_scoping_define_format_8_01() { runner1.runOneTest("scoping_define_format_8_01") }
   @Test def test_scoping_define_format_8_02() { runner1.runOneTest("scoping_define_format_8_02") }
   @Test def test_scoping_define_format_8_03() { runner1.runOneTest("scoping_define_format_8_03") }
+  @Test def test_scoping_define_format_8_04() { runner1.runOneTest("scoping_define_format_8_04") }
   @Test def test_scoping_define_format_8_05() { runner1.runOneTest("scoping_define_format_8_05") }
 
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/AttributeFormDefault.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/AttributeFormDefault.dfdl.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://www.example.com" attributeFormDefault="unqualified" >
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat" lengthKind="delimited" encoding="UTF-8" representation="text"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="elem" type="xs:string" />
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -212,4 +212,28 @@
 
   </tdml:parserTestCase>
 
+  <!--
+    Test Name: ignoreAttributeFormDefault
+       Schema: AttributeFormDefault.dfdl.xsd
+         Root: elem
+      Purpose: This test demonstrates the Schema Definition Warning for attributeFormDefault
+-->
+
+  <tdml:parserTestCase name="ignoreAttributeFormDefault" root="elem"
+    model="AttributeFormDefault.dfdl.xsd"
+    description="">
+    <tdml:document><![CDATA[test]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem>test</elem>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>attributeFormDefault is not part of DFDL and will be ignored</tdml:warning>
+    </tdml:warnings>
+
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -43,4 +43,5 @@ class TestSDE {
   @Test def test_schema_line_number() { runner.runOneTest("schema_line_number") }
   @Test def test_schema_warning() { runner.runOneTest("schema_warning") }
   @Test def test_missing_closing_tag() { runner.runOneTest("missing_closing_tag") }
+  @Test def test_ignoreAttributeFormDefault() { runner.runOneTest("ignoreAttributeFormDefault") }
 }


### PR DESCRIPTION
Previously an error was thrown when attributeFormDefault="qualified". This attribute
is not used by DFDL so now a warning is issued and the attribute is ignored.

Daffodil-565