### PR TITLE
Daffodil 2034 pools

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
@@ -23,7 +23,15 @@
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:defineFormat name="GeneralFormat">
+      <!--
+        This set of properties should never change. It can be added to 
+        if properties are missing, but should not be changed.
+        
+        Changes should be introduced by way of defining new formats in
+        terms of this one, which override definitions. See below in 
+        the file for examples. 
+       -->
+      <dfdl:defineFormat name="GeneralFormatOriginal">
         <dfdl:format
           alignment="1"
           alignmentUnits="bytes"
@@ -92,6 +100,17 @@
           truncateSpecifiedLengthString="no"
           utf16Width="fixed"
         />
+      </dfdl:defineFormat>
+      
+      <dfdl:defineFormat name="GeneralFormat">
+        <dfdl:format ref="GeneralFormatOriginal" />
+      </dfdl:defineFormat>
+        
+      <dfdl:defineFormat name="GeneralFormatForCrossTesting">
+        <dfdl:format ref="GeneralFormatOriginal"
+          calendarTimeZone=""
+          encodingErrorPolicy="error"
+        />   
       </dfdl:defineFormat>
 
     </xs:appinfo>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -59,6 +59,10 @@ import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.processors.dfa.Registers
+import org.apache.daffodil.processors.dfa.RegistersPool
+import org.apache.daffodil.processors.dfa.RegistersPool
+import org.apache.daffodil.processors.dfa.RegistersPool
 
 /**
  * Trait mixed into the PState.Mark object class and the ParseOrUnparseState
@@ -75,8 +79,7 @@ trait StateForDebugger {
   def discriminator: Boolean = false
 }
 
-case class TupleForDebugger(
-  val bytePos: Long,
+case class TupleForDebugger(val bytePos: Long,
   val childPos: Long,
   val groupPos: Long,
   val currentLocation: DataLocation,
@@ -119,8 +122,7 @@ trait SetProcessorMixin {
  * which should be isolated to the alternative parser, and repParsers, i.e.,
  * places where points-of-uncertainty are handled.
  */
-abstract class ParseOrUnparseState protected (
-  protected var variableBox: VariableBox,
+abstract class ParseOrUnparseState protected (protected var variableBox: VariableBox,
   var diagnostics: List[Diagnostic],
   var dataProc: Maybe[DataProcessor],
   val tunable: DaffodilTunables) extends DFDL.State
@@ -491,6 +493,17 @@ abstract class ParseOrUnparseState protected (
       val rsdw = new RuntimeSchemaDefinitionWarning(ctxt.schemaFileLocation, this, str, args: _*)
       diagnostics = rsdw :: diagnostics
     }
+  }
+
+  object dfaRegistersPool {
+    private val pool = new RegistersPool()
+
+    def getFromPool(requestorID: String) =
+      pool.getFromPool(requestorID)
+
+    def returnToPool(r: Registers) = pool.returnToPool(r)
+
+    def finalCheck() = pool.finalCheck
   }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
@@ -24,18 +24,7 @@ import org.apache.daffodil.util.Pool
 import org.apache.daffodil.util.Poolable
 import org.apache.daffodil.io.FormatInfo
 
