### PR TITLE
Allow lengthUnits to differ for element and its prefixed length

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -207,48 +207,73 @@ trait ElementBaseGrammarMixin
     // because we need to create a detached element with the same schema
     // document/parent of the GSTD.
     val prefixLengthTypeGSTD = schemaSet.getGlobalSimpleTypeDef(prefixLengthType).getOrElse(
-      schemaDefinitionError("Failed to resolve dfdl:prefixLengthType=\"%s\" to a simpleType", prefixLengthType.toQNameString)
+      schemaDefinitionError(
+        "Failed to resolve dfdl:prefixLengthType=\"%s\" to a simpleType",
+        prefixLengthType.toQNameString)
     )
 
-    val detachedNode = <element name={ name + " (prefixLength)" } type={ prefixLengthType.toQNameString } />.copy(scope = prefixLengthTypeGSTD.xml.scope)
-    val detachedElementDecl = new DetachedElementDecl(this, detachedNode, prefixLengthTypeGSTD.parent)
+    val detachedNode =
+      <element name={ name + " (prefixLength)" } type={ prefixLengthType.toQNameString } />
+        .copy(scope = prefixLengthTypeGSTD.xml.scope)
+    val detachedElementDecl =
+      new DetachedElementDecl(this, detachedNode, prefixLengthTypeGSTD.parent)
 
     val prefixedLengthKind = detachedElementDecl.lengthKind
     prefixedLengthKind match {
       case LengthKind.Delimited | LengthKind.EndOfParent | LengthKind.Pattern =>
-        schemaDefinitionError("%s is specified as a dfdl:prefixLengthType, but has a dfdl:lengthKind of %s", prefixLengthType, prefixedLengthKind)
+        schemaDefinitionError(
+          "%s is specified as a dfdl:prefixLengthType, but has a dfdl:lengthKind of %s",
+          prefixLengthType,
+          prefixedLengthKind)
       case LengthKind.Explicit if detachedElementDecl.optLengthConstant.isEmpty =>
-        schemaDefinitionError("%s is specified as a dfdl:prefixLengthType, but has an expression for dfdl:length", prefixLengthType)
-      case LengthKind.Implicit | LengthKind.Explicit if lengthUnits != detachedElementDecl.lengthUnits =>
-        schemaDefinitionError("%s is specified as a dfdl:prefixLengthType with dfdl:lengthKind %s, but has different dfdl:lengthUnits than the element", prefixLengthType, prefixedLengthKind)
+        schemaDefinitionError(
+          "%s is specified as a dfdl:prefixLengthType, but has an expression for dfdl:length",
+          prefixLengthType)
+      case LengthKind.Implicit | LengthKind.Explicit if prefixIncludesPrefixLength == YesNo.Yes &&
+        lengthUnits != detachedElementDecl.lengthUnits =>
+          schemaDefinitionError(
+            "%s is specified as a dfdl:prefixLengthType where dfdl:prefixIncludesPrefixLength=\"yes\" " +
+            "with dfdl:lengthKind %s, but has different dfdl:lengthUnits than the element",
+            prefixLengthType,
+            prefixedLengthKind)
       case _ =>
     }
 
     schemaDefinitionUnless(detachedElementDecl.primType.isSubtypeOf(NodeInfo.Integer),
-      "%s is specified as a dfdl:prefixLengthType, but its type xs:%s is not a subtype of xs:integer", prefixLengthType, detachedElementDecl.primType.toString.toLowerCase)
+      "%s is specified as a dfdl:prefixLengthType, but its type xs:%s is not a subtype of xs:integer",
+      prefixLengthType,
+      detachedElementDecl.primType.toString.toLowerCase)
 
     schemaDefinitionWhen(detachedElementDecl.isOutputValueCalc,
-      "%s is specified as a dfdl:prefixLengthType, but specifies dfdl:outputValueCalc", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies dfdl:outputValueCalc",
+      prefixLengthType)
     schemaDefinitionWhen(detachedElementDecl.hasInitiator,
-      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:initiator", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:initiator",
+      prefixLengthType)
     schemaDefinitionWhen(detachedElementDecl.hasTerminator,
-      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:terminator", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:terminator",
+      prefixLengthType)
     schemaDefinitionWhen(detachedElementDecl.alignment != 1,
-      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:alignment other than 1", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:alignment other than 1",
+      prefixLengthType)
     schemaDefinitionWhen(detachedElementDecl.leadingSkip != 0,
-      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:leadingSkip other than 0", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:leadingSkip other than 0",
+      prefixLengthType)
     schemaDefinitionWhen(detachedElementDecl.trailingSkip != 0,
-      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:trailingSkip other than 0", prefixLengthType)
+      "%s is specified as a dfdl:prefixLengthType, but specifies a dfdl:trailingSkip other than 0",
+      prefixLengthType)
 
     if (detachedElementDecl.lengthKind == LengthKind.Prefixed &&
         detachedElementDecl.prefixedLengthElementDecl.lengthKind == LengthKind.Prefixed) {
         schemaDefinitionError("Nesting level for dfdl:prefixLengthType exceeds 1: %s > %s > %s > %s",
-          name, prefixLengthType,
+          name,
+          prefixLengthType,
           detachedElementDecl.prefixLengthType,
           detachedElementDecl.prefixedLengthElementDecl.prefixLengthType)
     }
 
