### PR TITLE
Missed one name change: warnID incorrect in dafext.xsd.

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -138,7 +138,7 @@
                  <xsd:enumeration value="deprecatedFunctionDAFError"/>
                  <xsd:enumeration value="deprecatedPropertySeparatorPolicy" />
                  <xsd:enumeration value="deprecatedExpressionResultCoercion" />
-                 <xsd:enumeration value="emptyElementPolicyError" />
+                 <xsd:enumeration value="emptyElementParsePolicyError" />
                  <xsd:enumeration value="encodingErrorPolicyError"/>
                  <xsd:enumeration value="escapeSchemeRefUndefined"/>
                  <xsd:enumeration value="facetExplicitLengthOutOfRange"/>


### PR DESCRIPTION
Produces validation errors in TDML runner

DAFFODIL-2134