### PR TITLE
Add tunables for textBidi and floating properties

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -94,6 +94,7 @@ trait ElementBase
   requiredEvaluations(if (hasFractionDigits) fractionDigits)
   requiredEvaluations(erd.preSerialization)
   requiredEvaluations(checkForAlignmentAmbiguity)
+  requiredEvaluations(checkFloating)
 
   def name: String
 
@@ -1231,6 +1232,14 @@ trait ElementBase
         }
       }
     }
+  }
+
+  private lazy val optionFloating = findPropertyOption("floating")
+
+  private def checkFloating = (optionFloating.isDefined, tunable.requireFloatingProperty) match {
+    case (false, false) => SDW(WarnID.FloatingError, "Property 'dfdl:floating' is required but not defined.")
+    case (false, true) => floating
+    case (_, _) => this.subset((floating eq YesNo.No), "Property value floating='yes' is not supported.")
   }
 
 }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
@@ -73,11 +73,25 @@ case class DaffodilTunables(
   val requireBitOrderProperty: Boolean = false,
   //
   // If true, require that the encodingErrorPolicy property is specified. If
-  // false, use a default value not defined in a schema
+  // false, use a default value not defined in a schema and warn about missing property
   //
   // Looks to be compile-time as it gets 'tunable' from Term.
   //
   val requireEncodingErrorPolicyProperty: Boolean = false,
+  //
+  // If true, require that the encodingErrorPolicy property is specified. If
+  // false, warn about missing property
+  //
+  // Looks to be compile-time as it gets 'tunable' from Term.
+  //
+  val requireTextBidiProperty: Boolean = false,
+  //
+  // If true, require that the encodingErrorPolicy property is specified. If
+  // false, warn about missing property
+  //
+  // Looks to be compile-time as it gets 'tunable' from Term.
+  //
+  val requireFloatingProperty: Boolean = false,
   //
   // Whether to compile a schema to support parsing, unparsing, both, or to use
   // the daf:parseUnparsePolicy from the root node. None means to use the
@@ -215,6 +229,8 @@ case class DaffodilTunables(
       }
       case "requirebitorderproperty" => this.copy(requireBitOrderProperty = java.lang.Boolean.valueOf(value))
       case "requireencodingerrorpolicyproperty" => this.copy(requireEncodingErrorPolicyProperty = java.lang.Boolean.valueOf(value))
+      case "requiretextbidiproperty" => this.copy(requireTextBidiProperty = java.lang.Boolean.valueOf(value))
+      case "requirefloatingproperty" => this.copy(requireFloatingProperty = java.lang.Boolean.valueOf(value))
       case "maxskiplengthinbytes" => this.copy(maxSkipLengthInBytes = java.lang.Long.valueOf(value))
       case "maxbinarydecimalvirtualpoint" => this.copy(maxBinaryDecimalVirtualPoint = java.lang.Integer.valueOf(value))
       case "minbinarydecimalvirtualpoint" => this.copy(minBinaryDecimalVirtualPoint = java.lang.Integer.valueOf(value))

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
@@ -60,6 +60,8 @@ object WarnID extends PropsEnum[WarnID] {
    */
   case object DeprecatedPropertySeparatorPolicy extends WarnID; forceConstruction(DeprecatedPropertySeparatorPolicy)
   case object EncodingErrorPolicyError extends WarnID; forceConstruction(EncodingErrorPolicyError)
+  case object TextBidiError extends WarnID; forceConstruction(TextBidiError)
+  case object FloatingError extends WarnID; forceConstruction(FloatingError)
   case object EscapeSchemeRefUndefined extends WarnID; forceConstruction(EscapeSchemeRefUndefined)
   case object FacetExplicitLengthOutOfRange extends WarnID; forceConstruction(FacetExplicitLengthOutOfRange)
   case object InconsistentLengthKind extends WarnID; forceConstruction(InconsistentLengthKind)

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -85,6 +85,8 @@
       <xsd:sequence>
         <xsd:element name="requireBitOrderProperty" minOccurs="0" type="xsd:boolean" />
         <xsd:element name="requireEncodingErrorPolicyProperty" minOccurs="0" type="xsd:boolean" />
+        <xsd:element name="requireTextBidiProperty" minOccurs="0" type="xsd:boolean" />
+        <xsd:element name="requireFloatingProperty" minOccurs="0" type="xsd:boolean" />
         <xsd:element name="maxFieldContentLengthInBytes" minOccurs="0" type="xsd:int" />
         <xsd:element name="maxOccursBounds" minOccurs="0" type="xsd:int" />
         <xsd:element name="maxSkipLengthInBytes" minOccurs="0" type="xsd:int" />

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
@@ -50,6 +50,48 @@
 		</daf:tunables>
 	</tdml:defineConfig>
 
+	<tdml:defineConfig name="cfg_requireTextBidiPropertyTrue">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireTextBidiProperty>true</daf:requireTextBidiProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
+	<tdml:defineConfig name="cfg_requireTextBidiPropertyFalse">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireTextBidiProperty>false</daf:requireTextBidiProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
+	<tdml:defineConfig name="cfg_requireFloatingPropertyTrue">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireFloatingProperty>true</daf:requireFloatingProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
+	<tdml:defineConfig name="cfg_requireFloatingPropertyFalse">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireFloatingProperty>false</daf:requireFloatingProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
+	<tdml:defineConfig name="cfg_requireEncodingErrorPolicyPropertyTrue">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireEncodingErrorPolicyProperty>true</daf:requireEncodingErrorPolicyProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
+	<tdml:defineConfig name="cfg_requireEncodingErrorPolicyPropertyFalse">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:requireEncodingErrorPolicyProperty>false</daf:requireEncodingErrorPolicyProperty>
+		</daf:tunables>
+	</tdml:defineConfig>
+
 	<tdml:defineSchema name="unqualifiedPathStep" elementFormDefault="unqualified">
 		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
 
@@ -218,6 +260,305 @@
 			<tdml:error>char</tdml:error>
 		</tdml:errors>
 
-	</tdml:parserTestCase>
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="missingTextBidi">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="replace"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="requireTextBidiTrue" root="root"
+		model="missingTextBidi" description="Tunables - maxOccursBounds"
+		config="cfg_requireTextBidiPropertyTrue">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Property</tdml:error>
+      <tdml:error>textBidi</tdml:error>
+      <tdml:error>is not defined</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+	<tdml:parserTestCase
+		name="requireTextBidiFalse" root="root"
+		model="missingTextBidi" description="Tunables - maxOccursBounds"
+		config="cfg_requireTextBidiPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:warnings>
+      <tdml:warning>dfdl:textBidi</tdml:warning>
+      <tdml:warning>required but not defined</tdml:warning>
+    </tdml:warnings>
+
+		<tdml:infoset>
+			<tdml:dfdlInfoset>
+        <ex:root>
+          <ex:char>1</ex:char>
+          <ex:char>2</ex:char>
+          <ex:char>3</ex:char>
+          <ex:char>4</ex:char>
+        </ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="textBidiYes">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="yes"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="textBidiYes" root="root"
+		model="textBidiYes" description="Tunables - maxOccursBounds"
+		config="cfg_requireTextBidiPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:errors>
+      <tdml:error>textBidi='yes'</tdml:error>
+      <tdml:error>is not supported</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="missingFloating">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="requireFloatingTrue" root="root"
+		model="missingFloating" description="Tunables - maxOccursBounds"
+		config="cfg_requireFloatingPropertyTrue">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Property</tdml:error>
+      <tdml:error>floating</tdml:error>
+      <tdml:error>is not defined</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+	<tdml:parserTestCase
+		name="requireFloatingFalse" root="root"
+		model="missingFloating" description="Tunables - maxOccursBounds"
+		config="cfg_requireFloatingPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:warnings>
+      <tdml:warning>dfdl:floating</tdml:warning>
+      <tdml:warning>required but not defined</tdml:warning>
+    </tdml:warnings>
+
+		<tdml:infoset>
+			<tdml:dfdlInfoset>
+        <ex:root>
+          <ex:char>1</ex:char>
+          <ex:char>2</ex:char>
+          <ex:char>3</ex:char>
+          <ex:char>4</ex:char>
+        </ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="floatingYes">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no" floating="yes"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="floatingYes" root="root"
+		model="floatingYes" description="Tunables - maxOccursBounds"
+		config="cfg_requireFloatingPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:errors>
+      <tdml:error>floating='yes'</tdml:error>
+      <tdml:error>is not supported</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="encodingErrorPolicyError">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="error" textBidi="no"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="encodingErrorPolicyError" root="root"
+		model="encodingErrorPolicyError" description="Tunables - maxOccursBounds"
+		config="cfg_requireEncodingErrorPolicyPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:warnings>
+      <tdml:warning>dfdl:encodingErrorPolicy="error"</tdml:warning>
+      <tdml:warning>is not yet implemented</tdml:warning>
+      <tdml:warning>'replace' value will be used</tdml:warning>
+    </tdml:warnings>
+
+		<tdml:infoset>
+			<tdml:dfdlInfoset>
+        <ex:root>
+          <ex:char>1</ex:char>
+          <ex:char>2</ex:char>
+          <ex:char>3</ex:char>
+          <ex:char>4</ex:char>
+        </ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+	<tdml:defineSchema name="missingEncodingErrorPolicy">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" textBidi="no"/>
+
+		<xs:element name="root">
+			<xs:complexType>
+				<xs:sequence>
+					<xs:element name="char" type="xs:string" maxOccurs="unbounded" dfdl:lengthKind="explicit" dfdl:length="1" />
+				</xs:sequence>
+			</xs:complexType>
+		</xs:element>
+  </tdml:defineSchema>
+
+	<tdml:parserTestCase
+		name="requireEncodingErrorPolicyTrue" root="root"
+		model="missingEncodingErrorPolicy" description="Tunables - maxOccursBounds"
+		config="cfg_requireEncodingErrorPolicyPropertyTrue">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:errors>
+      <tdml:error>encodingErrorPolicy</tdml:error>
+      <tdml:error>is not defined</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+	<tdml:parserTestCase
+		name="requireEncodingErrorPolicyFalse" root="root"
+		model="missingEncodingErrorPolicy" description="Tunables - maxOccursBounds"
+		config="cfg_requireEncodingErrorPolicyPropertyFalse">
+
+		<tdml:document>
+			<tdml:documentPart type="text">1234</tdml:documentPart>
+		</tdml:document>
+
+    <tdml:warnings>
+      <tdml:warning>dfdl:encodingErrorPolicy</tdml:warning>
+      <tdml:warning>required but not defined</tdml:warning>
+    </tdml:warnings>
+
+		<tdml:infoset>
+			<tdml:dfdlInfoset>
+        <ex:root>
+          <ex:char>1</ex:char>
+          <ex:char>2</ex:char>
+          <ex:char>3</ex:char>
+          <ex:char>4</ex:char>
+        </ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -101,5 +101,14 @@ class TestGeneral {
   @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_02() { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_02") }
   
   @Test def test_maxOccursBoundsExceeded() { tunables_runner.runOneTest("maxOccursBoundsExceeded") }
+  @Test def test_textBidiYes() { tunables_runner.runOneTest("textBidiYes") }
+  @Test def test_requireTextBidiTrue() { tunables_runner.runOneTest("requireTextBidiTrue") }
+  @Test def test_requireTextBidiFalse() { tunables_runner.runOneTest("requireTextBidiFalse") }
+  @Test def test_floatingYes() { tunables_runner.runOneTest("floatingYes") }
+  @Test def test_requireFloatingTrue() { tunables_runner.runOneTest("requireFloatingTrue") }
+  @Test def test_requireFloatingFalse() { tunables_runner.runOneTest("requireFloatingFalse") }
+  @Test def test_encodingErrorPolicyError() { tunables_runner.runOneTest("encodingErrorPolicyError") }
+  @Test def test_requireEncodingErrorPolicyTrue() { tunables_runner.runOneTest("requireEncodingErrorPolicyTrue") }
+  @Test def test_requireEncodingErrorPolicyFalse() { tunables_runner.runOneTest("requireEncodingErrorPolicyFalse") }
 
 }


### PR DESCRIPTION
Many schemas may not have these rather uncommon properties defined, but
they are technically required and according to the DFDL spec missing
properties should not be defaulted. As a stop gap solution tunables have
been added for these properties that when enabled will cause an SDE if
the properties are not defined. If they are not enabled an SDW will be
shown about the missing property.

DAFFODIL-1720