### PR TITLE
Use Int instead of Integer in HexBinaryConversions

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/HexBinaryConversions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/HexBinaryConversions.scala
@@ -26,7 +26,7 @@ object HexBinaryConversions {
     val lower = (s & 0x00FF).toByte
     Array[Byte](upper, lower)
   }
-  def toByteArray(i: Integer): Array[Byte] = {
+  def toByteArray(i: Int): Array[Byte] = {
     val byte0 = ((i >> 24) & 0x000000FF).toByte
     val byte1 = ((i >> 16) & 0x000000FF).toByte
     val byte2 = ((i >> 8) & 0x000000FF).toByte

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -6691,6 +6691,7 @@
     <xs:element name="dfdlHexBinary02" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary('208') }"/>
     <xs:element name="dfdlHexBinary03" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(-2084) }"/>
     <xs:element name="dfdlHexBinary04" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(200000000000000000000) }"/>
+    <xs:element name="dfdlHexBinary05" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(xs:integer(32768)) }"/>
     
     <xs:element name="dfdlByte01" type="xs:byte" dfdl:inputValueCalc="{ dfdl:byte(127) }"/> <!-- valid -->
     <xs:element name="dfdlByte02" type="xs:byte" dfdl:inputValueCalc="{ dfdl:byte(208) }"/> <!-- invalid -->
@@ -11636,7 +11637,28 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
-  
+
+ <!--
+    Test name: dfdlHexBinary_constructor_05
+       Schema: constructorSchema
+         Root: dfdlHexBinary05
+      Purpose: This test demonstrates the use of the dfdl:hexBinary constructor function and its ability to
+               construct a hexBinary string from an xs:integer.
+  -->
+
+  <tdml:parserTestCase name="dfdlHexBinary_constructor_05" root="dfdlHexBinary05" model="constructorSchema"
+    description="Section 23 - Constructor Functions - xs:hexBinary()  - DFDL-23-077R">
+
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:dfdlHexBinary05>00008000</ex:dfdlHexBinary05>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   <!--
     Test name: dfdlByte_constructor_01
        Schema: constructorSchema

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -697,6 +697,7 @@ class TestDFDLExpressions {
   @Test def test_dfdlHexBinary_constructor_02() { runner2.runOneTest("dfdlHexBinary_constructor_02") }
   @Test def test_dfdlHexBinary_constructor_03() { runner2.runOneTest("dfdlHexBinary_constructor_03") }
   @Test def test_dfdlHexBinary_constructor_04() { runner2.runOneTest("dfdlHexBinary_constructor_04") }
+  @Test def test_dfdlHexBinary_constructor_05() { runner2.runOneTest("dfdlHexBinary_constructor_05") }
 
   @Test def test_dfdlByte_constructor_01() { runner2.runOneTest("dfdlByte_constructor_01") }
   @Test def test_dfdlByte_constructor_02() { runner2.runOneTest("dfdlByte_constructor_02") }


### PR DESCRIPTION
This was causing the dfdl:hexBinary constructor to use more bytes than
necessary, depending on the size of the integer being processed.

DAFFODIL-2075