### PR TITLE
Added test to verify correct behavior for non-existant groupRef

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -302,6 +302,39 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="hiddenGroupRefDoesNotExist">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="e">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="doesNotExist"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <!--
+    Test name: hiddenGroupRefDoesNotExist
+       Schema: hiddenGroupRefDoesNotExist
+       Purpose: This test demonstrates that hidden group references that don't exist are handled
+       cleanly
+  -->
+
+  <tdml:parserTestCase name="hiddenGroupRefDoesNotExist" root="e"
+    model="hiddenGroupRefDoesNotExist" description="Section 14 - Hidden Elements DFDL-14-037R.">
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[42,2]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Referenced group definition not found</tdml:error>
+      <tdml:error>doesNotExist</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
   <!--
     Test name: hiddenGroupWithAssert
        Schema: hiddenGroup3

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -81,6 +81,7 @@ class TestSequenceGroups {
 
   //DFDL-598(related to, but this test does not say this is fixed)
   @Test def test_hiddenGroupRefEmptyString() { runner_02.runOneTest("hiddenGroupRefEmptyString") }
+  @Test def test_hiddenGroupRefDoesNotExist() { runner_02.runOneTest("hiddenGroupRefDoesNotExist") }
 
   @Test def test_AC000() { runner_02.runOneTest("AC000") }
   @Test def test_AD000() { runner_02.runOneTest("AD000") }


### PR DESCRIPTION
In version 2.2.0 this test causes an infinite loop to occur, but this
issue has been fixed in one of the commits since 2.2.0's release. This
test simply verifies that the correct error message is displayed when the
group referenced by a hiddenGroupRef does not exist.

DAFFODIL-2020