### PR TITLE
Added additional note to UPA violation errors

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -23,6 +23,7 @@ import org.apache.daffodil.schema.annotation.props.gen.Choice_AnnotationMixin
 import org.apache.daffodil.grammar.ChoiceGrammarMixin
 import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.ChoiceRuntimeData
+import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.infoset.ChoiceBranchEvent
 import org.apache.daffodil.infoset.ChoiceBranchStartEvent
 import org.apache.daffodil.infoset.ChoiceBranchEndEvent
@@ -216,6 +217,7 @@ abstract class ChoiceTermBase(
             SDE(
               "UPA violation. Multiple choice branches begin with %s.\n" +
               "Note that elements with dfdl:outputValueCalc cannot be used to distinguish choice branches.\n" +
+              "Note that choice branches with entirely optional content are not allowed.\n" +
               "The offending choice branches are:\n%s",
               event.qname, trds.map { trd => "%s at %s".format(trd.diagnosticDebugName, trd.locationDescription) }.mkString("\n"))
           } else {
@@ -228,6 +230,7 @@ abstract class ChoiceTermBase(
               WarnID.MultipleChoiceBranches,
               "Multiple choice branches are associated with the %s of element %s.\n" +
                 "Note that elements with dfdl:outputValueCalc cannot be used to distinguish choice branches.\n" +
+                "Note that choice branches with entirely optional content are not allowed.\n" +
                 "The offending choice branches are:\n%s\n" +
                 "The first branch will be used during unparsing when an infoset ambiguity exists.",
               eventType, event.qname, trds.map { trd => "%s at %s".format(trd.diagnosticDebugName, trd.locationDescription) }.mkString("\n"))

--- a/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.dfdl.xsd
@@ -81,4 +81,19 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="entirelyOptionalChoice">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:choice>
+          <xs:sequence>
+            <xs:element name="a" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit" minOccurs="0"/>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element name="b" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit" minOccurs="0"/>
+          </xs:sequence>
+          </xs:choice>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
 </xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.tdml
@@ -60,4 +60,18 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+  <tdml:unparserTestCase name="unparse3" root="entirelyOptionalChoice" model="parseUnparseModeTest.dfdl.xsd"
+    roundTrip="false">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:entirelyOptionalChoice><a>1</a></ex:entirelyOptionalChoice>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>entirely optional content</tdml:warning>
+    </tdml:warnings>
+    <tdml:document>1</tdml:document>
+  </tdml:unparserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
@@ -42,4 +42,5 @@ class TestParseUnparseMode {
 
   @Test def test_unparse2() { runner.runOneTest("unparse2") }
 
+  @Test def test_unparse3() { runner.runOneTest("unparse3") }
 }


### PR DESCRIPTION
In cases where choice branches have entirely optional content it wasn't
clear why a UPA was occurring. I have added a note to the SDE/SDW
message that shows up in these cases mentioning that branches with
entirely optional content are not allowed.

DAFFODIL-2036