### PR TITLE
Change expression result type coercion to be a warning

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -613,9 +613,17 @@ case class WholeExpression(
     }
 
     if (!allowCoercion) {
-      SDE("Expression result type (%s) cannot be coerced to the expected type (%s)",
-        inherentType,
-        targetType)
+      if (tunable.allowExpressionResultCoercion) {
+        SDW(WarnID.DeprecatedExpressionResultCoercion,
+          "Expression result type (%s) should be manually cast to the expected type (%s) with the appropriate constructor. " +
+          "Performing deprecated automatic conversion.",
+          inherentType,
+          targetType)
+      } else {
+        SDE("Expression result type (%s) must be manually cast to the expected type (%s) with the approrpriate constructor.",
+          inherentType,
+          targetType)
+      }
     }
 
     targetType

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
@@ -160,7 +160,20 @@ case class DaffodilTunables(
    * from SimpleDateFormat are reasonable
    */
   val minValidYear: Int = 0,
-  val maxValidYear: Int = 9999)
+  val maxValidYear: Int = 9999,
+
+  /* Defines how Daffodil coerces expressions where the result type differs
+   * from the expected type. As an example, assume the expected type of an
+   * expression is an xs:string, but the expression is { 3 }. In this case, the
+   * expression result is an xs:int, which should not be automatically coerced
+   * to an xs:string. Instead, the expression should be { xs:string(3) } or { "3" }
+   * If the value of this tunable is false, these types of expressions will
+   * result in a schema definition error. If the value is true, Daffodil will
+   * provide a warning and attempt to coerce the result type to the expected
+   * type.
+   */
+  val allowExpressionResultCoercion: Boolean = true
+  )
 
   extends Serializable
   with Logging {
@@ -267,6 +280,7 @@ case class DaffodilTunables(
       case "maximumsimpleelementsizeincharacters" => this.copy(maximumSimpleElementSizeInCharacters = java.lang.Integer.valueOf(value))
       case "initialregexmatchlimitincharacters" => this.copy(initialRegexMatchLimitInCharacters = java.lang.Integer.valueOf(value))
       case "maximumregexmatchlengthincharacters" => this.copy(maximumRegexMatchLengthInCharacters = java.lang.Integer.valueOf(value))
+      case "allowexpressionresultcoercion" => this.copy(allowExpressionResultCoercion = java.lang.Boolean.valueOf(value))
       case _ => {
         log(LogLevel.Warning, "Ignoring unknown tunable: %s", tunable)
         this

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/WarnID.scala
@@ -87,6 +87,11 @@ object WarnID extends PropsEnum[WarnID] {
     */
   case object TextOutputMinLengthOutOfRange extends WarnID; forceConstruction(TextOutputMinLengthOutOfRange)
 
+  /**
+   * Automatic expression result type coercion
+   */
+  case object DeprecatedExpressionResultCoercion extends WarnID; forceConstruction(DeprecatedExpressionResultCoercion)
+
   override def apply(name: String, context: ThrowsSDE) = Assert.usageError("not to be called. Call find(name) method instead.")
 
   def find(name: String): Option[WarnID] = optionStringToEnum("warning identifier", name)

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -135,6 +135,7 @@
                  <xsd:enumeration value="deprecatedEncodingNameUSASCII7BitPacked"/>
                  <xsd:enumeration value="deprecatedFunctionDAFError"/>
                  <xsd:enumeration value="deprecatedPropertySeparatorPolicy" />
+                 <xsd:enumeration value="deprecatedExpressionResultCoercion" />
                  <xsd:enumeration value="escapeSchemeRefUndefined"/>
                  <xsd:enumeration value="facetExplicitLengthOutOfRange"/>
                  <xsd:enumeration value="inconsistentLengthKind"/>
@@ -154,6 +155,7 @@
            </xsd:list>
            </xsd:simpleType>
         </xsd:element>
+        <xsd:element name="allowExpressionResultCoercion" minOccurs="0" type="xsd:boolean" />
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1812,6 +1812,12 @@ c]]></value>
 
   </tdml:defineSchema>
 
+  <tdml:defineConfig name="cfg_errorOnResultCoercion">
+    <daf:tunables>
+      <daf:allowExpressionResultCoercion>false</daf:allowExpressionResultCoercion>
+    </daf:tunables>
+  </tdml:defineConfig>
+
   <tdml:parserTestCase name="expression_type_error1"
     root="e" model="expression-type-errors.dfdl.xsd"
     description="get a type error from an expression at runtime - DFDL-23-006R">
@@ -1828,12 +1834,13 @@ c]]></value>
 
   <tdml:parserTestCase name="expression_type_error2"
     root="f" model="expression-type-errors.dfdl.xsd"
-    description="get a type error from an expression at compile time - DFDL-23-006R">
+    description="get a type error from an expression at compile time - DFDL-23-006R"
+    config="cfg_errorOnResultCoercion">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Expression result type</tdml:error>
-      <tdml:error>cannot be coerced</tdml:error>
+      <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Double</tdml:error>
       <tdml:error>Int</tdml:error>
     </tdml:errors>
@@ -1869,12 +1876,13 @@ c]]></value>
 
   <tdml:parserTestCase name="expression_type_error5"
     root="i" model="expression-type-errors.dfdl.xsd"
-    description="get a type error from an expression at compilation time - no coercion">
+    description="get a type error from an expression at compilation time - no coercion"
+    config="cfg_errorOnResultCoercion">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Expression result type</tdml:error>
-      <tdml:error>cannot be coerced</tdml:error>
+      <tdml:error>must be manually cast</tdml:error>
       <tdml:error>String</tdml:error>
       <tdml:error>Boolean</tdml:error>
     </tdml:errors>
@@ -1882,12 +1890,13 @@ c]]></value>
 
   <tdml:parserTestCase name="expression_type_error6"
     root="j" model="expression-type-errors.dfdl.xsd"
-    description="get a type error from an expression at compilation time - no coercion">
+    description="get a type error from an expression at compilation time - no coercion"
+    config="cfg_errorOnResultCoercion">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Expression result type</tdml:error>
-      <tdml:error>cannot be coerced</tdml:error>
+      <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Int</tdml:error>
       <tdml:error>String</tdml:error>
     </tdml:errors>
@@ -1895,12 +1904,13 @@ c]]></value>
 
   <tdml:parserTestCase name="expression_type_error7"
     root="k" model="expression-type-errors.dfdl.xsd"
-    description="get a type error from an expression at compilation time - no coercion">
+    description="get a type error from an expression at compilation time - no coercion"
+    config="cfg_errorOnResultCoercion">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Expression result type</tdml:error>
-      <tdml:error>cannot be coerced</tdml:error>
+      <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Double</tdml:error>
       <tdml:error>Float</tdml:error>
     </tdml:errors>


### PR DESCRIPTION
Commit a2f56a3f44 modified expression coercion to be strict about the
result type of an expression matching the expected type. This proved to
break a lot of schemas that were too lax, and so isn't good for
backwards compatibility. Instead, perform the coercion as we used to,
but display a warning to the user instead of an SDE if coercion is
needed. Additionally, add a tunable to change the warning to an SDE so
we can deprecate the behavior and easily change it in the future.

DAFFODIL-2054