### PR TITLE
Fix hexBinary with non-byte lengths or non-byte boundaries

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -403,13 +403,13 @@ a few lines of pointless text like this.""".replace("\n", " ")
     val infoset =
       <e1 xmlns={ example }>
         <s0>00</s0>
-        <s1>01</s1>
+        <s1>10</s1>
         <s2>02</s2>
         <s3>333333</s3>
         <s4>44</s4>
-        <s5>0555</s5>
-        <s6>06</s6>
-        <s7>07</s7>
+        <s5>5505</s5>
+        <s6>60</s6>
+        <s7>70</s7>
       </e1>
 
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/HexBinaryLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/HexBinaryLengthParsers.scala
@@ -22,6 +22,7 @@ import java.lang.{ Long => JLong }
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.LengthInBitsEv
 import org.apache.daffodil.processors.Processor
+import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.LengthUnits
 import org.apache.daffodil.util.Numbers
 
@@ -41,7 +42,30 @@ sealed abstract class HexBinaryLengthParser(override val context: ElementRuntime
     } else if (!dis.isDefinedForLength(nBits)) {
       PENotEnoughBits(start, nBits, dis.remainingBits)
     } else {
-      val array = start.dataInputStream.getByteArray(nBits, start)
+      // We cannot use dataInputStream.getByteArray(nBits) because that
+      // function takes into account byteOrder. hexBinary should completely
+      // ignore byteOrder, only taking into account bitOrder. To do this, we
+      // want to just repeatedly read 8 bit's at a time and add them to an
+      // ByteArray, effecitively ignoring byteOrder.
+      val nBytes = (nBits + 7) >> 3
+      val array = new Array[Byte](nBytes)
+      var bitsRemaining = nBits
+      var pos = 0
+      while (bitsRemaining > 0) {
+        val bitsToGet = Math.min(bitsRemaining, 8)
+        val longVal = start.dataInputStream.getUnsignedLong(bitsToGet, start)
+
+        val adjustedForBitOrder =
+          if (bitsToGet < 8 && start.bitOrder == BitOrder.MostSignificantBitFirst) {
+            (longVal << (8 - bitsToGet))
+          } else {
+            longVal
+          }
+
+        array(pos) = adjustedForBitOrder.toByte
+        pos += 1
+        bitsRemaining -= bitsToGet
+      }
       currentElement.setDataValue(array)
     }
   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/BitOrder.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/BitOrder.tdml
@@ -375,7 +375,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://example.com">
-        <littleLeast>00925A</littleLeast>
+        <littleLeast>5A9200</littleLeast>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -394,7 +394,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://example.com">
-        <littleLeast>5A9200</littleLeast>
+        <littleLeast>00925A</littleLeast>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -7138,6 +7138,55 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="hB_bits_le_lsbf_2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="hb1" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="leastSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+          <xs:element name="hb2" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="22" dfdl:bitOrder="leastSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+          <xs:element name="hb3" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="leastSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hB_bits_be_msbf_2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="hb1" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="bigEndian" />
+          <xs:element name="hb2" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="22" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="bigEndian" />
+          <xs:element name="hb3" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="bigEndian" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hB_bits_le_msbf_2"
+      dfdl:bitOrder="mostSignificantBitFirst" dfdl:byteOrder="littleEndian">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="hb1" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+          <xs:element name="hb2" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="22" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+          <xs:element name="hb3" type="xs:hexBinary" dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit"
+            dfdl:lengthUnits="bits" dfdl:length="5" dfdl:bitOrder="mostSignificantBitFirst"
+            dfdl:byteOrder="littleEndian" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
   
   <!--
@@ -7491,7 +7540,7 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <hB_bits_le_lsbf>
-          <hb1>0A35</hb1>
+          <hb1>350A</hb1>
           <hb2>05</hb2>
         </hB_bits_le_lsbf>
       </tdml:dfdlInfoset>
@@ -7507,8 +7556,8 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <hB_bits_be_msbf>
-          <hb1>06B5</hb1>
-          <hb2>02</hb2>
+          <hb1>35A8</hb1>
+          <hb2>40</hb2>
         </hB_bits_be_msbf>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -7523,9 +7572,60 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <hB_bits_le_msbf>
-          <hb1>1535</hb1>
-          <hb2>02</hb2>
+          <hb1>35A8</hb1>
+          <hb2>40</hb2>
         </hB_bits_le_msbf>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="hexBinary_bits_le_lsbf_2"
+    root="hB_bits_le_lsbf_2" model="HexBinary"
+    description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="true">
+    <tdml:document>
+      <tdml:documentPart type="byte">DEADBEEF</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <hB_bits_le_lsbf_2>
+          <hb1>1E</hb1>
+          <hb2>6EF53D</hb2>
+          <hb3>1D</hb3>
+        </hB_bits_le_lsbf_2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="hexBinary_bits_be_msbf_2"
+    root="hB_bits_be_msbf_2" model="HexBinary"
+    description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="true">
+    <tdml:document>
+      <tdml:documentPart type="byte">DEADBEEF</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <hB_bits_be_msbf_2>
+          <hb1>D8</hb1>
+          <hb2>D5B7DC</hb2>
+          <hb3>78</hb3>
+        </hB_bits_be_msbf_2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="hexBinary_bits_le_msbf_2"
+    root="hB_bits_le_msbf_2" model="HexBinary"
+    description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="true">
+    <tdml:document>
+      <tdml:documentPart type="byte">DEADBEEF</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <hB_bits_le_msbf_2>
+          <hb1>D8</hb1>
+          <hb2>D5B7DC</hb2>
+          <hb3>78</hb3>
+        </hB_bits_le_msbf_2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -57,10 +57,13 @@ class TestSimpleTypes {
   @Test def test_hexBinary_func() { runner.runOneTest("hexBinary_func") }
   @Test def test_hexBinary_func_neg() { runner.runOneTest("hexBinary_func_neg") }
 
-  // DFDL-1707
   @Test def test_hexBinary_bits_be_msbf() { runner.runOneTest("hexBinary_bits_be_msbf") }
   @Test def test_hexBinary_bits_le_msbf() { runner.runOneTest("hexBinary_bits_le_msbf") }
   @Test def test_hexBinary_bits_le_lsbf() { runner.runOneTest("hexBinary_bits_le_lsbf") }
+
+  @Test def test_hexBinary_bits_be_msbf_2() { runner.runOneTest("hexBinary_bits_be_msbf_2") }
+  @Test def test_hexBinary_bits_le_msbf_2() { runner.runOneTest("hexBinary_bits_le_msbf_2") }
+  @Test def test_hexBinary_bits_le_lsbf_2() { runner.runOneTest("hexBinary_bits_le_lsbf_2") }
 
   @Test def test_dateTextNumberRep() { runner.runOneTest("dateTextNumberRep") }
 

--- a/tutorials/src/main/resources/bitorder.tutorial.tdml.xml
+++ b/tutorials/src/main/resources/bitorder.tutorial.tdml.xml
@@ -1714,7 +1714,7 @@ The schema corresponding to this table is given below. This schema is derived fr
     </document>
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns="http://example.com">
-        <littleLeast>00925A</littleLeast>
+        <littleLeast>5A9200</littleLeast>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -1744,7 +1744,7 @@ The schema corresponding to this table is given below. This schema is derived fr
     </document>
     <tdml:infoset>
       <tdml:dfdlInfoset xmlns="http://example.com">
-        <littleLeast>5A9200</littleLeast>
+        <littleLeast>00925A</littleLeast>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>


### PR DESCRIPTION
- Elements with xs:hexBinary type no longer take into account byte order
  when reading bytes. Previously, Daffodil used an algorithm where the
  hex binary was essentially the hex binary representation of the
  non-negative integer of the same bit length. This is wrong and not
  compatible with the specification (for example, the little endian hex
  binary how the bytes in the reverse order). This changes Daffodil so
  it now reads eight bits at time and converts each eight bits to hex
  binary digits. The eights bits are read according to the bitOrder, and
  if less than eight bits are available, zero bit padding is applied to
  either the left or right according to the bit order to reach a
  full byte.
- This is a non-backwards compatible change, but makes Daffodil now
  compatible with the DFDL specification. Any hexBinary element that
  either had little endian byte order or were non-byte size lengths
  will now have different output.

DAFFODIL-2019