### PR TITLE
Remove extraneous XML loads for repeating include/imports

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
@@ -132,9 +132,16 @@ abstract class IIBase( final override val xml: Node, xsdArg: XMLSchemaDocument, 
    * An import/include requires only that we can access the
    * schema file, recursively any of its includes/imports,
    * and that all the resulting are validated by the validating loader.
+   *
+   * It is important to point out that this intentionally references
+   * iiSchemaFileMaybe rather than iiSchemaFile because the former only loads a
+   * schema if it hasn't been seen before. If we instead required the
+   * evaluation of iiSchemaFile, it would force loading of schemas that have
+   * already been seen and result in duplicate effort and slower schema
+   * compilation.
    */
-  requiredEvaluations(iiSchemaFile)
-  requiredEvaluations(iiSchemaFile.iiXMLSchemaDocument)
+  requiredEvaluations(iiSchemaFileMaybe)
+  requiredEvaluations(iiSchemaFileMaybe.map(_.iiXMLSchemaDocument))
 
   protected final def notSeenThisBefore = LV('notSeenThisBefore) {
     val mp = mapPair


### PR DESCRIPTION
We already have logic to detect when the same file has been
included/imported so that we can prevent circular imports. However, we
defined requiredEvaluations on the iiSchemaFile, which forces a load and
parse of the schema regardless if it had already been loaded or not. For
large schemas with lots of imports of the same thing (e.g. multiple
schema files importing a common schema), this could result in a lot of
duplicated effort.

Instead, define the requiredEvaluations on the iiSchemaFileMaybe, which
will only load the schema if it hasn't been seen.

On some large schemas with lots of repeating imports, this saw a
reduction in schema compile time of about 15%.

DAFFODIL-2071