### PR TITLE
Switch XML/JSON infoset inputters/outputters to use streams

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
@@ -60,10 +60,8 @@ class TestInfosetInputterFromReader2 {
     def strings =
       (("<bar xmlns='" + ex + "' >") #:: foos.take(size))
 
-    val rdr = new java.io.InputStreamReader(
-      new StreamInputStream(strings))
-
-    val inputter = new XMLTextInfosetInputter(rdr)
+    val is = new StreamInputStream(strings)
+    val inputter = new XMLTextInfosetInputter(is)
     inputter.initialize(rootERD, u.getTunables())
     val ic = Adapter(inputter)
     ic

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
@@ -217,32 +217,74 @@ class ScalaXMLInfosetOutputter(showFormatInfo: Boolean = false)
   def getResult(): scala.xml.Node = infosetOutputter.getResult()
 }
 
-/**
- * Output the infoset as XML Text, written to a java.io.Writer
- *
- * @param writer the java.io.Writer to write the XML text to
- * @param pretty enable or disable pretty printing. Pretty printing will only
- *               inserts indentation and newlines where it will not affect the
- *               content of the XML.
- */
-class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+class XMLTextInfosetOutputter private (outputter: SXMLTextInfosetOutputter)
   extends InfosetOutputterProxy {
-  
-  override val infosetOutputter = new SXMLTextInfosetOutputter(writer, pretty)
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the XML text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the XML.
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean) = this(new SXMLTextInfosetOutputter(writer, pretty))
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the XML text to
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer) = this(writer, true)
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.OutputStream
+   *
+   * @param os the java.io.OutputStream to write the XML text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the XML.
+   */
+  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SXMLTextInfosetOutputter(os, pretty))
+
+  override val infosetOutputter = outputter
 }
 
-/**
- * Output the infoset as json text, written to a java.io.Writer
- *
- * @param writer the java.io.Writer to write the json text to
- * @param pretty enable or disable pretty printing. Pretty printing will only
- *               inserts indentation and newlines where it will not affect the
- *               content of the json.
- */
-class JsonInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+class JsonInfosetOutputter private (outputter: SJsonInfosetOutputter)
   extends InfosetOutputterProxy {
 
-  override val infosetOutputter = new SJsonInfosetOutputter(writer, pretty)  
+  /**
+   * Output the infoset as json text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the json text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the json.
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean) = this(new SJsonInfosetOutputter(writer, pretty))
+
+  /**
+   * Output the infoset as json text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the json text to
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer) = this(writer, true)
+
+  /**
+   * Output the infoset as json text, written to a java.io.OutputStream
+   *
+   * @param os the java.io.OutputStream to write the json text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the json.
+   */
+  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SJsonInfosetOutputter(os, pretty))
+
+  override val infosetOutputter = outputter
 }
 
 /**
@@ -288,26 +330,46 @@ class ScalaXMLInfosetInputter(node: scala.xml.Node)
   override val infosetInputter = new SScalaXMLInfosetInputter(node)
 }
 
-/**
- * Read in an infoset in the form of XML text from a java.io.Reader
- *
- * @param reader the java.io.Reader to read the XML text from
- */
-class XMLTextInfosetInputter(reader: java.io.Reader)
+class XMLTextInfosetInputter private (inputter: SXMLTextInfosetInputter)
   extends InfosetInputterProxy {
-  
-  override val infosetInputter = new SXMLTextInfosetInputter(reader)
+
+  /**
+   * Read in an infoset in the form of XML text from a java.io.Reader
+   *
+   * @param reader the java.io.Reader to read the XML text from
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = this(new SXMLTextInfosetInputter(reader))
+
+  /**
+   * Read in an infoset in the form of XML text from a java.io.InputStream
+   *
+   * @param is the java.io.InputStream to read the XML text from
+   */
+  def this(is: java.io.InputStream) = this(new SXMLTextInfosetInputter(is))
+
+  override val infosetInputter = inputter
 }
 
