### PR TITLE
Added tests that illustrate DAFFODIL-2069 bug.

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tdml:testSuite suiteName="outputValueCalc_bitOrder_interactions" 
+  description="Tests interactions of bitOrder with hexBinary and outputValueCalc"
+  xmlns:tns="http://example.com"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions" 
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:ex="http://example.com"
+  defaultRoundTrip="true"
+  defaultValidation="on">
+
+  <tdml:defineSchema name="s" elementFormDefault="unqualified">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormatPortable" sequenceKind='ordered' initiator=""
+      terminator="" separator="" initiatedContent='no' leadingSkip='0' trailingSkip='0'
+      textStringPadCharacter='%SP;' lengthUnits="bits" alignment="1" alignmentUnits="bits"
+      representation="binary" encoding="ASCII" binaryNumberRep="binary" byteOrder="littleEndian"
+      bitOrder="leastSignificantBitFirst" encodingErrorPolicy="replace" outputNewLine="%LF;"
+      textOutputMinLength="0" />
+
+    <xs:element name="rHexBinary">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence>
+            <xs:element name="len" type="xs:unsignedInt" dfdl:length="8"
+              dfdl:lengthKind="explicit" dfdl:outputValueCalc="{ dfdl:valueLength(../value, 'bytes') }" />
+            <xs:element name="value" type="xs:hexBinary" dfdl:length="{ ../len }"
+              dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:alignmentUnits="bytes"/>
+          </xs:sequence>
+          <xs:element name="next" type="xs:unsignedInt" dfdl:length="2"
+            dfdl:lengthKind="explicit" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="rHexBinaryPrefixed">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence>
+            <xs:element name="value" type="xs:hexBinary" dfdl:lengthKind="prefixed"
+              dfdl:prefixLengthType="tns:lenPrefixType"
+              dfdl:prefixIncludesPrefixLength="no"
+              dfdl:lengthUnits="bytes" dfdl:alignmentUnits="bytes"/>
+          </xs:sequence>
+          <xs:element name="next" type="xs:unsignedInt" dfdl:length="2"
+            dfdl:lengthKind="explicit" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+    <xs:simpleType name="lenPrefixType" 
+       dfdl:lengthKind="explicit" dfdl:length="8">
+       <xs:restriction base="xs:unsignedInt"/>
+    </xs:simpleType>
+    
+    
+    <xs:element name="rString">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence>
+            <xs:element name="len" type="xs:unsignedInt" dfdl:length="8"
+              dfdl:lengthKind="explicit" dfdl:outputValueCalc="{ dfdl:valueLength(../value, 'bytes') }" />
+            <xs:element name="value" type="xs:string" dfdl:length="{ ../len }"
+              dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:alignmentUnits="bytes"/>
+          </xs:sequence>
+          <xs:element name="next" type="xs:unsignedInt" dfdl:length="2"
+            dfdl:lengthKind="explicit" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:unparserTestCase name="rHexBinaryLSBF1" root="rHexBinary" model="s" roundTrip="onePass">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        01 31 03
+    </tdml:documentPart>
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:rHexBinary>
+          <len>1</len>
+          <value>31</value>
+          <next>3</next>
+        </ex:rHexBinary>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="rHexBinaryLSBF2" root="rHexBinaryPrefixed" model="s" roundTrip="onePass">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        01 31 03
+    </tdml:documentPart>
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:rHexBinaryPrefixed>
+          <value>31</value>
+          <next>3</next>
+        </ex:rHexBinaryPrefixed>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+  
+  <tdml:unparserTestCase name="rStringLSBF1" root="rString" model="s" roundTrip="onePass">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        01 31 03
+    </tdml:documentPart>
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:rString>
+          <len>1</len>
+          <value>1</value>
+          <next>3</next>
+        </ex:rString>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+  
+</tdml:testSuite>
+

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -26,10 +26,12 @@ object TestOutputValueCalc {
 
   val runner = Runner(testDir, "outputValueCalc.tdml")
   val runner2 = Runner(testDir, "outputValueCalc2.tdml")
+  val runner3 = Runner(testDir, "outputValueCalc3.tdml")
 
   @AfterClass def shutdown {
     runner.reset
     runner2.reset
+    runner3.reset
   }
 }
 
@@ -73,4 +75,9 @@ class TestOutputValueCalc {
   @Test def test_errorOneArg() { runner.runOneTest("errorOneArg") }
   @Test def test_errorTwoArg() { runner.runOneTest("errorTwoArg") }
   @Test def test_errorThreeArg() { runner.runOneTest("errorThreeArg") }
+
+  // DAFFODIL-2069
+  // @Test def test_ovcHexBinaryLSBF1() { runner3.runOneTest("rHexBinaryLSBF1") }
+  @Test def test_ovcHexBinaryLSBF2() { runner3.runOneTest("rHexBinaryLSBF2") }
+  @Test def test_ovcStringLSBF1() { runner3.runOneTest("rStringLSBF1") }
 }


### PR DESCRIPTION
DAFFODIL-2069 is a complex interaction of outputValueCalc with hexBinary with bitOrder LSBF.

This PR just adds tests that illustrate the bug, commented out so all tests still pass, but illustrates the issue for whomever investigates, and lets us consider the impact of the bug. 

This bug was discovered in unit tests of the mil-std-2045 schema. One of those tests no longer passes on 2.3.0-rc1. 

See https://issues.apache.org/jira/browse/DAFFODIL-2069 for description.