### PR TITLE
Add midBitsToEnd layer transform

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RawCommonRuntimeValuedPropertiesMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RawCommonRuntimeValuedPropertiesMixin.scala
@@ -64,6 +64,8 @@ trait RawLayeringRuntimeValuedPropertiesMixin
   extends PropertyMixin {
   protected final lazy val optionLayerTransformRaw = findPropertyOption("layerTransform")
   protected final lazy val layerTransformRaw = requireProperty(optionLayerTransformRaw)
+  protected final lazy val optionLayerTransformArgsRaw = findPropertyOption("layerTransformArgs")
+  protected final lazy val layerTransformArgsRaw = requireProperty(optionLayerTransformArgsRaw)
   protected final lazy val optionLayerEncodingRaw = findPropertyOption("layerEncoding")
   protected final lazy val layerEncodingRaw = requireProperty(optionLayerEncodingRaw)
   protected final lazy val optionLayerLengthRaw = findPropertyOption("layerLength")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -658,7 +658,7 @@ trait LayeringRuntimeValuedPropertiesMixin
   }
   
   final lazy val maybeLayerTransformArgsEv = {
-    if(optionLayerTransformArgsRaw.isDefined){
+    if (optionLayerTransformArgsRaw.isDefined) {
       val qn = this.qNameForProperty("layerTransformArgs")
       val expr = ExpressionCompilers.String.compileProperty(qn, NodeInfo.NonEmptyString, layerTransformArgsRaw, decl)
       val ev = new LayerTransformArgsEv(expr, termRuntimeData)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -72,6 +72,7 @@ import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.schema.annotation.props.TextStandardExponentRepMixin
 import org.apache.daffodil.schema.annotation.props.PropertyMixin
 import org.apache.daffodil.schema.annotation.props.Found
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 /*
  * These are the DFDL properties which can have their values come
@@ -649,6 +650,18 @@ trait LayeringRuntimeValuedPropertiesMixin
   final lazy val maybeLayerTransformEv = {
     if (optionLayerTransformRaw.isDefined) {
       val ev = new LayerTransformEv(layerTransformExpr, termRuntimeData)
+      ev.compile()
+      One(ev)
+    } else {
+      Nope
+    }
+  }
+  
+  final lazy val maybeLayerTransformArgsEv = {
+    if(optionLayerTransformArgsRaw.isDefined){
+      val qn = this.qNameForProperty("layerTransformArgs")
+      val expr = ExpressionCompilers.String.compileProperty(qn, NodeInfo.NonEmptyString, layerTransformArgsRaw, decl)
+      val ev = new LayerTransformArgsEv(expr, termRuntimeData)
       ev.compile()
       One(ev)
     } else {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -238,7 +238,7 @@ abstract class SequenceGroupTermBase(
       maybeCheckBitOrderAndCharset)
   }
 
-  private val layeredSequenceAllowedProps = Set("ref", "layerTransform", "layerEncoding", "layerLengthKind", "layerLength", "layerLengthUnits", "layerBoundaryMark")
+  private val layeredSequenceAllowedProps = Set("ref", "layerTransform", "layerEncoding", "layerLengthKind", "layerLength", "layerLengthUnits", "layerBoundaryMark", "layerTransformArgs")
 
   final lazy val maybeLayerTransformerEv: Maybe[LayerTransformerEv] = {
     if (maybeLayerTransformEv.isEmpty) Maybe.Nope
@@ -251,6 +251,7 @@ abstract class SequenceGroupTermBase(
 
       val lt = new LayerTransformerEv(
         maybeLayerTransformEv.get,
+        maybeLayerTransformArgsEv,
         maybeLayerCharsetEv,
         Maybe.toMaybe(optionLayerLengthKind),
         maybeLayerLengthInBytesEv,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -238,7 +238,8 @@ abstract class SequenceGroupTermBase(
       maybeCheckBitOrderAndCharset)
   }
 
-  private val layeredSequenceAllowedProps = Set("ref", "layerTransform", "layerEncoding", "layerLengthKind", "layerLength", "layerLengthUnits", "layerBoundaryMark", "layerTransformArgs")
+  private val layeredSequenceAllowedProps = Set("ref", "layerTransform", "layerEncoding", "layerLengthKind", "layerLength",
+    "layerLengthUnits", "layerBoundaryMark", "layerTransformArgs", "bitOrder", "byteOrder")
 
   final lazy val maybeLayerTransformerEv: Maybe[LayerTransformerEv] = {
     if (maybeLayerTransformEv.isEmpty) Maybe.Nope

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
@@ -794,6 +794,17 @@
            </xsd:documentation>
          </xsd:annotation>
        </xsd:enumeration>
+       <xsd:enumeration value="midBitsToEnd">
+         <xsd:annotation>
+           <xsd:documentation><![CDATA[
+             Move the bits with indecis [x, x+y] to
+             the end of the layer block.
+
+             x,y are provided as a space delimated list in layerTransformArgs
+             ]]>
+           </xsd:documentation>
+         </xsd:annotation>
+       </xsd:enumeration>
     </xsd:restriction>
   </xsd:simpleType>
   

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
@@ -797,7 +797,7 @@
        <xsd:enumeration value="midBitsToEnd">
          <xsd:annotation>
            <xsd:documentation><![CDATA[
-             Move the bits with indecis [x, x+y] to
+             Move the bits with indices [x, x+y] to
              the end of the layer block.
 
              x,y are provided as a space delimated list in layerTransformArgs

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -382,6 +382,8 @@
   
   <xsd:attribute name="layerTransform"
     type="dfdl:LayerTransformType_Or_DFDLExpression" />
+  <xsd:attribute name="layerTransformArgs"
+    type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
   <xsd:attribute name="layerEncoding"
     type="dfdl:EncodingEnum_Or_DFDLExpression" />
   <xsd:attribute name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />
@@ -394,6 +396,8 @@
   <xsd:attributeGroup name="LayeringAG">
     <xsd:attribute name="layerTransform"
       type="dfdl:LayerTransformType_Or_DFDLExpression" />
+    <xsd:attribute name="layerTransformArgs"
+      type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
     <xsd:attribute name="layerEncoding"
       type="dfdl:EncodingEnum_Or_DFDLExpression" />
     <xsd:attribute name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />
@@ -590,6 +594,7 @@
       <xsd:enumeration value="hiddenGroupRef" />
       
       <xsd:enumeration value="layerTransform"/>
+      <xsd:enumeration value="layerTransformArgs"/>
       <xsd:enumeration value="layerEncoding" />
       <xsd:enumeration value="layerLengthKind" />
       <xsd:enumeration value="layerLength" />
@@ -1021,6 +1026,8 @@
   <xsd:attributeGroup name="LayeringAGQualified">
     <xsd:attribute form="qualified" name="layerTransform"
       type="dfdl:LayerTransformType_Or_DFDLExpression" />
+    <xsd:attribute name="layerTransformArgs"
+      type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
     <xsd:attribute form="qualified" name="layerEncoding"
       type="dfdl:EncodingEnum_Or_DFDLExpression" />
     <xsd:attribute form="qualified" name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
@@ -45,6 +45,7 @@ import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 object AISPayloadArmoringTransformer {
   val iso8859 = StandardCharsets.ISO_8859_1
@@ -58,7 +59,7 @@ class AISPayloadArmoringTransformer()
    * Decoding AIS payload armoring is encoding the ASCII text into the
    * underlying binary data.
    */
-  override def wrapLayerDecoder(jis: java.io.InputStream) = {
+  override def wrapLayerDecoder(jis: java.io.InputStream, state: PState) = {
     new AISPayloadArmoringInputStream(jis)
   }
 
@@ -68,7 +69,7 @@ class AISPayloadArmoringTransformer()
     s
   }
 
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
     new AISPayloadArmoringOutputStream(jos)
   }
 
@@ -166,6 +167,7 @@ object AISPayloadArmoringTransformerFactory
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
     trd: TermRuntimeData): LayerTransformer = {
 
     val xformer = new AISPayloadArmoringTransformer()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
@@ -46,6 +46,7 @@ import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 object AISPayloadArmoringTransformer {
   val iso8859 = StandardCharsets.ISO_8859_1
@@ -168,6 +169,7 @@ object AISPayloadArmoringTransformerFactory
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer = {
 
     val xformer = new AISPayloadArmoringTransformer()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv: LayerBoundaryMarkEv)
   extends LayerTransformer() {
@@ -79,6 +80,7 @@ object Base64MIMETransformerFactory
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(scala.util.Properties.isJavaAtLeast("1.8"),

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
@@ -32,11 +32,12 @@ import org.apache.daffodil.processors.charset.BitsCharset
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv: LayerBoundaryMarkEv)
   extends LayerTransformer() {
 
-  override def wrapLayerDecoder(jis: java.io.InputStream): java.io.InputStream = {
+  override def wrapLayerDecoder(jis: java.io.InputStream, state: PState): java.io.InputStream = {
     val b64 = java.util.Base64.getMimeDecoder().wrap(jis)
     b64
   }
@@ -52,7 +53,7 @@ class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv:
     s
   }
 
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
     val b64 = java.util.Base64.getMimeEncoder().wrap(jos)
     b64
   }
@@ -77,6 +78,7 @@ object Base64MIMETransformerFactory
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(scala.util.Properties.isJavaAtLeast("1.8"),

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
@@ -34,6 +34,7 @@ import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 /**
  * An input stream wrapper that re-orders bytes according to wordsize.
@@ -200,6 +201,7 @@ sealed abstract class ByteSwapTransformerFactory(wordsize: Int, name: String)
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 /**
  * An input stream wrapper that re-orders bytes according to wordsize.
@@ -161,7 +162,7 @@ class ByteSwapOutputStream(wordsize: Int, jos: OutputStream)
 class ByteSwapTransformer(wordsize: Int, layerLengthInBytesEv: LayerLengthInBytesEv)
   extends LayerTransformer() {
 
-  override def wrapLayerDecoder(jis: java.io.InputStream) = {
+  override def wrapLayerDecoder(jis: java.io.InputStream, state: PState) = {
     val s = new ByteSwapInputStream(wordsize, jis)
     s
   }
@@ -173,7 +174,7 @@ class ByteSwapTransformer(wordsize: Int, layerLengthInBytesEv: LayerLengthInByte
     s
   }
 
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
     val s = new ByteSwapOutputStream(wordsize, jos)
     s
   }
@@ -198,6 +199,7 @@ sealed abstract class ByteSwapTransformerFactory(wordsize: Int, name: String)
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -27,11 +27,12 @@ import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
   extends LayerTransformer() {
 
-  override def wrapLayerDecoder(jis: java.io.InputStream) = {
+  override def wrapLayerDecoder(jis: java.io.InputStream, sate: PState) = {
     val s = new java.util.zip.GZIPInputStream(jis)
     s
   }
@@ -42,7 +43,7 @@ class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
     s
   }
 
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
     val s = new java.util.zip.GZIPOutputStream(jos)
     s
   }
@@ -62,6 +63,7 @@ object GZIPTransformerFactory
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
     trd: TermRuntimeData): LayerTransformer = {
 
     val xformer = new GZIPTransformer(maybeLayerLengthInBytesEv.get)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -32,7 +32,7 @@ import org.apache.daffodil.processors.LayerTransformArgsEv
 class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
   extends LayerTransformer() {
 
-  override def wrapLayerDecoder(jis: java.io.InputStream, sate: PState) = {
+  override def wrapLayerDecoder(jis: java.io.InputStream, state: PState) = {
     val s = new java.util.zip.GZIPInputStream(jis)
     s
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -28,6 +28,7 @@ import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
   extends LayerTransformer() {
@@ -64,6 +65,7 @@ object GZIPTransformerFactory
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer = {
 
     val xformer = new GZIPTransformer(maybeLayerLengthInBytesEv.get)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
@@ -41,6 +41,7 @@ import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
 import passera.unsigned.ULong
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 /**
  * Factory for a layer transformer.
@@ -60,6 +61,7 @@ abstract class LayerTransformerFactory(nom: String)
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer
 }
 
@@ -104,7 +106,7 @@ object LayerTransformerFactory {
   register(ICalendarLineFoldedTransformerFactory)
   register(AISPayloadArmoringTransformerFactory)
   register(FourByteSwapTransformerFactory)
-  register(midBitsToEndTransformerFactory)
+  register(MidBitsToEndTransformerFactory)
 }
 
 /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
@@ -34,6 +34,7 @@ import java.io.InputStream
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.schema.annotation.props.Enum
 import org.apache.daffodil.io.RegexLimitingStream
+import org.apache.daffodil.processors.LayerTransformArgsEv
 
 /*
  * This and related classes implement so called "line folding" from
@@ -115,11 +116,11 @@ class LineFoldedTransformerDelimited(mode: LineFoldMode)
     newJOS
   }
 
-  override protected def wrapLayerDecoder(jis: java.io.InputStream): java.io.InputStream = {
+  override protected def wrapLayerDecoder(jis: java.io.InputStream, state: PState): java.io.InputStream = {
     val s = new LineFoldedInputStream(mode, jis)
     s
   }
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
     val s = new LineFoldedOutputStream(mode, jos)
     s
   }
@@ -142,11 +143,11 @@ class LineFoldedTransformerImplicit(mode: LineFoldMode)
     jos // no limiting - just write output until EOF.
   }
 
-  override protected def wrapLayerDecoder(jis: java.io.InputStream): java.io.InputStream = {
+  override protected def wrapLayerDecoder(jis: java.io.InputStream, state:PState): java.io.InputStream = {
     val s = new LineFoldedInputStream(mode, jis)
     s
   }
-  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream, state:UState): java.io.OutputStream = {
     val s = new LineFoldedOutputStream(mode, jos)
     s
   }
@@ -160,6 +161,7 @@ sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: Str
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
@@ -35,6 +35,7 @@ import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.schema.annotation.props.Enum
 import org.apache.daffodil.io.RegexLimitingStream
 import org.apache.daffodil.processors.LayerTransformArgsEv
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 /*
  * This and related classes implement so called "line folding" from
@@ -162,6 +163,7 @@ sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: Str
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
     maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    state: ParseOrUnparseState,
     trd: TermRuntimeData): LayerTransformer = {
 
     trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/midBitsToEndTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/midBitsToEndTransformer.scala
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.layers
+
+import org.apache.daffodil.processors.TermRuntimeData
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.processors.LayerCharsetEv
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
+import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
+import org.apache.daffodil.processors.LayerBoundaryMarkEv
+import org.apache.daffodil.processors.LayerTransformArgsEv
+import java.io.InputStream
+import java.io.OutputStream
+import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.processors.parsers.PState
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.processors.ParseOrUnparseState
+import org.apache.daffodil.processors.parsers.Parser
+
+import org.apache.daffodil.processors.ExplicitLengthEv
+import org.apache.daffodil.io.ExplicitLengthLimitingStream
+import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
+import org.apache.daffodil.util.MaybeULong
+import org.apache.daffodil.processors.Failure
+
+class midBitsToEndTransformer(
+  layerLengthInBytesEv: LayerLengthInBytesEv,
+  layerTransformArgsEv: LayerTransformArgsEv)
+  extends LayerTransformer {
+  /*
+   * For unparsing, it is more or less unavoidable that we cannot stream, as we need to reach
+   * the end of the input before we can provide the mid-bits that were moved.
+   * In practice, it is not expected that this transform will be used on "large" blocks,
+   * so it is not worth the effort to figure out how to implement some form of streaming.
+   */
+
+  var length: Int = -1
+  var firstBitIndex: Int = -1
+  var numBits: Int = -1
+
+  /*
+   * Note the extra padding bytes. One of these bytes is just to accomodate rounding from integer division.
+   * The other one is because, to simplify the code, a portion of the encoder may attempt to read up to 7 extra bits,
+   * then discard them. (This would happen when the last bit that gets moved is the first bit of a byte in the encoded form;
+   * the encoder will attempt to read enough bits to be able to fully replace the entire byte, then mask out the lower 7 bits)
+   */
+  def tmpByteCount = numBits / 8 + 2
+  def buffSize = length + tmpByteCount
+
+  def byteShift = numBits / 8
+  def bitShift = numBits % 8
+
+  def firstBitByteIndex = (firstBitIndex / 8)
+  def lastBitByteIndex = ((firstBitIndex + numBits) / 8)
+  def firstBitBitIndex = firstBitIndex % 8
+  def lastBitBitIndex = (firstBitIndex + numBits) % 8
+
+  private def buffToHex(buff: Array[Byte]): String = {
+    buff.map(b => String.format("%02x", Byte.box(b))).mkString(" ")
+  }
+
+  private def initialize(state: ParseOrUnparseState) {
+    length = layerLengthInBytesEv.evaluate(state).toInt
+    val argsString = layerTransformArgsEv.evaluate(state)
+      .trim()
+      .split("\\ +")
+    if (argsString.length != 2) {
+      state.SDE(s"""midBitsToEnd layer transform requires exactly 2 arguements, recieved ${argsString.length}: "${argsString.mkString(",")}" """)
+    }
+    try {
+      firstBitIndex = argsString(0).toInt
+      numBits = argsString(1).toInt
+    } catch {
+      case _: NumberFormatException => state.SDE(s"""midBitsToEnd layer transform requires Integer arguements, recieved: "${argsString.mkString(",")}"""")
+    }
+
+  }
+
+  /*
+   * Scala does not seem to support bitwise operations on bytes; and instead silently upcasts to Int.
+   * Spamming toByte is insufficient since negative numbers will get padded with 1 instead of 0
+   * For this reason, we do most of our internal logic in Int, and mask out the upper 24 bits
+   */
+
+  val bitMask: Int = 0x000000ff
+
+  private def doDecode(buff: Array[Byte]): Unit = {
+
+    /*First, move the middle bits to the end.
+     *
+     * Since the layer is byte aligned, we know we are writing them a byte aligned location
+     * We will end up moving a multiple of 8 bits. This is okay, since, after we shift,
+     * any extra bytes will be left passed the length byte, and so will be ignored
+     */
+    var dstByteIndex = length
+    var srcByteIndex = firstBitByteIndex
+    while (dstByteIndex < buffSize) {
+      val srcByte = buff(srcByteIndex) & bitMask
+      val srcByteNext = buff(srcByteIndex + 1) & bitMask
+
+      val byteUpper = (srcByte << firstBitBitIndex) & bitMask
+      val byteLower = (srcByteNext >>> (8 - firstBitBitIndex))
+      val byte = (byteLower | byteUpper).toByte
+      buff(dstByteIndex) = byte
+      dstByteIndex += 1
+      srcByteIndex += 1
+    }
+
+    /*
+     * When we do the shift, we will end up overiting all the bits in byte containing firstBitIndex.
+     * We want to preserve all bits from before firstBitIndex
+     */
+    val savedBits = {
+      val srcByte = buff(firstBitByteIndex) & bitMask
+      ((srcByte >>> (8 - firstBitBitIndex)) << (8 - firstBitBitIndex)).toByte
+    }
+
+    /*
+     * Next, perform the shift
+     */
+    dstByteIndex = firstBitByteIndex
+    while (dstByteIndex < length) {
+      val srcByte = buff(dstByteIndex + byteShift) & bitMask
+      val srcByteNext = buff(dstByteIndex + byteShift + 1) & bitMask
+
+      val byteUpper = srcByte << bitShift & bitMask
+      val byteLower = srcByteNext >>> (8 - bitShift)
+      val byte = (byteLower | byteUpper).toByte
+      buff(dstByteIndex) = byte
+      dstByteIndex += 1
+    }
+
+    /*
+     * Finally, restore the upper bits of the byte containing firstBitIndex
+     */
+    {
+      val srcByte = buff(firstBitByteIndex) & bitMask
+      val byteLower = ((srcByte << firstBitBitIndex) & bitMask) >>> firstBitBitIndex
+      val byteUpper = savedBits
+      val byte = (byteLower | byteUpper).toByte
+      buff(firstBitByteIndex) = byte
+    }
+
+  }
+
+  private def doEncode(buff: Array[Byte]): Unit = {
+
+    /*
+     * When we shift, we move all the bits in byte containing firstBitIndex.
+     */
+    val savedBits1 = {
+      val srcByte = buff(firstBitByteIndex) & bitMask
+      ((srcByte >>> (8 - firstBitBitIndex)) << (8 - firstBitBitIndex)).toByte
+    }
+
+    /*
+     * First, do the shift
+     */
+
+    var dstByteIndex = buffSize - 1
+    while (dstByteIndex >= firstBitByteIndex) {
+      val srcByte = buff(dstByteIndex - byteShift) & bitMask
+      val prevIndex = dstByteIndex - byteShift - 1
+      val srcBytePrev = if (prevIndex < 0) {
+        0
+      } else {
+        buff(dstByteIndex - byteShift - 1) & bitMask
+      }
+      val byteLower = srcByte >>> bitShift
+      val byteUpper = (srcBytePrev << (8 - bitShift)) & bitMask
+      val byte = (byteLower | byteUpper).toByte
+      buff(dstByteIndex) = byte
+      dstByteIndex -= 1
+    }
+
+    /*
+     * When we move the end bits to the middle, we override all other bits in the byte containing the last bit of interest.
+     * (We also override all the other bits in the byte containing the first one, but we need to deal with that anyway thanks to the shift)
+     */
+
+    val savedBits2 = {
+      val srcByte = buff(lastBitByteIndex) & bitMask
+      (((srcByte << lastBitBitIndex) & bitMask) >>> lastBitBitIndex).toByte
+    }
+
+    /*
+     * Next, we move the end bits to the middle
+     */
+    var numBitsRemaining = numBits
+    var srcByteIndex = length
+    dstByteIndex = firstBitByteIndex
+    while (dstByteIndex <= lastBitByteIndex) {
+      val srcByte = buff(srcByteIndex) & bitMask
+      val srcBytePrev = buff(srcByteIndex - 1) & bitMask
+
+      val byteUpper = srcBytePrev << (8 - firstBitBitIndex)
+      val byteLower = srcByte >>> firstBitBitIndex
+      val byte = (byteLower | byteUpper).toByte
+
+      buff(dstByteIndex) = byte
+
+      dstByteIndex += 1
+      srcByteIndex += 1
+    }
+
+    /*
+     * Restore the upper bits of the byte containing firstBitIndex
+     */
+    {
+      val srcByte = buff(firstBitByteIndex) & bitMask
+      val byteLower = ((srcByte << firstBitBitIndex) & bitMask) >>> firstBitBitIndex
+      val byteUpper = savedBits1
+      val byte = (byteLower | byteUpper).toByte
+      buff(firstBitByteIndex) = byte
+    }
+
+    /*
+     * Restore the lower bits of the byte containing firstBitIndex
+     */
+    {
+      val srcByte = buff(lastBitByteIndex) & bitMask
+      val byteLower = savedBits2
+      val byteUpper = (srcByte >> (8 - lastBitBitIndex)) << (8 - lastBitBitIndex)
+      val byte = (byteLower | byteUpper).toByte
+      buff(lastBitByteIndex) = byte
+    }
+  }
+
+  protected def wrapLayerDecoder(jis: InputStream, state: PState): InputStream = {
+    val buff: Array[Byte] = new Array(buffSize)
+    var bytesRemaining = length
+    var offset = 0
+    var break = false
+    while (bytesRemaining > 0 && !break) {
+      val bytesRead = jis.read(buff, offset, bytesRemaining)
+      if (bytesRead <= 0) {
+        break = true
+      } else {
+        offset += bytesRead
+        bytesRemaining -= bytesRead
+      }
+    }
+    if (bytesRemaining > 0) {
+      state.processor.asInstanceOf[Parser].PENotEnoughBits(state, length*8, MaybeULong((length - bytesRemaining)*8))
+    } else {
+      doDecode(buff)
+    }
+    /*
+     * Even in the error path, we  still return buff and just rely on the fact that we marked this as a failure
+     */
+    new ByteArrayInputStream(buff)
+  }
+  protected def wrapLayerEncoder(jos: OutputStream, state: UState): OutputStream = {
+
+    new ByteArrayOutputStream() {
+
+      var written = 0
+
+      private def maybeFinish(): Unit = {
+        if (written == length) {
+          while (written < buffSize) {
+            /*
+             * Add the expected padding bits so the encoder has some scratch space
+             * We use super.write, because we have exceeded the amount that "this" is allowed to hold
+             */
+            super.write(0)
+            written += 1
+          }
+          val buff = toByteArray()
+          doEncode(buff)
+          jos.write(buff, 0, length)
+        }
+      }
+
+      override def write(b: Int): Unit = {
+        //Only writes the lower 8 bits
+        written += 1
+        Assert.invariant(written <= length)
+        super.write(b)
+        maybeFinish()
+      }
+      override def write(b: Array[Byte]): Unit = {
+        written += b.length
+        Assert.invariant(written <= length)
+        super.write(b)
+        maybeFinish()
+
+      }
+      override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+        written += len
+        Assert.invariant(written <= length)
+        super.write(b, off, len)
+        maybeFinish()
+      }
+    }
+  }
+  protected def wrapLimitingStream(jos: OutputStream, state: UState): OutputStream = {
+    initialize(state)
+    jos
+  }
+  protected def wrapLimitingStream(jis: InputStream, state: PState): InputStream = {
+    initialize(state)
+    new ExplicitLengthLimitingStream(jis, length)
+  }
+
+}
+
+object midBitsToEndTransformerFactory
+  extends LayerTransformerFactory("midBitsToEnd") {
+
+  override def newInstance(
+    maybeLayerCharsetEv:       Maybe[LayerCharsetEv],
+    maybeLayerLengthKind:      Maybe[LayerLengthKind],
+    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthUnits:     Maybe[LayerLengthUnits],
+    maybeLayerBoundaryMarkEv:  Maybe[LayerBoundaryMarkEv],
+    maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
+    trd:                       TermRuntimeData): LayerTransformer = {
+
+    val xformer = new midBitsToEndTransformer(maybeLayerLengthInBytesEv.get, maybeLayerTransformArgsEv.get)
+    xformer
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
@@ -36,6 +36,12 @@ final class LayerTransformEv(override val expr: CompiledExpression[String], trd:
     trd)
   with NoCacheEvaluatable[String]
 
+final class LayerTransformArgsEv(override val expr: CompiledExpression[String], trd: TermRuntimeData)
+  extends EvaluatableExpression[String](expr, trd)
+  with NoCacheEvaluatable[String]{
+  
+}
+
 final class LayerEncodingEv(override val expr: CompiledExpression[String], trd: TermRuntimeData)
   extends EncodingEvBase(expr, trd)
 
@@ -68,6 +74,7 @@ final class LayerBoundaryMarkEv(override val expr: CompiledExpression[String], o
 
 final class LayerTransformerEv(
   layerTransformEv: LayerTransformEv,
+  maybeLayerTransformArgsEv: Maybe[LayerTransformArgsEv],
   maybeLayerCharsetEv: Maybe[LayerCharsetEv],
   maybeLayerLengthKind: Maybe[LayerLengthKind],
   maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
@@ -94,6 +101,7 @@ final class LayerTransformerEv(
       maybeLayerLengthInBytesEv,
       maybeLayerLengthUnits,
       maybeLayerBoundaryMarkEv,
+      maybeLayerTransformArgsEv,
       trd)
     xformer
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
@@ -102,6 +102,7 @@ final class LayerTransformerEv(
       maybeLayerLengthUnits,
       maybeLayerBoundaryMarkEv,
       maybeLayerTransformArgsEv,
+      state,
       trd)
     xformer
   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
@@ -30,16 +30,24 @@
     </dfdl:defineFormat>
     <dfdl:format ref="ex:general" />
 
-    <xs:element name="root">
+    <xs:element name="e1">
       <xs:complexType>
         <xs:sequence dfdl:ref="tns:bits8_9_toEnd">
           <xs:element name="transformedContent" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="3" />
         </xs:sequence>
       </xs:complexType>
     </xs:element>
+
+    <xs:element name="e2">
+      <xs:complexType>
+        <xs:sequence dfdl:ref="tns:bits8_9_toEnd" dfdl:bitOrder="leastSignificantBitFirst" dfdl:byteOrder="littleEndian">
+          <xs:element name="transformedContent" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="3" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="midBitsToEnd1" root="root" model="s1">
+  <tdml:parserTestCase name="midBitsToEndMSBF1" root="e1" model="s1">
     <tdml:document>
       <tdml:documentPart type="bits"><![CDATA[
       0000 0011
@@ -50,19 +58,42 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:root>
+        <ex:e1>
           <!--
           0000 0011 # 03
           0000 0000 # 00
           0100 0011 # 43
           -->
           <transformedContent>030043</transformedContent>
-        </ex:root>
+        </ex:e1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="midBitsToEnd_unsufficentBits_1" root="root" model="s1">
+  <tdml:parserTestCase name="midBitsToEndLSBF1" root="e2" model="s1">
+    <tdml:document>
+      <tdml:documentPart type="bits"><![CDATA[
+      1100 0000
+      0000 0011
+      0000 1000
+      ]]>
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e2>
+          <!--
+          1100 0000 # C0
+          0000 0000 # 00
+          1100 0010 # C2
+          -->
+          <transformedContent>C000C2</transformedContent>
+        </ex:e2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="midBitsToEnd_unsufficentBits_1" root="e1" model="s1">
     <tdml:document>
       <tdml:documentPart type="bits"><![CDATA[
       0000 0011

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:ex="http://example.com" xmlns:tns="http://example.com" defaultRoundTrip="true">
+
+  <tdml:defineSchema name="s1" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:defineFormat name="general">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </dfdl:defineFormat>
+    <dfdl:defineFormat name="bits8_9_toEnd">
+      <dfdl:format ref="ex:general" layerTransform="midBitsToEnd" layerTransformArgs="7 2" layerLengthKind="explicit" layerLength="3" layerLengthUnits="bytes" />
+    </dfdl:defineFormat>
+    <dfdl:format ref="ex:general" />
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence dfdl:ref="tns:bits8_9_toEnd">
+          <xs:element name="transformedContent" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="3" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="midBitsToEnd1" root="root" model="s1">
+    <tdml:document>
+      <tdml:documentPart type="bits"><![CDATA[
+      0000 0011
+      1100 0000
+      0001 0000
+      ]]>
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root>
+          <!--
+          0000 0011 # 03
+          0000 0000 # 00
+          0100 0011 # 43
+          -->
+          <transformedContent>030043</transformedContent>
+        </ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="midBitsToEnd_unsufficentBits_1" root="root" model="s1">
+    <tdml:document>
+      <tdml:documentPart type="bits"><![CDATA[
+      0000 0011
+      1100 0000
+      ]]>
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Insufficient bits</tdml:error>
+      <tdml:error>Needed 24 Bit(s) but found only 16 available</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  
+</tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/midBitsToEnd.tdml
@@ -26,7 +26,7 @@
       <dfdl:format ref="ex:GeneralFormat" />
     </dfdl:defineFormat>
     <dfdl:defineFormat name="bits8_9_toEnd">
-      <dfdl:format ref="ex:general" layerTransform="midBitsToEnd" layerTransformArgs="7 2" layerLengthKind="explicit" layerLength="3" layerLengthUnits="bytes" />
+      <dfdl:format ref="ex:general" layerTransform="midBitsToEnd" layerTransformArgs="8 2" layerLengthKind="explicit" layerLength="3" layerLengthUnits="bytes" />
     </dfdl:defineFormat>
     <dfdl:format ref="ex:general" />
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -45,7 +45,9 @@ class TestLayers {
   @Test def test_layersErr1() { runner.runOneTest("layersErr1") }
   @Test def test_layers4() { runner.runOneTest("layers4") }
 
-  @Test def test_moveMidBitsToEnd() { midBitsToEndRunner.runOneTest("midBitsToEnd1") }
+  @Test def test_midBitsToEndMSBF1() { midBitsToEndRunner.runOneTest("midBitsToEndMSBF1") }
+  @Test def test_midBitsToEndLSBF1() { midBitsToEndRunner.runOneTest("midBitsToEndLSBF1") }
+
   @Test def test_midBitsToEnd_unsufficentBits_1() { midBitsToEndRunner.runOneTest("midBitsToEnd_unsufficentBits_1") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -28,6 +28,7 @@ import org.junit.AfterClass
 object TestLayers {
   lazy val testDir = "/org/apache/daffodil/layers/"
   lazy val runner = Runner(testDir, "layers.tdml")
+  lazy val midBitsToEndRunner = Runner(testDir, "midBitsToEnd.tdml")
 
   @AfterClass def shutDown() {
     runner.reset
@@ -43,5 +44,8 @@ class TestLayers {
   @Test def test_layers3() { runner.runOneTest("layers3") }
   @Test def test_layersErr1() { runner.runOneTest("layersErr1") }
   @Test def test_layers4() { runner.runOneTest("layers4") }
+
+  @Test def test_moveMidBitsToEnd() { midBitsToEndRunner.runOneTest("midBitsToEnd1") }
+  @Test def test_midBitsToEnd_unsufficentBits_1() { midBitsToEndRunner.runOneTest("midBitsToEnd_unsufficentBits_1") }
 
 }

--- a/eclipse-projects/tdml-processor/.classpath
+++ b/eclipse-projects/tdml-processor/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="src/main/scala"/>
 	<classpathentry kind="src" path="src/test/scala"/>
 	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/test/scala-debug"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>


### PR DESCRIPTION
Add new layer transform that can move a single contiguous block
of bits from a layer's content area to the end of the layer's
content area.

DAFFODIL-2109