### PR TITLE
Fix bug in handling parse errors

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessingError.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessingError.scala
@@ -47,13 +47,13 @@ abstract class ProcessingError protected (
    * looks like the same as other parse errors to tests that search for the
    * "Parse Error" string.
    */
-  def toParseError = new ParseError(schemaContext, dataContext, Maybe(this), maybeFormatString, args: _*)
+  def toParseError = new ParseError(schemaContext, dataContext, Maybe(this), Maybe.Nope)
 
   /**
    * Used to convert a processing error into a unparse error so that it
    * looks like the same as other unparse errors to tests that search for the
    * "Unparse Error" string.
    */
-  def toUnparseError = new UnparseError(schemaContext, dataContext, maybeCause, maybeFormatString, args: _*)
+  def toUnparseError = new UnparseError(schemaContext, dataContext, Maybe(this), Maybe.Nope)
 
 }


### PR DESCRIPTION
ProcessingError.toParseError would erroneasuly pass itself as the cause
to the ParseError instead of passings it's maybeCause

This is particuarly problematic because it would pass its maybeFormatString,
however only one of the maybeFormatString and maybeCause may be defined,
so if maybeFormatString is defined, then something will be passed for
both and no useful error message will be created.

DAFFODIL-2100