### PR TITLE
Properly handle malformed binding files

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.dsom
 
 import scala.xml.Node
-import org.apache.daffodil.externalvars.Binding
+import org.apache.daffodil.externalvars.{ Binding, BindingException }
 import org.apache.daffodil.compiler.RootSpec
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.xml._
@@ -472,7 +472,11 @@ final class SchemaSet(
       }
 
       val newNS = matchingDVs.head.namespace
-      val newBinding = Binding(v.varQName.local, Some(newNS), v.varValue)
+      val newBinding = try {
+        Binding(v.varQName.local, Some(newNS), v.varValue)
+      } catch {
+        case e: BindingException => this.SDE("Exception when processing external variable %s: %s", v.varQName, e.getMessage)
+      }
       finalExternalVariables.enqueue(newBinding)
     })
     finalExternalVariables

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/externalvars/Binding.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/externalvars/Binding.scala
@@ -45,6 +45,9 @@ class Binding(val varQName: RefQName, val varValue: String, scope: scala.xml.Nam
       GlobalQName(varQName.prefix, varQName.local, varQName.namespace)
 }
 
+case class BindingException(message: String)
+  extends Exception("Exception when processing external variable binding: %s".format(message))
+
 /**
  * This object is for cases when external variable bindings
  * are passed in via the Command Line Interface.
@@ -54,24 +57,36 @@ object Binding {
   /**
    * extSyntax is {uri}ncName, or {}ncName, or ncName
    */
-  def apply(extSyntax: String, value: String): Binding = {
+  def apply(extSyntax: String, value: String): Binding = try {
     val tryRefQName = QName.refQNameFromExtendedSyntax(extSyntax)
     new Binding(tryRefQName.get, value, null)
+  } catch {
+    case e: Throwable => throw BindingException(e.getMessage)
   }
 
   def apply(node: Node, tunable: DaffodilTunables): Binding = {
     val name = (node \ "@name").head.text
-    val refQName = QName.resolveRef(name, node.scope, tunable)
+    val refQName = try {
+      QName.resolveRef(name, node.scope, tunable)
+    } catch {
+      case e: Throwable => throw BindingException(e.getMessage)
+    }
     val value = node.text
     new Binding(refQName.get, value, node.scope)
   }
 
-  def apply(name: String, namespace: Option[NS], value: String): Binding = {
+  def apply(name: String, namespace: Option[NS], value: String): Binding = try {
     new Binding(RefQName(None, name, namespace.getOrElse(UnspecifiedNamespace)), value)
+  } catch {
+    case e: Throwable => throw BindingException(e.getMessage)
   }
 
   def getBindings(extVarBindings: Node, tunableArg: DaffodilTunables) = {
     val bindings = extVarBindings \ "bind"
-    bindings.map(b => Binding(b, tunableArg))
+    try {
+      bindings.map(b => Binding(b, tunableArg))
+    } catch {
+      case e: Throwable => throw BindingException(e.getMessage)
+    }
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesLoader.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesLoader.scala
@@ -83,7 +83,12 @@ object ExternalVariablesLoader {
   // return the mutated map.
 
   def loadVariables(vars: Map[String, String], referringContext: ThrowsSDE, vmap: VariableMap): VariableMap = {
-    val bindings = getVariables(vars)
+    val bindings = try {
+      getVariables(vars)
+    } catch {
+      case e: Throwable => referringContext.SDE("Exception when processing external variable binding file: %s", e.getMessage)
+    }
+
     val finalVMap = this.loadVariables(bindings, referringContext, vmap)
     finalVMap
   }
@@ -115,7 +120,12 @@ object ExternalVariablesLoader {
   def loadVariables(node: Node, referringContext: ThrowsSDE, vmap: VariableMap, tunableArg: DaffodilTunables): VariableMap = {
     Assert.usage(node != null, "loadVariables expects 'node' to not be null!")
     Assert.usage(referringContext != null, "loadVariables expects 'referringContext' to not be null!")
-    val bindings = Binding.getBindings(node, tunableArg)
+    val bindings = try {
+      Binding.getBindings(node, tunableArg)
+    } catch {
+      case e: Throwable => referringContext.SDE("Exception when processing external variable binding file: %s", e.getMessage)
+    }
+
     loadVariables(bindings, referringContext, vmap)
   }
 


### PR DESCRIPTION
There were a few unhandled exceptions that were originating from being
unable to resolve QNames in external variable config files. With these
changes these exceptions should be handled more cleanly.

DAFFODIL-2044

I wanted to push this up for review before developing test cases to trigger the various places these QName exceptions can occur.  I have one test case currently that is broken due to the fact that the exception is picked up in TDMLRunner, so that test may just be removed.