### PR TITLE
Remove JUnit4 compile dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,6 @@ lazy val sapi             = Project("daffodil-sapi", file("daffodil-sapi")).conf
 lazy val tdmlLib             = Project("daffodil-tdml-lib", file("daffodil-tdml-lib")).configs(IntegrationTest, TestDebug, IntegrationTestDebug)
                               .dependsOn(macroLib % "compile-internal", lib, io, io % "test->test")
                               .settings(commonSettings)
-                              .settings(libraryDependencies += Dependencies.junit)
 
 lazy val tdmlProc         = Project("daffodil-tdml-processor", file("daffodil-tdml-processor")).configs(IntegrationTest, TestDebug, IntegrationTestDebug)
                               .dependsOn(tdmlLib, core)

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLException.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLException.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.tdml
 
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.util.Maybe
-import org.junit.AssumptionViolatedException
 import org.apache.daffodil.util.Misc
 
 object TDMLException {
@@ -87,14 +86,10 @@ class TDMLDiagnostic(diag: String, implementation: Option[String])
 }
 
 /**
- * Causes a Junit test to be skipped, but otherwise is a TDMLException like
- * others thrown by the TDML runner.
+ * Used to determine when a test will not be run due to not being compatible
+ * with the implementation. Useful since this isn't necessarily a failure and
+ * may want to be treated differently in some cases.
  */
 class TDMLTestNotCompatibleException(testName: String, override val implementation: Option[String])
-  extends AssumptionViolatedException(
-    implementation.map { impl =>
-      "Test '%s' not compatible with implementation '%s'.".format(testName, impl)
-    }.get) with TDMLException {
-  override def msg = getMessage()
-  override def causes: Seq[Throwable] = Nil
+  extends TDMLExceptionImpl("Test '%s' not compatible with implementation.".format(testName), implementation) {
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,9 +31,6 @@ object Dependencies {
     "jline" % "jline" % "2.14.6",
   )
 
-  lazy val junit = "junit" % "junit" % "4.12" // needed for TDML runner use of AssertionViolationException
-  
-
   lazy val infoset = Seq(
     "org.jdom" % "jdom2" % "2.0.6",
     "com.fasterxml.woodstox" % "woodstox-core" % "5.1.0",
@@ -47,7 +44,7 @@ object Dependencies {
   )
 
   lazy val test = Seq(
-    junit % "it,test", 
+    "junit" % "junit" % "4.12" % "it,test",
     "com.novocode" % "junit-interface" % "0.11" % "it,test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "it,test"
   )


### PR DESCRIPTION
We currently have a JUnit4 compile dependency because the TDML Runner
throws a JUnit-based exception to indicate that a test should be skipped
when the current implementation does not support that test. The problem
with this is 1) we now have a compile dependency that is traditionally
only for tests, which is odd, and 2) JUnit is now distributed in our
binary helpers, and so requires licensing changes.

Neither of these are ideal, so this patch removes that compile
dependency. It does so by using reflection to create the appropriate
JUnit "skip this test" exception if JUnit is on the classpath (i.e.
we're probably running a JUnit test). If JUnit is not on the classpath,
then we just throws a standard TDML exception and lets the caller handle
it however it makes sense for them.

DAFFODIL-2067