-    subset(detachedElementDecl.lengthKind != LengthKind.Prefixed, "Nested dfdl:lengthKind=\"prefixed\" is not supported.")
+    subset(detachedElementDecl.lengthKind != LengthKind.Prefixed,
+      "Nested dfdl:lengthKind=\"prefixed\" is not supported.")
 
     detachedElementDecl
   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -121,6 +121,33 @@
     <xs:element name="pl_text_int_bin_bytes" type="xs:int" dfdl:ref="prefixedBinByte" />
     <xs:element name="pl_text_int_bin_bits" type="xs:int" dfdl:ref="prefixedBinBits" />
 
+
+    <xs:element name="pl_text_int_txt_bytes_plbits" type="xs:int" dfdl:ref="prefixedTxtByte"
+      dfdl:prefixLengthType="ex:twentyFourBitsTextInt" />
+    <xs:element name="pl_text_int_txt_bytes_plchars" type="xs:int" dfdl:ref="prefixedTxtByte"
+      dfdl:prefixLengthType="ex:threeCharTextInt" />
+
+    <xs:element name="pl_text_int_txt_bits_plbytes" type="xs:int" dfdl:ref="prefixedTxtBits"
+      dfdl:prefixLengthType="ex:threeByteTextInt" />
+    <xs:element name="pl_text_int_txt_bits_plchars" type="xs:int" dfdl:ref="prefixedTxtBits"
+      dfdl:prefixLengthType="ex:threeCharTextInt" />
+
+    <xs:element name="pl_text_int_txt_chars_plbits" type="xs:int" dfdl:ref="prefixedTxtChar"
+      dfdl:prefixLengthType="ex:twentyFourBitsTextInt"
+      daf:parseUnparsePolicy="parseOnly" />
+    <xs:element name="pl_text_int_txt_chars_plbytes" type="xs:int" dfdl:ref="prefixedTxtChar"
+      dfdl:prefixLengthType="ex:threeCharTextInt"
+      daf:parseUnparsePolicy="parseOnly" />
+
+    <xs:element name="pl_text_int_bin_bytes_plbits" type="xs:int" dfdl:ref="prefixedBinByte"
+      dfdl:prefixLengthType="ex:twentyFourBitsBinInt" />
+    <xs:element name="pl_text_int_bin_bytes_plchars" type="xs:int" dfdl:ref="prefixedBinByte"
+      dfdl:prefixLengthType="ex:threeCharTextInt" />
+    <xs:element name="pl_text_int_bin_bits_plbytes" type="xs:int" dfdl:ref="prefixedBinBits"
+      dfdl:prefixLengthType="ex:threeByteBinInt" />
+    <xs:element name="pl_text_int_bin_bits_plchars" type="xs:int" dfdl:ref="prefixedBinBits"
+      dfdl:prefixLengthType="ex:threeCharTextInt" />
+
     <xs:element name="pl_text_int_txt_bytes_includes" type="xs:int" dfdl:ref="prefixedTxtByte"
       dfdl:prefixIncludesPrefixLength="yes" />
     <xs:element name="pl_text_int_txt_bits_includes" type="xs:int" dfdl:ref="prefixedTxtBits"
@@ -495,7 +522,7 @@
     <xs:element name="pl_trailingskip" type="xs:string" dfdl:lengthKind="prefixed"
       dfdl:prefixLengthType="ex:prefixTrailingSkip" />
     <xs:element name="pl_lengthunits" type="xs:string" dfdl:lengthKind="prefixed"
-      dfdl:prefixLengthType="ex:prefixLengthUnits" />
+      dfdl:prefixLengthType="ex:prefixLengthUnits" dfdl:prefixIncludesPrefixLength="yes" />
     <xs:element name="pl_nest" type="xs:string" dfdl:lengthKind="prefixed"
       dfdl:prefixLengthType="ex:prefixLengthNest1" />
     <xs:element name="pl_decimal" type="xs:string" dfdl:lengthKind="prefixed"
