### PR TITLE
Output empty elements with self closing tags

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -1337,6 +1337,8 @@ sealed class DIComplex(override val erd: ElementRuntimeData, val tunable: Daffod
 
   override def children = childNodes.toStream
 
+  var hasVisibleChildren = false
+
   final def getChild(erd: ElementRuntimeData): InfosetElement = {
     getChild(erd.dpathElementCompileInfo)
   }
@@ -1381,6 +1383,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData, val tunable: Daffod
   }
 
   override def addChild(e: InfosetElement): Unit = {
+    if (!e.isHidden && !hasVisibleChildren) hasVisibleChildren = true
     if (e.runtimeData.isArray) {
       val childERD = e.runtimeData
       if (childNodes.isEmpty || childNodes.last.erd != childERD) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetOutputter.scala
@@ -41,7 +41,7 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
     if (prefix == null || prefix == "") elem.erd.name else prefix + ":" + elem.erd.name
   }
 
-  private def outputStartTag(elem: DIElement, name: String): Unit = {
+  private def outputStartTag(elem: DIElement, name: String, isEmpty: Boolean=false): Unit = {
     writer.write("<")
 
     writer.write(name)
@@ -58,7 +58,11 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
       writer.write(" xsi:nil=\"true\"")
     }
 
-    writer.write(">")
+    if (isEmpty) {
+      writer.write("/>")
+    } else {
+      writer.write(">")
+    }
   }
 
   private def outputEndTag(elem: DIElement, name: String): Unit = {
@@ -97,19 +101,24 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
   override def startComplex(complex: DIComplex): Boolean = {
     val name = getTagName(complex)
     if (pretty) outputIndentation(writer)
-    outputStartTag(complex, name)
+    outputStartTag(complex, name, !complex.hasVisibleChildren)
     incrementIndentation()
     if (pretty) writer.write(System.lineSeparator())
     true
   }
 
   override def endComplex(complex: DIComplex): Boolean = {
-    val name = getTagName(complex)
-    decrementIndentation()
-    if (pretty) outputIndentation(writer)
-    outputEndTag(complex, name)
-    if (pretty) writer.write(System.lineSeparator())
-    true
+    if (!complex.hasVisibleChildren) {
+      // Empty complex elements should have an inline closing tag
+      true
+    } else {
+      val name = getTagName(complex)
+      decrementIndentation()
+      if (pretty) outputIndentation(writer)
+      outputEndTag(complex, name)
+      if (pretty) writer.write(System.lineSeparator())
+      true
+    }
   }
 
   override def startArray(array: DIArray): Boolean = {


### PR DESCRIPTION
Before empty comlex elements would have to be represented with
<elem></elem>, which could cause some problems with non-schema aware XML
parsers. Now empty complex elements will show up as <elem /> in the
infoset.

DAFFODIL-2064