### PR TITLE
Daffodil 1080 sequences and separators - preliminary review

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -546,7 +546,7 @@ trait ElementBase
       isNillable,
       isArray, // can have more than 1 occurrence
       isOptional, // can have exactly 0 or 1 occurrence
-      isRequiredOrComputed, // must have at least 1 occurrence
+      isRequiredInInfoset, // must have at least 1 occurrence
       namedQName,
       isRepresented,
       couldHaveText,
@@ -1176,7 +1176,7 @@ trait ElementBase
       case None => true
       case Some(s: SequenceTermBase) if s.isOrdered => {
         !possibleNextSiblingTerms.exists {
-          case e: ElementBase => e.isRequiredOrComputed
+          case e: ElementBase => e.isRequiredInInfoset
           case mg: ModelGroup => mg.mustHaveRequiredElement
         }
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
@@ -100,12 +100,12 @@ trait LocalElementMixin
   }.value
 
   final def isLastDeclaredRequiredElementOfSequence = LV('isLastDeclaredRequiredElementOfSequence) {
-    if (isRequiredOrComputed) {
+    if (isRequiredInInfoset) {
       val es = nearestEnclosingSequence
       val res = es match {
         case None => true
         case Some(s) => {
-          val allRequired = s.groupMembers.filter(_.isRequiredOrComputed)
+          val allRequired = s.groupMembers.filter(_.isRequiredInInfoset)
           val lastDeclaredRequired = allRequired.last
           if (lastDeclaredRequired _eq_ this) true
           else false

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
@@ -74,11 +74,9 @@ trait LocalElementMixin
     res
   }.value
 
-  final override def hasKnownRequiredSyntax: Boolean = LV('hasKnownRequiredSyntax) {
-    !couldBeMissing
-  }.value
+  final override def hasKnownRequiredSyntax: Boolean = !couldBeMissing
 
-  final def couldBeMissing: Boolean = LV('couldBeMissing) {
+  final lazy val couldBeMissing: Boolean = LV('couldBeMissing) {
     val res =
       if (minOccurs == 0) true
       else if (isNillable && !hasNilValueRequiredSyntax) true

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
@@ -150,7 +150,7 @@ abstract class ModelGroup
 
   final override def isScalar = true
   final override def isOptional = false
-  final override def isRequiredOrComputed = true
+  final override def isRequiredInInfoset = false
   final override def isArray = false
 
   private def prettyIndex = LV('prettyIndex) {
@@ -237,7 +237,7 @@ abstract class ModelGroup
           val last = maybeLast.get
           val lastIsOptional = last match {
             case mg: ModelGroup => false // model group is mandatory
-            case eb: ElementBase => !eb.isRequiredOrComputed || !eb.isRepresented
+            case eb: ElementBase => !eb.isRequiredInInfoset || !eb.isRepresented
           }
           if (lastIsOptional) {
             val (priorSibs, parent) = last.potentialPriorTerms
@@ -263,7 +263,7 @@ abstract class ModelGroup
     LV('allSelfContainedTermsTerminatedByRequiredElement) {
       val listOfTerms = groupMembers.map(m => {
         m match {
-          case e: ElementBase if !e.isRequiredOrComputed => (Seq(e) ++ e.possibleNextTerms) // A LocalElement or ElementRef
+          case e: ElementBase if !e.isRequiredInInfoset => (Seq(e) ++ e.possibleNextTerms) // A LocalElement or ElementRef
           case e: ElementBase => Seq(e)
           case mg: ModelGroup => Seq(mg)
         }
@@ -374,7 +374,7 @@ abstract class ModelGroup
         // required next sibling if the last sibling element is required
         possibleNextSiblingTerms.lastOption match {
           case None => false
-          case Some(e: ElementBase) => e.isRequiredOrComputed
+          case Some(e: ElementBase) => e.isRequiredInInfoset
           case Some(mg: ModelGroup) => mg.mustHaveRequiredElement
           case Some(_) => Assert.invariantFailed()
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ParticleMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ParticleMixin.scala
@@ -63,13 +63,13 @@ trait RequiredOptionalMixin { self: ElementBase =>
    * True if the element is required to appear in the DFDL Infoset.
    *
    * This includes elements that have no representation in the
-   * data stream. That is, an element with dfdl:inputValueCalc will be isRequiredOrComputed true.
+   * data stream. That is, an element with dfdl:inputValueCalc will be isRequiredInInfoset true.
    *
    * Takes into account that some dfdl:occursCountKind can make
    * seemingly required elements (based on minOccurs) optional or
    * repeating.
    */
-  final override def isRequiredOrComputed: Boolean = LV('isRequired) {
+  final override def isRequiredInInfoset: Boolean = LV('isRequired) {
     val res = {
       if (isScalar) true
       else if (isOptional) false

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
@@ -38,7 +38,7 @@ abstract class Text(es: Term, e: Term, guard: Boolean) extends StringDelimBase(e
   lazy val eName = e.toString()
 
   lazy val positionalInfo = {
-    if (e.isDirectChildOfSequence) {
+    if (e.isSequenceChild) {
       e.nearestEnclosingSequence match {
         case Some(es) => {
           val pos = e.positionInNearestEnclosingSequence - 1

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -135,6 +135,7 @@
                  <xsd:enumeration value="deprecatedEncodingNameUSASCII7BitPacked"/>
                  <xsd:enumeration value="deprecatedFunctionDAFError"/>
                  <xsd:enumeration value="deprecatedPropertySeparatorPolicy" />
+                 <xsd:enumeration value="encodingErrorPolicyError"/>
                  <xsd:enumeration value="escapeSchemeRefUndefined"/>
                  <xsd:enumeration value="facetExplicitLengthOutOfRange"/>
                  <xsd:enumeration value="inconsistentLengthKind"/>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -402,8 +402,7 @@ abstract class ParseOrUnparseState protected (protected var variableBox: Variabl
   def dState = _dState
 
   def copyStateForDebugger = {
-    TupleForDebugger(
-      bytePos,
+    TupleForDebugger(bytePos,
       childPos,
       groupPos,
       currentLocation,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
@@ -21,14 +21,14 @@ import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.Failure
 import org.apache.daffodil.processors.OccursCountEv
+import org.apache.daffodil.processors.ModelGroupRuntimeData
 
 trait Unseparated { self: SequenceChildParser =>
 
   val childProcessors = Vector(childParser)
 }
 
-class ScalarOrderedUnseparatedSequenceChildParser(
-  override val childParser: Parser,
+class ScalarOrderedUnseparatedSequenceChildParser(override val childParser: Parser,
   override val srd: SequenceRuntimeData,
   override val trd: TermRuntimeData)
   extends SequenceChildParser(childParser, srd, trd) with Unseparated {
@@ -36,24 +36,21 @@ class ScalarOrderedUnseparatedSequenceChildParser(
   override protected def parse(state: PState) = childParser.parse1(state)
 }
 
-class RepOrderedExactlyNUnseparatedSequenceChildParser(
-  childParser: Parser,
+class RepOrderedExactlyNUnseparatedSequenceChildParser(childParser: Parser,
   srd: SequenceRuntimeData,
   erd: ElementRuntimeData,
   val repeatCount: Long)
   extends OccursCountExactParser(childParser, srd, erd)
   with Unseparated
 
-class RepOrderedExactlyTotalOccursCountUnseparatedSequenceChildParser(
-  childParser: Parser,
+class RepOrderedExactlyTotalOccursCountUnseparatedSequenceChildParser(childParser: Parser,
   ocEv: OccursCountEv,
   srd: SequenceRuntimeData,
   erd: ElementRuntimeData)
   extends OccursCountExpressionParser(childParser, srd, erd, ocEv)
   with Unseparated
 
-class RepOrderedWithMinMaxUnseparatedSequenceChildParser(
-  childParser: Parser,
+class RepOrderedWithMinMaxUnseparatedSequenceChildParser(childParser: Parser,
   srd: SequenceRuntimeData,
   erd: ElementRuntimeData) // pass -2 to force unbounded behavior
   extends OccursCountMinMaxParser(childParser, srd, erd)
@@ -70,8 +67,7 @@ class OrderedUnseparatedSequenceParser(rd: SequenceRuntimeData, childParsersArg:
    *
    * No backtracking supported.
    */
-  override protected def parseOneWithoutPoU(
-    parser: SequenceChildParser,
+  override protected def parseOneWithoutPoU(parser: SequenceChildParser,
     trd: TermRuntimeData,
     pstate: PState): ParseAttemptStatus = {
 
@@ -108,8 +104,7 @@ class OrderedUnseparatedSequenceParser(rd: SequenceRuntimeData, childParsersArg:
    *
    * Does not modify priorState.
    */
-  override protected def parseOneWithPoU(
-    parser: RepeatingChildParser,
+  override protected def parseOneWithPoU(parser: RepeatingChildParser,
     erd: ElementRuntimeData,
     pstate: PState,
     priorStateArg: PState.Mark,
@@ -138,8 +133,7 @@ class OrderedUnseparatedSequenceParser(rd: SequenceRuntimeData, childParsersArg:
               // success but no forward progress in unbounded case
               // This is the parser equivalent of an infinite loop.
               //
-              PE(
-                pstate,
+              PE(pstate,
                 "Repeating or Optional Element - No forward progress at byte %s. Attempt to parse %s " +
                   "succeeded but consumed no data.\nPlease re-examine your schema to correct this infinite loop.",
                 pstate.bytePos, erd.diagnosticDebugName)
@@ -160,6 +154,10 @@ class OrderedUnseparatedSequenceParser(rd: SequenceRuntimeData, childParsersArg:
       }
     res
   }
+
+  final override protected def parsePotentiallyTrailingGroup(parser: PotentiallyTrailingGroupSequenceChildParser,
+    trd: ModelGroupRuntimeData,
+    pstate: PState): ParseAttemptStatus = parseOneWithoutPoU(parser.scp, trd, pstate)
 
   override protected def zeroLengthSpecialChecks(pstate: PState, wasLastChildZeroLength: Boolean): Unit = {
     // Nothing for unseparated sequences

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression.tdml
@@ -1,0 +1,970 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="sequence" 
+  description="Tests for separators and separator suppression."
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  defaultImplementations="ibm daffodil"
+  defaultRoundTrip="none"
+  defaultConfig="cfg">
+  
+  <tdml:defineConfig name="cfg">
+    <daf:tunables>
+      <daf:suppressSchemaDefinitionWarnings>
+        unsupportedAttributeFormDefault 
+        encodingErrorPolicyError
+      </daf:suppressSchemaDefinitionWarnings>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:defineSchema name="s1">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:defineEscapeScheme name="CSVEscapeScheme">
+      <dfdl:escapeScheme 
+        escapeKind="escapeBlock" 
+        escapeBlockStart='"'
+        escapeBlockEnd='"' 
+        escapeCharacter='"' 
+        escapeEscapeCharacter='"' 
+        generateEscapeBlock="whenNeeded"
+        extraEscapedCharacters=", %#x0D; %#x0A;">
+      </dfdl:escapeScheme>
+    </dfdl:defineEscapeScheme>
+
+    <dfdl:format ref="ex:GeneralFormatPortable" 
+      lengthKind="delimited"
+      occursCountKind="implicit" 
+      escapeSchemeRef="ex:CSVEscapeScheme" />
+
+    <!-- 
+      for exploring when groups are 'potentially trailing' meaning their 
+      separator (in enclosing sequence) might be suppressed/not-required.
+     -->
+    <xs:element name="ptg1" dfdl:initiator="%NL;">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="">
+          <xs:element name="record" dfdl:terminator="%NL;%WSP*;" maxOccurs="unbounded" >
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorSuppressionPolicy="trailingEmpty">
+                <xs:element name="required1" type="xs:string" />
+                <xs:element name="positional2" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:element name="positional3" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:choice> <!-- choice is required -->
+                  <xs:element name="positional4_n" type="xs:decimal" />
+                  <xs:element name="positional4_s" type="xs:string" /> 
+                </xs:choice>
+                <!-- 
+                  Element potTrailing5 is potentially trailing because the sequence
+                  following it is a potentially trailing group.
+                 -->
+                <xs:element name="potTrailing5" type="xs:string" minOccurs="0"/>
+                <xs:sequence dfdl:separator="*" dfdl:separatorSuppressionPolicy="trailingEmpty"> 
+                  <!-- 
+                    This sequence is potentially trailing, 
+                    If empty and trailing the comma for this group in the enclosing sequence may be omitted.
+                  -->
+                  <xs:element name="potTrailing6" type="xs:int" minOccurs="0" maxOccurs="3" />
+                </xs:sequence>
+                <xs:element name="potTrailing7" type="xs:string" minOccurs="0"/> 
+                <xs:element name="potTrailing8" type="xs:string" minOccurs="0"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  
+  </tdml:defineSchema>
+  
+
+
+  <tdml:parserTestCase name="ptg1_1p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,1*2*3,g,h
+a,b,c,7.1,e,1*2*3,g,h
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing6>1</potTrailing6>
+            <potTrailing6>2</potTrailing6>
+            <potTrailing6>3</potTrailing6>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing6>1</potTrailing6>
+            <potTrailing6>2</potTrailing6>
+            <potTrailing6>3</potTrailing6>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="ptg1_2p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1,e
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="ptg1_3p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+ <tdml:parserTestCase name="ptg1_4p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  
+  <tdml:parserTestCase name="ptg1_5p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"><!-- twoPass if round tripping, since trailing final comma won't be unparsed. -->
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="ptg1_6p" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,,,d
+a,,,d
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+    <tdml:unparserTestCase name="ptg1_1u" root="ptg1" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,1*2*3,g,h
+a,b,c,7.1,e,1*2*3,g,h
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing6>1</potTrailing6>
+            <potTrailing6>2</potTrailing6>
+            <potTrailing6>3</potTrailing6>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing6>1</potTrailing6>
+            <potTrailing6>2</potTrailing6>
+            <potTrailing6>3</potTrailing6>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="ptg1_2u_daf" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1,e
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_2u_ibm" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1,e
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_3u_daf" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_3u_ibm" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,b,c,7.1,e,,g,h
+a,b,c,7.1
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+            <potTrailing5>e</potTrailing5>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional2>b</positional2>
+            <positional3>c</positional3>
+            <positional4_n>7.1</positional4_n>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+ <tdml:unparserTestCase name="ptg1_4u_daf" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_4u_ibm" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_5u_daf" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"
+    implementations="daffodil"> 
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g
+]]></tdml:document><!-- Note: trailing final comma from the parse example ptg1_5 test removed here -->
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+   <tdml:unparserTestCase name="ptg1_5u_ibm" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"
+    implementations="ibm"> 
+
+    <tdml:document><![CDATA[
+a,,,d,,,g,h
+a,,,d,,,g
+]]></tdml:document><!-- Note: trailing final comma from the parse example ptg1_5 test removed here -->
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7>
+            <potTrailing8>h</potTrailing8>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+            <potTrailing7>g</potTrailing7> 
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_6u_daf" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,,,d
+a,,,d
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg1_6u_ibm" root="ptg1" model="s1"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,,,d
+a,,,d
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg1>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+          <record>
+            <required1>a</required1>
+            <positional4_s>d</positional4_s>
+          </record>
+        </ptg1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:defineSchema name="s2">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    
+    <dfdl:format ref="ex:GeneralFormatPortable" 
+      lengthKind="delimited" 
+      occursCountKind="implicit"/>    
+    <!-- 
+      ptg2 explores whether a choice can also become potentially trailing
+      based on its content.
+     -->
+    <xs:element name="ptg2" dfdl:initiator="%NL;">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="">
+          <xs:element name="record" dfdl:terminator="%NL;%WSP*;" maxOccurs="unbounded" >
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorSuppressionPolicy="trailingEmpty">
+                <xs:element name="required1" type="xs:string" />
+                <xs:element name="potTrailing2" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:element name="potTrailing3" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:choice> 
+                  <!-- 
+                    choice is potTrailing because last sequence within is potentially trailing
+                    IBM DFDL does not find this though. So this test doesn't pass on IBM DFDL.
+                    
+                    This clarifies things substantially. There is no notion of a model
+                    group being "simply required". It depends on what is inside it.
+                    
+                    If it has no framing, and one branch is potTrailing, then if 
+                    everything after it is potentially trailing, it too is potentially 
+                    trailing.
+                   -->
+                  <xs:sequence>
+                    <!-- This sequence is NOT potentially trailing -->
+                    <xs:element name="potTrailing4_n" type="xs:decimal"/>
+                  </xs:sequence>
+                  <xs:sequence>
+                    <!-- 
+                      This sequence is potentially trailing
+                      We're working around a restriction in DFDL here.
+                      DFDL says you can't have a root of a choice branch be optional.
+                      But we can just wrap it in a sequence that has no framing.
+                      This satisfies the letter of the law.
+                      
+                      But it illustrates that this rule is kind of bogus.
+                      
+                      Of course if any branch but the last was like this, it 
+                      wouldn't make much sense, because branches past this one
+                      would never be tried. This sort of a branch can always succeed.
+                      -->
+                    <xs:element name="potTrailing4_s" type="xs:string" minOccurs="0"/>
+                  </xs:sequence> 
+                </xs:choice>
+                <!-- 
+                  Element potTrailing5 is potentially trailing because the sequence
+                  following it is a potentially trailing group.
+                 -->
+                <xs:element name="potTrailing5" type="xs:string" minOccurs="0"/>
+                <xs:sequence dfdl:separator="*" dfdl:separatorSuppressionPolicy="trailingEmpty"> 
+                  <!-- 
+                    This sequence is potentially trailing, 
+                    If empty and trailing the comma for this group in the enclosing sequence may be omitted.
+                  -->
+                  <xs:element name="potTrailing6" type="xs:int" minOccurs="0" maxOccurs="3" />
+                </xs:sequence>
+                <xs:element name="potTrailing7" type="xs:string" minOccurs="0"/> 
+                <xs:element name="potTrailing8" type="xs:string" minOccurs="0"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+  </tdml:defineSchema>
+    
+  <tdml:parserTestCase name="ptg2_1p_daf" root="ptg2" model="s2"
+    description="Test shows potentially trailing CHOICE group is missing, and that's ok."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a
+a
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg2>
+          <record>
+            <required1>a</required1>
+          </record>
+          <record>
+            <required1>a</required1>
+          </record>
+        </ptg2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="ptg2_1p_ibm" root="ptg2" model="s2"
+    description="Test shows potentially trailing CHOICE group is missing, and that's ok."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a
+a
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg2>
+          <record>
+            <required1>a</required1>
+          </record>
+          <record>
+            <required1>a</required1>
+          </record>
+        </ptg2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  
+  <tdml:unparserTestCase name="ptg2_1u_daf" root="ptg2" model="s2"
+    description="Test shows potentially trailing CHOICE group is missing, and that's ok."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a
+a
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg2>
+          <record>
+            <required1>a</required1>
+          </record>
+          <record>
+            <required1>a</required1>
+          </record>
+        </ptg2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptg2_1u_ibm" root="ptg2" model="s2"
+    description="Test shows potentially trailing CHOICE group is missing, and that's ok."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a
+a
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg2>
+          <record>
+            <required1>a</required1>
+          </record>
+          <record>
+            <required1>a</required1>
+          </record>
+        </ptg2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+    
+  <tdml:defineSchema name="s3">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    
+    <dfdl:format ref="ex:GeneralFormatPortable" 
+      lengthKind="delimited" 
+      occursCountKind="implicit"/>
+      
+    <!-- 
+      ptg3 explores spoiling the choice's potentially trailing by just having
+      a single branch that has required framing.
+     -->
+    <xs:element name="ptg3" dfdl:initiator="%NL;">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="">
+          <xs:element dfdl:occursCountKind="implicit" dfdl:terminator="%NL;%WSP*;"
+            maxOccurs="unbounded" name="record">
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorSuppressionPolicy="trailingEmpty">
+                <xs:element name="required1" type="xs:string" />
+                <xs:element name="positional2" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:element name="positional3" type="xs:string" minOccurs="0" /> <!-- never trailing due to choice -->
+                <xs:choice> 
+                  <!-- 
+                    choice is not trailing, because none of the choice branches are.
+                    (In general, it ought to be the last choice branch, otherwise 
+                    finding zero length will cut off consideration of any branches after
+                    the first potentially trailing branch.)
+                   -->
+                  <xs:sequence>
+                    <xs:element name="potTrailing4_n" type="xs:decimal"/>
+                  </xs:sequence>
+                  <xs:sequence>
+                    <xs:element name="potTrailing4_s" type="xs:string" />
+                  </xs:sequence>
+                  <xs:sequence /> 
+                </xs:choice>
+                <!-- 
+                  Element potTrailing5 is potentially trailing because the sequence
+                  following it is a potentially trailing group.
+                 -->
+                <xs:element name="potTrailing5" type="xs:string" minOccurs="0"/>
+                <xs:sequence dfdl:separator="*" dfdl:separatorSuppressionPolicy="trailingEmpty"> 
+                  <!-- 
+                    This sequence is potentially trailing, 
+                    If empty and trailing the comma for this group in the enclosing sequence may be omitted.
+                  -->
+                  <xs:element name="potTrailing6" type="xs:int" minOccurs="0" maxOccurs="3" />
+                </xs:sequence>
+                <xs:element name="potTrailing7" type="xs:string" minOccurs="0"/> 
+                <xs:element name="potTrailing8" type="xs:string" minOccurs="0"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+  </tdml:defineSchema>
+  
+  <tdml:parserTestCase name="ptg3_1p_daf" root="ptg3" model="s3"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,,,,
+a,,,,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg3>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+        </ptg3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+ 
+  <tdml:parserTestCase name="ptg3_1p_ibm" root="ptg3" model="s3"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,,,,
+a,,,,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg3>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+        </ptg3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase> 
+   
+  <tdml:unparserTestCase name="ptg3_1u_daf" root="ptg3" model="s3"
+    description="Test of potentially trailing groups."
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a,,,
+a,,,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg3>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+        </ptg3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+   <tdml:unparserTestCase name="ptg3_1u_ibm" root="ptg3" model="s3"
+    description="Test of potentially trailing groups."
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a,,,
+a,,,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptg3>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+          <record>
+            <required1>a</required1>
+            <potTrailing4_s/> <!-- must be present, as the element is scalar -->
+          </record>
+        </ptg3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+</tdml:testSuite>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression2.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression2.tdml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="sequence" 
+  description="Tests for separators and separator suppression."
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  defaultImplementations="ibm daffodil"
+  defaultConfig="cfg">
+  
+  <tdml:defineConfig name="cfg">
+    <daf:tunables>
+      <daf:suppressSchemaDefinitionWarnings>
+        unsupportedAttributeFormDefault 
+        encodingErrorPolicyError
+      </daf:suppressSchemaDefinitionWarnings>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:defineSchema name="s0">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormatPortable" 
+      lengthKind="delimited"
+      occursCountKind="implicit"/>
+
+    <xs:element name="ptLax0" dfdl:initiator="%NL;">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="">
+          <xs:element name="record" maxOccurs="unbounded" minOccurs="0"  dfdl:terminator="%NL;%WSP*;" >
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorSuppressionPolicy="trailingEmpty">
+                <xs:element name="required1" type="xs:string" />    
+                <xs:element name="potTrailing2" type="xs:string" minOccurs="0" maxOccurs="2"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+    
+ 
+  
+  <tdml:unparserTestCase name="ptLax0_1u" root="ptLax0" model="s0"
+    description="Test of potentially trailing groups."
+    roundTrip="none">
+
+    <tdml:document><![CDATA[
+a
+]]></tdml:document>   
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax0>
+         <record>
+            <required1>a</required1>
+          </record>
+        </ptLax0>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptLax0_2u" root="ptLax0" model="s0"
+    description="Test of potentially trailing groups."
+    roundTrip="none">
+
+    <tdml:document><![CDATA[
+a
+]]></tdml:document>   
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax0>
+         <record>
+            <required1>a</required1>
+            <potTrailing2/> <!-- daffodil detects this is zero length and suppresses separator for it. -->
+          </record>
+        </ptLax0>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptLax0_3u" root="ptLax0" model="s0"
+    description="Test of potentially trailing groups."
+    roundTrip="none">
+
+    <tdml:document><![CDATA[
+a,,c
+]]></tdml:document>   
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax0>
+         <record>
+            <required1>a</required1>
+            <potTrailing2/> <!-- must not suppress sep -->
+            <potTrailing2>c</potTrailing2> 
+          </record>
+        </ptLax0>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+ <tdml:defineSchema name="s1">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormatPortable" 
+      lengthKind="delimited"
+      occursCountKind="implicit"/>
+      
+    <!-- 
+      for exploring when groups are 'potentially trailing' meaning their 
+      separator (in enclosing sequence) might be suppressed/not-required.
+     -->
+    <xs:element name="ptLax" dfdl:initiator="%NL;">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="">
+          <xs:element name="record" maxOccurs="unbounded" minOccurs="0"  dfdl:terminator="%NL;%WSP*;" >
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorSuppressionPolicy="trailingEmpty">
+                <xs:element name="required1" type="xs:string" />
+                <xs:sequence dfdl:separator="*" dfdl:separatorSuppressionPolicy="trailingEmpty"> 
+                  <xs:element name="potTrailing2" type="xs:int" minOccurs="0" maxOccurs="3" />
+                </xs:sequence>                
+                <xs:element name="potTrailing3" type="xs:string" minOccurs="0"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+    
+  </tdml:defineSchema>
+      
+  <tdml:parserTestCase name="ptLax1rt" root="ptLax" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="twoPass">
+
+  <!-- should require twoPass to round trip, because unpasing won't produce the
+    trailing comma.
+   -->
+    <tdml:document><![CDATA[
+a,2,
+]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax>
+          <record>
+            <required1>a</required1>
+            <potTrailing2>2</potTrailing2>
+          </record>
+        </ptLax>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="ptLax2p" root="ptLax" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"><!-- twoPass if round tripping -->
+
+  <!-- 
+  This should require two passes, because unparse won't produce the trailing comma.
+ -->
+    <tdml:document><![CDATA[
+a,
+]]></tdml:document>   
+
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax>
+         <record>
+            <required1>a</required1>
+          </record>
+        </ptLax>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+  
+  <tdml:unparserTestCase name="ptLax2u_daf" root="ptLax" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"
+    implementations="daffodil">
+
+    <tdml:document><![CDATA[
+a
+]]></tdml:document>   
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax>
+         <record>
+            <required1>a</required1>
+            <!--
+              The sequence that follows is potentially trailing, and nothing
+              is in it, AND it is actually trailing. So it should not generate a separator.  
+             -->
+          </record>
+        </ptLax>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="ptLax2u_ibm" root="ptLax" model="s1"
+    description="Test of potentially trailing groups."
+    roundTrip="none"
+    implementations="ibm">
+
+    <tdml:document><![CDATA[
+a
+]]></tdml:document>   
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax>
+         <record>
+            <required1>a</required1>
+            <!--
+              The sequence that follows is potentially trailing, and nothing
+              is in it, AND it is actually trailing. So it should not generate a separator.  
+             -->
+          </record>
+        </ptLax>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
+  
+  
+ 
+  <tdml:parserTestCase name="ptLax3rt" root="ptLax" model="s1"
+    description="Test of potentially trailing groups.">
+
+    <tdml:document><![CDATA[
+a
+]]></tdml:document>   
+
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns="http://example.com">
+        <ptLax>
+         <record>
+            <required1>a</required1>
+          </record>
+        </ptLax>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase> 
+</tdml:testSuite>

--- a/daffodil-test-ibm1/src/test/scala-debug/org/apache/daffodil/TestSepSuppression3.scala
+++ b/daffodil-test-ibm1/src/test/scala-debug/org/apache/daffodil/TestSepSuppression3.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.Test
+
+object TestSepSuppression3 {
+  val testDir = "/test-suite/tresys-contributed/"
+  lazy val runner = Runner(testDir, "sepSuppression.tdml")
+  lazy val runner2 = Runner(testDir, "sepSuppression2.tdml")
+}
+
+class TestSepSuppression3 {
+  import TestSepSuppression3._
+
+  // These do not work on Daffodil
+  // Unable to suppress separator before a potentiallyTrailingGroup that
+  // is not present.
+  //
+  @Test def test_ptLax2u_daf() = { runner2.trace.runOneTest("ptLax2u_daf") }
+
+  // These unparser tests also do not work on Daffodil
+  //
+  // Some due to lack of output of a separator for a
+  // non-existing but positional element - the separator is required
+  // to hold the place for it even though the element is not present
+  // in the infoset.
+  //
+  // Others due to lack of ability to suppress separator for empty
+  // potentially trailing group.
+  //
+  // Or both
+  //
+  @Test def test_ptg1_2u_daf() = { runner.trace.runOneTest("ptg1_2u_daf") }
+  @Test def test_ptg1_3u_daf() = { runner.trace.runOneTest("ptg1_3u_daf") }
+  @Test def test_ptg1_4u_daf() = { runner.trace.runOneTest("ptg1_4u_daf") }
+  @Test def test_ptg1_5u_daf() = { runner.trace.runOneTest("ptg1_5u_daf") }
+  @Test def test_ptg1_6u_daf() = { runner.trace.runOneTest("ptg1_6u_daf") }
+
+  @Test def test_ptg2_1u_daf() = { runner.trace.runOneTest("ptg2_1u_daf") }
+
+  @Test def test_ptg3_1u_daf() = { runner.trace.runOneTest("ptg3_1u_daf") }
+
+  // IBM fails this test because its parser suppresses an empty string
+  // in a case where the element is not optional. It is suppressing the
+  // element for an empty string even though the element is not an optional/array.
+  @Test def test_ptg3_1p_ibm() = { runner.trace.runOneTest("ptg3_1p_ibm") }
+
+  // IBM fails this test because it cannot determine that a CHOICE
+  // is a potentially trailing group.
+  @Test def test_ptg2_1p_ibm() = { runner.trace.runOneTest("ptg2_1p_ibm") }
+
+  // IBM fails this test because it cannot determine that a CHOICE
+  // is a potentially trailing group, and therefore none of its contents
+  // may be present. In general it cannot figure out because no element that
+  // is within the choice is in the infoset, so it cannot resolve the choice.
+  @Test def test_ptg2_1u_ibm() = { runner.trace.runOneTest("ptg2_1u_ibm") }
+}

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.Test
+
+object TestSepSuppression {
+  val testDir = "/test-suite/tresys-contributed/"
+  lazy val runner = Runner(testDir, "sepSuppression.tdml")
+}
+
+class TestSepSuppression {
+  import TestSepSuppression._
+
+  @Test def test_ptg1_1p() = { runner.runOneTest("ptg1_1p") }
+  @Test def test_ptg1_2p() = { runner.runOneTest("ptg1_2p") }
+  @Test def test_ptg1_3p() = { runner.runOneTest("ptg1_3p") }
+  @Test def test_ptg1_4p() = { runner.runOneTest("ptg1_4p") }
+  @Test def test_ptg1_5p() = { runner.runOneTest("ptg1_5p") }
+  @Test def test_ptg1_6p() = { runner.runOneTest("ptg1_6p") }
+
+  @Test def test_ptg1_1u() = { runner.runOneTest("ptg1_1u") }
+  @Test def test_ptg1_2u_ibm() = { runner.runOneTest("ptg1_2u_ibm") }
+  @Test def test_ptg1_3u_ibm() = { runner.runOneTest("ptg1_3u_ibm") }
+  @Test def test_ptg1_4u_ibm() = { runner.runOneTest("ptg1_4u_ibm") }
+  @Test def test_ptg1_5u_ibm() = { runner.runOneTest("ptg1_5u_ibm") }
+  @Test def test_ptg1_6u_ibm() = { runner.runOneTest("ptg1_6u_ibm") }
+
+  @Test def test_ptg2_1p_daf() = { runner.runOneTest("ptg2_1p_daf") }
+  @Test def test_ptg3_1p_daf() = { runner.runOneTest("ptg3_1p_daf") }
+  @Test def test_ptg3_1u_ibm() = { runner.runOneTest("ptg3_1u_ibm") }
+
+}

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.Test
+
+object TestSepSuppression2 {
+  val testDir = "/test-suite/tresys-contributed/"
+  lazy val runner2 = Runner(testDir, "sepSuppression2.tdml")
+}
+
+class TestSepSuppression2 {
+  import TestSepSuppression2._
+
+  @Test def test_ptLax0_1u() = { runner2.runOneTest("ptLax0_1u") }
+  @Test def test_ptLax0_2u() = { runner2.runOneTest("ptLax0_2u") }
+  @Test def test_ptLax0_3u() = { runner2.runOneTest("ptLax0_3u") }
+
+  @Test def test_ptLax1rt() = { runner2.runOneTest("ptLax1rt") }
+
+  @Test def test_ptLax2p() = { runner2.runOneTest("ptLax2p") }
+  @Test def test_ptLax2u_ibm() = { runner2.runOneTest("ptLax2u_ibm") }
+
+  @Test def test_ptLax3rt() = { runner2.runOneTest("ptLax3rt") }
+
+}


### PR DESCRIPTION
This is a checkpoint in work to improve Sequences and Separators.
I do not intend to merge this branch; however, review would be helpful perhaps.
There are some difficult issues here. 
    
    Tests that distinguish proper function in Daffodil, proper function in
    IBM DFDL, failures of each, and differences between them added.
    
    The tests that fail (either implementation) are in scala-debug.
    
    Parsing is working better than unparsing. Unparsing is failing in a
    number
    of important scenarios still.
    
    There is much duplication of test-case logic in order to provide
    distinct parse/unparse and daffodil/ibm variants of a test.
    
    In many cases there are 4 copies of a test. Ex: for a test named "foo":
       fooN_Np_daf
       fooN_Np_ibm
       fooN_Nu_daf
       fooN_Nu_ibm
    In these cases the test document data, and test infoset are IDENTICAL
    AND SHOULD BE KEPT THAT WAY. Eventually as we improve things we would
    hope
    to collapse these back to a single, portable and round-trip test.
    
    (alternatively, TDML Runner features allowing a single test to be
    expressed by drawing in infoset and document from shared definitions,
    would be helpful. That way one could have 4 tests, but have them
    explicitly share the same data document definition and infoset
    definition.
    You can do this today, but only by putting the infoset and document part
    into external files. I'd like to keep this self contained.)
    
    For now this split up allow us to have tests which work only some of
    the 4 possible combinations, and to split those up over scala vs.
    scala-debug.
    
    The "_ibm" tests are to understand and characterize the behavior of
    that implementation that we need to interoperate with, because in some
    cases this behavior is NOT conforming to current DFDL specification
    due to well known bugs and limitations.
    
    == Affect of changes so far on general function/regression tests ==
    
    1 regression in daffodil-test-ibm1 - AX000 fails. Complex situation at
    first glance.
    
    1 regression in daffodil-tdml-processor tests - the 'threePass' test
    doesn't work because it was depending on an empty element being created
    that is now suppressed. See below discussion.
    
    36 regressions in daffodil-test.
    A substantial number of these are due to empty elements that we were
    creating, but no longer are, and some are nilled elements we used to
    create but no longer are.
    
    There are some other failure scenarios also however.
    
    Right now the code does too much suppression of elements having zero
    length. They are not supposed to be suppressed if ZL is the nil
    representation nor if ZL is the "empty string" or "empty hexBinary"
    representation.
    
    Daffodil should implement the correct DFDL-spec-compliant behavior,
    and did prior to these changes. In order to get interop with IBM DFDL
    on some of the new EDI-style tests, I changed behavior for string and
    hexbinary elements so that they are more often suppressed as elements.
    
    However, IBM DFDL does not implement this functionality according to
    the DFDL spec, so interoperability with IBM DFDL will require a flag
    that changes this behavior. Many of these changes were added to DFDL
    spec several years ago before the 2014 revision of DFDL v1.0. But
    IBM's DFDL implementation was already in operation, so they have a
    legacy of behavior they'll have to eventually adjust. This big set of
    subtle revisions were associated with the DFDL Workgroup "Action 140"
    work/action item. Basically IBM DFDL did not implement (some ? or all
    of) the Action 140 changes.
    
    So we either need a flag, or alternatively, 36 tests have to be made
    Daffodil specific - which may be preferable. This depends on whether
    the behavior is required to make "real" schemas work portably, or just
    little test cases.
    
    DAFFODIL-1080