### PR TITLE
Fixed infinite loop due to not gathering the error reliably.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
@@ -289,7 +289,7 @@ trait AnnotatedMixin { self: AnnotatedSchemaComponent =>
    * The DFDL annotations on the component, as objects
    * that are subtypes of DFDLAnnotation.
    */
-  final lazy val annotationObjs = {
+  final lazy val annotationObjs = LV('annotationObjs) {
     val objs = dfdlAppInfos.flatMap { dai =>
       {
         val children = dai.child
@@ -302,7 +302,7 @@ trait AnnotatedMixin { self: AnnotatedSchemaComponent =>
       }
     }
     objs
-  }
+  }.value
 
   /**
    * Here we establish an invariant which is that every annotatable schema component has, definitely, has an
@@ -317,6 +317,9 @@ trait AnnotatedMixin { self: AnnotatedSchemaComponent =>
    * is imposed. There *is* a formatAnnotation.
    */
   protected def emptyFormatFactory: DFDLFormatAnnotation
+
+  final lazy val formatAnnotationExpectedName = emptyFormatFactory.xml.asInstanceOf[scala.xml.Elem].label
+
   protected def isMyFormatAnnotation(a: DFDLAnnotation): Boolean
 
   final lazy val formatAnnotation = LV('formatAnnotation) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
@@ -145,7 +145,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
   //    seq
   //  }
 
-  private lazy val shortFormProperties: Set[PropItem] = {
+  private lazy val shortFormProperties: Set[PropItem] = LV[Set[PropItem]]('shortFormProperties) {
     // shortForm properties should be prefixed by dfdl
     // Remove the dfdl prefix from the attributes so that they
     // can be properly combined later.
@@ -159,9 +159,9 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     val kvPairsButNotRef = kvPairs.filterNot { _._1 == "ref" } // dfdl:ref is NOT a property
     val pairs = kvPairsButNotRef.map { case (k, v) => (k, (v, annotatedSC)).asInstanceOf[PropItem] }
     pairs.toSet
-  }
+  }.value
 
-  private lazy val longFormProperties: Set[PropItem] = {
+  private lazy val longFormProperties: Set[PropItem] = LV[Set[PropItem]]('longFormProperties) {
     // longForm Properties are not prefixed by dfdl
     val dfdlAttrs = dfdlAttributes(xml).asAttrMap
     schemaDefinitionUnless(dfdlAttrs.isEmpty, "long form properties are not prefixed by dfdl:")
@@ -181,7 +181,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     val dfdlAndDafAttribs = unqualifiedAttribs ++ dafAttrMap
     val res = dfdlAndDafAttribs.map { case (k, v) => (k, (v, this.asInstanceOf[LookupLocation])) }.toSet
     res
-  }
+  }.value
 
   private lazy val elementFormPropertyAnnotations = {
     val props = xml \\ "property"
@@ -191,9 +191,9 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     res
   }
 
-  private lazy val elementFormProperties: Set[PropItem] = {
+  private lazy val elementFormProperties: Set[PropItem] = LV[Set[PropItem]]('elementFormProperties) {
     elementFormPropertyAnnotations.map { p => (p.name, (p.value, p)) }.toSet
-  }
+  }.value
 
   /**
    * 'locallyConflicting' means conflicting between the short form and long form and
@@ -212,9 +212,10 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
 
   private lazy val hasConflictingPropertyError = locallyConflictingProperties.size != 0
 
-  private lazy val combinedJustThisOneProperties: PropMap = {
+  private lazy val combinedJustThisOneProperties: PropMap = LV('combinedJustThisOneOproperties) {
     // We need this error to occur immediately! Didn't seem to be checked otherwise.
-    schemaDefinitionUnless(!hasConflictingPropertyError,
+    schemaDefinitionUnless(
+      !hasConflictingPropertyError,
       "Short, long, and element form properties overlap: %s at %s",
       locallyConflictingProperties.mkString(", "),
       this.locationDescription)
@@ -222,7 +223,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     val jtoSet = shortFormProperties.union(longFormProperties).union(elementFormProperties)
     val jto = jtoSet.toMap
     jto
-  }
+  }.value
 
   /**
    * Just this one, as in the short, long, and element form properties, on just this

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLProperty.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLProperty.scala
@@ -39,7 +39,7 @@ final class DFDLProperty(xmlArg: Node, formatAnnotation: DFDLFormatAnnotation)
   // TODO: if we grab the value from here, then any qnames inside that value
   // have to be resolved by THIS Object
   lazy val value = {
-    lazy val values: Option[NodeSeq] = xml match {
+    val values: Option[NodeSeq] = xml match {
       case <dfdl:property/> => None
       case <daf:property/> => None
       case <dfdl:property>{ valueNodes @ _* }</dfdl:property> => Some(valueNodes)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLStatementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLStatementMixin.scala
@@ -112,7 +112,19 @@ trait ProvidesDFDLStatementMixin extends ThrowsSDE with HasTermCheck { self: Ann
       //
       case <dfdl:property>{ _* }</dfdl:property> =>
         SDE("A dfdl:property annotation element is not allowed without a surrounding dfdl:format, dfdl:element, etc. ")
+      case e: scala.xml.Elem if mismatchedFormatAnnotation(e) =>
+        SDE("DFDL annotation type 'dfdl:%s' invalid. Expected 'dfdl:%s'.", e.label, self.formatAnnotationExpectedName)
       case _ => SDE("Invalid DFDL annotation found: %s", node)
+    }
+  }
+
+  private def mismatchedFormatAnnotation(e: scala.xml.Elem): Boolean = {
+    (e.label, self) match {
+      case ("element", _: ElementBase) => false
+      case ("choice", _: ChoiceTermBase) => false
+      case ("sequence", _: SequenceTermBase) => false
+      case ("simpleType", _: SimpleTypeBase) => false
+      case _ => true
     }
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -479,7 +479,7 @@ trait ElementBase
   }.value
 
   protected def computeElementRuntimeData(): ElementRuntimeData = {
-    
+
     lazy val childrenERDs: Seq[ElementRuntimeData] =
       elementChildren.map { _.elementRuntimeData }
 
@@ -551,14 +551,14 @@ trait ElementBase
    *
    * Include both represented and non-represented elements.
    */
-  final lazy val elementChildren: Seq[ElementBase] = {
+  final lazy val elementChildren: Seq[ElementBase] = LV('elementChildren) {
     this.typeDef match {
       case ct: ComplexTypeBase => {
         ct.group.elementChildren
       }
       case _ => Nil
     }
-  }
+  }.value
 
   final lazy val elementChildrenCompileInfo =
     elementChildren.map {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
@@ -66,21 +66,22 @@ trait GroupDefLike
 
   def xmlChildren: Seq[Node]
 
+  private lazy val goodXmlChildren = LV('goodXMLChildren) { xmlChildren.flatMap { removeNonInteresting(_) } }.value
+
   /** Returns the group members that are elements or model groups. */
-  final lazy val groupMembers : Seq[Term] = {
+  final lazy val groupMembers: Seq[Term] = LV('groupMembers) {
     //
     // So we have to flatMap, so that we can tolerate annotation objects (like documentation objects).
     // and our ModelGroup factory has to return Nil for annotations and Text nodes.
     //
-    val goodXmlChildren = LV('goodXMLChildren) { xmlChildren.flatMap { removeNonInteresting(_) } }.value
     val positions = List.range(1, goodXmlChildren.length + 1) // range is exclusive on 2nd arg. So +1.
     val pairs = goodXmlChildren zip positions
     pairs.flatMap {
       case (n, i) =>
         TermFactory(n, this, i)
     }
-  }
-  
+  }.value
+
   /**
    * XML is full of uninteresting text nodes. We just want the element children, not all children.
    */
@@ -143,4 +144,3 @@ final class GlobalChoiceGroupDef(defXMLArg: Node, choiceXML: Node, schemaDocumen
   with ChoiceDefMixin {
 
 }
-

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
@@ -32,7 +32,9 @@ trait GroupRef { self: ModelGroup =>
 
   final override lazy val optReferredToComponent = Some(referredToComponent)
 
-  final override lazy val groupMembers = groupDef.groupMembers
+  final override lazy val groupMembers = LV('groupMembers) {
+    groupDef.groupMembers
+  }.value
 
   override protected def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
@@ -62,17 +64,18 @@ final class GroupRefFactory(refXMLArg: Node, val refLexicalParent: SchemaCompone
 
   final def qname = this.refQName
 
-  lazy val groupRef = {
+  lazy val groupRef = LV('groupRef) {
     val gdefFactory = parent.schemaSet.getGlobalGroupDef(qname).getOrElse {
       SDE("Referenced group definition not found: %s", this.ref)
     }
     val (gref, _) = gdefFactory.forGroupRef(refXMLArg, refLexicalParent, position, isHidden)
     gref
-  }
+  }.value
 
 }
 
-final class SequenceGroupRef(globalGroupDef: => GlobalSequenceGroupDef,
+final class SequenceGroupRef(
+  globalGroupDef: => GlobalSequenceGroupDef,
   refXML: Node,
   refLexicalParent: SchemaComponent,
   positionArg: Int,
@@ -92,11 +95,12 @@ final class SequenceGroupRef(globalGroupDef: => GlobalSequenceGroupDef,
 
   override def hiddenGroupRefOption = nf
 
-  override lazy val groupDef = globalGroupDef
+  override lazy val groupDef = LV('groupDef) { globalGroupDef }.value
 
 }
 
-final class ChoiceGroupRef(globalGroupDef: => GlobalChoiceGroupDef,
+final class ChoiceGroupRef(
+  globalGroupDef: => GlobalChoiceGroupDef,
   refXML: Node,
   refLexicalParent: SchemaComponent,
   positionArg: Int,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -295,8 +295,9 @@ trait SequenceDefMixin
   // attribute, not a format property in the usual sense.
   // So we retrieve it by this lower-level mechanism which only combines short and long form.
   //
-  final lazy val hiddenGroupRefOption =
+  final lazy val hiddenGroupRefOption = LV('hiddenGroupRefOption) {
     findPropertyOptionThisComponentOnly("hiddenGroupRef")
+  }.value
 
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
@@ -46,10 +46,12 @@ trait SequenceGrammarMixin extends GrammarMixin { self: SequenceTermBase =>
     LayeredSequence(this, new ScalarOrderedSequenceChild(this, term, 1)) // We use 1-based indexing for children.
   }
 
-  private lazy val seqChildren = (groupMembers zip Stream.from(1)).map {
-    case (gm, i) =>
-      sequenceChild(gm, i)
-  }
+  private lazy val seqChildren = LV('seqChildren) {
+    (groupMembers zip Stream.from(1)).map {
+      case (gm, i) =>
+        sequenceChild(gm, i)
+    }
+  }.value
 
   private lazy val orderedSequence = {
     val res = new OrderedSequence(this, seqChildren)
@@ -156,4 +158,3 @@ trait SequenceGrammarMixin extends GrammarMixin { self: SequenceTermBase =>
     delimMTA ~ SequenceSeparator(this)
   }
 }
-

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/PropertySyntax.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/PropertySyntax.tdml
@@ -271,5 +271,18 @@
       <tdml:error>badElementFormProperty</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+  
+    <tdml:parserTestCase name="badElementFormProperty2" root="badElementFormProperty2"
+    model="property_syntax.dfdl.xsd" description="wrong annotation element.">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>DFDL annotation type</tdml:error>
+      <tdml:error>dfdl:sequence</tdml:error>
+      <tdml:error>expected</tdml:error>
+      <tdml:error>dfdl:element</tdml:error>
+      <tdml:error>badElementFormProperty2</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/property_syntax.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/property_syntax.dfdl.xsd
@@ -74,4 +74,20 @@
            </xs:appinfo>
         </xs:annotation> 
       </xs:element>
+      
+      <xs:element name="badElementFormProperty2" type="xs:int">
+        <xs:annotation>
+          <xs:documentation><![CDATA[ 
+            Example of a User mistake. They forgot that element form property
+            syntax must be contained within a format element that matches the
+            annotated object. I.e., dfdl:sequence on an xs:sequence.
+            This was causing DAFFODIL-2202 bug. 
+          ]]></xs:documentation> 
+          <xs:appinfo source="http://www.ogf.org/dfdl/" > 
+             <dfdl:sequence>
+               <dfdl:property name="representation">text</dfdl:property>
+             </dfdl:sequence>
+           </xs:appinfo>
+        </xs:annotation> 
+      </xs:element>
 </xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -271,7 +271,7 @@
     </xs:element>
   </tdml:defineSchema>
   
-  <tdml:defineSchema name="hiddenGroupEmpty">
+  <tdml:defineSchema name="hiddenGroupRefEmptyString">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
 
@@ -286,18 +286,19 @@
   </tdml:defineSchema>
   
   <!--
-    Test name: hiddenGroupEmpty
-       Schema: hiddenGroupEmpty
+    Test name: hiddenGroupRefEmptyString
+       Schema: hiddenGroupRefEmptyString
       Purpose: This test demonstrates that hidden group references cannot be the empty string.
   -->
   
-  <tdml:parserTestCase name="hiddenGroupEmpty" root="e"
-    model="hiddenGroup3" description="Section 14 - Hidden Elements DFDL-14-037R.">
+  <tdml:parserTestCase name="hiddenGroupRefEmptyString" root="e"
+    model="hiddenGroupRefEmptyString" description="Section 14 - Hidden Elements DFDL-14-037R.">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[42,2]]></tdml:documentPart>
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>QName</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -530,6 +531,7 @@
     </tdml:document>
     <tdml:errors> 
       <tdml:error>Schema Definition Error</tdml:error> 
+      <tdml:error>circular</tdml:error>
     </tdml:errors> 
  </tdml:parserTestCase>
 
@@ -1000,6 +1002,7 @@ more ignored input
 
 	<tdml:defineSchema name="nestedGroupRefs">
 		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
           occursCountKind='parsed'/>
 
@@ -1105,7 +1108,7 @@ A,B,C|D,E,F|G,H,I]]></tdml:document>
 
 	<tdml:defineSchema name="nestedGroupRefs2">
 		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" 
+        <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" 
           occursCountKind='parsed'/>
 
 		<xs:element name="root">

--- a/daffodil-test/src/test/scala-debug/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupsDebug.scala
@@ -42,9 +42,6 @@ class TestSequenceGroupsDebug {
   //DFDL-284
   @Test def test_hiddenGroupLoop() { runner_02.runOneTest("hiddenGroupLoop") }
 
-  //DFDL-598
-  @Test def test_hiddenGroupEmpty() { runner_02.runOneTest("hiddenGroupEmpty") }
-
   @Test def test_emptySequenceSDE() { runner_02.runOneTest("emptySequenceSDE") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
@@ -39,4 +39,7 @@ class TestPropertySyntax2 {
   // JIRA DFDL-1722
   @Test def test_badElementFormProperty() { runner.runOneTest("badElementFormProperty") }
 
+  // DAFFODIL-2202
+  @Test def test_badElementFormProperty2() { runner.runOneTest("badElementFormProperty2") }
+
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -79,8 +79,8 @@ class TestSequenceGroups {
   //DFDL-284
   // @Test def test_hiddenGroupLoop() { runner_02.runOneTest("hiddenGroupLoop") }
 
-  //DFDL-598
-  // @Test def test_hiddenGroupEmpty() { runner_02.runOneTest("hiddenGroupEmpty") }
+  //DFDL-598(related to, but this test does not say this is fixed)
+  @Test def test_hiddenGroupRefEmptyString() { runner_02.runOneTest("hiddenGroupRefEmptyString") }
 
   @Test def test_AC000() { runner_02.runOneTest("AC000") }
   @Test def test_AD000() { runner_02.runOneTest("AD000") }

--- a/eclipse-projects/cli-test/.classpath
+++ b/eclipse-projects/cli-test/.classpath
@@ -1,92 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/it/resources"/><classpathentry kind="src" path="src/it/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-cli"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/it/resources"/>
+	<classpathentry kind="src" path="src/it/scala"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-cli"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/cli/.classpath
+++ b/eclipse-projects/cli/.classpath
@@ -1,92 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" path="src/main/scala"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/japi-test/.classpath
+++ b/eclipse-projects/japi-test/.classpath
@@ -1,92 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry path="src/test/java" kind="src"/><classpathentry path="src/test/resources" kind="src"/><classpathentry path="org.scala-ide.sdt.launching.SCALA_CONTAINER" kind="con"/><classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/><classpathentry path="/daffodil-japi" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-tdml" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-core" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-runtime1" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-lib-unittest" kind="src" combineaccessrules="false"/><classpathentry path="/daffodil-io" kind="src" combineaccessrules="false"/><classpathentry path="target/eclipse/classes" kind="output"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-japi"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/japi/.classpath
+++ b/eclipse-projects/japi/.classpath
@@ -1,92 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="src" path="src/main/java"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/main/scala"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/sapi-test/.classpath
+++ b/eclipse-projects/sapi-test/.classpath
@@ -1,92 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-sapi"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/test/scala"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-sapi"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/sapi/.classpath
+++ b/eclipse-projects/sapi/.classpath
@@ -1,92 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/main/scala"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/tdml-test/.classpath
+++ b/eclipse-projects/tdml-test/.classpath
@@ -5,7 +5,6 @@
 	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
 	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
@@ -110,5 +109,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io-unittest"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
 	<classpathentry kind="output" path="target/eclipse/classes"/>
 </classpath>

--- a/eclipse-projects/test-stdLayout/.classpath
+++ b/eclipse-projects/test-stdLayout/.classpath
@@ -1,92 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="src" path="src/test/scala"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="src" path="src/test/scala"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core-unittest"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>

--- a/eclipse-projects/test/.classpath
+++ b/eclipse-projects/test/.classpath
@@ -6,7 +6,6 @@
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
@@ -114,5 +113,7 @@
 			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
 	<classpathentry kind="output" path="target/eclipse/classes"/>
 </classpath>

--- a/eclipse-projects/tutorials/.classpath
+++ b/eclipse-projects/tutorials/.classpath
@@ -1,92 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <!-- This file is updated by the UpdateEclipseClasspath app. -->
-        <classpathentry kind="src" path="src/test/scala"/><classpathentry kind="src" path="src/main/resources"/><classpathentry kind="src" path="src/test/resources"/><classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/><classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/><classpathentry kind="output" path="target/eclipse/classes"/><!--
-***********
-*********** Entries below this comment are maintained using the UpdateEclipseClasspaths
-*********** Utility and should not be modified by hand or using the Eclipse
-*********** BuildPath... GUI dialog.
-***********
---><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar" exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar">
-            
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar" exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar" exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar" exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry><classpathentry sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar" exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar">
-            <attributes>
-                  <attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
-                </attributes>
-          </classpathentry>
-      </classpath>
+	<classpathentry kind="src" path="src/test/scala"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-macro-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib-unittest"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/net.sf.expectit/expectit-core/expectit-core-0.9.0.jar" sourcepath="lib_managed/srcs/net.sf.expectit/expectit-core/expectit-core-0.9.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/net.sf.expectit/expectit-core/expectit-core-0.9.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.fusesource.jansi/jansi/jansi-1.17.1.jar" sourcepath="lib_managed/srcs/org.fusesource.jansi/jansi/jansi-1.17.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.fusesource.jansi/jansi/jansi-1.17.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0.jar" sourcepath="lib_managed/srcs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.scalacheck/scalacheck_2.12/scalacheck_2.12-1.14.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.rogach/scallop_2.12/scallop_2.12-3.1.3.jar" sourcepath="lib_managed/srcs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.rogach/scallop_2.12/scallop_2.12-3.1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="target/eclipse/classes"/>
+</classpath>


### PR DESCRIPTION
Problem is that a regular scala lazy val x = expression
If the expression throws, this lazy val will be re-evaluated over and
over each time it is requested.

That's why we have the LV system. This insures such values are attempted
exactly once, and if they throw, the fact that they threw is remembered,
and they're not attempted again.

To reduce overhead we've taken out a bunch of the LVs. But this results
in compiler errors that ripple. When parts of the compiler can't be LVs
because they are methods with parameters, it's important to CALL such
methods from something that IS an LV so that if an error is thrown, it's not
repeatedly thrown.

So a number of LVs have been put back in. Especially on things that
involve recursive descent or traversal of the DSOM objects or
corresponding XML.

This also fixes some other minor bugs which were being masked. E.g., a
test for hiddenGroupRef where the ref is empty string. I also renamed this
test since it was poorly named.

DAFFODIL-2202