-private[dfa] object TLRegistersPool extends ThreadLocal[RegistersPool] {
-  override def initialValue = new RegistersPool()
-
-  def pool() = this.get
-
-  def getFromPool(requestorID: String) =
-    pool.getFromPool(requestorID)
-
-  def returnToPool(r: Registers) = pool.returnToPool(r)
-}
-
-private[dfa] class RegistersPool() extends Pool[Registers] {
+class RegistersPool() extends Pool[Registers] {
   override def allocate = new Registers()
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextPaddingParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextPaddingParser.scala
@@ -24,6 +24,7 @@ import org.apache.daffodil.processors.DelimiterIterator
 import org.apache.daffodil.io.DataInputStream
 import scala.collection.mutable.ArrayBuffer
 import org.apache.daffodil.io.FormatInfo
+import org.apache.daffodil.processors.parsers.PState
 
 class TextPaddingParser(val padChar: Char,
   override val context: TermRuntimeData)
@@ -34,9 +35,9 @@ class TextPaddingParser(val padChar: Char,
 
   val paddingDFA = CreatePaddingDFA(padChar, context)
 
-  def parse(finfo: FormatInfo, input: DataInputStream, delimIter: DelimiterIterator): Maybe[ParseResult] = {
+  def parse(finfo: PState, input: DataInputStream, delimIter: DelimiterIterator): Maybe[ParseResult] = {
 
-    val paddingReg: Registers = TLRegistersPool.getFromPool("TextPaddingParser1")
+    val paddingReg: Registers = finfo.dfaRegistersPool.getFromPool("TextPaddingParser1")
 
     paddingReg.reset(finfo, input, delimIter)
 
@@ -44,8 +45,8 @@ class TextPaddingParser(val padChar: Char,
 
     val paddingValue = One(paddingReg.resultString.toString)
 
-    TLRegistersPool.returnToPool(paddingReg)
-    TLRegistersPool.pool.finalCheck
+    finfo.dfaRegistersPool.returnToPool(paddingReg)
+    finfo.dfaRegistersPool.finalCheck
 
     One(new ParseResult(paddingValue, Nope, ArrayBuffer()))
   }

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -67,7 +67,20 @@ object Runner {
    * A test or test suite can override this to specify more or different implementations
    * that the test should pass for.
    */
-  def defaultImplementationsDefaultDefault = Seq("daffodil")
+  def defaultImplementationsDefaultDefault = Seq("daffodil", "ibm")
+
+  /**
+   * By default we don't run Daffodil negative TDML tests against cross-testers.
+   * The error messages are simply too varied.
+   *
+   * Negative tests must fail, but error messages aren't compared.
+   */
+  def defaultShouldCrossTestNegativeTests = false
+  
+  /**
+   * By default we don't cross test warning messages because they are too varied.
+   */
+  def defaultShouldCrossTestWarnings = false
 
 }
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -164,6 +164,9 @@ private[tdml] object DFDLTestSuite {
  *
  * defaultImplementationsDefault the implementations default for the test suite will be
  * taken from this value if it is not specified on the testSuite itself.
+ *
+ * shouldCrossTestNegativeTests controls whether negative test error messages  are compared
+ * or the tests are just run to determine that they fail.
  */
 
 class DFDLTestSuite private[tdml] (val __nl: Null, // this extra arg allows us to make this primary constructor package private so we can deprecate the one generally used.
@@ -173,7 +176,9 @@ class DFDLTestSuite private[tdml] (val __nl: Null, // this extra arg allows us t
   val compileAllTopLevel: Boolean,
   val defaultRoundTripDefault: RoundTrip,
   val defaultValidationDefault: String,
-  val defaultImplementationsDefault: Seq[String])
+  val defaultImplementationsDefault: Seq[String],
+  val shouldCrossTestNegativeTests: Boolean,
+  val shouldCrossTestWarnings: Boolean)
   extends Logging
   with HasSetDebugger {
 
@@ -188,11 +193,15 @@ class DFDLTestSuite private[tdml] (val __nl: Null, // this extra arg allows us t
     compileAllTopLevel: Boolean = false,
     defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
     defaultValidationDefault: String = Runner.defaultValidationDefaultDefault,
-    defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault) =
+    defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault,
+    shouldCrossTestNegativeTests: Boolean = Runner.defaultShouldCrossTestNegativeTests,
+    shouldCrossTestWarnings: Boolean = Runner.defaultShouldCrossTestWarnings) =
     this(null, aNodeFileOrURL, validateTDMLFile, validateDFDLSchemas, compileAllTopLevel,
       defaultRoundTripDefault,
       defaultValidationDefault,
-      defaultImplementationsDefault)
+      defaultImplementationsDefault,
+      shouldCrossTestNegativeTests,
+      shouldCrossTestWarnings)
 
   if (!aNodeFileOrURL.isInstanceOf[scala.xml.Node])
     System.err.println("Creating DFDL Test Suite for " + aNodeFileOrURL)
@@ -442,6 +451,10 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite)
     }
   }
 
+  final def isCrossTest(implString: String) = implString != "daffodil"
+
+  final def isNegativeTest = optExpectedErrors.isDefined
+
   lazy val tdmlDFDLProcessorFactory: AbstractTDMLDFDLProcessorFactory = {
     import scala.language.reflectiveCalls
     import scala.language.existentials
@@ -653,7 +666,10 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite)
     //
     // Should we run the test?
     //
-    if (!implementationStrings.contains(impl.implementationName)) {
+    val implName = impl.implementationName
+    val istrings = implementationStrings
+    val useThisImpl = istrings.contains(implName)
+    if (!useThisImpl) {
       //
       // skip the test
       //
@@ -706,6 +722,22 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite)
 
     }
   }
+
+  protected def checkDiagnosticMessages(diagnostics: Seq[Throwable],
+    errors: ExpectedErrors,
+    optWarnings: Option[ExpectedWarnings],
+    implString: Option[String]) {
+    Assert.usage(this.isNegativeTest)
+
+    // check for any test-specified errors or warnings
+    if (!isCrossTest(implString.get) ||
+      parent.shouldCrossTestNegativeTests)
+      VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, Some(errors), implString)
+
+    if (!isCrossTest(implString.get) ||
+      parent.shouldCrossTestWarnings)
+      VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, optWarnings, implString)
+  }
 }
 
 case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
@@ -735,9 +767,9 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
         }
       }
 
