### PR TITLE
Do not abort when an import/includes fails

### DIFF
--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/xcatalog_import_failure.dfdl.xsd
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/xcatalog_import_failure.dfdl.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:tns="http://example.com" 
+  targetNamespace="http://example.com">
+
+  <xs:import namespace="http://example.com/xcatalog" />
+
+</xs:schema>

--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/xcatalog_invalid.xml
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/xcatalog_invalid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://example.com/xcatalog" uri="file:/this/path/does/not/exist" />
+</catalog>

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
@@ -237,14 +237,13 @@ class DFDLCatalogResolver private ()
     optURI match {
       case None => null
       case Some(uri) => {
-        val resourceAsStream =
-          try {
-            uri.toURL.openStream() // This will work.
-          } catch {
-            case _: java.io.IOException => Assert.invariantFailed("found resource but couldn't open")
-          }
-        val input = new Input(publicId, uri.toString, new BufferedInputStream(resourceAsStream))
-        input
+        try {
+          val resourceAsStream = uri.toURL.openStream()
+          val input = new Input(publicId, uri.toString, new BufferedInputStream(resourceAsStream))
+          input
+        } catch {
+          case _: java.io.IOException => null
+        }
       }
     }
   }


### PR DESCRIPTION
When using XML Catalogs, it's very easy for import/includes to resolve
to URI's that do not exist. This results in an IOException when trying
to open the stream. There are also other cases related to IO that could
causing opening of the stream to fail. When these failures happen, we
currently abort. This is wrong, since these exception are expected to be
able to happen.

So instead of aborting with an assert when there's an exception, we
should instead just let any exceptions from opening the stream bubble
up. The XML Catalog Resolver handles exceptions correctly, and Daffodil
handles those failures and creates a helpful SDE about what stream it
tried to open and why it failed.

DAFFODIL-2126