### PR TITLE
Fix poor diagnostic.

### DIFF
--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -98,7 +98,7 @@ public class TestJavaAPI {
              * For more information, see https://github.com/sbt/sbt/issues/163
              */
             @Override
-            protected Class resolveClass(java.io.ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+            protected Class<?> resolveClass(java.io.ObjectStreamClass desc) throws IOException, ClassNotFoundException {
                 try {
                     return Class.forName(desc.getName(), false, getClass().getClassLoader());
                 } catch (ClassNotFoundException e) {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/Cookers.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/Cookers.scala
@@ -55,13 +55,13 @@ object ExtraEscapedCharactersCooker extends ListOfSingleCharacterLiteralNoCharCl
 
 object FillByteCooker extends SingleCharacterLiteralNoCharClassEntitiesWithByteEntities()
 
-object InitiatorCooker extends DelimiterCooker()
+object InitiatorCooker extends DelimiterCooker("initiator")
 
-object TerminatorCooker extends DelimiterCooker()
+object TerminatorCooker extends DelimiterCooker("terminator")
 
 object TerminatorCookerNoES extends DelimiterCookerNoES("terminator")
 
-object SeparatorCooker extends DelimiterCookerNoES(null)
+object SeparatorCooker extends DelimiterCookerNoES("separator")
 
 object TextStandardDecimalSeparatorCooker extends ListOfSingleCharacterLiteralNoCharClassEntitiesNoByteEntities()
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
@@ -40,15 +40,13 @@ object SchemaUtils {
    * Constructs a DFDL schema more conveniently than having to specify all those xmlns attributes.
    */
 
-  def dfdlTestSchemaUnqualified(
-    includeImports: Seq[Node],
+  def dfdlTestSchemaUnqualified(includeImports: Seq[Node],
     topLevelAnnotations: Seq[Node],
     contentElements: Seq[Node],
     fileName: String = ""): Elem =
     dfdlTestSchema(includeImports, topLevelAnnotations, contentElements, fileName = fileName, elementFormDefault = "unqualified")
 
-  def dfdlTestSchemaWithTarget(
-    includeImports: Seq[Node],
+  def dfdlTestSchemaWithTarget(includeImports: Seq[Node],
     topLevelAnnotations: Seq[Node],
     contentElements: Seq[Node],
     theTargetNS: String,
@@ -70,8 +68,7 @@ object SchemaUtils {
    * as those were aggravating a xerces bug that we might as well avoid.
    * This also makes these much more readable.
    */
-  def dfdlTestSchema(
-    includeImports: Seq[Node],
+  def dfdlTestSchema(includeImports: Seq[Node],
     topLevelAnnotations: Seq[Node],
     contentElements: Seq[Node],
     schemaScope: NamespaceBinding = TopScope, // from the defineSchema node
@@ -97,7 +94,7 @@ object SchemaUtils {
     scope = XMLUtils.combineScopes("ex", targetNamespace, scope)
 
     val schemaNode =
-      <xs:schema elementFormDefault={ elementFormDefault } attributeFormDefault="unqualified">
+      <xs:schema elementFormDefault={ elementFormDefault }>
         {
           includeImports
         }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
@@ -397,7 +397,7 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>cannot start or end</tdml:error>
-      <tdml:error>use '%SP;' instead</tdml:error>
+      <tdml:error>'%SP;'</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -412,7 +412,7 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>cannot start or end</tdml:error>
-      <tdml:error>use '%SP;' instead</tdml:error>
+      <tdml:error>'%SP;'</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1678,7 +1678,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>property 'initiator'</tdml:error>
-      <tdml:error>cannot start or end with the string " "</tdml:error>
+      <tdml:error>cannot start or end with the string</tdml:error>
+      <tdml:error>U+0020</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1723,7 +1724,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>property 'initiator'</tdml:error>
-      <tdml:error>cannot start or end with the string " "</tdml:error>
+      <tdml:error>cannot start or end with the string</tdml:error>
+      <tdml:error>U+0020</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/runtime_properties/dynamicSeparator.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/runtime_properties/dynamicSeparator.tdml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tdml:testSuite 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
+  xmlns:tns="http://example.com" 
+  xmlns:ex="http://example.com"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  defaultRoundTrip="onePass">
+
+  <tdml:defineSchema name="s" elementFormDefault="unqualified">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" 
+      representation="text"
+      lengthKind="delimited" 
+      encoding="ASCII"  />
+
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="sep" type="xs:string" dfdl:lengthKind="explicit"
+          dfdl:length="1" dfdl:lengthUnits="characters" />
+        <xs:sequence dfdl:separator='{./sep}'>
+          <xs:element name="a" type="xs:string" />
+          <xs:element name="b" type="xs:string" />
+        </xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  </tdml:defineSchema>
+  
+  <tdml:parserTestCase name="dynSepAllWhitespace" root="r" model="s"
+    description="Shows that when separator is all whitespace characters, that we get a good diagnostic">
+    <tdml:document>
+      <tdml:documentPart type="byte">0a</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error><!-- at runtime -->
+      <tdml:error>The property 'separator'</tdml:error>
+      <tdml:error>U+000a</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section23.runtime_properties
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestDynamicSeparator {
+
+  val testDir = "org/apache/daffodil/section23/runtime_properties/"
+  val runner = Runner(testDir, "dynamicSeparator.tdml")
+
+  @AfterClass def shutdown = {
+    runner.reset
+  }
+}
+
+class TestDynamicSeparator {
+  import TestDynamicSeparator._
+
+  // DAFFODIL-2092
+  @Test def test_dynSepAllWhitespace() { runner.runOneTest("dynSepAllWhitespace") }
+}


### PR DESCRIPTION
DAFFODIL-2092

This bug was found in a new-user training class in an example using dynamic separators that are the first character of a line.

If you just so happen to have a blank line (just a LF), then that LF gets lifted as the first character of the line, and made into the separator. But LF is whitespace, and separator is defined to be a list of DFDL string literals, separated by whitespace, so cannot contain whitespace characters.

The diagnostic was ineffective enough to make figuring that this is what was happening quite hard. 

Also fixes DAFFODIL-2084 (attributeFormDefault spurious warning issue)