### PR TITLE
Fix incorrect line numbers and ensure XML errors include line numbers

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -122,12 +122,10 @@ final class DFDLSchemaFile(val sset: SchemaSet,
       //
       ldr.setValidation(false)
       val node = ldr.load(schemaSource)
-      schemaDefinitionUnless(node != null, "No XML Node could be loaded from %s.", schemaSource)
+      schemaDefinitionUnless(node != null, "Unable to load XML from %s.", diagnosticDebugName)
       node
     } catch {
       case e: java.io.IOException => die(e)
-      case e: SAXException => die(e)
-      case e: scala.xml.parsing.FatalError => die(e)
     }
     node
   }.value

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -207,7 +207,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>lineNumber.dfdl.xsd</tdml:error>
-      <tdml:error>lineNumber: 35</tdml:error>
+      <tdml:error>line 65</tdml:error>
+      <tdml:error>column 10</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/lineNumber.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/lineNumber.dfdl.xsd
@@ -20,6 +20,35 @@
 
   <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
+  <!--
+    This group doesn't do anything. It's just a convenient way to insert a
+    multline CDATA, which has been a cause of incorrect line numbers
+  -->
+  <xs:group name="groupWithCDATA">
+    <xs:sequence>
+      <xs:element name="ivc">
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:element>
+              <dfdl:property name="inputValueCalc"><![CDATA[{
+                   if (1 eq 2) then 2
+              else if (3 eq 4) then 4
+              else if (5 eq 6) then 6
+              else if (7 eq 8) then 8
+              else if (9 eq 10) then 10
+              else 11
+              }]]>
+              </dfdl:property>
+            </dfdl:element>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:int" />
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:format ref="GeneralFormat" lengthKind="delimited" separator="."
@@ -32,7 +61,8 @@
   <xs:element name="e1">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="inty" type="blah" maxOccurs="unbounded"/>
+        <!-- missing dfdl:length causes an SDE deteced by Daffodil instead of Saxon -->
+        <xs:element name="inty" type="xs:int" dfdl:lengthKind="explicit" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
- A bug in scala-xml caused line numbers to be reset to zero after
  parsing CDATA and processing instructions. This can be worked around
  by calling lookahead() when a DaffodilConstructingLoader is
  initialized
- When using the DaffodilConstructingLoader to parse XML, if any
  exceptions are thrown, convert them to SAXParseExceptions and return
  null. This makes our errors consistent and also causes line numbers to
  be included in errors that previously did not (e.g. missing closing
  tag)
- Change the DaffodilConstructingLoader to override the elem(...)
  function to add file/line/column attributes there instead of
  overriding xTag and mkAttributes. Those functions are probably less
  safe to override since they are more internal to the scala-xml
  ConstructingLoader, and they also required position state to be
  carried around outside. Using the elem function is a bit cleaner and
  probably safer
- Remove the addColLineInfo flag. We need to handle removing line/col
  information for IBM compatibility differently as part of another
  commit. It's too difficult to use this flag in the way that's
  intended.

DAFFODIL-1476