-/**
- * Read in an infoset in the form of json text from a java.io.Reader
- *
- * @param reader the java.io.Reader to read the json text from
- */
-class JsonInfosetInputter(reader: java.io.Reader)
+class JsonInfosetInputter private (inputter: SJsonInfosetInputter)
   extends InfosetInputterProxy {
 
-  override val infosetInputter = new SJsonInfosetInputter(reader)
+  /**
+   * Read in an infoset in the form of json text from a java.io.Reader
+   *
+   * @param reader the java.io.Reader to read the json text from
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = this(new SJsonInfosetInputter(reader))
+
+  /**
+   * Read in an infoset in the form of json text from a java.io.InputStream
+   *
+   * @param is the java.io.InputStream to read the json text from
+   */
+  def this(is: java.io.InputStream) = this(new SJsonInfosetInputter(is))
+
+  override val infosetInputter = inputter
 }
 
 /**

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Validator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Validator.scala
@@ -41,7 +41,7 @@ object Validator extends NoBindingFactoryAdapter {
         new CacheType
     }
 
-  def validateXMLSources(schemaFileNames: Seq[String], document: String, errHandler: ErrorHandler): Unit = {
+  def validateXMLSources(schemaFileNames: Seq[String], document: java.io.InputStream, errHandler: ErrorHandler): Unit = {
     val cache = validationSchemaCache.get()
     val validator = {
       val optCachedValidator = cache.get(schemaFileNames)
@@ -83,7 +83,7 @@ object Validator extends NoBindingFactoryAdapter {
         }
       }
     }
-    val documentSource = new StreamSource(new StringReader(document))
+    val documentSource = new StreamSource(document)
     validator.validate(documentSource)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -449,10 +449,11 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   private def debugPrettyPrintXML(ie: InfosetElement) {
-    val sw = new java.io.StringWriter()
-    val xml = new XMLTextInfosetOutputter(sw)
+    val bos = new java.io.ByteArrayOutputStream()
+    val xml = new XMLTextInfosetOutputter(bos, true)
     ie.visit(xml, DebuggerConfig.removeHidden)
-    debugPrintln(sw.toString)
+    xml.endDocument() // causes the outputter to flush to the stream
+    debugPrintln(bos.toString("UTF-8"))
   }
 
   /**********************************/
