### PR TITLE
Ensure fragment bytes are delivered correctly when dfdl:outputValueCalc is followed by a different bitOrder

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
@@ -90,6 +90,26 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="ovcBitOrderChange">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="zero" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="8"
+            dfdl:bitOrder="mostSignificantBitFirst" dfdl:byteOrder="bigEndian"
+            dfdl:outputValueCalc="{ ../body/zero }" />
+          <xs:element name="body">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="a" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="4"/>
+                <xs:element name="b" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="4"
+                  dfdl:outputValueCalc="{ ../zero }"/>
+                <xs:element name="zero" type="xs:int" dfdl:inputValueCalc="{ 0 }"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:unparserTestCase name="rHexBinaryLSBF1" root="rHexBinary" model="s" roundTrip="onePass">
@@ -141,6 +161,27 @@
           <value>1</value>
           <next>3</next>
         </ex:rString>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="ovc_bitOrderChange" root="ovcBitOrderChange" model="s" roundTrip="onePass">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        00 02
+      </tdml:documentPart>
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ovcBitOrderChange>
+          <zero>0</zero>
+          <body>
+            <a>2</a>
+            <b>0</b>
+            <zero>0</zero>
+          </body>
+        </ex:ovcBitOrderChange>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -80,4 +80,6 @@ class TestOutputValueCalc {
   @Test def test_ovcHexBinaryLSBF1() { runner3.runOneTest("rHexBinaryLSBF1") }
   @Test def test_ovcHexBinaryLSBF2() { runner3.runOneTest("rHexBinaryLSBF2") }
   @Test def test_ovcStringLSBF1() { runner3.runOneTest("rStringLSBF1") }
+
+  @Test def test_ovcBitOrderChange() { runner3.runOneTest("ovc_bitOrderChange") }
 }


### PR DESCRIPTION
When an OVC element is followed by an element with a different bitOrder,
the OVC causes a suspension and the buffered data output stream will
have a different bitOrder. Eventually the suspension will be resolved
and we may need to deliver a fragment byte to the direct data output
stream. We previously did that with putLong, but that uses the
FormatInfo from the suspension with the incorrect bitOrder. And
unfortunately we do not have a FormatInfo associated with the buffered
data output stream with the correct bitOrder.

To resolve this issue, this patch only uses putLong + FormatInfo when we
know the bitOrders of the direct and buffered data output streams must
be the same, i.e. the direct data output stream *does not* end on a byte
boundary. In this case, the FormatInfo from the suspension has the right
information, and we can use putLong to handle the complexities for
combining fragment bytes.

On the other hand, if the direct data output stream *does* end on a byte
boundary, then the bitOrder could be different, so we can't use putLong
since the FormatInfo is wrong. But we don't need to--we can just copy
the fragment byte from buffer to direct since it already ended on a byte
boundary.

DAFFODIL-2125