### PR TITLE
Removed use of ThreadLocal for DFA Register Pool.

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -59,6 +59,10 @@ import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.processors.dfa.Registers
+import org.apache.daffodil.processors.dfa.RegistersPool
+import org.apache.daffodil.processors.dfa.RegistersPool
+import org.apache.daffodil.processors.dfa.RegistersPool
 
 /**
  * Trait mixed into the PState.Mark object class and the ParseOrUnparseState
@@ -75,8 +79,7 @@ trait StateForDebugger {
   def discriminator: Boolean = false
 }
 
-case class TupleForDebugger(
-  val bytePos: Long,
+case class TupleForDebugger(val bytePos: Long,
   val childPos: Long,
   val groupPos: Long,
   val currentLocation: DataLocation,
@@ -119,8 +122,7 @@ trait SetProcessorMixin {
  * which should be isolated to the alternative parser, and repParsers, i.e.,
  * places where points-of-uncertainty are handled.
  */
-abstract class ParseOrUnparseState protected (
-  protected var variableBox: VariableBox,
+abstract class ParseOrUnparseState protected (protected var variableBox: VariableBox,
   var diagnostics: List[Diagnostic],
   var dataProc: Maybe[DataProcessor],
   val tunable: DaffodilTunables) extends DFDL.State
@@ -491,6 +493,20 @@ abstract class ParseOrUnparseState protected (
       val rsdw = new RuntimeSchemaDefinitionWarning(ctxt.schemaFileLocation, this, str, args: _*)
       diagnostics = rsdw :: diagnostics
     }
+  }
+
+  /**
+   * Pool of registers for use by low-level text DFA code.
+   */
+  object dfaRegistersPool {
+    private val pool = new RegistersPool()
+
+    def getFromPool(requestorID: String) =
+      pool.getFromPool(requestorID)
+
+    def returnToPool(r: Registers) = pool.returnToPool(r)
+
+    def finalCheck() = pool.finalCheck
   }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
@@ -24,18 +24,7 @@ import org.apache.daffodil.util.Pool
 import org.apache.daffodil.util.Poolable
 import org.apache.daffodil.io.FormatInfo
 
-private[dfa] object TLRegistersPool extends ThreadLocal[RegistersPool] {
-  override def initialValue = new RegistersPool()
-
-  def pool() = this.get
-
-  def getFromPool(requestorID: String) =
-    pool.getFromPool(requestorID)
-
-  def returnToPool(r: Registers) = pool.returnToPool(r)
-}
-
-private[dfa] class RegistersPool() extends Pool[Registers] {
+class RegistersPool() extends Pool[Registers] {
   override def allocate = new Registers()
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextPaddingParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextPaddingParser.scala
@@ -24,6 +24,7 @@ import org.apache.daffodil.processors.DelimiterIterator
 import org.apache.daffodil.io.DataInputStream
 import scala.collection.mutable.ArrayBuffer
 import org.apache.daffodil.io.FormatInfo
+import org.apache.daffodil.processors.parsers.PState
 
 class TextPaddingParser(val padChar: Char,
   override val context: TermRuntimeData)
@@ -34,18 +35,18 @@ class TextPaddingParser(val padChar: Char,
 
   val paddingDFA = CreatePaddingDFA(padChar, context)
 
-  def parse(finfo: FormatInfo, input: DataInputStream, delimIter: DelimiterIterator): Maybe[ParseResult] = {
+  def parse(state: PState, input: DataInputStream, delimIter: DelimiterIterator): Maybe[ParseResult] = {
 
-    val paddingReg: Registers = TLRegistersPool.getFromPool("TextPaddingParser1")
+    val paddingReg: Registers = state.dfaRegistersPool.getFromPool("TextPaddingParser1")
 
-    paddingReg.reset(finfo, input, delimIter)
+    paddingReg.reset(state, input, delimIter)
 
     paddingDFA.run(paddingReg) // Will always succeed.
 
     val paddingValue = One(paddingReg.resultString.toString)
 
-    TLRegistersPool.returnToPool(paddingReg)
-    TLRegistersPool.pool.finalCheck
+    state.dfaRegistersPool.returnToPool(paddingReg)
+    state.dfaRegistersPool.finalCheck
 
     One(new ParseResult(paddingValue, Nope, ArrayBuffer()))
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/TextParser.scala
@@ -23,15 +23,15 @@ import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.DelimiterIterator
 import org.apache.daffodil.io.DataInputStream
 import org.apache.daffodil.io.FormatInfo
+import org.apache.daffodil.processors.parsers.PState
 
-class TextParser(
-  override val context: TermRuntimeData)
+class TextParser(override val context: TermRuntimeData)
   extends DFAParser {
 
   override lazy val name: String = "TextParser"
   override lazy val info: String = "" // Nothing additional to add here
 
-  def parse(finfo: FormatInfo, input: DataInputStream, delimIter: DelimiterIterator, isDelimRequired: Boolean): Maybe[ParseResult] = {
+  def parse(state: PState, input: DataInputStream, delimIter: DelimiterIterator, isDelimRequired: Boolean): Maybe[ParseResult] = {
 
     val lmt = new LongestMatchTracker()
 
@@ -39,14 +39,14 @@ class TextParser(
     delimIter.reset()
     while (delimIter.hasNext()) {
       val d = delimIter.next()
-      val reg = TLRegistersPool.getFromPool("TextParser1")
-      reg.reset(finfo, input, delimIter, m)
+      val reg = state.dfaRegistersPool.getFromPool("TextParser1")
+      reg.reset(state, input, delimIter, m)
       m = input.markPos
       d.run(reg)
       if (reg.status == StateKind.Succeeded) {
         lmt.successfulMatch(reg.matchStartPos, reg.delimString, d, delimIter.currentIndex)
       }
-      TLRegistersPool.returnToPool(reg)
+      state.dfaRegistersPool.returnToPool(reg)
     }
     input.resetPos(m)
 
@@ -55,7 +55,7 @@ class TextParser(
         if (isDelimRequired) Nope
         else {
           val totalNumCharsRead = 0
-          input.getString(totalNumCharsRead, finfo)
+          input.getString(totalNumCharsRead, state)
           One(new ParseResult(Nope, Nope, lmt.longestMatches))
         }
       } else {
@@ -66,7 +66,7 @@ class TextParser(
       }
     }
 
-    TLRegistersPool.pool.finalCheck
+    state.dfaRegistersPool.finalCheck
 
     result
   }


### PR DESCRIPTION
We were getting pool interactions between tests because TLRegisterPool used by the DFA/Parser stuff was a threadLocal. It wasn't cleaned up on Assertion failures and other throws like that but then the thread would get reused for a later test, and the pool would be corrupted. So you'd get this false test failure.

Removed this use of ThreadLocal, now just keeps it on the PState/UState object, which is a per-thread state block.

The tests no longer interact.

The interacting tests were visible if you modified the global GeneralFormat to have encodingErrorPolicy="error". Then some tests like test_hexBinary_unparse_14 will fail with Assert.nyi, but later tests (15, and 19) would fail with pool leaks on the RegisterPool. With the change this no longer happens.

DAFFODIL-2034