### PR TITLE
Add a distinction between how expressions and literals are compiled

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -253,7 +253,7 @@ class TestCLIdebugger {
       shell.sendLine("condition 2 dfdl:occursIndex() mod 2 eq 0")
 
       shell.sendLine("info breakpoints")
-      shell.expect(contains("2: cell   dfdl:occursIndex() mod 2 eq 0"))
+      shell.expect(contains("2: cell   { dfdl:occursIndex() mod 2 eq 0 }"))
 
       shell.sendLine("display info arrayIndex")
 
@@ -311,10 +311,10 @@ class TestCLIdebugger {
       shell.sendLine("break cell")
       shell.expect(contains("1: cell"))
       shell.sendLine("condition 1 xsd:string(.) eq '3'")
-      shell.expect(contains("1: cell   xsd:string(.) eq '3'"))
+      shell.expect(contains("1: cell   { xsd:string(.) eq '3' }"))
 
       shell.sendLine("info breakpoints")
-      shell.expect(allOf(contains("breakpoints:"), contains("1: cell   xsd:string(.) eq '3'")))
+      shell.expect(allOf(contains("breakpoints:"), contains("1: cell   { xsd:string(.) eq '3' }")))
 
       shell.sendLine("continue")
       shell.expect(contains("<tns:cell>3</tns:cell>\n      </tns:row>\n    </tns:matrix>"))
@@ -424,7 +424,7 @@ class TestCLIdebugger {
       shell.sendLine("condition 1 dfdl:occursIndex() eq 3")
 
       shell.sendLine("info breakpoints")
-      shell.expect(contains("1: cell   dfdl:occursIndex() eq 3"))
+      shell.expect(contains("1: cell   { dfdl:occursIndex() eq 3 }"))
 
       shell.sendLine("continue")
       shell.expect(contains("</tns:cell>"))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
@@ -191,9 +191,8 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
   def EqualityComp = "eq" | "ne" | "!=" | "="
   def NumberComp = "lt" | "le" | "gt" | "ge" | "<=" | ">=" | "<" | ">"
   def Comp = EqualityComp | NumberComp
-  //
-  // we don't care if it has braces around it or not.
-  def TopLevel: Parser[WholeExpression] = ("{" ~> Expr <~ "}" | Expr) ^^ { xpr =>
+
+  def TopLevel: Parser[WholeExpression] = ("{" ~> Expr <~ "}") ^^ { xpr =>
     WholeExpression(nodeInfoKind, xpr, namespaces, context, host)
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
@@ -255,7 +255,7 @@ class TestDFDLExpressionTree extends Parsers {
   }
 
   @Test def test_numbers1() = {
-    testExpr(dummySchema, "0.") { actual: Expression =>
+    testExpr(dummySchema, "{ 0. }") { actual: Expression =>
       val res = BigDecimal("0.0")
       val a @ WholeExpression(_, LiteralExpression(actualRes), _, _, _) = actual; assertNotNull(a)
       val bd = BigDecimal(actualRes.asInstanceOf[JBigDecimal])
@@ -265,32 +265,32 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_numbers() = {
 
-    testExpr(dummySchema, "5.0E2") { case WholeExpression(_, LiteralExpression(500.0), _, _, _) => /* ok */ ; }
-    testExpr(dummySchema, "5E2") { case WholeExpression(_, LiteralExpression(500.0), _, _, _) => /* ok */ ; }
-    testExpr(dummySchema, ".2E2") { case WholeExpression(_, LiteralExpression(20.0), _, _, _) => /* ok */ ; }
-    testExpr(dummySchema, ".2E-3") { case WholeExpression(_, LiteralExpression(0.0002), _, _, _) => /* ok */ ; }
-    testExpr(dummySchema, ".2E+3") { case WholeExpression(_, LiteralExpression(200.0), _, _, _) => /* ok */ ; }
+    testExpr(dummySchema, "{ 5.0E2 }") { case WholeExpression(_, LiteralExpression(500.0), _, _, _) => /* ok */ ; }
+    testExpr(dummySchema, "{ 5E2 }") { case WholeExpression(_, LiteralExpression(500.0), _, _, _) => /* ok */ ; }
+    testExpr(dummySchema, "{ .2E2 }") { case WholeExpression(_, LiteralExpression(20.0), _, _, _) => /* ok */ ; }
+    testExpr(dummySchema, "{ .2E-3 }") { case WholeExpression(_, LiteralExpression(0.0002), _, _, _) => /* ok */ ; }
+    testExpr(dummySchema, "{ .2E+3 }") { case WholeExpression(_, LiteralExpression(200.0), _, _, _) => /* ok */ ; }
 
     //    testExpr(dummySchema, "0.") { actual =>
     //      val res = new JBigDecimal("0.0")
     //      val a @ WholeExpression(_, LiteralExpression(`res`), _, _, _) = actual; assertNotNull(a)
     //    }
-    testExpr(dummySchema, ".1") { actual =>
+    testExpr(dummySchema, "{ .1 }") { actual =>
       val res = new JBigDecimal("0.1")
       val a @ WholeExpression(_, LiteralExpression(`res`), _, _, _) = actual; assertNotNull(a)
     }
-    testExpr(dummySchema, "982304892038409234982304892038409234.0909808908982304892038409234") { actual =>
+    testExpr(dummySchema, "{ 982304892038409234982304892038409234.0909808908982304892038409234 }") { actual =>
       val res = new JBigDecimal("982304892038409234982304892038409234.0909808908982304892038409234")
       val WholeExpression(_, LiteralExpression(r: JBigDecimal), _, _, _) = actual
       assertEquals(res, r)
     }
 
-    testExpr(dummySchema, "0") { actual =>
+    testExpr(dummySchema, "{ 0 }") { actual =>
       val res = scala.math.BigInt(0)
       val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _) = actual; assertNotNull(a)
       assertEquals(res, BigInt(actualRes))
     }
-    testExpr(dummySchema, "9817239872193792873982173948739879128370982398723897921370") { actual =>
+    testExpr(dummySchema, "{ 9817239872193792873982173948739879128370982398723897921370 }") { actual =>
       val res = scala.math.BigInt("9817239872193792873982173948739879128370982398723897921370")
       val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _) = actual; assertNotNull(a)
       assertEquals(res, BigInt(actualRes))
@@ -305,8 +305,8 @@ class TestDFDLExpressionTree extends Parsers {
         case WholeExpression(_, LiteralExpression(expr), _, _, _) => /* ok */
       }
     }
-    testStringLit("'abc'")
-    testStringLit("\"def\"")
+    testStringLit("{ 'abc' }")
+    testStringLit("{ \"def\" }")
   }
 
   @Test def test_funCall1() = {
@@ -328,8 +328,8 @@ class TestDFDLExpressionTree extends Parsers {
       }
     }
 
-    testFn("fn:true()") { actual => assertEquals("true", actual.functionQName.local) }
-    testFn("fn:concat('a', 'b')") { actual => assertEquals("concat", actual.functionQName.local) }
+    testFn("{ fn:true() }") { actual => assertEquals("true", actual.functionQName.local) }
+    testFn("{ fn:concat('a', 'b') }") { actual => assertEquals("concat", actual.functionQName.local) }
 
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -784,9 +784,12 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
       def act(args: Seq[String], prestate: StateForDebugger, state: ParseOrUnparseState, processor: Processor): DebugState.Type = {
         val id = args.head.toInt
         val expression = args.tail.mkString(" ")
+        val expressionWithBraces =
+          if (!DPathUtil.isExpression(expression)) "{ " + expression + " }"
+          else expression
         val b = DebuggerConfig.breakpoints.find(_.id == id).get
-        b.condition = Some(expression)
-        debugPrintln("%s: %s   %s".format(b.id, b.breakpoint, expression))
+        b.condition = Some(expressionWithBraces)
+        debugPrintln("%s: %s   %s".format(b.id, b.breakpoint, expressionWithBraces))
         DebugState.Pause
       }
     }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathUtil.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathUtil.scala
@@ -21,23 +21,14 @@ package org.apache.daffodil.dpath
 object DPathUtil {
 
   /**
-   * Whether a string is a DFDL expression (an XPath expression surrounded by brackets).
-   *
-   * This function does not verify a string conforms to the DFDL subset of XPath
+   * Whether a string is a DFDL expression. The definition of a DFDL expression
+   * is a string that starts with an unescaped curly brace. If this is true,
+   * then we want to consider this an expression and likely try to compile it
+   * later and check for validity.
    */
   def isExpression(expression: String): Boolean = {
     val trimmed = expression.trim
-    trimmed.startsWith("{") && trimmed.endsWith("}") &&
-      (trimmed(1) != '{')
-  }
-  /**
-   * Returns the XPath expression contained in a DFDL expression (an XPath expression surrounded by brackets).
-   *
-   * @param expression a valid DFDL expression
-   */
-  def getExpression(expression: String): String = {
-    val v = expression.trim
-    v.substring(1, v.length - 1)
+    trimmed.startsWith("{") && !trimmed.startsWith("{{")
   }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -400,8 +400,11 @@ object NodeInfo extends Enum {
     }
 
     def fromNameString(name: String): Option[PrimType] = {
-      val m: Option[PrimType] = allPrims.find { _.pname.toLowerCase == name.toLowerCase }
-      m
+      allPrims.find { _.pname.toLowerCase == name.toLowerCase }
+    }
+
+    def fromNodeInfo(nodeInfo: NodeInfo.Kind): Option[PrimType] = {
+      allPrims.find { nodeInfo.isSubtypeOf(_) }
     }
 
     protected sealed trait FloatKind extends SignedNumeric.Kind

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -1061,4 +1061,67 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+
+  <tdml:defineSchema name="logical_default_values">
+    
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="float" type="xs:float" defaultValue="-INF" />
+    <dfdl:defineVariable name="double" type="xs:double" defaultValue="1.0e-5" />
+    <dfdl:defineVariable name="bool" type="xs:boolean" defaultValue="false" />
+    <dfdl:defineVariable name="string" type="xs:string" defaultValue="str" />
+    <dfdl:defineVariable name="date" type="xs:date" defaultValue="1999-12-31" />
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="float" type="xs:float" dfdl:inputValueCalc="{ $float }" />
+          <xs:element name="double" type="xs:double" dfdl:inputValueCalc="{ $double + 2.0 }" />
+          <xs:element name="bool" type="xs:boolean" dfdl:inputValueCalc="{ $bool }" />
+          <xs:element name="string" type="xs:string" dfdl:inputValueCalc="{ $string }" />
+          <xs:element name="date" type="xs:date" dfdl:inputValueCalc="{ $date }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="logical_default_values" root="root"
+    model="logical_default_values" description="Section 7 - ">
+    <tdml:document/>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root xmlns="http://example.com">
+          <float>-INF</float>
+          <double>2.00001</double>
+          <bool>false</bool>
+          <string>str</string>
+          <date>1999-12-31</date>
+        </root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+  <tdml:defineSchema name="logical_default_values_err">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="float" type="xs:float" defaultValue="float" />
+    <xs:element name="float" type="xs:float" dfdl:inputValueCalc="{ $float }" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="logical_default_values_err" root="float"
+    model="logical_default_values_err" description="Section 7 - ">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Unable to convert logical value</tdml:error>
+      <tdml:error>float</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -74,6 +74,9 @@ class TestVariables {
   @Test def test_var_end_path() { runner.runOneTest("var_end_path") }
   @Test def test_var_in_path() { runner.runOneTest("var_in_path") }
 
+  @Test def test_logical_default_values() { runner.runOneTest("logical_default_values") }
+  @Test def test_logical_default_values_err() { runner.runOneTest("logical_default_values_err") }
+
   @Test def test_doubleSetErr_d() { runner_01.runOneTest("doubleSetErr_d") }
   @Test def test_setVar1_d() { runner_01.runOneTest("setVar1_d") }
   // DFDL-1443 & DFDL-1448


### PR DESCRIPTION
Sometimes, we compile non-expressions just to benefit from the value
conversion capabilities of DPath. For example, if a property was either
"{ 1.234 }" or just "1.234", compilation would still convert it to the
correct float value, regardless if there were curly braces or not.

This is flexible, but can lead to unexpected behavior, specifically with
the defaultValue attribute in dfdl:defineVariable. This attribute can
accept either an expression or a literal value, so we use the above
logic to compile the expression or literval value to an expression. But
this does not always work as expected. For example, if the
defineVariable type was an xs:boolean, the defaultAttribute could accept
either "{ fn:false() }" or "false". Note that "false" is not a valid
expression, so if we try to compile this literval value we get an error.
So our current behavior of compiling literals as if they were
expressions without curly braces prevents the correct use of literals in
some cases.

To resolve this, we need to make a clear distinction between how to
handle expression and literals. With this change, a property value is
now only considered an expression and compiled if it starts with an
unescaped curly brace. All other values are treated as literal values,
the appropriate type conversion is performed by the fromXMLString()
method of the primitive type, and a ConstantExpression is created.
Additionally, the DPath expression grammar is modified to be more strict
and to only accept actual expressions that start and end with a
curly--this should help to prevent accidental compilation of
non-expressions.

This change allows the use of literal values in the defaultValue
attribute in a dfdl:defineVariable element and have them converted
appropriately.

DAFFODIL-2033