### PR TITLE
Add better error message for '/' vs 'div'

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
@@ -157,7 +157,14 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
           nextRdr = nextRdr.rest
           i += 1
         }
-        context.SDE("Unable to parse expression. Message: %s\nNext: %s.", msg, nextString.toString())
+        val err_msg = {
+          if (msg.contains('/')) {
+            msg + ", did you mean to use 'div'?"
+          } else {
+            msg
+          }
+        }
+        context.SDE("Unable to parse expression. Message: %s\nNext: %s.", err_msg, nextString.toString())
       }
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
@@ -242,6 +242,7 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
     })("add")
 
   def MultiplicativeExpr: Parser[Expression] = log(
+    UnaryExpr ~ (("/") ~ UnaryExpr) ^^ { _ => context.SDE("'/' is not a valid operator in DFDL Expression Syntax. Did you mean to use 'div'?") } |
     UnaryExpr ~ (("*" | "div" | "idiv" | "mod") ~ UnaryExpr).* ^^ {
       case u1 ~ uMore => uMore.foldLeft(u1) { case (a, op ~ b) => MultiplicativeExpression(op, List(a, b)) }
     })("mult")

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -7188,7 +7188,7 @@
   <tdml:parserTestCase name="div22" root="div22" model="XPathDiv" description="Section 23 - DFDL Expressions - div">
     <tdml:document></tdml:document>
     <tdml:errors>
-      <tdml:error>use 'div'?</tdml:error>
+      <tdml:error>Did you mean to use 'div'?</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -7047,6 +7047,7 @@
     <xs:element name="div19" type="xs:double" dfdl:inputValueCalc="{ xs:double(5) div xs:double('INF') }" />
     <xs:element name="div20" type="xs:float" dfdl:inputValueCalc="{ xs:float(5) div xs:float('INF') }" />
     <xs:element name="div21" type="xs:double" dfdl:inputValueCalc="{ 90.0 div 1234567.0 }" />
+    <xs:element name="div22" type="xs:double" dfdl:inputValueCalc="{ 90.0 / 1234567.0 }" />
 
     <xs:element name="idiv01" type="xs:int" dfdl:inputValueCalc="{ xs:double(5) idiv xs:double(2) }" />
     <xs:element name="idiv02" type="xs:int" dfdl:inputValueCalc="{ xs:float(5) idiv xs:float(2) }" />
@@ -7184,6 +7185,12 @@
     <tdml:infoset><tdml:dfdlInfoset><div21>7.290005321703885E-5</div21></tdml:dfdlInfoset></tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase name="div22" root="div22" model="XPathDiv" description="Section 23 - DFDL Expressions - div">
+    <tdml:document></tdml:document>
+    <tdml:errors>
+      <tdml:error>use 'div'?</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
   <tdml:parserTestCase name="idiv01" root="idiv01" model="XPathDiv" description="Section 23 - DFDL Expressions - idiv">
     <tdml:document></tdml:document>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -94,6 +94,7 @@ class TestDFDLExpressions2 {
   @Test def test_div19 { runner.runOneTest("div19") }
   @Test def test_div20 { runner.runOneTest("div20") }
   @Test def test_div21 { runner.runOneTest("div21") }
+  @Test def test_div22 { runner.runOneTest("div22") }
 
   @Test def test_idiv01 { runner.runOneTest("idiv01") }
   @Test def test_idiv02 { runner.runOneTest("idiv02") }


### PR DESCRIPTION
Suggests using 'div' instead of '/' when this error is detected by the
expression parser.

DAFFODIL-2042