### PR TITLE
Fixed instance of NadaParser not being optimized out

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SpecifiedLength.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SpecifiedLength.scala
@@ -120,11 +120,14 @@ class SpecifiedLengthExplicit(e: ElementBase, eGram: => Gram, bitsMultiplier: In
 
   lazy val kind = "Explicit_" + e.lengthUnits.toString
 
-  lazy val parser: Parser = new SpecifiedLengthExplicitParser(
-    eParser,
-    e.elementRuntimeData,
-    e.lengthEv,
-    bitsMultiplier)
+  lazy val parser: Parser = {
+    if (eParser.isEmpty) eParser
+    else new SpecifiedLengthExplicitParser(
+      eParser,
+      e.elementRuntimeData,
+      e.lengthEv,
+      bitsMultiplier)
+  }
 
 }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -117,6 +117,45 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="NadaParser.dfdl.xsd">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+    <xs:element name="test">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="count" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="record" dfdl:lengthKind="explicit" dfdl:length="0" maxOccurs="unbounded"
+            dfdl:occursCountKind="expression" dfdl:occursCount="{ ../ex:count }">
+            <xs:complexType>
+              <xs:sequence>
+              <!--
+                <xs:element name="value1" dfdl:lengthKind="explicit" dfdl:length="1" type="xs:string" />
+                <xs:element name="value2" dfdl:lengthKind="explicit" dfdl:length="1" type="xs:string" />
+              -->
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nadaParser" root="test"
+    model="NadaParser.dfdl.xsd" description="Tests to make sure that the NadaParser generated in SpecifiedLengthExplicit is optimized out"
+    roundTrip="false">
+    <tdml:document>
+      <tdml:documentPart type="text">1,</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <test>
+          <count>1</count>
+          <record/>
+        </test>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
    <tdml:defineSchema name="SequenceGroup-Embedded.dfdl.xsd">
      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
      <dfdl:format ref="ex:GeneralFormat" lengthUnits="bytes"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -54,6 +54,7 @@ class TestSequenceGroups {
   @Test def test_delimitedByNextInitFail() { runner_01.runOneTest("delimitedByNextInitFail") }
 
   //  @Test def test_emptySequenceSDE() { runner_02.runOneTest("emptySequenceSDE") }
+  @Test def test_NadaParser() { runner_02.runOneTest("nadaParser") }
   @Test def test_complexEmptyContent() { runner_02.runOneTest("complexEmptyContent") }
   @Test def test_noContentComplexSDE() { runner_02.runOneTest("noContentComplexSDE") }
   @Test def test_noContentAnnotatedComplexSDE() { runner_02.runOneTest("noContentAnnotatedComplexSDE") }


### PR DESCRIPTION
SpecifiedLengthExplicitParser was not checking for isEmpty, which was
resulting in prodcuing a NadaParser.

DAFFODIL-2062