### PR TITLE
Adding error when dfdl:initiator is "%"

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
@@ -318,6 +318,12 @@ final class EntityReplacer {
     result
   }
 
+  private def errBadEntityLonePercent(ent: String, orig: String, context: Maybe[ThrowsSDE]) {
+    val msg = "Invalid DFDL Entity (%s) found in \"%s\". If a single percent was intended instead of a DFDL Entity, it must be self escaped (%%%%).".format(ent, orig)
+    if (context.isDefined) context.get.SDE(msg)
+    else throw new EntitySyntaxException(msg)
+  }
+
   private def errBadEntityNoSemi(ent: String, orig: String, context: Maybe[ThrowsSDE]) {
     val msg = "Invalid DFDL Entity (%%%s) found in \"%s\". Missing semicolon at end of entity name?".format(stripLeadingPercent(ent), orig)
     if (context.isDefined) context.get.SDE(msg)
@@ -331,6 +337,10 @@ final class EntityReplacer {
     allowByteEntities: Boolean = true): String = {
     Assert.usage(!input.contains("%%"))
     if (!input.contains("%")) { return input }
+
+    if (input.equals("%")) {
+      errBadEntityLonePercent(input, orig, context)
+    }
 
     val tokens = input.split("""%""") ++ (if (input.endsWith("%")) List("") else Nil)
     // we must have a minimum of 2 tokens here. The first token never was for an entity. Only 2nd to last ones.

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -4127,6 +4127,8 @@
 
     <xs:element name="string11" dfdl:textStringPadCharacter=" " dfdl:lengthKind="delimited" type="xs:string" />
 
+    <xs:element name="string12" dfdl:textStringPadCharacter="%" dfdl:lengthKind="delimited" type="xs:string" />
+
   </tdml:defineSchema>
   
   <!--
@@ -4506,6 +4508,24 @@
         </seq>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: percentPadding
+    Schema: SimpleTypes-padding
+    Purpose: This document demonstrates the use of a percent sign for textStringPadCharacter and throws an error.
+  -->
+
+  <tdml:parserTestCase name="percentPadding" root="string12"
+      model="SimpleTypes-padding" description="Section 13 Simple Types - textStringPadCharacter DFDL-13-042R"
+      >
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[remove padding please%%%%%%%%%%]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
   
   <tdml:defineSchema name="dateTimeSchemaTNR">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
@@ -129,6 +129,56 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="DP_05" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence dfdl:initiatedContent="no"
+          dfdl:separatorPosition="infix" dfdl:separator=",">
+          <xs:element name="num1" type="xs:int"
+            dfdl:initiator="%" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DP_06" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence dfdl:initiatedContent="no"
+          dfdl:separatorPosition="infix" dfdl:separator="%">
+          <xs:element name="num1" type="xs:int"
+            dfdl:initiator=":" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DP_07" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence dfdl:initiatedContent="no"
+          dfdl:separatorPosition="infix" dfdl:separator=",">
+          <xs:element name="num1" type="xs:int"
+            dfdl:terminator="%" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DP_08" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence dfdl:initiatedContent="no"
+          dfdl:separatorPosition="infix" dfdl:separator=",">
+          <xs:element name="num1" type="xs:int"
+            dfdl:terminator="test%" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DP_09" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence dfdl:initiatedContent="no"
+          dfdl:separatorPosition="infix" dfdl:separator=",">
+          <xs:element name="num1" type="xs:int"
+            dfdl:terminator="{if ('true') then '%' else 'IMPOSSIBLE'}" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:defineSchema name="DelimiterProperties-Embedded2.dfdl.xsd">
@@ -808,6 +858,62 @@
         </e2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="percentInitiator"
+    model="DelimiterProperties-Embedded.dfdl.xsd"
+    description="An initiator of '%' causes an error"
+    root="DP_05">
+    <tdml:document><![CDATA[%1,%2,%3,%4]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="percentSeparator"
+    model="DelimiterProperties-Embedded.dfdl.xsd"
+    description="A separator of '%' causes an error"
+    root="DP_06">
+    <tdml:document><![CDATA[:1%:2%:3%:4]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="percentTerminator"
+    model="DelimiterProperties-Embedded.dfdl.xsd"
+    description="A terminator of '%' causes an error"
+    root="DP_07">
+    <tdml:document><![CDATA[1%,2%,3%,4%]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+      <tdml:error>%%</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="percentTerminator2"
+    model="DelimiterProperties-Embedded.dfdl.xsd"
+    description="A terminator that ends in a '%' causes an error"
+    root="DP_08">
+    <tdml:document><![CDATA[1test%,2test%,3test%,4test%]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="percentExpression"
+    model="DelimiterProperties-Embedded.dfdl.xsd"
+    description="A terminator that is an expression that results in '%' causes an error"
+    root="DP_09">
+    <tdml:document><![CDATA[1%,2%,3%,4%]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid DFDL Entity (%) found</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -445,6 +445,7 @@ class TestSimpleTypes {
   @Test def test_padding_nil2() { runner.runOneTest("padding_nil2") }
   @Test def test_padding_empty() { runner.runOneTest("padding_empty") }
   @Test def test_justification_1() { runner.runOneTest("justification_1") }
+  @Test def test_percentPadding() { runner.runOneTest("percentPadding") }
 
   // Verification that user's test works for DFDL-677
   @Test def test_unsignedInt() { runner.runOneTest("TestUnsignedInt") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
@@ -82,4 +82,10 @@ class TestDelimiterProperties {
   }
 
   @Test def test_delims_ignorecase_01() = { runner_02.runOneTest("delims_ignorecase_01") }
+
+  @Test def test_percentInitiator() = { runner_02.runOneTest("percentInitiator") }
+  @Test def test_percentSeparator() = { runner_02.runOneTest("percentSeparator") }
+  @Test def test_percentTerminator() = { runner_02.runOneTest("percentTerminator") }
+  @Test def test_percentTerminator2() = { runner_02.runOneTest("percentTerminator2") }
+  @Test def test_percentExpression() = { runner_02.runOneTest("percentExpression") }
 }


### PR DESCRIPTION
When the initiator is a percent sign the initiator was being ignored
so this will now throw an error.

DAFFODIL-1840