### PR TITLE
Support building MSI packages with wine on Linux

### DIFF
--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -139,6 +139,7 @@ wixProductUpgradeId := "4C966AFF-585E-4E17-8CC2-059FD70FEC77"
 // specific XML to enable this, the WiX compiler and linker
 // complain about it unless you specifically suppress the warning.
 lightOptions := Seq(
+	"-sval", // validation does not currently work under Wine, this disables that
 	"-sice:ICE61",
 	"-ext", "WixUIExtension",
 	"-cultures:en-us",
@@ -161,11 +162,12 @@ wixProductLicense := {
 
   val licenseLines = scala.io.Source.fromFile(sourceLicense, "UTF-8").getLines
   val writer = new java.io.PrintWriter(targetLicense, "UTF-8")
-  writer.println(rtfHeader)
+  // windows style line endings in the license are required by the WiX toolkit
+  writer.write(rtfHeader + "\r\n")
   licenseLines.foreach { line =>
-    writer.println(line + """\line""")
+    writer.write(line + """\line""" + "\r\n")
   }
-  writer.println(rtfFooter)
+  writer.write(rtfFooter + "\r\n")
   writer.close
   Option(targetLicense)
 }

--- a/scripts/wix_wine.sh
+++ b/scripts/wix_wine.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We use sbt-native-packager plugin to build a Windows MSI installer.
+# Unfortunately, that uses WiX toolset which requires Windows. It can be run
+# under Wine, but the plugin cannot be easily configured to use Wine. This
+# script is one part of getting that to work. The full steps for setting up the
+# environment are documented in the Daffodil Release Workflow wiki page.
+
+# We run a few wine commands, let's disable all wine debug information since it
+# is interpreted by sbt as errors and makes the output look like something
+# failed.
+export WINEDEBUG=-all
+
+# If the WiX environment is setup correctly, the sbt native-packager will
+# execute a symlink to this script, and the $0 variable should look something
+# like "path/to/wix_directory/\\bin\\candle.exe". The following will extract
+# evertyhing after the last backslash, returning either "candle.exe" or
+# "light.exe" depending on what the plugin executes.
+CMD=${0##*\\}
+
+# The paths passed into this script by the plugin are all absolute Linux style
+# paths. For arguments that look like a path (i.e. starts with a /), use
+# winepath to convert them to a Windows style path that wine applications can
+# understand. Leave all other arguments unmodified.
+i=0
+NEWARGS=()
+for VAR in "$@"
+do
+	if [[ $VAR == /* ]]
+	then
+		NEWARGS[$i]=$(winepath -w "$VAR")
+	else
+		NEWARGS[$i]=$VAR
+	fi
+	((++i))
+done
+
+# Tell bash to output the command we are about to execute, helpful for
+# debugging when something goes wrong with wine
+set -x
+
+# Execute wine with the right WiX command and modified arguments
+wine $WIX/$CMD "${NEWARGS[@]}"


### PR DESCRIPTION
- Disable MSI validation by providing the -sval flag to light.exe. When
  generating an MSI in wine without this flag, light.exe fails with a
  generic Windows error. Some reports of similar issues make it sound
  like validation is performed by installing the MSI in some sort of
  dry-run mode--not too surprising that would fail in wine.
- Modify release script to build the MSI and install to apache-dist.
  Also clean up the release script to have consistent indentation.
- Modify RTF license generator to always output windows style line
  endings, required by MSI generator

DAFFODIL-2066