### PR TITLE
Reverse whitespace changes that use incorrect style.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -35,7 +35,7 @@ import org.apache.daffodil.xml.GetAttributesMixin
 import org.apache.daffodil.schema.annotation.props.PropTypes
 
 abstract class SchemaComponentImpl(
-  final override val xml:    Node,
+  final override val xml: Node,
   final override val parent: SchemaComponent)
   extends SchemaComponent
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -47,8 +47,8 @@ import org.apache.daffodil.exceptions.Assert
  * that are choice branches, are all instances.
  */
 abstract class SequenceTermBase(
-  final override val xml:      Node,
-  final override val parent:   SchemaComponent,
+  final override val xml: Node,
+  final override val parent: SchemaComponent,
   final override val position: Int)
   extends ModelGroup(position)
   with SequenceGrammarMixin {
@@ -83,8 +83,8 @@ abstract class SequenceTermBase(
  * but NOT implied sequences inside choice branches.
  */
 abstract class SequenceGroupTermBase(
-  xml:      Node,
-  parent:   SchemaComponent,
+  xml: Node,
+  parent: SchemaComponent,
   position: Int)
   extends SequenceTermBase(xml, parent, position)
   with Sequence_AnnotationMixin

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -316,7 +316,7 @@ final class LocalSimpleTypeDef(
       //Note that this.toString=diagnosticDebugName, so cannot be used here
       Assert.invariantFailed("Anonymous Simple type is neither a union nor a restriction. Enclosing element is " + this.parent)))
     val repName = optRepTypeFactory.map(_.name)
-    repName match{
+    repName match {
       case None => baseName.diagnosticDebugName
       case Some(n) => s"${n} -> ${baseName.diagnosticDebugName}"
     }
@@ -340,7 +340,7 @@ trait SimpleTypeFactory {
   def forDerivedType(derivedType: SimpleTypeDefBase): SimpleTypeBase
 
   def primType: PrimType
-  
+
   def name: String
 }
 
@@ -352,7 +352,7 @@ abstract class SimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocum
   with ProvidesDFDLStatementMixin {
 
   override def name = diagnosticDebugName
-  
+
   override final def optReferredToComponent = optRestriction.flatMap { _.optBaseDef }
   override final def emptyFormatFactory = new DFDLSimpleType(newDFDLAnnotationXML("simpleType"), this)
 
@@ -461,7 +461,7 @@ abstract class SimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocum
         })
         (optInputCompiled, optOutputCompiled) match {
           case (None, None) => None
-          case _            => Some(TypeCalculatorCompiler.compileExpression(optInputCompiled, optOutputCompiled, srcType, dstType))
+          case _ => Some(TypeCalculatorCompiler.compileExpression(optInputCompiled, optOutputCompiled, srcType, dstType))
         }
       }
 
