### PR TITLE
Avoid CircularDefinition error for appinfo

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -635,7 +635,7 @@ class TestCLIdebugger {
       shell.sendLine("display info path")
 
       shell.sendLine("continue")
-      shell.expect(contains("matrix::matrixType::sequence::row::LocalComplexTypeDef::sequence::cell"))
+      shell.expect(contains("matrix::matrixType::sequence[1]::row::LocalComplexTypeDef::sequence[1]::cell"))
 
       shell.sendLine("delete breakpoint 1")
       shell.expect(contains("debug"))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -97,7 +97,7 @@ abstract class ChoiceTermBase(
   final override val xml: Node,
   final override val parent: SchemaComponent,
   final override val position: Int)
-  extends ModelGroup
+  extends ModelGroup(position)
   with Choice_AnnotationMixin
   with RawDelimitedRuntimeValuedPropertiesMixin // initiator and terminator (not separator)
   with ChoiceGrammarMixin {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
@@ -136,7 +136,7 @@ object TermFactory {
  * There are ultimately 4 concrete classes that implement this:
  * Sequence, Choice, SequenceGroupRef, and ChoiceGroupRef
  */
-abstract class ModelGroup
+abstract class ModelGroup(index: Int)
   extends Term
   with ModelGroupGrammarMixin
   with OverlapCheckMixin
@@ -153,14 +153,7 @@ abstract class ModelGroup
   final override def isRequiredOrComputed = true
   final override def isArray = false
 
-  private def prettyIndex = LV('prettyIndex) {
-    myPeers.map { peers =>
-      {
-        if (peers.length == 1) "" // no index expression if we are the only one
-        else "[" + (peers.indexOf(this) + 1) + "]" // 1-based indexing in XML/XSD
-      }
-    }.getOrElse("")
-  }.value
+  private def prettyIndex = "[" + index + "]" // 1-based indexing in XML/XSD
 
   override lazy val diagnosticDebugName = prettyBaseName + prettyIndex
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -50,7 +50,7 @@ abstract class SequenceTermBase(
   final override val xml: Node,
   final override val parent: SchemaComponent,
   final override val position: Int)
-  extends ModelGroup
+  extends ModelGroup(position)
   with SequenceGrammarMixin {
 
   def separatorSuppressionPolicy: SeparatorSuppressionPolicy

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/MissingAppinfoSource.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/MissingAppinfoSource.dfdl.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+>
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format
+          terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
+          alignment="implicit" alignmentUnits="bits" trailingSkip="0" ignoreCase="no"
+          separatorPosition="infix" occursCountKind="implicit"
+          emptyValueDelimiterPolicy="both" representation="text" textNumberRep="standard"
+          lengthKind="delimited" encoding="ASCII" textPadKind="none" outputNewLine="%LF;"
+          calendarTimeZone="UTC" truncateSpecifiedLengthString="no" escapeSchemeRef=""
+          separatorSuppressionPolicy="trailingEmpty" initiator=""
+          calendarFirstDayOfWeek="Sunday" calendarDaysInFirstWeek="1" calendarCheckPolicy="strict"
+          calendarPatternKind="implicit" calendarLanguage="en" sequenceKind="ordered" separator=""
+      />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="elem">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:annotation>
+            <!-- 
+            <xs:appinfo source="http://www.ogf.org/dfdl/"> 
+            -->
+            <xs:appinfo>
+              <dfdl:discriminator testKind="pattern" testPattern="."/>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -173,6 +173,25 @@
   </tdml:parserTestCase>
 
 <!--
+    Test Name: missing_appinfo_source
+       Schema: warning
+         Root: elem
+      Purpose: This test demonstrates tdml:warnings
+-->
+
+  <tdml:parserTestCase name="missing_appinfo_source" root="elem"
+    model="MissingAppinfoSource.dfdl.xsd"
+    description="">
+    <tdml:document><![CDATA[test]]></tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Warning</tdml:error>
+      <tdml:error>xs:appinfo without source attribute</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+<!--
     Test Name: schema_line_number
        Schema: lineNumber.dfdl.xsd
          Root: e1

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -42,6 +42,7 @@ class TestSDE {
 
   @Test def test_schema_line_number() { runner.runOneTest("schema_line_number") }
   @Test def test_schema_warning() { runner.runOneTest("schema_warning") }
+  @Test def test_missing_appinfo_source() { runner.runOneTest("missing_appinfo_source") }
   @Test def test_missing_closing_tag() { runner.runOneTest("missing_closing_tag") }
   @Test def test_ignoreAttributeFormDefault() { runner.runOneTest("ignoreAttributeFormDefault") }
 }


### PR DESCRIPTION
When we were detecting that an appinfo annotation did not have a source
attribute we would try to show a schema definition warning. However, the
lack of source attribute was somehow causing a CircularDefinition error
within the OOLAG/LV code when trying to print out the position of the
sequence where the error was occuring.

Instead of relying on the OOLAG/LV code to sort of reverse lookup the
sequences position, the position is now passed in as an argument to
ModelGroup.

DAFFODIL-2046