### PR TITLE
Fix incorrect diagnostic.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
@@ -92,35 +92,29 @@ abstract class StaticText(delim: String, e: Term, eb: Term, kindString: String, 
   lazy val textParser = new TextParser(e.termRuntimeData)
 }
 
-abstract class DelimiterText(e: Term, eb: Term, guard: Boolean = true)
+abstract class DelimiterText(e: Term, eb: Term, delimiterType: DelimiterTextType.Type, guard: Boolean = true)
   extends Text(e, eb, guard) {
 
   lazy val textParser = new TextParser(e.termRuntimeData)
-
-  def delimiterType: DelimiterTextType.Type
 
   override lazy val parser: DaffodilParser = new DelimiterTextParser(e.termRuntimeData, textParser, positionalInfo, delimiterType)
   override lazy val unparser: DaffodilUnparser = new DelimiterTextUnparser(e.termRuntimeData, delimiterType)
 }
 
-case class Initiator(e: Term) extends DelimiterText(e, e) {
+case class Initiator(e: Term) extends DelimiterText(e, e, DelimiterTextType.Initiator) {
   Assert.invariant(e.hasInitiator)
-  val delimiterType: DelimiterTextType.Type = DelimiterTextType.Initiator
 }
 
-case class SequenceSeparator(s: SequenceTermBase) extends DelimiterText(s, s, s.hasSeparator) {
-  val delimiterType: DelimiterTextType.Type = DelimiterTextType.Separator
-}
-case class Terminator(e: Term) extends DelimiterText(e, e) {
+case class SequenceSeparator(s: SequenceTermBase) extends DelimiterText(s, s, DelimiterTextType.Separator, s.hasSeparator)
+
+case class Terminator(e: Term) extends DelimiterText(e, e, DelimiterTextType.Terminator) {
   Assert.invariant(e.hasTerminator)
-  val delimiterType: DelimiterTextType.Type = DelimiterTextType.Terminator
 }
 
 abstract class StringDelimBase(e: Term, guard: Boolean) extends Terminal(e, guard) {
   override def toString = "StringDelimBase[" + name + "]"
 
-  def checkDelimiterDistinctness(
-    escapeSchemeKind: EscapeKind,
+  def checkDelimiterDistinctness(escapeSchemeKind: EscapeKind,
     optPadChar: Option[String],
     optEscChar: Option[String], // Could be a DFDL expression
     optEscEscChar: Option[String], // Could be a DFDL expression

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes2.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes2.tdml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="SimpleTypes2" description="Section 5 - simple types"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com" xmlns:tns="http://example.com"
+  defaultRoundTrip="true">
+
+  <tdml:defineSchema name="s">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" representation="text" />
+    
+    <xs:element name="r" type="xs:string" dfdl:terminator="AAAAA"/>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="terminatorErrorMessage" root="r"
+    model="s" description="Insure parse error about missing delimiter says 'terminator' when it is a terminator that is missing.">
+
+    <tdml:document><![CDATA[abcde]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>terminator</tdml:error>
+      <tdml:error>AAAAA</tdml:error>
+      <tdml:error>not found</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesNew.scala
@@ -26,9 +26,11 @@ object TestSimpleTypesNew {
 
   val runner = Runner(testDir, "SimpleTypes.tdml")
   val runner1 = Runner(testDir, "BitOrder.tdml")
+  val runner2 = Runner(testDir, "SimpleTypes2.tdml")
   @AfterClass def shutdown {
     runner.reset
     runner1.reset
+    runner2.reset
   }
 }
 
@@ -46,4 +48,7 @@ class TestSimpleTypesNew {
 
   // DAFFODIL-1001 fixed.
   @Test def test_bigEndianLeastFirst() { runner1.runOneTest("bigEndianLeastFirst") }
+
+  // DAFFODIL-2204
+  @Test def test_terminatorErrorMessage() { runner2.runOneTest("terminatorErrorMessage") }
 }

--- a/eclipse-projects/tdml-test/.project
+++ b/eclipse-projects/tdml-test/.project
@@ -29,7 +29,7 @@
 		<link>
 			<name>src/test</name>
 			<type>2</type>
-			<locationURI>DAFFODIL_ROOT/daffodil-tdml/src/test</locationURI>
+			<locationURI>DAFFODIL_ROOT/daffodil-tdml-lib/src/test</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Missing terminator was reporting itself as a missing initiator.
I.e., message like Parse Error: Initiator ';' not found.
Except ";" is the terminator of the element, not the initiator. 

Due to object-construction-timing stuff I think. That or scala bugs. 
But sub-class overrides were not happening to provide the member from
which this name was derived. Why it got the wrong one, I don't know, I
would have expected "unbound/undefined" or something. 

Just passing the parameter to constructor rather than overriding a 
member to provide it, solves the problem.