### PR TITLE
Don't require binaryNumberRep for hexBinary

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section10/representation_properties/RepProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section10/representation_properties/RepProps.tdml
@@ -243,4 +243,39 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+	<tdml:defineSchema name="noBinaryNumberRep">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format lengthKind="implicit" leadingSkip="0" sequenceKind="ordered" representation="text"
+      trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
+      terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
+      initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
+      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no" floating="no"
+      byteOrder="bigEndian"/>
+
+    <xs:element name="hb_01" type="xs:hexBinary"
+      dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes" dfdl:length="4"/>
+  </tdml:defineSchema>
+
+
+  <!--
+    Test name: hexBinary_01
+    Schema: noBinaryNumberRep
+    Purpose: This test demonstrates that when using hexBinary the property
+    "binaryNumberRep" is not requried.
+  -->
+
+  <tdml:parserTestCase name="hexBinary_01" root="hb_01"
+      model="noBinaryNumberRep" description="Don't require binaryNumberRep for hexBinary" roundTrip="true">
+    <tdml:document>
+      <tdml:documentPart type="byte"><![CDATA[a1b1c1d1]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <hb_01>A1B1C1D1</hb_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
@@ -39,6 +39,8 @@ class TestRepProps {
   @Test def test_repPropMissing2() { runner.runOneTest("repPropMissing2") }
   @Test def test_repPropMissing3() { runner.runOneTest("repPropMissing3") }
 
+  @Test def test_hexBinary_01() { runner.runOneTest("hexBinary_01") }
+
   //These tests are temporary - see DFDL-994
   @Test def test_temporaryDefaultProps_01() { runner.runOneTest("temporaryDefaultProps_01") }
   @Test def test_temporaryDefaultProps_02() { runner.runOneTest("temporaryDefaultProps_02") }


### PR DESCRIPTION
The property binaryNumberRep should not need to be defined for hexBinary
elements.

DAFFODIL-2031