### PR TITLE
Provide more detail for failed assertions

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/AssertPatternParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/AssertPatternParsers.scala
@@ -24,6 +24,7 @@ import org.apache.daffodil.dsom.SchemaDefinitionDiagnosticBase
 import org.apache.daffodil.processors._
 import org.apache.daffodil.util.LogLevel
 import org.apache.daffodil.util.OnStack
+import org.apache.daffodil.util.Maybe
 
 trait AssertMessageEvaluationMixin {
   def messageExpr: CompiledExpression[AnyRef]
@@ -75,7 +76,9 @@ class AssertPatternParser(
       val isMatch = dis.lookingAt(m, start)
       if (!isMatch) {
         val message = getAssertFailureMessage(start)
-        val diag = new AssertionFailed(context.schemaFileLocation, start, message)
+        val currentElem = start.infoset
+        val details = "\nParsed value was: " + currentElem.toString
+        val diag = new AssertionFailed(context.schemaFileLocation, start, message, Some(details))
         start.setFailed(diag)
       } else if (discrim) {
         // Only want to set the discriminator if there was a match.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -29,6 +29,7 @@ import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.Success
 import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.util.LogLevel
+import org.apache.daffodil.util.Maybe
 
 // import java.lang.{ Boolean => JBoolean }
 
@@ -143,9 +144,16 @@ class AssertExpressionEvaluationParser(
         start.setDiscriminator(discrim)
       } else {
         val message = getAssertFailureMessage(start)
-        val currentElem = start.infoset
-        val details = "\nParsed value was: " + currentElem.toString
-        val diag = new AssertionFailed(decl.schemaFileLocation, start, message, Some(details))
+
+        Assert.invariant(start.currentNode.isDefined)
+        val currentElem = start.currentNode.get
+        val details = if (currentElem.isSimple) {
+          "\nParsed value was: " + currentElem.toString
+        } else {
+          "<" + currentElem.name + ">...</" + currentElem.name + ">"
+        }
+
+        val diag = new AssertionFailed(decl.schemaFileLocation, start, message, Maybe.One(details))
         start.setFailed(diag)
       }
     }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -143,7 +143,9 @@ class AssertExpressionEvaluationParser(
         start.setDiscriminator(discrim)
       } else {
         val message = getAssertFailureMessage(start)
-        val diag = new AssertionFailed(decl.schemaFileLocation, start, message)
+        val currentElem = start.infoset
+        val details = "\nParsed value was: " + currentElem.toString
+        val diag = new AssertionFailed(decl.schemaFileLocation, start, message, Some(details))
         start.setFailed(diag)
       }
     }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
@@ -39,8 +39,7 @@ class TestAssertions {
   @Test def test_assertFail1() { runner.runOneTest("assertFail1") }
   @Test def test_assertFail2() { runner.runOneTest("assertFail2") }
 
-  // DAFFODIL-752
-  //@Test def test_assertFailShowsValue() { runner.runOneTest("assertFailShowsValue") }
+  @Test def test_assertFailShowsValue() { runner.runOneTest("assertFailShowsValue") }
   // DFDL-1043
   // @Test def test_assertFailShowsValue2() { runner.runOneTest("assertFailShowsValue2") }
   @Test def test_assertFailShowsDetails() { runner.runOneTest("assertFailShowsDetails") }


### PR DESCRIPTION
We used to have more detailed assertion failed messages that included
the value that was parsed, but it seems to have been lost over the
course of some redesigns to the error system. This commit adds the extra
detail back in.

DAFFODIL-752