### PR TITLE
Updated broken tests to check for error message

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1670,13 +1670,11 @@ c]]></value>
     model="expressions-Embedded.dfdl.xsd" description="">
 
     <tdml:document><![CDATA[1blastoff]]></tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <expr_space5b>
-          <value>blastoff</value>
-        </expr_space5b>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>property 'initiator'</tdml:error>
+      <tdml:error>cannot start or end with the string " "</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -1715,14 +1713,11 @@ c]]></value>
     model="expressions-Embedded.dfdl.xsd" description="">
 
     <tdml:document><![CDATA[321blastoff]]></tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <expr_space4>
-          <dummy>2</dummy>
-          <value><![CDATA[a b c]]></value>
-        </expr_space4>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>property 'initiator'</tdml:error>
+      <tdml:error>cannot start or end with the string " "</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="expression-type-errors.dfdl.xsd">

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
@@ -58,10 +58,6 @@ class TestDFDLExpressionsDebug {
 
   import TestDFDLExpressionsDebug._
 
-  //DFDL-1287
-  @Test def test_internal_space_preserved4() { runner.runOneTest("internal_space_preserved4") }
-  @Test def test_internal_space_not_preserved2() { runner.runOneTest("internal_space_not_preserved2") }
-
   //DFDL-1146
   @Test def test_attribute_axis_01() { runner.runOneTest("attribute_axis_01") }
   @Test def test_attribute_axis_02() { runner.runOneTest("attribute_axis_02") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -239,11 +239,9 @@ class TestDFDLExpressions {
   @Test def test_internal_space_preserved2() { runner.runOneTest("internal_space_preserved2") }
   @Test def test_internal_space_preserved3a() { runner.runOneTest("internal_space_preserved3a") }
   @Test def test_internal_space_preserved3b() { runner.runOneTest("internal_space_preserved3b") }
+  @Test def test_internal_space_preserved4() { runner.runOneTest("internal_space_preserved4") }
   @Test def test_internal_space_not_preserved1() { runner.runOneTest("internal_space_not_preserved1") }
-
-  //DFDL-1287
-  //@Test def test_internal_space_preserved4() { runner.runOneTest("internal_space_preserved4") }
-  //@Test def test_internal_space_not_preserved2() { runner.runOneTest("internal_space_not_preserved2") }
+  @Test def test_internal_space_not_preserved2() { runner.runOneTest("internal_space_not_preserved2") }
 
   @Test def test_whitespace_expression() { runner.runOneTest("whitespace_expression") }
   @Test def test_whitespace_expression2() { runner.runOneTest("whitespace_expression2") }


### PR DESCRIPTION
These tests were trying to use expressions in attributes that end up
starting with a " ". This is not valid for attributes that are space
separated lists. The tests have been updated to check for the
appropriate error message.

DAFFODIL-1287