@@ -1515,11 +1516,11 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
 
           val infoset = getInfoset(state.infoset)
           if (infoset.getRootElement != null) {
-            val sw = new java.io.StringWriter()
-            val xml = new XMLTextInfosetOutputter(sw)
+            val bos = new java.io.ByteArrayOutputStream()
+            val xml = new XMLTextInfosetOutputter(bos, true)
             infoset.visit(xml, DebuggerConfig.removeHidden)
-
-            val infosetString = sw.toString()
+            xml.endDocument() // causes the outputter to flush to the stream
+            val infosetString = bos.toString("UTF-8")
             val lines = infosetString.split("\n")
             val tailLines =
               if (DebuggerConfig.infosetLines > 0) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DAFFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DAFFunctions.scala
@@ -28,10 +28,11 @@ case class DAFTrace(recipe: CompiledDPath, msg: String)
   extends RecipeOpWithSubRecipes(recipe) {
 
   private def asXMLString(ie: InfosetCommon) = {
-    val sw = new java.io.StringWriter()
-    val xml = new XMLTextInfosetOutputter(sw)
+    val bos = new java.io.ByteArrayOutputStream()
+    val xml = new XMLTextInfosetOutputter(bos, true)
     ie.visit(xml, false)
-    sw.toString()
+    xml.endDocument() // causes the outputter to flush to the stream
+    bos.toString("UTF-8")
   }
 
   override def run(dstate: DState): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
@@ -31,11 +31,19 @@ object JsonInfosetInputter {
   lazy val jsonFactory = new JsonFactory()
 }
 
-class JsonInfosetInputter(reader: java.io.Reader)
+class JsonInfosetInputter private (input: Either[java.io.Reader, java.io.InputStream])
   extends InfosetInputter {
 
+  @deprecated("This constructor is deprecated. Use JsonInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = { this(Left(reader)) }
+
+  def this(is: java.io.InputStream) = { this(Right(is)) }
+
   private lazy val jsp = {
-    val j = JsonInfosetInputter.jsonFactory.createParser(reader)
+    val j = input match {
+      case Left(reader) => JsonInfosetInputter.jsonFactory.createParser(reader)
+      case Right(is) => JsonInfosetInputter.jsonFactory.createParser(is)
+    }
     val tok = getNextToken(j)
     if (tok != JsonToken.START_OBJECT) {
       throw new IllegalContentWhereEventExpected("Expected json content beginning with '{' but got '" + j.getText + "'")

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetOutputter.scala
@@ -17,13 +17,25 @@
 
 package org.apache.daffodil.infoset
 
-import org.apache.daffodil.util.MStackOfBoolean
-import org.apache.daffodil.util.Indentable
-import com.fasterxml.jackson.core.util.BufferRecyclers
-import org.apache.daffodil.dpath.NodeInfo
+import java.nio.charset.Charset
 
-class JsonInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+import com.fasterxml.jackson.core.util.BufferRecyclers
+
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.util.Indentable
+import org.apache.daffodil.util.MStackOfBoolean
+
+class JsonInfosetOutputter private (writer: java.io.Writer, pretty: Boolean, dummy: Int)
   extends InfosetOutputter with Indentable {
+
+  @deprecated("This constructor is deprecated. Use JsonInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean = true) = {
+    this(writer, pretty, 0)
+  }
+
+  def this(os: java.io.OutputStream, pretty: Boolean) = {
+    this(new java.io.OutputStreamWriter(os, Charset.forName("UTF-8")), pretty, 0)
+  }
 
   // Keeps track of if the next element we see is the first child or not of a
   // document/array/complex type. The top of the stack is true if the an

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
@@ -48,8 +48,13 @@ object XMLTextInfosetInputter {
   }
 }
 
-class XMLTextInfosetInputter(reader: java.io.Reader)
+class XMLTextInfosetInputter private (input: Either[java.io.Reader, java.io.InputStream])
   extends InfosetInputter {
+
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = { this(Left(reader)) }
+
+  def this(is: java.io.InputStream) = { this(Right(is)) }
 
   /**
    * evAlloc is only to be used for diagnostic messages. It lets us easily
@@ -57,7 +62,11 @@ class XMLTextInfosetInputter(reader: java.io.Reader)
    * as it allocates an object, and we're trying to avoid that.
    */
   private lazy val (xsr: XMLStreamReader, evAlloc: XMLEventAllocator) = {
-    val xsr = XMLTextInfosetInputter.xmlInputFactory.createXMLStreamReader(reader)
+    val xsr = input match {
+      case Left(reader) => XMLTextInfosetInputter.xmlInputFactory.createXMLStreamReader(reader)
+      case Right(is) => XMLTextInfosetInputter.xmlInputFactory.createXMLStreamReader(is)
+    }
+
     //
     // This gets the event allocator corresponding to the xmlStreamReader just created.
     // Strange API. They should let you get this from the xmlStreamReader itself.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetOutputter.scala
@@ -17,6 +17,8 @@
 
 package org.apache.daffodil.infoset
 
+import java.nio.charset.Charset
+
 import org.apache.daffodil.util.Indentable
 import org.apache.daffodil.dpath.NodeInfo
 
@@ -27,8 +29,17 @@ import org.apache.daffodil.dpath.NodeInfo
  * @param pretty Whether or to enable pretty printing. Set to true, XML
  *               elements are indented and newlines are inserted.
  */
-class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+class XMLTextInfosetOutputter private (writer: java.io.Writer, pretty: Boolean, dummy: Int)
   extends InfosetOutputter with Indentable with XMLInfosetOutputter {
+
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean = true) = {
+    this(writer, pretty, 0)
+  }
+
+  def this(os: java.io.OutputStream, pretty: Boolean) = {
+    this(new java.io.OutputStreamWriter(os, Charset.forName("UTF-8")), pretty, 0)
+  }
 
   private val sb = new StringBuilder()
 
@@ -59,7 +70,7 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
     }
 
     if (isEmpty) {
-      writer.write("/>")
+      writer.write(" />")
     } else {
       writer.write(">")
     }
@@ -102,18 +113,18 @@ class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
     val name = getTagName(complex)
     if (pretty) outputIndentation(writer)
     outputStartTag(complex, name, !complex.hasVisibleChildren)
-    incrementIndentation()
     if (pretty) writer.write(System.lineSeparator())
+    incrementIndentation()
     true
   }
 
   override def endComplex(complex: DIComplex): Boolean = {
+    decrementIndentation()
     if (!complex.hasVisibleChildren) {
       // Empty complex elements should have an inline closing tag
       true
     } else {
       val name = getTagName(complex)
-      decrementIndentation()
       if (pretty) outputIndentation(writer)
       outputEndTag(complex, name)
       if (pretty) writer.write(System.lineSeparator())

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Runtime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Runtime.scala
@@ -418,10 +418,11 @@ class ParseResult(dp: DataProcessor, override val resultState: PState)
     if (dp.getValidationMode == ValidationMode.Full) {
       val schemaURIStrings = resultState.infoset.asInstanceOf[InfosetElement].runtimeData.schemaURIStringsForFullValidation
       try {
-        val sw = new java.io.StringWriter()
-        val xml = new XMLTextInfosetOutputter(sw)
+        val bos = new java.io.ByteArrayOutputStream()
+        val xml = new XMLTextInfosetOutputter(bos, false)
         resultState.infoset.visit(xml)
-        Validator.validateXMLSources(schemaURIStrings, sw.toString, this)
+        val bis = new java.io.ByteArrayInputStream(bos.toByteArray)
+        Validator.validateXMLSources(schemaURIStrings, bis, this)
       } catch {
         //
         // Some SAX Parse errors are thrown even if you specify an error handler to the

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
@@ -217,32 +217,74 @@ class ScalaXMLInfosetOutputter(showFormatInfo: Boolean = false)
   def getResult(): scala.xml.Node = infosetOutputter.getResult()
 }
 
-/**
- * Output the infoset as XML Text, written to a java.io.Writer
- *
- * @param writer the java.io.Writer to write the XML text to
- * @param pretty enable or disable pretty printing. Pretty printing will only
- *               inserts indentation and newlines where it will not affect the
- *               content of the XML.
- */
-class XMLTextInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+class XMLTextInfosetOutputter private (outputter: SXMLTextInfosetOutputter)
   extends InfosetOutputterProxy {
-  
-  override val infosetOutputter = new SXMLTextInfosetOutputter(writer, pretty)
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the XML text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the XML.
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean) = this(new SXMLTextInfosetOutputter(writer, pretty))
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the XML text to
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer) = this(writer, true)
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.OutputStream
+   *
+   * @param os the java.io.OutputStream to write the XML text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the XML.
+   */
+  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SXMLTextInfosetOutputter(os, pretty))
+
+  override val infosetOutputter = outputter
 }
 
-/**
- * Output the infoset as json text, written to a java.io.Writer
- *
- * @param writer the java.io.Writer to write the json text to
- * @param pretty enable or disable pretty printing. Pretty printing will only
- *               inserts indentation and newlines where it will not affect the
- *               content of the json.
- */
-class JsonInfosetOutputter(writer: java.io.Writer, pretty: Boolean = true)
+class JsonInfosetOutputter private (outputter: SJsonInfosetOutputter)
   extends InfosetOutputterProxy {
 
-  override val infosetOutputter = new SJsonInfosetOutputter(writer, pretty)  
+  /**
+   * Output the infoset as json text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the json text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the json.
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer, pretty: Boolean) = this(new SJsonInfosetOutputter(writer, pretty))
+
+  /**
+   * Output the infoset as json text, written to a java.io.Writer
+   *
+   * @param writer the java.io.Writer to write the json text to
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetOutputter(java.io.OutputStream, Boolean) instead.", "2.4.0")
+  def this(writer: java.io.Writer) = this(writer, true)
+
+  /**
+   * Output the infoset as json text, written to a java.io.OutputStream
+   *
+   * @param os the java.io.OutputStream to write the json text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the json.
+   */
+  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SJsonInfosetOutputter(os, pretty))
+
+  override val infosetOutputter = outputter
 }
 
 /**
@@ -288,26 +330,46 @@ class ScalaXMLInfosetInputter(node: scala.xml.Node)
   override val infosetInputter = new SScalaXMLInfosetInputter(node)
 }
 
-/**
- * Read in an infoset in the form of XML text from a java.io.Reader
- *
- * @param reader the java.io.Reader to read the XML text from
- */
-class XMLTextInfosetInputter(reader: java.io.Reader)
+class XMLTextInfosetInputter private (inputter: SXMLTextInfosetInputter)
   extends InfosetInputterProxy {
-  
-  override val infosetInputter = new SXMLTextInfosetInputter(reader)
+
+  /**
+   * Read in an infoset in the form of XML text from a java.io.Reader
+   *
+   * @param reader the java.io.Reader to read the XML text from
+   */
+  @deprecated("This constructor is deprecated. Use XMLTextInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = this(new SXMLTextInfosetInputter(reader))
+
+  /**
+   * Read in an infoset in the form of XML text from a java.io.InputStream
+   *
+   * @param is the java.io.InputStream to read the XML text from
+   */
+  def this(is: java.io.InputStream) = this(new SXMLTextInfosetInputter(is))
+
+  override val infosetInputter = inputter
 }
 
-/**
- * Read in an infoset in the form of json text from a java.io.Reader
- *
- * @param reader the java.io.Reader to read the json text from
- */
-class JsonInfosetInputter(reader: java.io.Reader)
+class JsonInfosetInputter private (inputter: SJsonInfosetInputter)
   extends InfosetInputterProxy {
 
-  override val infosetInputter = new SJsonInfosetInputter(reader)
+  /**
+   * Read in an infoset in the form of json text from a java.io.Reader
+   *
+   * @param reader the java.io.Reader to read the json text from
+   */
+  @deprecated("This constructor is deprecated. Use JsonInfosetInputter(java.io.InputStream) instead.", "2.4.0")
+  def this(reader: java.io.Reader) = this(new SJsonInfosetInputter(reader))
+
+  /**
+   * Read in an infoset in the form of json text from a java.io.InputStream
+   *
+   * @param is the java.io.InputStream to read the json text from
+   */
+  def this(is: java.io.InputStream) = this(new SJsonInfosetInputter(is))
+
+  override val infosetInputter = inputter
 }
 
 /**

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetOutputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetOutputter.scala
@@ -17,35 +17,36 @@
 
 package org.apache.daffodil.tdml
 
-import org.apache.daffodil.infoset.XMLTextInfosetOutputter
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
 import org.apache.daffodil.infoset.DIArray
-import org.apache.daffodil.infoset.XMLTextInfosetInputter
-import org.apache.daffodil.infoset.JDOMInfosetInputter
-import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
-import java.io.StringReader
+import org.apache.daffodil.infoset.DIComplex
 import org.apache.daffodil.infoset.DISimple
+import org.apache.daffodil.infoset.InfosetOutputter
+import org.apache.daffodil.infoset.JDOMInfosetInputter
+import org.apache.daffodil.infoset.JDOMInfosetOutputter
+import org.apache.daffodil.infoset.JsonInfosetInputter
+import org.apache.daffodil.infoset.JsonInfosetOutputter
+import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
+import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
 import org.apache.daffodil.infoset.W3CDOMInfosetInputter
 import org.apache.daffodil.infoset.W3CDOMInfosetOutputter
-import org.apache.daffodil.infoset.DIComplex
-import java.io.StringWriter
-import org.apache.daffodil.infoset.JsonInfosetOutputter
-import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
-import org.apache.daffodil.infoset.JDOMInfosetOutputter
-import org.apache.daffodil.infoset.InfosetOutputter
-import org.apache.daffodil.infoset.JsonInfosetInputter
+import org.apache.daffodil.infoset.XMLTextInfosetInputter
+import org.apache.daffodil.infoset.XMLTextInfosetOutputter
 
 class TDMLInfosetOutputter() extends InfosetOutputter {
 
   private def implString: String = "daffodil"
 
-  private val jsonWriter = new StringWriter()
-  private val xmlWriter = new StringWriter()
+  private val jsonStream = new ByteArrayOutputStream()
+  private val xmlStream = new ByteArrayOutputStream()
 
   private val scalaOut = new ScalaXMLInfosetOutputter()
   private val jdomOut = new JDOMInfosetOutputter()
   private val w3cdomOut = new W3CDOMInfosetOutputter()
-  private val jsonOut = new JsonInfosetOutputter(jsonWriter)
-  private val xmlOut = new XMLTextInfosetOutputter(xmlWriter)
+  private val jsonOut = new JsonInfosetOutputter(jsonStream, false)
+  private val xmlOut = new XMLTextInfosetOutputter(xmlStream, false)
 
   private val outputters = Seq(xmlOut, scalaOut, jdomOut, w3cdomOut, jsonOut)
 
@@ -107,8 +108,8 @@ class TDMLInfosetOutputter() extends InfosetOutputter {
     val scalaIn = new ScalaXMLInfosetInputter(scalaOut.getResult)
     val jdomIn = new JDOMInfosetInputter(jdomOut.getResult)
     val w3cdomIn = new W3CDOMInfosetInputter(w3cdomOut.getResult)
-    val jsonIn = new JsonInfosetInputter(new StringReader(jsonWriter.toString))
-    val xmlIn = new XMLTextInfosetInputter(new StringReader(xmlWriter.toString))
+    val jsonIn = new JsonInfosetInputter(new ByteArrayInputStream(jsonStream.toByteArray))
+    val xmlIn = new XMLTextInfosetInputter(new ByteArrayInputStream(xmlStream.toByteArray))
     new TDMLInfosetInputter(scalaIn, Seq(jdomIn, w3cdomIn, jsonIn, xmlIn))
   }
 }


### PR DESCRIPTION
The API for XML and JSON Infoset Inputters/Outputters requires that
users pass in a Reader or a Writer. The problem is that Readers/Writers
must be assigned an encoding, which the user may not always know. This
can result in situations where XML infosets are read in a different
encoding than how the XML was actually encoded, and can even lead to
cases where the XML preamble is completely ignored. Making things worse,
we don't even specify an encoding for some Readers/Writers, so whether
something works or not was entirely dependent on default Java
properties.

This modifies the API for XML and JSON Infoset Inputter/Outputters to use
Input/OutputStreams instead of Readers/Writers. This allows the infoset
outputters to control what encoding is used during parsing, and allows
infoset inputters to inspect the preamble to determine the encoding
during unparsing.

The API changes add new new constructors for the Input/OutputStreams and
deprecates the old ones using Reader/Writers.

DAFFODIL-2128