### PR TITLE
Make the JAPI/SAPI DataProcessors serializable

### DIFF
--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -302,7 +302,8 @@ class ProcessorFactory private[japi] (pf: SProcessorFactory)
  * functions in [[WithDiagnostics]], is invalid and will result in an
  * Exception.
  */
-abstract class WithDiagnostics private[japi] (wd: SWithDiagnostics) {
+abstract class WithDiagnostics private[japi] (wd: SWithDiagnostics)
+  extends Serializable {
 
   /**
    * Determine if any errors occurred in the creation of the parent object.
@@ -419,7 +420,8 @@ class LocationInSchemaFile private[japi] (lsf: SLocationInSchemaFile) {
  * Compiled version of a DFDL Schema, used to parse data and get the DFDL infoset
  */
 class DataProcessor private[japi] (dp: SDataProcessor)
-  extends WithDiagnostics(dp) {
+  extends WithDiagnostics(dp)
+  with Serializable {
 
   /**
    * Enable/disable debugging.

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -53,7 +53,7 @@ import org.apache.daffodil.japi.io.InputSourceDataInputStream;
 
 public class TestJavaAPI {
 
-    public java.io.File getResource(String resPath) {
+    private java.io.File getResource(String resPath) {
         try {
             return new java.io.File(this.getClass().getResource(resPath).toURI());
         } catch (Exception e) {
@@ -61,7 +61,30 @@ public class TestJavaAPI {
         }
     }
 
-    public DataProcessor reserializeDataProcessor(DataProcessor dp) throws IOException, ClassNotFoundException {
+    /**
+     * This is a test-only helper function used to serialize and deserialize a
+     * DataProcessor to ensure all JAPI classes that need to extend
+     * Serializable do so appropriately.
+     *
+     * All of the JAPI tests create a DataProcessor. To test that we correctly
+     * made all the necessary changes to make the JAPI DataProcessor
+     * serializable, it is important to serialize and deserialize that
+     * DataProcessor before use in the tests. This function acts as a helper
+     * function to accomplish that task.
+     *
+     * So this functions accepts a DataProcessor, serializes and deserializes
+     * that DataProcessor in memory, and then returns the result. The test
+     * should then use that resulting DataProcessor for the rest of the test.
+     * This function is only used for testing purposes.
+     *
+     * Note that this function contains an ObjectInputStream for
+     * deserialization, but one that is extended to override the resolveClass
+     * function. This override is necessary to work around a bug when running
+     * tests in SBT that causes an incorrect class loader to be used. Normal
+     * users of the Java API should not need this and can serialize/deserialize
+     * as one would normally do with a standard Object{Input,Output}Stream.
+     */
+    private DataProcessor reserializeDataProcessor(DataProcessor dp) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(dp);

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -285,7 +285,8 @@ class ProcessorFactory private[sapi] (pf: SProcessorFactory)
  * functions in [[WithDiagnostics]], is invalid and will result in an
  * Exception.
  */
-abstract class WithDiagnostics private[sapi] (wd: SWithDiagnostics) {
+abstract class WithDiagnostics private[sapi] (wd: SWithDiagnostics)
+  extends Serializable {
 
   /**
    * Determine if any errors occurred in the creation of the parent object.
@@ -396,7 +397,8 @@ class LocationInSchemaFile private[sapi] (lsf: SLocationInSchemaFile) {
  * Compiled version of a DFDL Schema, used to parse data and get the DFDL infoset
  */
 class DataProcessor private[sapi] (dp: SDataProcessor)
-  extends WithDiagnostics(dp) {
+  extends WithDiagnostics(dp)
+  with Serializable {
 
   /**
    * Enable/disable debugging.

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -41,7 +41,7 @@ import org.apache.daffodil.sapi.io.InputSourceDataInputStream
 
 class TestScalaAPI {
 
-  def getResource(resPath: String): File = {
+  private def getResource(resPath: String): File = {
     val f = try {
       new File(this.getClass().getResource(resPath).toURI())
     } catch {
@@ -50,7 +50,30 @@ class TestScalaAPI {
     f
   }
 
-  def reserializeDataProcessor(dp: DataProcessor): DataProcessor = {
+  /**
+   * This is a test-only helper function used to serialize and deserialize a
+   * DataProcessor to ensure all SAPI classes that need to extend
+   * Serializable do so appropriately.
+   *
+   * All of the SAPI tests create a DataProcessor. To test that we correctly
+   * made all the necessary changes to make the SAPI DataProcessor
+   * serializable, it is important to serialize and deserialize that
+   * DataProcessor before use in the tests. This function acts as a helper
+   * function to accomplish that task.
+   *
+   * So this functions accepts a DataProcessor, serializes and deserializes
+   * that DataProcessor in memory, and then returns the result. The test
+   * should then use that resulting DataProcessor for the rest of the test.
+   * This function is only used for testing purposes.
+   *
+   * Note that this function contains an ObjectInputStream for
+   * deserialization, but one that is extended to override the resolveClass
+   * function. This override is necessary to work around a bug when running
+   * tests in SBT that causes an incorrect class loader to be used. Normal
+   * users of the Scala API should not need this and can serialize/deserialize
+   * as one would normally do with a standard Object{Input,Output}Stream.
+   */
+  private def reserializeDataProcessor(dp: DataProcessor): DataProcessor = {
       val baos = new ByteArrayOutputStream()
       val oos = new ObjectOutputStream(baos)
       oos.writeObject(dp)

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -23,10 +23,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
 import java.io.File
 import java.nio.channels.Channels
 import org.junit.Test
 import org.apache.daffodil.sapi.Daffodil
+import org.apache.daffodil.sapi.DataProcessor
 import org.apache.daffodil.sapi.ParseResult
 import org.apache.daffodil.sapi.logger.ConsoleLogWriter
 import org.apache.daffodil.sapi.logger.LogLevel
@@ -47,6 +50,31 @@ class TestScalaAPI {
     f
   }
 
+  def reserializeDataProcessor(dp: DataProcessor): DataProcessor = {
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      oos.writeObject(dp)
+      oos.close()
+
+      val bais = new ByteArrayInputStream(baos.toByteArray())
+      val ois = new ObjectInputStream(bais) {
+        /**
+         * This override is here because of a bug in sbt where the wrong class loader is being
+         * used when deserializing an object.
+         * For more information, see https://github.com/sbt/sbt/issues/163
+         */
+        override protected def resolveClass(desc: java.io.ObjectStreamClass): Class[_] = {
+          try {
+            Class.forName(desc.getName, false, getClass.getClassLoader)
+          } catch {
+            case e: ClassNotFoundException => super.resolveClass(desc);
+          }
+        }
+      }
+
+      ois.readObject().asInstanceOf[DataProcessor]
+    }
+
   @Test
   def testScalaAPI1() {
     val lw = new LogWriterForSAPITest()
@@ -59,9 +87,11 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
     dp.setDebugger(debugger)
     dp.setDebugging(true)
+
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -164,7 +194,9 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myDataBroken.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -206,7 +238,9 @@ class TestScalaAPI {
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     pf.setDistinguishedRootNode("e3", null)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData16.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -275,7 +309,9 @@ class TestScalaAPI {
     val schemaFileName = getResource("/test/sapi/mySchema3.dfdl.xsd")
     c.setDistinguishedRootNode("e4", null)
     val pf = c.compileFile(schemaFileName)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData2.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -304,7 +340,9 @@ class TestScalaAPI {
     c.setDistinguishedRootNode("e4", null); // e4 is a 4-byte long string
     // element
     val pf = c.compileFile(schemaFileName)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData3.dat"); // contains 5
     // bytes
     val fis = new java.io.FileInputStream(file)
@@ -381,7 +419,9 @@ class TestScalaAPI {
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
     c.setDistinguishedRootNode("TopLevel", null)
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/01very_simple.txt")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -424,7 +464,9 @@ class TestScalaAPI {
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
     c.setDistinguishedRootNode("TopLevel2", null)
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/01very_simple.txt")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -463,7 +505,9 @@ class TestScalaAPI {
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
     c.setDistinguishedRootNode("TopLevel2", null)
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/01very_simple.txt")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -507,7 +551,9 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema4.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData4.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -531,7 +577,9 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema5.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData5.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -566,7 +614,9 @@ class TestScalaAPI {
 
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     dp.setDebugger(debugger)
     dp.setDebugging(true)
     val file = getResource("/test/sapi/myData.dat")
@@ -610,7 +660,9 @@ class TestScalaAPI {
     c.setExternalDFDLVariables(extVarsFile)
     val pf = c.compileFile(schemaFile)
 
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     dp.setDebugger(debugger)
     dp.setDebugging(true)
     val file = getResource("/test/sapi/myData.dat")
@@ -647,10 +699,12 @@ class TestScalaAPI {
     val extVarFile = getResource("/test/sapi/external_vars_1.xml")
     val schemaFile = getResource("/test/sapi/mySchemaWithVars.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    dp1.setExternalVariables(extVarFile)
+    val dp = reserializeDataProcessor(dp1)
+
     dp.setDebugger(debugger)
     dp.setDebugging(true)
-    dp.setExternalVariables(extVarFile)
 
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
@@ -733,9 +787,11 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
     dp.setDebugger(debugger)
     dp.setDebugging(true)
+
     val file = getResource("/test/sapi/myInfosetBroken.xml")
     val xml = scala.xml.XML.loadFile(file)
     val bos = new java.io.ByteArrayOutputStream()
@@ -763,8 +819,10 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
-    dp.setValidationMode(ValidationMode.Limited)
+    val dp1 = pf.onPath("/")
+    dp1.setValidationMode(ValidationMode.Limited)
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -789,8 +847,10 @@ class TestScalaAPI {
     c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
-    dp.setValidationMode(ValidationMode.Full)
+    val dp1 = pf.onPath("/")
+    dp1.setValidationMode(ValidationMode.Full)
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -827,7 +887,9 @@ class TestScalaAPI {
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
     c.setDistinguishedRootNode("e4", null)
     val pf = c.compileFile(schemaFile)
-    val dp = pf.onPath("/")
+    val dp1 = pf.onPath("/")
+    val dp = reserializeDataProcessor(dp1)
+
     val file = getResource("/test/sapi/myData2.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)


### PR DESCRIPTION
Some tools, like Apache Spark, need the ability to serialize the
DataProcessor to be sent to cluster nodes where it is then deserialized
and used to process data. We have the save/reload methods, but Spark
does not now how to use these. So this modifies the JAPI/SAPI
DataProcessors so that they are serializable, and modifies the JAPI/SAPI
tests to serialize/deserialize each DataProcessor before being used.

DAFFODIL-1440