### PR TITLE
Updating to set encoding of CLI output to UTF-8

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -845,7 +845,7 @@ object Main extends Logging {
               case Some("-") | None => System.out
               case Some(file) => new FileOutputStream(file)
             }
-            val writer = new BufferedWriter(new OutputStreamWriter(output))
+            val writer = new BufferedWriter(new OutputStreamWriter(output, "UTF-8"))
             val outputter = getInfosetOutputter(parseOpts.infosetType.toOption.get, writer)
 
             var lastParseBitPosition = 0L


### PR DESCRIPTION
Without an encoding specified the system default is used for outputting
the infoset in the CLI, which could result in unexpected output. This
will ensure UTF-8 is used instead of the system default.

Daffodil-2011