### PR TITLE
Exclude the KEYS file when git archive is used create source releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/KEYS export-ignore 


### PR DESCRIPTION
The KEYS should not be part of source releases, but instead should only
be accessed from https://www.apache.org/dist/incubator/daffodil/KEYS.
This change tells git-archive, which our release script uses to create
source releases, to not include the KEYS file in the generated archive.

DAFFODIL-2070