@@ -843,6 +870,154 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <pl_text_int_bin_bits>12</pl_text_int_bin_bits>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_txt_bytes_plbits" roundTrip="twoPass"
+    root="pl_text_int_txt_bytes_plbits"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">002</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_bytes_plbits>12</pl_text_int_txt_bytes_plbits>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_txt_bytes_plchars" roundTrip="twoPass"
+    root="pl_text_int_txt_bytes_plchars"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">002</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_bytes_plchars>12</pl_text_int_txt_bytes_plchars>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_txt_bits_plbytes" roundTrip="twoPass"
+    root="pl_text_int_txt_bits_plbytes"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">016</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_bits_plbytes>12</pl_text_int_txt_bits_plbytes>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_txt_bits_plchars" roundTrip="twoPass"
+    root="pl_text_int_txt_bits_plchars"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">016</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_bits_plchars>12</pl_text_int_txt_bits_plchars>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    DAFFODIL-2029: Cannot roundTrip due to unimplemented unparsing with
+    dfdl:lengthKind="prefixed" and dfdl:lengthUnits="characters"
+  -->
+  <tdml:parserTestCase name="pl_text_int_txt_chars_plbits" roundTrip="false"
+    root="pl_text_int_txt_chars_plbits"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">002</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_chars_plbits>12</pl_text_int_txt_chars_plbits>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    DAFFODIL-2029: Cannot roundTrip due to unimplemented unparsing with
+    dfdl:lengthKind="prefixed" and dfdl:lengthUnits="characters"
+  -->
+  <tdml:parserTestCase name="pl_text_int_txt_chars_plbytes" roundTrip="false"
+    root="pl_text_int_txt_chars_plbytes"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">002</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_txt_chars_plbytes>12</pl_text_int_txt_chars_plbytes>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_bin_bytes_plbits"
+    root="pl_text_int_bin_bytes_plbits"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 02</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_bin_bytes_plbits>12</pl_text_int_bin_bytes_plbits>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_bin_bytes_plchars" roundTrip="twoPass"
+    root="pl_text_int_bin_bytes_plchars"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">002</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_bin_bytes_plchars>12</pl_text_int_bin_bytes_plchars>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_bin_bits_plbytes"
+    root="pl_text_int_bin_bits_plbytes"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 10</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_bin_bits_plbytes>12</pl_text_int_bin_bits_plbytes>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_int_bin_bits_plchars" roundTrip="twoPass"
+    root="pl_text_int_bin_bits_plchars"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">016</tdml:documentPart>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <pl_text_int_bin_bits_plchars>12</pl_text_int_bin_bits_plchars>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -1947,6 +2122,7 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>ex:prefixLengthUnits</tdml:error>
+      <tdml:error>dfdl:prefixIncludesPrefixLength="yes"</tdml:error>
       <tdml:error>dfdl:prefixLengthType</tdml:error>
       <tdml:error>dfdl:lengthUnits</tdml:error>
     </tdml:errors>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -81,6 +81,17 @@ class TestLengthKindPrefixed {
   @Test def test_pl_text_bool_bin_bytes() = { runner.runOneTest("pl_text_bool_bin_bytes") }
   @Test def test_pl_text_bool_bin_bits() = { runner.runOneTest("pl_text_bool_bin_bits") }
 
+  @Test def test_pl_text_int_txt_bytes_plbits() = { runner.runOneTest("pl_text_int_txt_bytes_plbits") }
+  @Test def test_pl_text_int_txt_bytes_plchars() = { runner.runOneTest("pl_text_int_txt_bytes_plchars") }
+  @Test def test_pl_text_int_txt_bits_plbytes() = { runner.runOneTest("pl_text_int_txt_bits_plbytes") }
+  @Test def test_pl_text_int_txt_bits_plchars() = { runner.runOneTest("pl_text_int_txt_bits_plchars") }
+  @Test def test_pl_text_int_txt_chars_plbits() = { runner.runOneTest("pl_text_int_txt_chars_plbits") }
+  @Test def test_pl_text_int_txt_chars_plbytes() = { runner.runOneTest("pl_text_int_txt_chars_plbytes") }
+  @Test def test_pl_text_int_bin_bytes_plbits() = { runner.runOneTest("pl_text_int_bin_bytes_plbits") }
+  @Test def test_pl_text_int_bin_bytes_plchars() = { runner.runOneTest("pl_text_int_bin_bytes_plchars") }
+  @Test def test_pl_text_int_bin_bits_plbytes() = { runner.runOneTest("pl_text_int_bin_bits_plbytes") }
+  @Test def test_pl_text_int_bin_bits_plchars() = { runner.runOneTest("pl_text_int_bin_bits_plchars") }
+
   @Test def test_pl_complex_bin_bytes() = { runner.runOneTest("pl_complex_bin_bytes") }
   @Test def test_pl_complex_bin_bits() = { runner.runOneTest("pl_complex_bin_bits") }
   @Test def test_pl_complex_bin_bytes_suspension() = { runner.runOneTest("pl_complex_bin_bytes_suspension") }


### PR DESCRIPTION
Except in the case when prefixIncludesPrefixLength="yes". The spec does
not contain this excpetion so reads as if lengthUnits must always be the
same. Errata 2.76 clarifies that this should be allowed.

DAFFODIL-2035