@@ -474,7 +474,7 @@ abstract class SimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocum
           if (dstType != srcType) {
             val repTypeName = optRepTypeDefFactory match {
               case Some(r) => r.diagnosticDebugName
-              case None    => repType.toString()
+              case None => repType.toString()
             }
             context.SDE(
               "repType (%s) with primitive type (%s) used without defining a transformation is not compatable with the baseType of (%s) with primitive type (%s)",
@@ -511,11 +511,12 @@ abstract class SimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocum
     lazy val fromSelf: Option[SimpleTypeFactory with NamedMixin] = {
       val qName = findPropertyOptionThisComponentOnly("repType").toOption
         .map(qn => {
-          QName.resolveRef(qn, namespaces, tunable).toOption match{
+          QName.resolveRef(qn, namespaces, tunable).toOption match {
             case Some(x) => x
             case None => SDE(s"Cannot resolve type ${qn}")
-        }})
-      
+          }
+        })
+
       val optRepTypeDef = qName.flatMap(schemaSet.getGlobalSimpleTypeDef(_))
       val optRepPrimType = qName.flatMap(schemaSet.getPrimitiveTypeFactory(_))
       Assert.invariant(!(optRepPrimType.isDefined && optRepTypeDef.isDefined))
@@ -563,7 +564,7 @@ abstract class SimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocum
     val fromSelf: Option[RepValueSet[AnyRef]] = optRepValueSetFromAttribute
 
     (fromRestriction, fromUnion, fromSelf) match {
-      case (None, None, None)    => None
+      case (None, None, None) => None
       case (Some(a), None, None) => Some(a)
       case (None, Some(a), None) => Some(a)
       case (None, None, Some(a)) => Some(a)
@@ -590,7 +591,7 @@ final class PrimitiveSimpleTypeFactory(primitiveType: PrimitiveType, schemaDocum
   with NamedMixin {
 
   override lazy val name = diagnosticDebugName
-  
+
   override def forElement(elementDecl: ElementDeclMixin) = primitiveType
   override def forDerivedType(derivedType: SimpleTypeDefBase) = primitiveType
 
@@ -637,7 +638,7 @@ final class GlobalSimpleTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDo
   override def forDerivedType(derivedType: SimpleTypeDefBase) = new GlobalSimpleTypeDef(Some(derivedType), this, None)
 
   override lazy val name = super[NamedMixin].name
-  
+
 }
 /**
  * The instance type for global simple type definitions.
@@ -660,13 +661,13 @@ final class GlobalSimpleTypeDef(
       case (Some(dt), None) => derivedType
       case (None, Some(elem)) => referringElement
       case (Some(_), Some(_)) => Assert.impossible("SimpleType must either have a derivedType or an element. Not both.")
-      case (None, None)       => None
+      case (None, None) => None
     }
 
   override lazy val elementDecl: ElementDeclMixin = referringComponent match {
     case Some(dt: SimpleTypeDefBase) => dt.elementDecl
-    case Some(e: ElementDeclMixin)   => e
-    case _                           => Assert.invariantFailed("unexpected referringComponent")
+    case Some(e: ElementDeclMixin) => e
+    case _ => Assert.invariantFailed("unexpected referringComponent")
   }
 
 }
@@ -674,14 +675,14 @@ final class GlobalSimpleTypeDef(
 /*
  * This isn't really a Factory class, as it already knows everything about the enumeration,
  * and we never actually use it to construct a concrete EnumerationDef object.
- * 
+ *
  * It is, however, a "Factory" in the sense that DSOM makes a factory/object distinction,
  * where a factory holds all the information stored on the node itself, while the object
  * computes additional information based on the context in the schema where it is being used.
  * In this sense, all usages of EnumerationDefs are using them as a "factory".
  */
 final class EnumerationDefFactory(
-  xml:               Node,
+  xml: Node,
   parentTypeFactory: SimpleTypeDefFactory)
   extends SchemaComponentFactory(xml, parentTypeFactory.schemaDocument)
   with NestingLexicalMixin
@@ -716,4 +717,3 @@ final class EnumerationDefFactory(
   protected def isMyFormatAnnotation(a: DFDLAnnotation): Boolean = Assert.invariantFailed("Should not be called")
 
 }
-

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDelimiters.scala
@@ -115,14 +115,14 @@ abstract class StringDelimBase(e: Term, guard: Boolean) extends Terminal(e, guar
   override def toString = "StringDelimBase[" + name + "]"
 
   def checkDelimiterDistinctness(
-    escapeSchemeKind:  EscapeKind,
-    optPadChar:        Option[String],
-    optEscChar:        Option[String], // Could be a DFDL expression
-    optEscEscChar:     Option[String], // Could be a DFDL expression
-    optEscBlkStart:    Option[String],
-    optEscBlkEnd:      Option[String],
+    escapeSchemeKind: EscapeKind,
+    optPadChar: Option[String],
+    optEscChar: Option[String], // Could be a DFDL expression
+    optEscEscChar: Option[String], // Could be a DFDL expression
+    optEscBlkStart: Option[String],
+    optEscBlkEnd: Option[String],
     terminatingMarkup: Seq[String],
-    context:           ThrowsSDE): Unit = {
+    context: ThrowsSDE): Unit = {
 
     // TODO: DFDL-451 - After conversing with Mike B. about this, we're putting this on the backburner.
     // Leaving the code here, just commented out the entry point until we can decide what is the appropriate

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
@@ -746,8 +746,8 @@ object DirectOrBufferedDataOutputStream {
    */
   private def deliverBufferContent(
     directDOS: DirectOrBufferedDataOutputStream,
-    bufDOS:    DirectOrBufferedDataOutputStream,
-    finfo:     FormatInfo) {
+    bufDOS: DirectOrBufferedDataOutputStream,
+    finfo: FormatInfo) {
     Assert.invariant(bufDOS.isBuffering)
     Assert.invariant(!directDOS.isBuffering)
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilTunables.scala
@@ -60,11 +60,11 @@ object DaffodilTunables {
 }
 
 case class DaffodilTunables(
-  val maxSkipLengthInBytes:         Long   = 1024, // applicable to leadingSkip and trailingSkip
-  val maxBinaryDecimalVirtualPoint: Int    = 200, // Can be as large as Int.MaxValue
-  val minBinaryDecimalVirtualPoint: Int    = -200, // Can be as small as Int.MinValue
+  val maxSkipLengthInBytes: Long = 1024, // applicable to leadingSkip and trailingSkip
+  val maxBinaryDecimalVirtualPoint: Int = 200, // Can be as large as Int.MaxValue
+  val minBinaryDecimalVirtualPoint: Int = -200, // Can be as small as Int.MinValue
   val generatedNamespacePrefixStem: String = "tns",
-  val readerByteBufferSize:         Long   = 8192,
+  val readerByteBufferSize: Long = 8192,
   //
   // If true, require that the bitOrder property is specified. If false, use a
   // default value for bitOrder if not defined in a schema
@@ -111,8 +111,8 @@ case class DaffodilTunables(
   // If true, require that the emptyElementParsePolicy property is specified. If
   // false, warn about missing property
   //
-  val requireEmptyElementParsePolicyProperty: Boolean                 = false,
-  val defaultEmptyElementParsePolicy:         EmptyElementParsePolicy = EmptyElementParsePolicy.TreatAsEmpty,
+  val requireEmptyElementParsePolicyProperty: Boolean = false,
+  val defaultEmptyElementParsePolicy: EmptyElementParsePolicy = EmptyElementParsePolicy.TreatAsEmpty,
   //
   // Whether to compile a schema to support parsing, unparsing, both, or to use
   // the daf:parseUnparsePolicy from the root node. None means to use the
@@ -120,11 +120,11 @@ case class DaffodilTunables(
   //
   // Looks to be compile-time. Set in Compiler.
   ///
-  val parseUnparsePolicy:                Option[ParseUnparsePolicy] = None,
-  val maxFieldContentLengthInBytes:      Long                       = 1024 * 1024, // Can be as large as Int.MaxValue
-  val defaultInitRegexMatchLimitInChars: Long                       = 32,
-  val maxDataDumpSizeInBytes:            Long                       = 256,
-  val maxOccursBounds:                   Long                       = Int.MaxValue, // Can be as large as Int.MaxValue
+  val parseUnparsePolicy: Option[ParseUnparsePolicy] = None,
+  val maxFieldContentLengthInBytes: Long = 1024 * 1024, // Can be as large as Int.MaxValue
+  val defaultInitRegexMatchLimitInChars: Long = 32,
+  val maxDataDumpSizeInBytes: Long = 256,
+  val maxOccursBounds: Long = Int.MaxValue, // Can be as large as Int.MaxValue
   //
   // When unexpected text is found where a delimiter is expected, this is the maximum
   // number of bytes (characters) to display when the expected delimiter is a variable
@@ -152,9 +152,9 @@ case class DaffodilTunables(
   //
   // Applies to InfosetImpl, as such is a run-time thing
   //
-  val initialElementOccurrencesHint:    Long                           = 10,
-  val unqualifiedPathStepPolicy:        UnqualifiedPathStepPolicy.Type = UnqualifiedPathStepPolicy.NoNamespace,
-  val suppressSchemaDefinitionWarnings: List[WarnID]                   = Nil,
+  val initialElementOccurrencesHint: Long = 10,
+  val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy.Type = UnqualifiedPathStepPolicy.NoNamespace,
+  val suppressSchemaDefinitionWarnings: List[WarnID] = Nil,
 
   // By default, path expressions in Daffodil will only work correctly if path
   // steps are used in an expression defined in the schema when compiled. To
@@ -172,8 +172,8 @@ case class DaffodilTunables(
   val errorOnUnsupportedJavaVersion: Boolean = true,
 
   val maximumSimpleElementSizeInCharacters: Int = 1024 * 1024,
-  val initialRegexMatchLimitInCharacters:   Int = 64,
-  val maximumRegexMatchLengthInCharacters:  Int = 1024 * 1024,
+  val initialRegexMatchLimitInCharacters: Int = 64,
+  val maximumRegexMatchLengthInCharacters: Int = 1024 * 1024,
 
   /* Due to differences in the DFDL spec and ICU4J SimpleDateFormat, we must have SimpleDateFormat
    * parse in lenient mode, which allows the year value to overflow with very large years

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SeparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SeparatedSequenceUnparsers.scala
@@ -46,17 +46,17 @@ trait Separated { self: SequenceChildUnparser =>
 }
 
 sealed abstract class ScalarOrderedSeparatedSequenceChildUnparserBase(
-  childUnparser:                                        Unparser,
-  srd:                                                  SequenceRuntimeData,
-  trd:                                                  TermRuntimeData,
-  override val sep:                                     Unparser,
-  override val spos:                                    SeparatorPosition,
-  override val ssp:                                     SeparatorSuppressionPolicy,
-  override val zeroLengthDetector:                      ZeroLengthDetector,
-  override val isPotentiallyTrailing:                   Boolean,
+  childUnparser: Unparser,
+  srd: SequenceRuntimeData,
+  trd: TermRuntimeData,
+  override val sep: Unparser,
+  override val spos: SeparatorPosition,
+  override val ssp: SeparatorSuppressionPolicy,
+  override val zeroLengthDetector: ZeroLengthDetector,
+  override val isPotentiallyTrailing: Boolean,
   override val isKnownStaticallyNotToSuppressSeparator: Boolean,
-  override val isPositional:                            Boolean,
-  override val isDeclaredLast:                          Boolean)
+  override val isPositional: Boolean,
+  override val isDeclaredLast: Boolean)
   extends SequenceChildUnparser(childUnparser, srd, trd)
   with Separated {
 
@@ -64,33 +64,33 @@ sealed abstract class ScalarOrderedSeparatedSequenceChildUnparserBase(
 }
 
 class ScalarOrderedSeparatedSequenceChildUnparser(
-  childUnparser:                           Unparser,
-  srd:                                     SequenceRuntimeData,
-  trd:                                     TermRuntimeData,
-  sep:                                     Unparser,
-  spos:                                    SeparatorPosition,
-  ssp:                                     SeparatorSuppressionPolicy,
-  zlDetector:                              ZeroLengthDetector,
-  isPotentiallyTrailing:                   Boolean,
+  childUnparser: Unparser,
+  srd: SequenceRuntimeData,
+  trd: TermRuntimeData,
+  sep: Unparser,
+  spos: SeparatorPosition,
+  ssp: SeparatorSuppressionPolicy,
+  zlDetector: ZeroLengthDetector,
+  isPotentiallyTrailing: Boolean,
   isKnownStaticallyNotToSuppressSeparator: Boolean,
-  isPositional:                            Boolean,
-  isDeclaredLast:                          Boolean)
+  isPositional: Boolean,
+  isDeclaredLast: Boolean)
   extends ScalarOrderedSeparatedSequenceChildUnparserBase(childUnparser, srd, trd, sep, spos, ssp,
     zlDetector, isPotentiallyTrailing, isKnownStaticallyNotToSuppressSeparator, isPositional,
     isDeclaredLast)
 
 class RepOrderedSeparatedSequenceChildUnparser(
-  childUnparser:                                        Unparser,
-  srd:                                                  SequenceRuntimeData,
-  erd:                                                  ElementRuntimeData,
-  override val sep:                                     Unparser,
-  override val spos:                                    SeparatorPosition,
-  override val ssp:                                     SeparatorSuppressionPolicy, // need for diagnostics perhaps
-  override val zeroLengthDetector:                      ZeroLengthDetector,
-  override val isPotentiallyTrailing:                   Boolean,
+  childUnparser: Unparser,
+  srd: SequenceRuntimeData,
+  erd: ElementRuntimeData,
+  override val sep: Unparser,
+  override val spos: SeparatorPosition,
+  override val ssp: SeparatorSuppressionPolicy, // need for diagnostics perhaps
+  override val zeroLengthDetector: ZeroLengthDetector,
+  override val isPotentiallyTrailing: Boolean,
   override val isKnownStaticallyNotToSuppressSeparator: Boolean,
-  override val isPositional:                            Boolean,
-  override val isDeclaredLast:                          Boolean)
+  override val isPositional: Boolean,
+  override val isDeclaredLast: Boolean)
   extends RepeatingChildUnparser(childUnparser, srd, erd)
   with Separated {
 
@@ -99,10 +99,10 @@ class RepOrderedSeparatedSequenceChildUnparser(
 }
 
 class OrderedSeparatedSequenceUnparser(
-  rd:                SequenceRuntimeData,
-  ssp:               SeparatorSuppressionPolicy,
-  spos:              SeparatorPosition,
-  sep:               Unparser,
+  rd: SequenceRuntimeData,
+  ssp: SeparatorSuppressionPolicy,
+  spos: SeparatorPosition,
+  sep: Unparser,
   childUnparsersArg: Vector[SequenceChildUnparser])
   extends OrderedSequenceUnparserBase(rd, childUnparsersArg :+ sep) {
 
@@ -114,8 +114,8 @@ class OrderedSeparatedSequenceUnparser(
    */
   protected def unparseOne(
     unparser: SequenceChildUnparser,
-    trd:      TermRuntimeData,
-    state:    UState): Unit = {
+    trd: TermRuntimeData,
+    state: UState): Unit = {
 
     if (trd.isRepresented) {
       spos match {
@@ -154,8 +154,8 @@ class OrderedSeparatedSequenceUnparser(
    * Does not have to deal with infix and first child.
    */
   private def unparseJustSeparatorWithTrailingSuppression(
-    trd:                  TermRuntimeData,
-    state:                UState,
+    trd: TermRuntimeData,
+    state: UState,
     trailingSuspendedOps: Buffer[SuppressableSeparatorUnparserSuspendableOperation]): Unit = {
 
     val suspendableOp = new SuppressableSeparatorUnparserSuspendableOperation(sep, trd)
@@ -179,11 +179,11 @@ class OrderedSeparatedSequenceUnparser(
   }
 
   private def unparseOneWithSuppression(
-    unparser:             SequenceChildUnparser,
-    trd:                  TermRuntimeData,
-    state:                UState,
+    unparser: SequenceChildUnparser,
+    trd: TermRuntimeData,
+    state: UState,
     trailingSuspendedOps: Buffer[SuppressableSeparatorUnparserSuspendableOperation],
-    onlySeparatorFlag:    Boolean): Unit = {
+    onlySeparatorFlag: Boolean): Unit = {
     val doUnparseChild = !onlySeparatorFlag
     // We don't know if the unparse will result in zero length or not.
     // We have to use a suspendable unparser here for the separator
@@ -414,7 +414,7 @@ class OrderedSeparatedSequenceUnparser(
 
   private def unparsePositionallyRequiredSeps(
     unparserArg: SequenceChildUnparser,
-    erd:         ElementRuntimeData, state: UState, numOccurs: Int, trailingSuspendedOps: Buffer[SuppressableSeparatorUnparserSuspendableOperation]): Int = {
+    erd: ElementRuntimeData, state: UState, numOccurs: Int, trailingSuspendedOps: Buffer[SuppressableSeparatorUnparserSuspendableOperation]): Int = {
     var numOccurrences = numOccurs
     unparserArg match {
       case unparser: RepOrderedSeparatedSequenceChildUnparser => {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
@@ -39,8 +39,8 @@ import org.apache.daffodil.processors.ModelGroupRuntimeData
  */
 abstract class SequenceChildUnparser(
   val childUnparser: Unparser,
-  val srd:           SequenceRuntimeData,
-  val trd:           TermRuntimeData)
+  val srd: SequenceRuntimeData,
+  val trd: TermRuntimeData)
   extends CombinatorUnparser(srd) {
 
   override def runtimeDependencies = Vector()
@@ -55,8 +55,8 @@ abstract class SequenceChildUnparser(
  */
 abstract class RepeatingChildUnparser(
   override val childUnparser: Unparser,
-  override val srd:           SequenceRuntimeData,
-  val erd:                    ElementRuntimeData)
+  override val srd: SequenceRuntimeData,
+  val erd: ElementRuntimeData)
   extends SequenceChildUnparser(childUnparser, srd, erd)
   with MinMaxRepeatsMixin {
 
@@ -219,8 +219,8 @@ abstract class RepeatingChildUnparser(
    * 'unbounded', then maxReps will be Long.MaxValue.
    */
   def checkFinalOccursCountBetweenMinAndMaxOccurs(
-    state:          UState,
-    unparser:       RepeatingChildUnparser,
+    state: UState,
+    unparser: RepeatingChildUnparser,
     numOccurrences: Int, maxReps: Long, arrPos: Long): Unit = {
     import OccursCountKind._
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceUnparserBases.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceUnparserBases.scala
@@ -21,7 +21,7 @@ import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.exceptions.Assert
 
 abstract class OrderedSequenceUnparserBase(
-  srd:            SequenceRuntimeData,
+  srd: SequenceRuntimeData,
   childUnparsers: Vector[Unparser])
   extends CombinatorUnparser(srd) {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SuppressableSeparatorUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SuppressableSeparatorUnparser.scala
@@ -36,7 +36,7 @@ import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
  * But we need none of the state needed to unparse or evaluate expressions.
  */
 final class SuppressableSeparatorUnparserSuspendableOperation(
-  sepUnparser:     Unparser,
+  sepUnparser: Unparser,
   override val rd: TermRuntimeData)
   extends SuspendableOperation {
 
@@ -186,8 +186,8 @@ final class SuppressableSeparatorUnparserSuspendableOperation(
 }
 
 final class SuppressableSeparatorUnparser private (
-  sepUnparser:                       Unparser,
-  override val context:              TermRuntimeData,
+  sepUnparser: Unparser,
+  override val context: TermRuntimeData,
   override val suspendableOperation: SuspendableOperation)
   extends PrimUnparser
   with SuspendableUnparser {
@@ -200,8 +200,8 @@ final class SuppressableSeparatorUnparser private (
 object SuppressableSeparatorUnparser {
 
   def apply(
-    sepUnparser:          Unparser,
-    context:              TermRuntimeData,
+    sepUnparser: Unparser,
+    context: TermRuntimeData,
     suspendableOperation: SuspendableOperation) = {
     val res = new SuppressableSeparatorUnparser(sepUnparser, context, suspendableOperation)
     Processor.initialize(res)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -80,12 +80,12 @@ trait StateForDebugger {
 }
 
 case class TupleForDebugger(
-  val bytePos:                Long,
-  val childPos:               Long,
-  val groupPos:               Long,
-  val currentLocation:        DataLocation,
-  val arrayPos:               Long,
-  val bitLimit0b:             MaybeULong,
+  val bytePos: Long,
+  val childPos: Long,
+  val groupPos: Long,
+  val currentLocation: DataLocation,
+  val arrayPos: Long,
+  val bitLimit0b: MaybeULong,
   override val discriminator: Boolean) extends StateForDebugger
 
 trait SetProcessorMixin {
@@ -125,9 +125,9 @@ trait SetProcessorMixin {
  */
 abstract class ParseOrUnparseState protected (
   protected var variableBox: VariableBox,
-  var diagnostics:           List[Diagnostic],
-  var dataProc:              Maybe[DataProcessor],
-  val tunable:               DaffodilTunables) extends DFDL.State
+  var diagnostics: List[Diagnostic],
+  var dataProc: Maybe[DataProcessor],
+  val tunable: DaffodilTunables) extends DFDL.State
   with StateForDebugger
   with ThrowsSDE
   with SavesErrorsAndWarnings
@@ -403,9 +403,9 @@ abstract class ParseOrUnparseState protected (
   }
 
   def currentNode: Maybe[DINode]
-  
-  private val maybeSsrd = if(dataProc.isDefined){One(dataProc.get.ssrd)} else Maybe.Nope
-  
+
+  private val maybeSsrd = if (dataProc.isDefined) { One(dataProc.get.ssrd) } else Maybe.Nope
+
   private val _dState = new DState(maybeSsrd)
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
@@ -130,9 +130,9 @@ trait Suspension
   }
 
   private def splitDOS(
-    ustate:                 UState,
+    ustate: UState,
     maybeKnownLengthInBits: MaybeULong,
-    original:               DirectOrBufferedDataOutputStream) {
+    original: DirectOrBufferedDataOutputStream) {
     Assert.usage(ustate.currentInfosetNodeMaybe.isDefined)
 
     val buffered = original.addBuffered

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Parser.scala
@@ -67,9 +67,9 @@ class LongestMatchTracker {
 }
 
 class ParseResult(
-  val field:                 Maybe[String],
+  val field: Maybe[String],
   val matchedDelimiterValue: Maybe[String],
-  val matchedDFAs:           ArrayBuffer[DFADelimiter]) {
+  val matchedDFAs: ArrayBuffer[DFADelimiter]) {
 
   override def toString(): String = {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/DelimiterParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/DelimiterParsers.scala
@@ -40,10 +40,10 @@ object DelimiterTextType extends Enum {
 }
 
 class DelimiterTextParser(
-  rd:             TermRuntimeData,
-  textParser:     TextParser,
+  rd: TermRuntimeData,
+  textParser: TextParser,
   positionalInfo: String,
-  delimiterType:  DelimiterTextType.Type)
+  delimiterType: DelimiterTextType.Type)
   extends TextPrimParser {
 
   override lazy val runtimeDependencies = rd.encodingInfo.runtimeDependencies

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedParseHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedParseHelper.scala
@@ -35,9 +35,9 @@ object SeparatorParseStatus {
  * item and associated separator into a summary status.
  */
 sealed abstract class SeparatorParseHelper(
-  protected val sep:         Parser,
+  protected val sep: Parser,
   protected val childParser: Parser,
-  scParserArg:               Separated)
+  scParserArg: Separated)
   extends Serializable {
 
   import ParseAttemptStatus._
@@ -95,8 +95,8 @@ trait InfixPrefixSeparatorHelperMixin { self: SeparatorParseHelper =>
 
   final protected def parseOneWithInfixOrPrefixSeparator(
     shouldParseTheSep: Boolean,
-    pstate:            PState,
-    requiredOptional:  RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
 
     val sepStatus =
       if (shouldParseTheSep) {
@@ -134,7 +134,7 @@ trait InfixPrefixSeparatorHelperMixin { self: SeparatorParseHelper =>
 }
 
 final class PostfixSeparatorHelper(sep: Parser, child: Parser, scParserArg: Separated,
-                                   isSimpleDelimited: Boolean)
+  isSimpleDelimited: Boolean)
   extends SeparatorParseHelper(sep, child, scParserArg) {
   import ParseAttemptStatus._
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceChildParseResultHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceChildParseResultHelper.scala
@@ -89,11 +89,11 @@ trait SeparatedSequenceChildParseResultHelper
   def isSimpleDelimited: Boolean
 
   def computeFailedSeparatorParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    isZL:                  Boolean,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    isZL: Boolean,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     // computeFailedParseAttemptStatus(parser, prevBitPosBeforeChild, pstate, isZL, requiredOptional)
     ParseAttemptStatus.MissingSeparator
   }
@@ -103,7 +103,7 @@ trait SeparatedSequenceChildParseResultHelper
    * traits/classes just for this one little issue.
    */
   final override def finalChecks(parser: SequenceChildParser, pstate: PState, resultOfTry: ParseAttemptStatus,
-                                 priorResultOfTry: ParseAttemptStatus): Unit = {
+    priorResultOfTry: ParseAttemptStatus): Unit = {
     import ParseAttemptStatus._
 
     if ((sscb eq PositionalTrailingStrict)) {
@@ -130,7 +130,7 @@ trait PositionalLikeElementSeparatedSequenceChildParseResultMixin
 
   final override protected def anyTypeElementFailedParseAttemptStatus(
     pstate: PState,
-    isZL:   Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
+    isZL: Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     requiredOptional match {
       case _: RequiredOptionalStatus.Optional if isZL => {
         //
@@ -160,32 +160,32 @@ trait PositionalLikeElementSeparatedSequenceChildParseResultMixin
 
 class PositionalScalarElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends ScalarElementSeparatedSequenceChildParseResultHelper
   with ScalarElementSequenceChildParseResultHelper
   with PositionalLikeElementSeparatedSequenceChildParseResultMixin
 
 class NonPositionalScalarElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends ScalarElementSeparatedSequenceChildParseResultHelper
   with NonPositionalLikeElementSequenceChildParseResultMixin
 
 class PositionalTrailingScalarElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends ScalarElementSeparatedSequenceChildParseResultHelper
   with PositionalLikeElementSeparatedSequenceChildParseResultMixin
 
@@ -195,22 +195,22 @@ trait RepElementSeparatedSequenceChildParseResultHelper
 
 class PositionalTrailingRepElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends PositionalRepElementSeparatedSequenceChildParseResultHelper(
     separatedSequenceChildBehavior, erd, isSimpleDelimited, emptyElementParsePolicy,
     isEmptyRepZeroLength, isEmptyRepNonZeroLength)
 
 class PositionalRepElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends RepElementSeparatedSequenceChildParseResultHelper
   with PositionalLikeElementSeparatedSequenceChildParseResultMixin {
 
@@ -218,11 +218,11 @@ class PositionalRepElementSeparatedSequenceChildParseResultHelper(
 
 class NonPositionalRepElementSeparatedSequenceChildParseResultHelper(
   override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
-  override val erd:                            ElementRuntimeData,
-  override val isSimpleDelimited:              Boolean,
-  override val emptyElementParsePolicy:             EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:           Boolean,
-  override val isEmptyRepNonZeroLength:        Boolean)
+  override val erd: ElementRuntimeData,
+  override val isSimpleDelimited: Boolean,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
+  override val isEmptyRepNonZeroLength: Boolean)
   extends RepElementSeparatedSequenceChildParseResultHelper
   with NonPositionalLikeElementSequenceChildParseResultMixin
 
@@ -241,10 +241,10 @@ trait PositionalLikeGroupSequenceChildParseResultMixin
    * Used by trickier parser (e.g., postfix separator helper) that
    */
   final protected def modelGroupSuccessParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    mgrd:             ModelGroupRuntimeData,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    mgrd: ModelGroupRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     Assert.invariant(pstate.isSuccess)
     checkModelGroupZL(pstate, isZL)
@@ -256,28 +256,28 @@ trait PositionalLikeGroupSequenceChildParseResultMixin
 
 }
 class PositionalGroupSeparatedSequenceChildParseResultHelper(
-  override val mgrd:                              ModelGroupRuntimeData,
-  override val separatedSequenceChildBehavior:    SeparatedSequenceChildBehavior,
+  override val mgrd: ModelGroupRuntimeData,
+  override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
   override val isModelGroupRepPossiblyZeroLength: Boolean,
-  override val isModelGroupRepNonZeroLength:      Boolean)
+  override val isModelGroupRepNonZeroLength: Boolean)
   extends GroupSeparatedSequenceChildParseResultHelper
   with PositionalLikeGroupSequenceChildParseResultMixin {
 
 }
 class PositionalTrailingGroupSeparatedSequenceChildParseResultHelper(
-  override val mgrd:                              ModelGroupRuntimeData,
-  override val separatedSequenceChildBehavior:    SeparatedSequenceChildBehavior,
+  override val mgrd: ModelGroupRuntimeData,
+  override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
   override val isModelGroupRepPossiblyZeroLength: Boolean,
-  override val isModelGroupRepNonZeroLength:      Boolean)
+  override val isModelGroupRepNonZeroLength: Boolean)
   extends GroupSeparatedSequenceChildParseResultHelper
   with PositionalLikeGroupSequenceChildParseResultMixin {
 
   final override def computeFailedSeparatorParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    isZL:                  Boolean,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    isZL: Boolean,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
 
     // When we're parsing a separated sequence, and we're positional trailing
     // and we don't find a separator, the child never even gets attempted to parse
@@ -296,10 +296,10 @@ class PositionalTrailingGroupSeparatedSequenceChildParseResultHelper(
 }
 
 class NonPositionalGroupSeparatedSequenceChildParseResultHelper(
-  override val mgrd:                              ModelGroupRuntimeData,
-  override val separatedSequenceChildBehavior:    SeparatedSequenceChildBehavior,
+  override val mgrd: ModelGroupRuntimeData,
+  override val separatedSequenceChildBehavior: SeparatedSequenceChildBehavior,
   override val isModelGroupRepPossiblyZeroLength: Boolean,
-  override val isModelGroupRepNonZeroLength:      Boolean)
+  override val isModelGroupRepNonZeroLength: Boolean)
   extends GroupSeparatedSequenceChildParseResultHelper {
 
   /**
@@ -307,10 +307,10 @@ class NonPositionalGroupSeparatedSequenceChildParseResultHelper(
    * Used by trickier parser (e.g., postfix separator helper) that
    */
   final protected def modelGroupSuccessParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    mgrd:             ModelGroupRuntimeData,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    mgrd: ModelGroupRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     if (isZL)
       ParseAttemptStatus.MissingItem // it is an error if ZL in NonPositional

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildParseResultHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildParseResultHelper.scala
@@ -67,10 +67,10 @@ trait SequenceChildParseResultHelper
    * the item (which could be group or element).
    */
   def computeParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus
+    pstate: PState,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus
 
   /**
    * Computes the parse attempt status after a failure to parse.
@@ -83,17 +83,17 @@ trait SequenceChildParseResultHelper
    * though we failed to parse.
    */
   def computeFailedParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    isZL:                  Boolean,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus
+    pstate: PState,
+    isZL: Boolean,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus
 
   /**
    * Overridden for PositionalTrailingStrict case.
    */
   def finalChecks(parser: SequenceChildParser, pstate: PState, resultOfTry: ParseAttemptStatus,
-                  priorResultOfTry: ParseAttemptStatus): Unit = {
+    priorResultOfTry: ParseAttemptStatus): Unit = {
     // do nothing by default
   }
 }
@@ -158,10 +158,10 @@ trait ElementSequenceChildParseResultHelper
    * the item (which could be group or element).
    */
   final override def computeParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
 
     val currentBitPosAfterChild = pstate.bitPos0b
     val isZL = {
@@ -195,11 +195,11 @@ trait ElementSequenceChildParseResultHelper
    * Used by trickier parser (e.g., postfix separator helper) that
    */
   final override def computeFailedParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    isZL:                  Boolean,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    isZL: Boolean,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     Assert.usage(pstate.isFailure)
     val optPrimType = erd.optPrimType
     if (optPrimType.isDefined) {
@@ -261,11 +261,11 @@ trait ElementSequenceChildParseResultHelper
   }
 
   final protected def simpleTypeSuccessParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    erd:              ElementRuntimeData,
-    elem:             DISimple,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    erd: ElementRuntimeData,
+    elem: DISimple,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     Assert.invariant(pstate.isSuccess)
     val isEmpty = isEmptyRep(parser, pstate, isZL, Maybe(elem))
@@ -304,11 +304,11 @@ trait ElementSequenceChildParseResultHelper
   } // end method
 
   final protected def complexTypeSuccessParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    erd:              ElementRuntimeData,
-    elem:             DIComplex,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    erd: ElementRuntimeData,
+    elem: DIComplex,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     requiredOptional match {
       case _: RequiredOptionalStatus.Required if isZL =>
@@ -327,21 +327,21 @@ trait ElementSequenceChildParseResultHelper
    */
   protected def anyTypeElementFailedParseAttemptStatus(
     pstate: PState,
-    isZL:   Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus
+    isZL: Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus
 
   final protected def simpleTypeFailedParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    erd:              ElementRuntimeData,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    erd: ElementRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus =
     anyTypeElementFailedParseAttemptStatus(pstate, isZL, requiredOptional)
 
   final protected def complexTypeFailedParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    erd:              ElementRuntimeData,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    erd: ElementRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus =
     anyTypeElementFailedParseAttemptStatus(pstate, isZL, requiredOptional)
 }
@@ -378,10 +378,10 @@ trait ModelGroupSequenceChildParseResultHelper
    * the item (which could be group or element).
    */
   final override def computeParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     val currentBitPosAfterChild = pstate.bitPos0b
     val isZL = {
       Assert.invariant(currentBitPosAfterChild >= prevBitPosBeforeChild)
@@ -424,18 +424,18 @@ trait ModelGroupSequenceChildParseResultHelper
    * Used by trickier parser (e.g., postfix separator helper) that
    */
   protected def modelGroupSuccessParseAttemptStatus(
-    parser:           SequenceChildParser,
-    pstate:           PState,
-    isZL:             Boolean,
-    mgrd:             ModelGroupRuntimeData,
+    parser: SequenceChildParser,
+    pstate: PState,
+    isZL: Boolean,
+    mgrd: ModelGroupRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus
 
   final def computeFailedParseAttemptStatus(
-    parser:                SequenceChildParser,
+    parser: SequenceChildParser,
     prevBitPosBeforeChild: Long,
-    pstate:                PState,
-    isZL:                  Boolean,
-    requiredOptional:      RequiredOptionalStatus): ParseAttemptStatus = {
+    pstate: PState,
+    isZL: Boolean,
+    requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     if (isZL) ParseAttemptStatus.MissingItem
     else ParseAttemptStatus.FailureUnspecified
   }
@@ -473,7 +473,7 @@ trait NonPositionalLikeElementSequenceChildParseResultMixin
 
   override protected def anyTypeElementFailedParseAttemptStatus(
     pstate: PState,
-    isZL:   Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
+    isZL: Boolean, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     if (isZL)
       ParseAttemptStatus.MissingItem
     else

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -35,7 +35,7 @@ import org.apache.daffodil.processors.ModelGroupRuntimeData
  * all the parsing of the sequence child parsers.
  */
 abstract class SequenceParserBase(
-  srd:                        SequenceRuntimeData,
+  srd: SequenceRuntimeData,
   protected val childParsers: Vector[Parser])
   extends CombinatorParser(srd) {
   override def nom = "Sequence"
@@ -45,7 +45,7 @@ abstract class SequenceParserBase(
 }
 
 abstract class OrderedSequenceParserBase(
-  srd:             SequenceRuntimeData,
+  srd: SequenceRuntimeData,
   childParsersArg: Vector[Parser])
   extends SequenceParserBase(srd, childParsersArg) {
 
@@ -62,10 +62,10 @@ abstract class OrderedSequenceParserBase(
   }
 
   final protected def checkForwardProgress(
-    pstate:     PState,
+    pstate: PState,
     currentPos: Long,
-    priorPos:   Long,
-    ais:        ArrayIndexStatus): ArrayIndexStatus = {
+    priorPos: Long,
+    ais: ArrayIndexStatus): ArrayIndexStatus = {
     Assert.invariant(currentPos >= priorPos)
     if (currentPos == priorPos && pstate.groupPos > 1) {
       PE(pstate, "No forward progress.")
@@ -238,9 +238,9 @@ abstract class OrderedSequenceParserBase(
   }
 
   private def parseOneInstance(
-    parser:         SequenceChildParser,
-    pstate:         PState,
-    roStatus:       RequiredOptionalStatus,
+    parser: SequenceChildParser,
+    pstate: PState,
+    roStatus: RequiredOptionalStatus,
     resultOfTryArg: ParseAttemptStatus): (ArrayIndexStatus, ParseAttemptStatus) = {
     var resultOfTry = resultOfTryArg
     var ais: ArrayIndexStatus = ArrayIndexStatus.Uninitialized

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnorderedSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnorderedSequenceParser.scala
@@ -21,9 +21,9 @@ import org.apache.daffodil.processors.ModelGroupRuntimeData
 
 class UnorderedSequenceParser(
   override val context: ModelGroupRuntimeData,
-  sortOrder:            Seq[(String, org.jdom2.Namespace)],
-  scalarMembers:        Seq[(String, String, org.jdom2.Namespace)],
-  uoSeqParser:          Parser)
+  sortOrder: Seq[(String, org.jdom2.Namespace)],
+  scalarMembers: Seq[(String, String, org.jdom2.Namespace)],
+  uoSeqParser: Parser)
   extends CombinatorParser(context) {
 
   override lazy val runtimeDependencies = Vector()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceChildParseResultHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceChildParseResultHelper.scala
@@ -37,27 +37,27 @@ trait UnseparatedSequenceChildParseResultHelper
 }
 
 class ScalarElementUnseparatedSequenceChildParseResultHelper(
-  override val erd:                     ElementRuntimeData,
-  override val emptyElementParsePolicy:      EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:    Boolean,
+  override val erd: ElementRuntimeData,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
   override val isEmptyRepNonZeroLength: Boolean)
   extends UnseparatedSequenceChildParseResultHelper
   with ScalarElementSequenceChildParseResultHelper
   with NonPositionalLikeElementSequenceChildParseResultMixin
 
 class RepElementUnseparatedSequenceChildParseResultHelper(
-  override val erd:                     ElementRuntimeData,
-  override val emptyElementParsePolicy:      EmptyElementParsePolicy,
-  override val isEmptyRepZeroLength:    Boolean,
+  override val erd: ElementRuntimeData,
+  override val emptyElementParsePolicy: EmptyElementParsePolicy,
+  override val isEmptyRepZeroLength: Boolean,
   override val isEmptyRepNonZeroLength: Boolean)
   extends UnseparatedSequenceChildParseResultHelper
   with RepElementSequenceChildParseResultHelper
   with NonPositionalLikeElementSequenceChildParseResultMixin
 
 final class GroupUnseparatedSequenceChildParseResultHelper(
-  override val mgrd:                              ModelGroupRuntimeData,
+  override val mgrd: ModelGroupRuntimeData,
   override val isModelGroupRepPossiblyZeroLength: Boolean,
-  override val isModelGroupRepNonZeroLength:      Boolean)
+  override val isModelGroupRepNonZeroLength: Boolean)
   extends UnseparatedSequenceChildParseResultHelper
   with ModelGroupSequenceChildParseResultHelper
   with PositionalLikeGroupSequenceChildParseResultMixin {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
@@ -37,36 +37,36 @@ trait Unseparated { self: SequenceChildParser =>
 }
 
 class ScalarOrderedUnseparatedSequenceChildParser(
-  override val childParser:       Parser,
-  override val srd:               SequenceRuntimeData,
-  override val trd:               TermRuntimeData,
+  override val childParser: Parser,
+  override val srd: SequenceRuntimeData,
+  override val trd: TermRuntimeData,
   override val parseResultHelper: UnseparatedSequenceChildParseResultHelper)
   extends SequenceChildParser(childParser, srd, trd)
   with Unseparated
   with NonRepeatingSequenceChildParser
 
 class RepOrderedExactlyNUnseparatedSequenceChildParser(
-  childParser:                    Parser,
-  srd:                            SequenceRuntimeData,
-  erd:                            ElementRuntimeData,
+  childParser: Parser,
+  srd: SequenceRuntimeData,
+  erd: ElementRuntimeData,
   override val parseResultHelper: UnseparatedSequenceChildParseResultHelper,
-  val repeatCount:                Long)
+  val repeatCount: Long)
   extends OccursCountExactParser(childParser, srd, erd)
   with Unseparated
 
 class RepOrderedExactlyTotalOccursCountUnseparatedSequenceChildParser(
-  childParser:                    Parser,
-  ocEv:                           OccursCountEv,
-  srd:                            SequenceRuntimeData,
-  erd:                            ElementRuntimeData,
+  childParser: Parser,
+  ocEv: OccursCountEv,
+  srd: SequenceRuntimeData,
+  erd: ElementRuntimeData,
   override val parseResultHelper: UnseparatedSequenceChildParseResultHelper)
   extends OccursCountExpressionParser(childParser, srd, erd, ocEv)
   with Unseparated
 
 class RepOrderedWithMinMaxUnseparatedSequenceChildParser(
-  childParser:                    Parser,
-  srd:                            SequenceRuntimeData,
-  erd:                            ElementRuntimeData,
+  childParser: Parser,
+  srd: SequenceRuntimeData,
+  erd: ElementRuntimeData,
   override val parseResultHelper: UnseparatedSequenceChildParseResultHelper)
   extends OccursCountMinMaxParser(childParser, srd, erd)
   with Unseparated


### PR DESCRIPTION
DAFFODIL-2136

This should be 100% whitespace changes.

If there's a better way to fix this than with a change set, e.g., by going back and revising things, (like squashing these into the prior commit) I'm open to that instead, but that sort of thing on a public repo is often unwise. 