-      case (None, Some(_)) => {
+      case (None, Some(errors)) => {
         compileResult.left.foreach { diags =>
-          VerifyTestCase.verifyAllDiagnosticsFound(diags, optExpectedErrors, implString)
+          checkDiagnosticMessages(diags, errors, optExpectedWarnings, implString)
         }
         compileResult.right.foreach {
           case (_, processor) =>
@@ -790,15 +822,11 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
         (actual, diagnostics, isErr)
       }
     }
-    // check for any test-specified warnings
-    VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, optWarnings, implString)
-    if (isError) {
-      // good we expected an error
-      // check for any test-specified errors
-      VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, Some(errors), implString)
-    } else {
+    if (!isError) {
       throw TDMLException("Expected error. Didn't get one. Actual result was\n" + parseResult.getResult.toString, implString)
     }
+
+    checkDiagnosticMessages(diagnostics, errors, optWarnings, implString)
   }
 
   /**
@@ -859,7 +887,9 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
     }
 
     val allDiags = processor.getDiagnostics ++ actual.getDiagnostics
-    VerifyTestCase.verifyAllDiagnosticsFound(allDiags, optExpectedWarnings, implString)
+    if (!isCrossTest(implString.get) ||
+      parent.shouldCrossTestWarnings)
+      VerifyTestCase.verifyAllDiagnosticsFound(allDiags, optExpectedWarnings, implString)
   }
 
   /**
@@ -1067,9 +1097,7 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
 
       case (_, Some(errors)) => {
         compileResult.left.foreach { diags =>
-          VerifyTestCase.verifyAllDiagnosticsFound(diags, Some(errors), implString)
-          // check warnings even if there are errors expected.
-          VerifyTestCase.verifyAllDiagnosticsFound(diags, optWarnings, implString)
+          checkDiagnosticMessages(diags, errors, optWarnings, implString)
         }
         compileResult.right.foreach {
           case (_, processor) =>
@@ -1123,7 +1151,9 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
       VerifyTestCase.verifyBinaryOrMixedData(expectedData, outStream, implString)
     }
     val allDiags = actual.getDiagnostics ++ processor.getDiagnostics
-    VerifyTestCase.verifyAllDiagnosticsFound(allDiags, optWarnings, implString)
+    if (!isCrossTest(implString.get) ||
+      parent.shouldCrossTestWarnings)
+      VerifyTestCase.verifyAllDiagnosticsFound(allDiags, optWarnings, implString)
 
     if (roundTrip eq OnePassRoundTrip) {
 
@@ -1151,7 +1181,9 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
 
       val xmlNode = parseActual.getResult
       VerifyTestCase.verifyParserTestData(xmlNode, inputInfoset, implString)
-      VerifyTestCase.verifyAllDiagnosticsFound(actual.getDiagnostics, optWarnings, implString)
+      if (!isCrossTest(implString.get) ||
+        parent.shouldCrossTestWarnings)
+        VerifyTestCase.verifyAllDiagnosticsFound(actual.getDiagnostics, optWarnings, implString)
 
       (shouldValidate, expectsValidationError) match {
         case (true, true) => {
@@ -1194,7 +1226,6 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
             case t: Throwable => toss(t, implString)
           }
 
-        // Verify that some partial output has shown up in the bytes.
         val dataErrors = {
           optExpectedData.flatMap { data =>
             try {
@@ -1224,9 +1255,9 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
       }
     }
 
-    // check for any test-specified errors or warnings
-    VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, Some(errors), implString)
-    VerifyTestCase.verifyAllDiagnosticsFound(diagnostics, optWarnings, implString)
+    if (diagnostics.isEmpty)
+      throw TDMLException("Unparser test expected error. Didn't get one.", implString)
+    checkDiagnosticMessages(diagnostics, errors, optWarnings, implString)
   }
 }
 

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
@@ -21,7 +21,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" 
   xmlns:ex="http://example.com" xmlns="http://example.com"
-  defaultImplementations="ibm dfdl">
+  defaultImplementations="ibm daffodil">
 
 
   <tdml:defineSchema name="baseline">

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -109,10 +109,10 @@ class TresysTests {
   // not found. Debug later.
   // @Test def test_duplicateDefineFormatsOneSchema() { runnerMD.runOneTest("duplicateDefineFormatsOneSchema") }
 
-  @Test def test_nested_separator_delimited_baseline() { runnerNSD.trace.runOneTest("baseline") }
+  @Test def test_nested_separator_delimited_baseline() { runnerNSD.runOneTest("baseline") }
 
   // Fails in IBM DFDL - ambiguous separator/terminator not accepted.
-  @Test def test_nested_separator_delimited_baseline_ibm() { runnerNSD.trace.runOneTest("baseline_ibm") }
+  @Test def test_nested_separator_delimited_baseline_ibm() { runnerNSD.runOneTest("baseline_ibm") }
 
   @Test def test_nested_separator_delimited_basicNest() { runnerNSD.runOneTest("basicNest") }
   // Fails infinite loop


### PR DESCRIPTION
We were getting pool interactions between tests because TLRegisterPool used by the DFA/Parser stuff was a threadLocal. It wasn't cleaned up on Assertion failures and other throws like that but then the thread would get reused for a later test, and the pool would be corrupted. So you'd get this false test failure.

Removed this use of ThreadLocal, now just keeps it on the PState/UState object, which is a per-thread state block. 

The tests no longer interact. 

The interacting tests were visible if you modified the global GeneralFormat to have encodingErrorPolicy="error". Then some tests like test_hexBinary_unparse_14 will fail with Assert.nyi, but later tests (15, and 19) would fail with pool leaks on the RegisterPool. With the change this no longer happens.
