### PR TITLE
Fix non-thread safe code related to text date times

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvCalendarLanguage.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvCalendarLanguage.scala
@@ -79,6 +79,12 @@ class CalendarEv(localeEv: CalendarLanguageEv,
       if (calendarTz.isDefined) calendarTz.get else TimeZone.UNKNOWN_ZONE
     }
     cal.setTimeZone(tz)
+
+    // The Calendar is initialized with time values based on the current system
+    // which aren't always overwritten during a parse. We don't want that, so
+    // clear out those values.
+    cal.clear()
+
     cal
   }
 }


### PR DESCRIPTION
We create an ICU Calendar object to handle parsing/unparsing text date
times. Unfortunately, this Calendar object isn't thread safe, but we
share it among all threads when all the DFDL calendar properties are
constant. This can lead to random errors.

To make it thread safe, change the text calendar code to never modify
the original Calendar object, but instead create a clone of it before
use and use the clone for all dateTime calculations. The effectively
treats the original calendar as immutable and avoids thread safety
issues. Also reorganize the code a bit and rename some variables to make
the purpose of the different Calendar objects more clear.

DAFFODIL-2097