### PR TITLE
Fix contact information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ sbt coverageAggregate
 
 ## Getting Help
 
-For questions, we can be reached at the dev@daffodil.apache.org or user@daffodil.apache.org mailing lists or in #Daffodil on [ASF HipChat](https://www.hipchat.com/gJt9EQs5l). Bugs can be reported via the [Daffodil JIRA](https://issues.apache.org/jira/projects/DAFFODIL).
+For questions, we can be reached at the dev@daffodil.apache.org or users@daffodil.apache.org mailing lists. Bugs can be reported via the [Daffodil JIRA](https://issues.apache.org/jira/projects/DAFFODIL).
 
 ## License
 

--- a/daffodil-cli/README.md
+++ b/daffodil-cli/README.md
@@ -57,7 +57,7 @@ See the [Interactive Debugger](https://daffodil.apache.org/debugger/) page for i
 
 ## Getting Help
 
-For questions, we can be reached at the dev@daffodil.apache.org or user@daffodil.apache.org mailing lists or in #Daffodil on [ASF HipChat](https://www.hipchat.com/gJt9EQs5l). Bugs can be reported via the [Daffodil JIRA](https://issues.apache.org/jira/projects/DAFFODIL).
+For questions, we can be reached at the dev@daffodil.apache.org or users@daffodil.apache.org mailing lists. Bugs can be reported via the [Daffodil JIRA](https://issues.apache.org/jira/projects/DAFFODIL).
 
 ## License
 


### PR DESCRIPTION
- Correct the users@daffodil.a.o mailing list
- Remove HipChat, this is defunct and no longer used

DAFFODIL-2073