### PR TITLE
Daffodil 1444 schema comp simple types

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -635,7 +635,7 @@ class TestCLIdebugger {
       shell.sendLine("display info path")
 
       shell.sendLine("continue")
-      shell.expect(contains("matrix::matrixType::sequence[1]::row::LocalComplexTypeDef::sequence[1]::cell"))
+      shell.expect(contains("matrixType::sequence[1]::row::LocalComplexTypeDef::sequence[1]::cell"))
 
       shell.sendLine("delete breakpoint 1")
       shell.expect(contains("debug"))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
@@ -44,11 +44,11 @@ import org.apache.daffodil.api.WarnID
  * All "real" terms are able to resolve properties. Most other objects just contribute
  * properties to the mix, but they are not points where properties are
  * used to generate processors.
- * 
- * EnumerationFactory and SimpleTypeDefFactory are the oddballs out. In addition to 
- * being used to generate processors, these classes our also used to generate abstract 
- * TypeCalculators, which are not nessasarily attached to any particular element, nor 
- * used to generate any processor (for instance, there may be a globalSimpleType whose 
+ *
+ * EnumerationFactory and SimpleTypeDefFactory are the oddballs out. In addition to
+ * being used to generate processors, these classes our also used to generate abstract
+ * TypeCalculators, which are not nessasarily attached to any particular element, nor
+ * used to generate any processor (for instance, there may be a globalSimpleType whose
  * only purpose is to define a TypeCalculator for use in DPath expressions)
  */
 trait ResolvesProperties
@@ -110,7 +110,7 @@ trait ResolvesProperties
 /** Convenience class for implemening AnnotatedSchemaComponent trait */
 abstract class AnnotatedSchemaComponentImpl(
   final override val xml: Node,
-  final override val parent: SchemaComponent)
+  final override val lexicalParent: SchemaComponent)
   extends AnnotatedSchemaComponent
 
 /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -100,7 +100,7 @@ trait ChoiceDefMixin
 
 abstract class ChoiceTermBase(
   final override val xml: Node,
-  final override val parent: SchemaComponent,
+  final override val lexicalParent: SchemaComponent,
   final override val position: Int)
   extends ModelGroup(position)
   with Choice_AnnotationMixin
@@ -162,12 +162,12 @@ abstract class ChoiceTermBase(
 
   // If choiceDispatchKeyKind is byType, verify that all our children share a repType,
   // and use that. Otherwise, there is no need to associate a repType with this choice
-  override final lazy val optRepTypeFactory: Option[SimpleTypeDefFactory with NamedMixin] = defaultableChoiceDispatchKeyKind match {
+  override final lazy val optRepType: Option[SimpleTypeDefBase] = defaultableChoiceDispatchKeyKind match {
     case ChoiceKeyKindType.ByType => {
-      val branchReptypes: Seq[SimpleTypeDefFactory with NamedMixin] = groupMembers.map(term => {
+      val branchReptypes: Seq[SimpleTypeDefBase] = groupMembers.map(term => {
         term match {
           case e: ElementDeclMixin => e.typeDef match {
-            case t: SimpleTypeDefBase => t.optRepTypeDefFactory match {
+            case t: SimpleTypeDefBase => t.optRepTypeDef match {
               case None => SDE("When <xs:choice> has choiceBranchKey=\"byType\", all branches must have a type which defines a repType")
               case Some(x) => x
             }
@@ -366,8 +366,8 @@ abstract class ChoiceTermBase(
   }
 }
 
-final class Choice(xmlArg: Node, parent: SchemaComponent, position: Int)
-  extends ChoiceTermBase(xmlArg, parent, position)
+final class Choice(xmlArg: Node, lexicalParent: SchemaComponent, position: Int)
+  extends ChoiceTermBase(xmlArg, lexicalParent, position)
   with ChoiceDefMixin {
 
   override lazy val optReferredToComponent = None

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ComplexTypes.scala
@@ -32,8 +32,6 @@ abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
 
   requiredEvaluations(modelGroup)
 
-  override def elementDecl: ElementDeclMixin
-
   protected final lazy val <complexType>{ xmlChildren @ _* }</complexType> = xml
 
   final def group = modelGroup
@@ -65,19 +63,6 @@ abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
   lazy val localAndFormatRefProperties: Map[String, String] = {
     Map.empty[String, String]
   }
-
-  //  lazy val isScannable: Boolean = {
-  //    val selfOK = modelGroup.group.isScannable
-  //    if (!selfOK) false
-  //    else {
-  //      val parentElem: ElementBase = enclosingComponent.get.asInstanceOf[ElementBase]
-  //      val unScannableChildren = modelGroup.group.groupMembers.filterNot { child =>
-  //        (child.knownEncodingCharset == parentElem.knownEncodingCharset) && child.isScannable
-  //      }
-  //      unScannableChildren.length == 0
-  //    }
-  //  }
-
 }
 
 final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
@@ -92,16 +77,18 @@ final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaD
 /**
  * For unit testing purposes, the element argument might be supplied as null.
  */
-final class GlobalComplexTypeDef(xmlArg: Node, schemaDocumentArg: SchemaDocument, override val elementDecl: ElementDeclMixin)
+final class GlobalComplexTypeDef(
+  xmlArg: Node,
+  schemaDocumentArg: SchemaDocument,
+  val elementDecl: ElementDeclMixin)
   extends ComplexTypeBase(xmlArg, schemaDocumentArg)
   with GlobalNonElementComponentMixin
   with NestingTraversesToReferenceMixin {
 
   override lazy val referringComponent = Option(elementDecl)
-
 }
 
-final class LocalComplexTypeDef(xmlArg: Node, override val elementDecl: ElementDeclMixin)
+final class LocalComplexTypeDef(xmlArg: Node, val elementDecl: ElementDeclMixin)
   extends ComplexTypeBase(xmlArg, elementDecl)
   with LocalNonElementComponentMixin
   with NestingLexicalMixin {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLAnnotation.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLAnnotation.scala
@@ -39,8 +39,7 @@ abstract class DFDLAnnotation(xmlArg: Node, annotatedSCArg: AnnotatedSchemaCompo
   with NestingLexicalMixin {
 
   final override val xml = xmlArg
-  final override def parent = annotatedSCArg
-  final override val context: AnnotatedSchemaComponent = annotatedSCArg
+  final override def lexicalParent = annotatedSCArg
 
   final lazy val annotatedSC = annotatedSCArg
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormat.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormat.scala
@@ -47,7 +47,7 @@ final class DFDLSequence(node: Node, decl: SequenceDefMixin)
 final class DFDLChoice(node: Node, decl: ChoiceDefMixin)
   extends DFDLModelGroup(node, decl)
 
-final class DFDLSimpleType(node: Node, decl: SimpleTypeDefFactory)
+final class DFDLSimpleType(node: Node, decl: SimpleTypeDefBase)
   extends DFDLNonDefaultFormatAnnotation(node, decl) {
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
@@ -223,7 +223,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     val jtoSet = shortFormProperties.union(longFormProperties).union(elementFormProperties)
     val jto = jtoSet.toMap
     jto
-  }.value
+  }.toOption.getOrElse(emptyPropMap)
 
   /**
    * Just this one, as in the short, long, and element form properties, on just this
@@ -237,7 +237,7 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
     val res = combinedJustThisOneProperties
     log(LogLevel.Debug, "%s::%s justThisOneProperties are: %s", annotatedSC.diagnosticDebugName, diagnosticDebugName, res)
     res
-  }.value
+  }.toOption.getOrElse(emptyPropMap)
 
   /**
    * For unit testing convenience, or for use when debugging.
@@ -249,8 +249,8 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
    * For unit testing convenience, or for use when debugging.
    */
   def verifyPropValue(propName: String, expectedValue: String): Boolean = {
-    val optInfo = justThisOneProperties.get(propName)
-    optInfo match {
+    val info = justThisOneProperties.get(propName)
+    info match {
       case None => false
       case Some((actualValue, _)) => actualValue == expectedValue
     }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -181,7 +181,7 @@ trait ElementBase
     val isReferenced =
       if (this.isInstanceOf[PrefixLengthQuasiElementDecl]) false
       else {
-        val setElems = rootElementRef.get.contentLengthParserReferencedElementInfos
+        val setElems = schemaSet.root.contentLengthParserReferencedElementInfos
         setElems.contains(this.dpathElementCompileInfo)
       }
     isReferenced
@@ -195,7 +195,7 @@ trait ElementBase
     val isReferenced =
       if (this.isInstanceOf[PrefixLengthQuasiElementDecl]) false
       else {
-        val setElems = rootElementRef.get.contentLengthUnparserReferencedElementInfos
+        val setElems = schemaSet.root.contentLengthUnparserReferencedElementInfos
         setElems.contains(this.dpathElementCompileInfo)
       }
 
@@ -219,7 +219,7 @@ trait ElementBase
     val isReferenced =
       if (this.isInstanceOf[PrefixLengthQuasiElementDecl]) false
       else {
-        val setElems = rootElementRef.get.valueLengthParserReferencedElementInfos
+        val setElems = schemaSet.root.valueLengthParserReferencedElementInfos
         setElems.contains(this.dpathElementCompileInfo)
       }
 
@@ -248,7 +248,7 @@ trait ElementBase
     val isReferenced =
       if (this.isInstanceOf[PrefixLengthQuasiElementDecl]) false
       else {
-        val setElems = rootElementRef.get.valueLengthUnparserReferencedElementInfos
+        val setElems = schemaSet.root.valueLengthUnparserReferencedElementInfos
         setElems.contains(this.dpathElementCompileInfo)
       }
 
@@ -270,11 +270,6 @@ trait ElementBase
    * None for complex types, Some(primType) for simple types.
    */
   final lazy val optPrimType: Option[PrimType] = Misc.boolToOpt(isSimpleType, primType) // .typeRuntimeData)
-
-  /**
-   * scalar means minOccurs=1 and maxOccurs=1
-   */
-  def isScalar: Boolean
 
   /**
    * An array element is required if its index is less than the minOccurs of the
@@ -382,7 +377,7 @@ trait ElementBase
   private lazy val myOwnNSPairs: Set[(String, NS)] = thisElementsRequiredNamespaceBindings
   private lazy val myParentNSPairs = enclosingElement match {
     case None => emptyNSPairs
-    case Some(parent) => parent.myOwnNSPairs
+    case Some(ee) => ee.myOwnNSPairs
   }
 
   private lazy val myUniquePairs: Set[(String, NS)] = {
@@ -668,7 +663,7 @@ trait ElementBase
   }
 
   final lazy val isParentUnorderedSequence: Boolean = {
-    parent match {
+    lexicalParent match {
       case s: SequenceTermBase if !s.isOrdered => true
       case _ => false
     }
@@ -928,14 +923,6 @@ trait ElementBase
       else false
     else false
   }
-
-  /**
-   * Means the element is in a context where there is a separator (from some enclosing sequence)
-   * expected after it.
-   *
-   * Abstract here because implementations are different for local vs. global things.
-   */
-  def hasSep: Boolean
 
   /**
    * check length and if there are delimiters such that there is a concept of something that we can call 'empty'

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementDeclMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementDeclMixin.scala
@@ -62,7 +62,7 @@ trait ElementDeclMixin
     val ct = xml \ "complexType"
     val nt = typeName
     if (st.length == 1) {
-      val lstd = new LocalSimpleTypeDefFactory(st(0), schemaDocument).forElement(this)
+      val lstd = new LocalSimpleTypeDef(st(0), this)
       Some(lstd)
     } else if (ct.length == 1)
       Some(new LocalComplexTypeDef(ct(0), this))
@@ -94,7 +94,7 @@ trait ElementDeclMixin
           val gstd = ss.getGlobalSimpleTypeDef(qn)
           val gctd = ss.getGlobalComplexTypeDef(qn)
           val res = (gstd, gctd) match {
-            case (Some(gstdFactory), None) => Some(gstdFactory.forElement(this))
+            case (Some(_), None) => gstd
             case (None, Some(gctdFactory)) => Some(gctdFactory.forElement(this))
             // Note: Validation of the DFDL Schema doesn't necessarily check referential integrity
             // or other complex constraints like conflicting names.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
@@ -25,10 +25,11 @@ import org.apache.daffodil.dpath.NodeInfo
  * There are 3 first-class concrete children of ElementBase.
  * Root, LocalElementDecl, and ElementRef
  */
-final class ElementRef(xmlArg: Node, parent: GroupDefLike, position: Int)
-  extends AbstractElementRef(xmlArg, parent, position)
+final class ElementRef(xmlArg: Node, lexicalParent: GroupDefLike, position: Int)
+  extends AbstractElementRef(xmlArg, lexicalParent, position)
 
-abstract class AbstractElementRef(xmlArg: Node,
+abstract class AbstractElementRef(
+  xmlArg: Node,
   parentArg: SchemaComponent,
   positionArg: Int)
   extends ElementBase
@@ -37,7 +38,7 @@ abstract class AbstractElementRef(xmlArg: Node,
   with NestingLexicalMixin {
 
   override lazy val xml = xmlArg
-  final override lazy val parent = parentArg
+  final override lazy val lexicalParent = parentArg
   final override lazy val position = positionArg
 
   requiredEvaluations(referencedElement)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Facets.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Facets.scala
@@ -22,7 +22,7 @@ import scala.xml.Node
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.dpath.NodeInfo.PrimType
 
-trait Facets { self: RestrictionFactory =>
+trait Facets { self: Restriction =>
   import org.apache.daffodil.dsom.FacetTypes._
 
   requiredEvaluations(if (hasPattern) patternValues)
@@ -82,14 +82,14 @@ trait Facets { self: RestrictionFactory =>
     // Must be unique
     val enumerations = enumeration(xml)
     val distinctEnums = enumerations.distinct
-    if (enumerations.size != distinctEnums.size) context.SDE("Enumerations must be unique!")
+    if (enumerations.size != distinctEnums.size) SDE("Enumerations must be unique!")
     // Not a regular expression, but we plan to use it as one
     // so we must escape characters that can be interpreted as RegEx
     enumerations.map(s => escapeForRegex(s)).mkString("|")
   }
   final lazy val localWhitespaceValue: String = {
     whitespace(xml)
-    context.SDE("whitespaceValue is not implemented for DFDL v1.0 schemas but reserved for future use.")
+    SDE("whitespaceValue is not implemented for DFDL v1.0 schemas but reserved for future use.")
   }
 
   private def escapeForRegex(s: String): String = {
@@ -139,7 +139,7 @@ trait Facets { self: RestrictionFactory =>
     if (values.size > 0) {
       val (_, value) = values(0)
       Some(value)
-    } else None // context.SDE("Enumeration was not found in this context.")
+    } else None // SDE("Enumeration was not found in this context.")
   }
   // TODO: Tidy up.  Can likely replace getFacetValue with a similar call to combinedBaseFacets
   // as combinedBaseFacets should contain the 'narrowed' values.
@@ -154,33 +154,41 @@ trait Facets { self: RestrictionFactory =>
   final lazy val fractionDigitsValue: java.math.BigDecimal = getFacetValue(localFractionDigitsValue, Facet.fractionDigits, hasFractionDigits)
 
   //  private def errorOnLocalLessThanBaseFacet(local: Long, base: Long, theFacetType: Facet.Type) = {
-  //    if (local < base) context.SDE("SimpleTypes: The local %s (%s) was less than the base %s (%s) ", theFacetType, local, theFacetType, base)
+  //    if (local < base) SDE("SimpleTypes: The local %s (%s) was less than the base %s (%s) ", theFacetType, local, theFacetType, base)
   //  }
   //  private def errorOnLocalGreaterThanBaseFacet(local: Long, base: Long, theFacetType: Facet.Type) = {
-  //    if (local > base) context.SDE("SimpleTypes: The local %s (%s) was greater than the base %s (%s) ", theFacetType, local, theFacetType, base)
+  //    if (local > base) SDE("SimpleTypes: The local %s (%s) was greater than the base %s (%s) ", theFacetType, local, theFacetType, base)
   //  }
-  private def errorOnLocalLessThanBaseFacet(local: BigInteger,
+  private def errorOnLocalLessThanBaseFacet(
+    local: BigInteger,
     base: BigInteger, theFacetType: Facet.Type) = {
     val res = local.compareTo(base)
-    if (res < 0) context.SDE("SimpleTypes: The local %s (%s) was less than the base %s (%s) ",
+    if (res < 0) SDE(
+      "SimpleTypes: The local %s (%s) was less than the base %s (%s) ",
       theFacetType, local, theFacetType, base)
   }
-  private def errorOnLocalGreaterThanBaseFacet(local: BigInteger,
+  private def errorOnLocalGreaterThanBaseFacet(
+    local: BigInteger,
     base: BigInteger, theFacetType: Facet.Type) = {
     val res = local.compareTo(base)
-    if (res > 0) context.SDE("SimpleTypes: The local %s (%s) was greater than the base %s (%s) ",
+    if (res > 0) SDE(
+      "SimpleTypes: The local %s (%s) was greater than the base %s (%s) ",
       theFacetType, local, theFacetType, base)
   }
-  private def errorOnLocalLessThanBaseFacet(local: java.math.BigDecimal,
+  private def errorOnLocalLessThanBaseFacet(
+    local: java.math.BigDecimal,
     base: java.math.BigDecimal, theFacetType: Facet.Type) = {
     val res = local.compareTo(base)
-    if (res < 0) context.SDE("SimpleTypes: The local %s (%s) was less than the base %s (%s) ",
+    if (res < 0) SDE(
+      "SimpleTypes: The local %s (%s) was less than the base %s (%s) ",
       theFacetType, local, theFacetType, base)
   }
-  private def errorOnLocalGreaterThanBaseFacet(local: java.math.BigDecimal,
+  private def errorOnLocalGreaterThanBaseFacet(
+    local: java.math.BigDecimal,
     base: java.math.BigDecimal, theFacetType: Facet.Type) = {
     val res = local.compareTo(base)
-    if (res > 0) context.SDE("SimpleTypes: The local %s (%s) was greater than the base %s (%s) ",
+    if (res > 0) SDE(
+      "SimpleTypes: The local %s (%s) was greater than the base %s (%s) ",
       theFacetType, local, theFacetType, base)
   }
 
@@ -208,7 +216,7 @@ trait Facets { self: RestrictionFactory =>
   }
 
   private def getFacetValue(theLocalValue: String, theRemoteValue: String, theType: Facet.Type, exists: Boolean): java.math.BigDecimal = {
-    if (!exists) context.SDE("The facet %s was not found.", theType)
+    if (!exists) SDE("The facet %s was not found.", theType)
     else if (theLocalValue != "" && theRemoteValue != "") {
       val resFacet = doNumericFacetNarrowing(theLocalValue, theRemoteValue, theType)
       new java.math.BigDecimal(resFacet)
@@ -221,7 +229,7 @@ trait Facets { self: RestrictionFactory =>
 
   private def getFacetValue(theLocalValue: String, theType: Facet.Type, exists: Boolean): java.math.BigDecimal = {
     val remoteFacets = getRemoteFacetValues(theType)
-    if (!exists) context.SDE("The facet %s was not found.", theType)
+    if (!exists) SDE("The facet %s was not found.", theType)
     else if (theLocalValue != "" && remoteFacets.size > 0) {
       val (_, remoteValue) = getRemoteFacetValues(theType)(0)
       val resFacet = doNumericFacetNarrowing(theLocalValue, remoteValue, theType)
@@ -237,7 +245,7 @@ trait Facets { self: RestrictionFactory =>
   private def narrowNonNegativeFacets(localFacet: String, remoteFacet: String, facetType: Facet.Type): String = {
     val theLocalFacet = new BigInteger(localFacet)
     val theRemoteFacet = new BigInteger(remoteFacet)
-    if (theLocalFacet.signum() != 1) context.SDE("The %s facet must be a non-negative integer.", facetType)
+    if (theLocalFacet.signum() != 1) SDE("The %s facet must be a non-negative integer.", facetType)
     facetType match {
       case Facet.minLength => {
         errorOnLocalLessThanBaseFacet(theLocalFacet, theRemoteFacet, facetType)
@@ -257,7 +265,7 @@ trait Facets { self: RestrictionFactory =>
   private def narrowPositiveIntegerFacets(localFacet: String, remoteFacet: String, facetType: Facet.Type): String = {
     val theLocalFacet = new BigInteger(localFacet)
     val theRemoteFacet = new BigInteger(remoteFacet)
-    if ((theLocalFacet.signum() != 1) || (theLocalFacet.compareTo(BigInteger.ZERO) == 0)) context.SDE("The %s facet must be a positive integer.", facetType)
+    if ((theLocalFacet.signum() != 1) || (theLocalFacet.compareTo(BigInteger.ZERO) == 0)) SDE("The %s facet must be a positive integer.", facetType)
     facetType match {
       case Facet.totalDigits => {
         errorOnLocalGreaterThanBaseFacet(theLocalFacet, theRemoteFacet, facetType)
@@ -290,9 +298,9 @@ trait Facets { self: RestrictionFactory =>
 
   private def convertFacetToBigDecimal(facet: String): java.math.BigDecimal = {
     self.primType match {
-      case PrimType.DateTime => dateToBigDecimal(facet, "uuuu-MM-dd'T'HH:mm:ss.SSSSSSxxx", PrimType.DateTime.toString(), context)
-      case PrimType.Date => dateToBigDecimal(facet, "uuuu-MM-ddxxx", PrimType.Date.toString(), context)
-      case PrimType.Time => dateToBigDecimal(facet, "HH:mm:ss.SSSSSSxxx", PrimType.Time.toString(), context)
+      case PrimType.DateTime => dateToBigDecimal(facet, "uuuu-MM-dd'T'HH:mm:ss.SSSSSSxxx", PrimType.DateTime.toString(), this)
+      case PrimType.Date => dateToBigDecimal(facet, "uuuu-MM-ddxxx", PrimType.Date.toString(), this)
+      case PrimType.Time => dateToBigDecimal(facet, "HH:mm:ss.SSSSSSxxx", PrimType.Time.toString(), this)
       case _ => new java.math.BigDecimal(facet)
     }
   }
@@ -312,75 +320,87 @@ trait Facets { self: RestrictionFactory =>
         primType match {
           case PrimType.Int => {
             if (!isFacetInIntRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Int range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Int range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Byte => {
             if (!isFacetInByteRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Byte range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Byte range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Short => {
             if (!isFacetInShortRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Short range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Short range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Long => {
             if (!isFacetInLongRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Long range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Long range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Integer => {
             // Unbounded integer
             if (!isFacetInIntegerRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Integer range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Integer range.",
                 facetType, localFacet)
             }
           }
           case PrimType.UnsignedInt => {
             if (!isFacetInUnsignedIntRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of unsigned int range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of unsigned int range.",
                 facetType, localFacet)
             }
           }
           case PrimType.UnsignedByte => {
             if (!isFacetInUnsignedByteRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of unsigned byte range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of unsigned byte range.",
                 facetType, localFacet)
             }
           }
           case PrimType.UnsignedShort => {
             if (!isFacetInUnsignedShortRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of unsigned short range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of unsigned short range.",
                 facetType, localFacet)
             }
           }
           case PrimType.UnsignedLong => {
             if (!isFacetInUnsignedLongRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of unsigned long range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of unsigned long range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Double => {
             if (!isFacetInDoubleRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Double range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Double range.",
                 facetType, localFacet)
             }
           }
           case PrimType.Float => {
             if (!isFacetInFloatRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of Float range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of Float range.",
                 facetType, localFacet)
             }
           }
           case PrimType.NonNegativeInteger => {
             // Unsigned Unbounded Integer
             if (!isFacetInNonNegativeIntegerRange(theLocalFacet)) {
-              context.SDE("%s facet value (%s) was found to be outside of NonNegativeInteger range.",
+              SDE(
+                "%s facet value (%s) was found to be outside of NonNegativeInteger range.",
                 facetType, localFacet)
             }
           }
@@ -399,7 +419,8 @@ trait Facets { self: RestrictionFactory =>
     theLocalFacet
   }
 
-  private def checkValueSpaceFacetRange(localFacet: String,
+  private def checkValueSpaceFacetRange(
+    localFacet: String,
     remoteFacet: String, facetType: Facet.Type): (java.math.BigDecimal, java.math.BigDecimal) = {
     // Neccessary for min/max Inclusive/Exclusive Facets
 
@@ -488,7 +509,7 @@ trait Facets { self: RestrictionFactory =>
     val lValue = getLocalValue(Facet.enumeration)
     val rValue = getRemoteFacetValue(Facet.enumeration)
     lValue.foreach(e => {
-      if (rValue.length() > 0 && !rValue.contains(e)) context.SDE("Local enumerations must be a subset of base enumerations.")
+      if (rValue.length() > 0 && !rValue.contains(e)) SDE("Local enumerations must be a subset of base enumerations.")
     })
     if (lValue.length() > 0) { lValue }
     else { rValue }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
@@ -37,7 +37,7 @@ class GlobalElementDeclFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
   def forRoot() = asRoot // cache. Not a new one every time.
 
   private lazy val asRoot = {
-    lazy val ged = new GlobalElementDecl(xml, parent, root)
+    lazy val ged = new GlobalElementDecl(xml, schemaDocument, root)
     lazy val root: Root = new Root(xml, schemaDocument, namedQName, ged)
     root
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
@@ -65,7 +65,7 @@ final class GroupRefFactory(refXMLArg: Node, val refLexicalParent: SchemaCompone
   final def qname = this.refQName
 
   lazy val groupRef = LV('groupRef) {
-    val gdefFactory = parent.schemaSet.getGlobalGroupDef(qname).getOrElse {
+    val gdefFactory = lexicalParent.schemaSet.getGlobalGroupDef(qname).getOrElse {
       SDE("Referenced group definition not found: %s", this.ref)
     }
     val (gref, _) = gdefFactory.forGroupRef(refXMLArg, refLexicalParent, position, isHidden)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
@@ -126,7 +126,7 @@ object IIUtils {
 abstract class IIBase( final override val xml: Node, xsdArg: XMLSchemaDocument, val seenBefore: IIMap)
   extends SchemaComponent
   with NestingLexicalMixin {
-  final override def parent = xsdArg
+  final override def lexicalParent = xsdArg
 
   /**
    * An import/include requires only that we can access the

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
@@ -19,9 +19,9 @@ package org.apache.daffodil.dsom
 
 import scala.xml.Node
 
-sealed class LocalElementDecl(
+sealed abstract class LocalElementDeclBase(
   final override val xml: Node,
-  final override val parent: SchemaComponent,
+  final override val lexicalParent: SchemaComponent,
   final override val position: Int)
   extends ElementBase
   with LocalElementComponentMixin
@@ -31,35 +31,38 @@ sealed class LocalElementDecl(
   requiredEvaluations(minOccurs, maxOccurs)
 }
 
+class LocalElementDecl(
+  xml: Node,
+  lexicalParent: SchemaComponent,
+  position: Int)
+  extends LocalElementDeclBase(xml, lexicalParent, position)
+
 /**
  * A QuasiElement is similar to a LocalElement except it will have no
  * representation in the infoset, acting only as a temporary element that can
- * be parsed/unparsed. As an example, this is used as an element foar
+ * be parsed/unparsed. As an example, this is used as an element for
  * parsing/unparsing prefix lengths. No element exists in the infoset or in the
  * schema to represent a prefix length (only a simple type), so a
- * DetachedElementDecl is used as a place where properties related to the
- * prefix simpel type can be accessed.
+ * quasi-element is used as a place where properties related to the
+ * prefix simple type can be accessed.
  */
 sealed abstract class QuasiElementDeclBase(
-  val detachedReference: ElementBase,
   xml: Node,
-  parent: SchemaComponent)
-  extends LocalElementDecl(xml, parent, -1){
-  
+  lexicalParent: SchemaComponent)
+  extends LocalElementDeclBase(xml, lexicalParent, -1) {
+
   override lazy val isQuasiElement = true
 }
 
-final class PrefixLengthQuasiElementDecl(
-  detachedReference: ElementBase,
+class PrefixLengthQuasiElementDecl(
   xml: Node,
-  parent: SchemaComponent)
-  extends QuasiElementDeclBase(detachedReference, xml, parent){
+  lexicalParent: SchemaComponent)
+  extends QuasiElementDeclBase(xml, lexicalParent) {
 }
 
-final class RepTypeQuasiElementDecl(
-  detachedReference: ElementBase,
+class RepTypeQuasiElementDecl(
   xml: Node,
-  parent: SchemaComponent)
-  extends QuasiElementDeclBase(detachedReference, xml, parent){
-  
+  lexicalParent: SchemaComponent)
+  extends QuasiElementDeclBase(xml, lexicalParent) {
+
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementMixin.scala
@@ -32,16 +32,6 @@ trait LocalElementMixin
   extends ParticleMixin
   with LocalElementGrammarMixin { self: ElementBase =>
 
-  final lazy val hasSep = LV('hasSep) {
-    nearestEnclosingSequence match {
-      case None => false
-      case Some(es) => {
-        val res = es.separatorParseEv.isKnownNonEmpty
-        res
-      }
-    }
-  }.value
-
   /**
    * True if the length of the SimpleContent region or the ComplexContent region
    * (see DFDL Spec section 9.2) is known to be greater than zero.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
@@ -22,7 +22,7 @@ import org.apache.daffodil.exceptions.Assert
 trait NestingMixin {
 
   /** The lexically enclosing schema component */
-  def parent: SchemaComponent
+  def lexicalParent: SchemaComponent
 
   /**
    * Define this for schema components that have back-references to ref
@@ -57,7 +57,7 @@ trait NestingLexicalMixin
   extends NestingMixin {
 
   override protected def enclosingComponentDef =
-    if (parent eq null) None else Some(parent)
+    if (lexicalParent eq null) None else Some(lexicalParent)
 
 }
 
@@ -70,7 +70,7 @@ trait NestingTraversesToReferenceMixin
   def referringComponent: Option[SchemaComponent]
 
   final override protected def enclosingComponentDef: Option[SchemaComponent] = {
-    Assert.invariant(parent.isInstanceOf[SchemaDocument]) // global things have schema documents as their parents.
+    Assert.invariant(lexicalParent.isInstanceOf[SchemaDocument]) // global things have schema documents as their parents.
     referringComponent
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ReptypeMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ReptypeMixins.scala
@@ -28,23 +28,38 @@ import org.apache.daffodil.processors.RepValueSet
  * need to get a quasi element with said type.
  */
 trait HasOptRepTypeMixinImpl extends SchemaComponent with HasOptRepTypeMixin {
-  
-  override lazy val optRepTypeElement: Option[RepTypeQuasiElementDecl] = optRepTypeFactory.map(repType => {
-    val xmlElem = Elem(null, "QuasiElementForTypeCalc", new UnprefixedAttribute("type", repType.namedQName.toAttributeNameString, Null), namespaces, true)
-    new RepTypeQuasiElementDecl(this.enclosingElement.get, xmlElem, parent)
-  })
+
+  override lazy val optRepTypeElement: Option[RepTypeQuasiElementDecl] =
+    optRepTypeDef.map(repType => {
+      val xmlElem = Elem(null, "QuasiElementForTypeCalc", new UnprefixedAttribute("type", repType.namedQName.toAttributeNameString, Null), namespaces, true)
+      new RepTypeQuasiElementDecl(xmlElem, lexicalParent)
+    })
 
 }
 
 trait HasOptRepTypeMixin {
-  def optRepTypeFactory: Option[SimpleTypeFactory with NamedMixin]
-  
-  lazy val optRepTypeDefFactory: Option[SimpleTypeDefFactory with NamedMixin] = optRepTypeFactory match {
-    case Some(x:SimpleTypeDefFactory) => Some(x)
+
+  /**
+   *  Provides the repType. Can be a "def" or a primitive type.
+   *
+   *  optRepType and optRepTypeDef are different, because it is possible for the
+   *  repType to be a primitive type. The resulting type would be difficult
+   *  (maybe impossible?) to use as the type for an element, as a primitive repType
+   *  would be missing any annotations that tell Daffodil what the physical
+   *  characteristics are; however the type can be used purely to define a
+   *  function for use by DPath expressions.
+   */
+  def optRepType: Option[SimpleTypeBase]
+
+  /**
+   * optRepTypeDef - there is no "def" for a primitive type.
+   */
+  final lazy val optRepTypeDef: Option[SimpleTypeDefBase] = optRepType match {
+    case Some(x: SimpleTypeDefBase) => Some(x)
     case _ => None
   }
   def optRepValueSet: Option[RepValueSet[AnyRef]]
-  
+
   def optRepTypeElement: Option[RepTypeQuasiElementDecl]
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
@@ -29,21 +29,19 @@ import scala.xml.Node
  * Anything that can be computed without reference to the point of use
  * or point of reference can be computed here on these factory objects.
  */
-abstract class SchemaComponentFactory( final override val xml: Node,
-  final override val schemaDocument: SchemaDocument)
+abstract class SchemaComponentFactory(
+  final override val xml: Node,
+  final override val lexicalParent: SchemaComponent)
   extends SchemaComponent
   with NestingLexicalMixin {
 
-  final override def parent = schemaDocument
-
 }
 
-abstract class AnnotatedSchemaComponentFactory( final override val xml: Node,
-  final override val schemaDocument: SchemaDocument)
+abstract class AnnotatedSchemaComponentFactory(
+  final override val xml: Node,
+  final override val lexicalParent: SchemaComponent)
   extends AnnotatedSchemaComponent
   with NestingLexicalMixin {
-
-  final override def parent = schemaDocument
 
 }
 
@@ -52,7 +50,7 @@ trait SchemaFileLocatableImpl
 
   def xml: scala.xml.Node
   def schemaFile: Option[DFDLSchemaFile]
-  def parent: SchemaComponent
+  def lexicalParent: SchemaComponent
 
   /**
    * Annotations can contain expressions, so we need to be able to compile them.
@@ -65,7 +63,7 @@ trait SchemaFileLocatableImpl
     val attrText = xml.attribute(XMLUtils.INT_NS, XMLUtils.LINE_ATTRIBUTE_NAME).map { _.text }
     if (attrText.isDefined) {
       attrText
-    } else if (parent != null) parent.lineAttribute
+    } else if (lexicalParent != null) lexicalParent.lineAttribute
     else None
   }
 
@@ -81,14 +79,14 @@ trait SchemaFileLocatableImpl
 trait CommonContextMixin
   extends NestingMixin { self: OOLAGHost with ThrowsSDE =>
 
-  def parent: SchemaComponent
+  def lexicalParent: SchemaComponent
 
-  lazy val schemaFile: Option[DFDLSchemaFile] = parent.schemaFile
-  lazy val schemaSet: SchemaSet = parent.schemaSet
-  def schemaDocument: SchemaDocument = parent.schemaDocument
-  lazy val xmlSchemaDocument: XMLSchemaDocument = parent.xmlSchemaDocument
-  lazy val schema: Schema = parent.schema
-  def uriString: String = parent.uriString
+  lazy val schemaFile: Option[DFDLSchemaFile] = lexicalParent.schemaFile
+  lazy val schemaSet: SchemaSet = lexicalParent.schemaSet
+  def schemaDocument: SchemaDocument = lexicalParent.schemaDocument
+  lazy val xmlSchemaDocument: XMLSchemaDocument = lexicalParent.xmlSchemaDocument
+  lazy val schema: Schema = lexicalParent.schema
+  def uriString: String = lexicalParent.uriString
 
   def xml: scala.xml.Node
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentIncludesAndImportsMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentIncludesAndImportsMixin.scala
@@ -30,7 +30,7 @@ trait SchemaComponentIncludesAndImportsMixin
    * Used in diagnostic messages; hence, valueOrElse to avoid
    * problems when this can't get a value due to an error.
    */
-  override def uriString: String = uriString_.valueOrElse(orElseURL)
+  override def uriString: String = uriString_.toOption.getOrElse(orElseURL)
   private def uriString_ = LV('fileName) {
     xmlSchemaDocument.uriString
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
@@ -61,7 +61,8 @@ trait SchemaDocumentMixin { self: SchemaComponent =>
  * do with DFDL. Things like namespace, include, import, elementFormDefault
  * etc.
  */
-final class XMLSchemaDocument(xmlArg: Node,
+final class XMLSchemaDocument(
+  xmlArg: Node,
   schemaSetArg: SchemaSet,
 
   /**
@@ -181,7 +182,7 @@ final class SchemaDocument(xmlSDoc: XMLSchemaDocument)
   with SeparatorSuppressionPolicyMixin {
 
   final override val xml = xmlSDoc.xml
-  final override def parent = xmlSDoc
+  final override def lexicalParent = xmlSDoc
 
   override lazy val optReferredToComponent = None
 
@@ -287,7 +288,7 @@ final class SchemaDocument(xmlSDoc: XMLSchemaDocument)
     val factories = xmlelts.map { new GlobalElementDeclFactory(_, this) }
     factories
   }
-  lazy val globalSimpleTypeDefs = (xml \ "simpleType").map { new GlobalSimpleTypeDefFactory(_, this) }
+  lazy val globalSimpleTypeDefs = (xml \ "simpleType").map { new GlobalSimpleTypeDef(_, this) }
   lazy val globalComplexTypeDefs = (xml \ "complexType").map { new GlobalComplexTypeDefFactory(_, this) }
   lazy val globalGroupDefs = (xml \ "group").map { new GlobalGroupDefFactory(_, this) }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -48,7 +48,7 @@ import org.apache.daffodil.exceptions.Assert
  */
 abstract class SequenceTermBase(
   final override val xml: Node,
-  final override val parent: SchemaComponent,
+  final override val lexicalParent: SchemaComponent,
   final override val position: Int)
   extends ModelGroup(position)
   with SequenceGrammarMixin {
@@ -84,9 +84,9 @@ abstract class SequenceTermBase(
  */
 abstract class SequenceGroupTermBase(
   xml: Node,
-  parent: SchemaComponent,
+  lexicalParent: SchemaComponent,
   position: Int)
-  extends SequenceTermBase(xml, parent, position)
+  extends SequenceTermBase(xml, lexicalParent, position)
   with Sequence_AnnotationMixin
   with SequenceRuntimeValuedPropertiesMixin
   with SeparatorSuppressionPolicyMixin
@@ -318,8 +318,8 @@ trait SequenceDefMixin
 /**
  * Represents a local sequence definition.
  */
-class Sequence(xmlArg: Node, parent: SchemaComponent, position: Int)
-  extends SequenceGroupTermBase(xmlArg, parent, position)
+class Sequence(xmlArg: Node, lexicalParent: SchemaComponent, position: Int)
+  extends SequenceGroupTermBase(xmlArg, lexicalParent, position)
   with SequenceDefMixin {
 
   requiredEvaluations(checkHiddenGroupRefHasNoChildren)
@@ -356,7 +356,7 @@ class Sequence(xmlArg: Node, parent: SchemaComponent, position: Int)
  * handled as a degenerate sequence having only one element decl within it.
  */
 final class ChoiceBranchImpliedSequence(rawGM: Term)
-  extends SequenceTermBase(rawGM.xml, rawGM.parent, rawGM.position)
+  extends SequenceTermBase(rawGM.xml, rawGM.lexicalParent, rawGM.position)
   with GroupDefLike {
 
   override def separatorSuppressionPolicy: SeparatorSuppressionPolicy = SeparatorSuppressionPolicy.TrailingEmptyStrict

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
@@ -281,7 +281,7 @@ trait Term
     }
 
   final lazy val immediatelyEnclosingModelGroup: Option[ModelGroup] = {
-    val res = parent match {
+    val res = lexicalParent match {
       case c: ChoiceTermBase => Some(c)
       case s: SequenceTermBase => Some(s)
       case d: SchemaDocument => {
@@ -298,7 +298,7 @@ trait Term
         // but if we have a CT as our parent, the group around the element whose type
         // that is, isn't "immediately enclosing".
       }
-      case _ => Assert.invariantFailed("immediatelyEnclosingModelGroup called on " + this + "with parent " + parent)
+      case _ => Assert.invariantFailed("immediatelyEnclosingModelGroup called on " + this + "with lexical parent " + lexicalParent)
     }
     res
   }
@@ -539,11 +539,11 @@ trait Term
   /**
    * Returns a tuple, where the first item in the tuple is the list of sibling
    * terms that could appear before this. The second item in the tuple is a
-   * One(parent) if all prior siblings are optional or this element has no prior siblings
+   * One(enclosingParent) if all prior siblings are optional or this element has no prior siblings
    */
   lazy val potentialPriorTerms: (Seq[Term], Option[Term]) = {
     val et = enclosingTerm
-    val (potentialPrior, parent) = et match {
+    val (potentialPrior, optEnclosingParent) = et match {
       case None => (Seq(), None)
       case Some(eb: ElementBase) => (Seq(), Some(eb))
       case Some(ch: ChoiceTermBase) => (Seq(), Some(ch))
@@ -576,7 +576,7 @@ trait Term
         case _ => true
       }
     }
-    (potentialPriorRepresented, parent)
+    (potentialPriorRepresented, optEnclosingParent)
   }
 
   /*
@@ -740,7 +740,7 @@ trait Term
 
   /*
    * Returns a list of Elements that could follow this Term, including
-   * siblings, children of siblings, and siblings of the parent and their children.
+   * siblings, children of siblings, and siblings of the enclosingParent and their children.
    *
    * What stops this is when the end of an enclosing element has to be next.
    */
@@ -770,7 +770,7 @@ trait Term
 
   /*
    * Returns a list of sibling Terms that could follow this term. This will not
-   * return any children of sibling Terms, or any siblings of the parent.
+   * return any children of sibling Terms, or any siblings of the enclosingParent.
    */
   final def possibleNextSiblingTerms: Seq[Term] = LV('possibleNextSiblingTerms) {
     val et = enclosingTerm

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/AlignedMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/AlignedMixin.scala
@@ -79,7 +79,7 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
         true
       else
         false
-    } else if (this.rootElementRef.get.isScannable)
+    } else if (schemaSet.root.isScannable)
       true
     else
       false
@@ -93,7 +93,7 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
         true
       else
         false
-    } else if (this.rootElementRef.get.isScannable)
+    } else if (schemaSet.root.isScannable)
       true
     else
       false
@@ -131,7 +131,7 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
     if (this.isInstanceOf[Root] || this.isInstanceOf[QuasiElementDeclBase]) {
       AlignmentMultipleOf(0) // root and quasi elements are aligned with anything
     } else {
-      val (priorSibs, parent) = potentialPriorTerms
+      val (priorSibs, optEnclosingParent) = potentialPriorTerms
       val arraySelfAlignment =
         if (isArray) {
           val e = this.asInstanceOf[ElementBase]
@@ -174,7 +174,7 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
         val eaa = ps.endingAlignmentApprox
         eaa
       }
-      val parentAlignmentApprox = parent.map { p =>
+      val parentAlignmentApprox = optEnclosingParent.map { p =>
         val csa = p.contentStartAlignment
         csa
       }.toSeq

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -217,7 +217,7 @@ trait ElementBaseGrammarMixin
       <element name={ name + " (prefixLength)" } type={ prefixLengthType.toQNameString }/>
         .copy(scope = prefixLengthTypeGSTD.xml.scope)
     val detachedElementDecl =
-      new PrefixLengthQuasiElementDecl(this, detachedNode, prefixLengthTypeGSTD.parent)
+      new PrefixLengthQuasiElementDecl(detachedNode, prefixLengthTypeGSTD.lexicalParent)
 
     val prefixedLengthKind = detachedElementDecl.lengthKind
     prefixedLengthKind match {
@@ -577,17 +577,18 @@ trait ElementBaseGrammarMixin
     lazy val allowedValue = allowedValueArg
     if (this.isOutputValueCalc)
       SimpleTypeRetry(this, allowedValue)
-    else if (this.isInstanceOf[PrefixLengthQuasiElementDecl] &&
-      this.asInstanceOf[PrefixLengthQuasiElementDecl].detachedReference.impliedRepresentation == Representation.Text)
-      // If an element has text representation and has a prefixed length, it
+    else if (this.isInstanceOf[PrefixLengthQuasiElementDecl]) {
+      //
+      // If an element has a prefixed length, it
       // means that the prefix length value will be calculated using a
       // specified length unparser. This unparser works by suspending the
       // prefix length unaprser, eventually calculating the length of the
-      // unaprsed data, then setting the length to the value of the detached
+      // unparsed data, then setting the length to the value of the detached
       // element. Since the prefixed length unparser will need to suspend until
-      // its data value is dynaically set, it needs this SimpleTypeRetry.
+      // its data value is dynamically set, it needs this SimpleTypeRetry.
+      //
       SimpleTypeRetry(this, allowedValue)
-    else
+    } else
       allowedValue
   }
 
@@ -1434,8 +1435,8 @@ trait ElementBaseGrammarMixin
     else body
   }
 
-  lazy val hasRepType = (isSimpleType && simpleType.optRepTypeFactory.isDefined)
-  lazy val optRepType = if (hasRepType) Some(simpleType.optRepTypeFactory.get) else None
+  lazy val hasRepType = (isSimpleType && simpleType.optRepType.isDefined)
+  lazy val optRepType = if (hasRepType) Some(simpleType.optRepType.get) else None
   lazy val optRepTypeElement = if (isSimpleType && simpleType.optRepTypeElement.isDefined) Some(simpleType.optRepTypeElement.get) else None
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -48,7 +48,8 @@ import org.apache.daffodil.processors.unparsers.NadaUnparser
 import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.unparsers.TypeValueCalcUnparser
 
-abstract class AssertBase(decl: AnnotatedSchemaComponent,
+abstract class AssertBase(
+  decl: AnnotatedSchemaComponent,
   exprWithBraces: String,
   namespacesForNamespaceResolution: scala.xml.NamespaceBinding,
   scWherePropertyWasLocated: AnnotatedSchemaComponent,
@@ -73,10 +74,11 @@ abstract class AssertBase(decl: AnnotatedSchemaComponent,
 
   override val forWhat = ForParser
 
-  lazy val msgExpr ={
+  lazy val msgExpr = {
     if (msgOpt.isDefined) {
-      ExpressionCompilers.String.compileExpression(qn,
-      NodeInfo.String, msgOpt.get, exprNamespaces, exprComponent.dpathCompileInfo, false, this, exprComponent.dpathCompileInfo)
+      ExpressionCompilers.String.compileExpression(
+        qn,
+        NodeInfo.String, msgOpt.get, exprNamespaces, exprComponent.dpathCompileInfo, false, this, exprComponent.dpathCompileInfo)
     } else {
       new ConstantExpression[String](qn, NodeInfo.String, exprWithBraces + " failed")
     }
@@ -111,7 +113,8 @@ case class DiscriminatorBooleanPrim(
 // an XPath evaluator that runs fn:true() expression.
 case class InitiatedContent(
   decl: AnnotatedSchemaComponent)
-  extends AssertBase(decl,
+  extends AssertBase(
+    decl,
     "{ fn:true() }", <xml xmlns:fn={ XMLUtils.XPATH_FUNCTION_NAMESPACE }/>.scope, decl,
     // always true. We're just an assertion that says an initiator was found.
     None,
@@ -120,7 +123,7 @@ case class InitiatedContent(
 }
 
 case class SetVariable(stmt: DFDLSetVariable)
-  extends ExpressionEvaluatorBase(stmt.context) {
+  extends ExpressionEvaluatorBase(stmt.lexicalParent) {
 
   val baseName = "SetVariable[" + stmt.varQName.local + "]"
 
@@ -178,12 +181,14 @@ abstract class ExpressionEvaluatorBase(e: AnnotatedSchemaComponent) extends Term
   protected def qn = GlobalQName(Some("daf"), baseName, XMLUtils.dafintURI)
 
   lazy val expr = LV('expr) {
-    ExpressionCompilers.AnyRef.compileExpression(qn,
+    ExpressionCompilers.AnyRef.compileExpression(
+      qn,
       nodeKind, exprText, exprNamespaces, exprComponent.dpathCompileInfo, false, this, exprComponent.dpathCompileInfo)
   }.value
 }
 
-abstract class ValueCalcBase(e: ElementBase,
+abstract class ValueCalcBase(
+  e: ElementBase,
   property: PropertyLookupResult)
   extends ExpressionEvaluatorBase(e) {
 
@@ -199,7 +204,8 @@ abstract class ValueCalcBase(e: ElementBase,
 
 }
 
-case class InputValueCalc(e: ElementBase,
+case class InputValueCalc(
+  e: ElementBase,
   property: PropertyLookupResult)
   extends ValueCalcBase(e, property) {
 
@@ -213,8 +219,8 @@ case class InputValueCalc(e: ElementBase,
 }
 
 case class TypeValueCalc(e: ElementBase)
-    extends Terminal(e,e.hasRepType){
-  
+  extends Terminal(e, e.hasRepType) {
+
   private lazy val simpleTypeDefBase = e.simpleType.asInstanceOf[SimpleTypeDefBase]
   private lazy val typeCalculator = {
     val a = simpleTypeDefBase
@@ -224,20 +230,20 @@ case class TypeValueCalc(e: ElementBase)
   private lazy val repTypeRuntimeData = simpleTypeDefBase.optRepTypeElement.get.elementRuntimeData
   private lazy val repTypeParser = simpleTypeDefBase.optRepTypeElement.get.enclosedElement.parser
   private lazy val repTypeUnparser = simpleTypeDefBase.optRepTypeElement.get.enclosedElement.unparser
-  
+
   override lazy val parser: DaffodilParser = {
-    if(!typeCalculator.supportsParse){
+    if (!typeCalculator.supportsParse) {
       SDE("Parsing not defined by typeValueCalc")
     }
     new TypeValueCalcParser(typeCalculator, repTypeParser, e.elementRuntimeData, repTypeRuntimeData)
   }
   override lazy val unparser: DaffodilUnparser = {
-    if(!typeCalculator.supportsUnparse){
+    if (!typeCalculator.supportsUnparse) {
       SDE("Unparsing not defined by typeValueCalc")
     }
     new TypeValueCalcUnparser(typeCalculator, repTypeUnparser, e.elementRuntimeData, repTypeRuntimeData)
   }
-  
+
 }
 
 //case class OutputValueCalcStaticLength(e: ElementBase,
@@ -296,7 +302,7 @@ case class TypeValueCalc(e: ElementBase)
 
 abstract class AssertPatternPrimBase(decl: Term, stmt: DFDLAssertionBase, discrim: Boolean)
   extends ExpressionEvaluatorBase(decl) {
- 
+
   override val baseName = if (discrim) "Discriminator" else "Assert"
   override lazy val exprText = stmt.messageAttrib.get
   override lazy val exprNamespaces = decl.namespaces
@@ -325,7 +331,6 @@ abstract class AssertPatternPrimBase(decl: Term, stmt: DFDLAssertionBase, discri
 
 case class AssertPatternPrim(term: Term, stmt: DFDLAssert)
   extends AssertPatternPrimBase(term, stmt, false)
-
 
 case class DiscriminatorPatternPrim(term: Term, stmt: DFDLDiscriminator)
   extends AssertPatternPrimBase(term, stmt, true)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -246,7 +246,7 @@ class TestDsomCompiler extends Logging {
 
     // Explore global simple type defs
     val Seq(st1, _, _, _) = sd.globalSimpleTypeDefs // there are two.
-    val Seq(b1, b2, _, b4) = st1.forElement(e1).annotationObjs // first one has 4 annotations
+    val Seq(b1, b2, _, b4) = st1.annotationObjs // first one has 4 annotations
     assertEquals(AlignmentUnits.Bytes.toString.toLowerCase, b1.asInstanceOf[DFDLSimpleType].getPropertyForUnitTest("alignmentUnits")) // first has alignmentUnits
     assertEquals("tns:myVar1", b2.asInstanceOf[DFDLSetVariable].ref) // second is setVariable with a ref
     assertEquals("yadda yadda yadda", b4.asInstanceOf[DFDLAssert].messageAttrib.get) // fourth is an assert with yadda message
@@ -419,7 +419,7 @@ class TestDsomCompiler extends Logging {
 
     val Seq(gs1f, _, gs3f, _) = sd.globalSimpleTypeDefs
 
-    val gs1 = gs1f.forElement(e1.referencedElement) // Global Simple Type - aType
+    val gs1 = gs1f // Global Simple Type - aType
 
     val baseQName = gs1.optRestriction.get.baseQName
 
@@ -435,7 +435,7 @@ class TestDsomCompiler extends Logging {
     assertTrue(e1.verifyPropValue("textStandardBase", "10")) // Define Format - def2
     assertTrue(e1.verifyPropValue("escapeSchemeRef", "tns:quotingScheme")) // Define Format - def2
 
-    val gs3 = gs3f.forElement(e1.referencedElement) // Global SimpleType - aTypeError - overlapping base props
+    val gs3 = gs3f // Global SimpleType - aTypeError - overlapping base props
 
     // Tests overlapping properties
     // because these unit tests are outside the normal framework,
@@ -672,7 +672,6 @@ class TestDsomCompiler extends Logging {
     assertTrue(ese.path.contains("sequence[3]"))
   }
 
-
   val dummyGroupRef = null // just because otherwise we have to construct too many things.
 
   def FindValue(collection: Map[String, String], key: String, value: String): Boolean = {
@@ -692,7 +691,7 @@ class TestDsomCompiler extends Logging {
     //    val actualString = actual.result.toString
     //    assertTrue(actualString.startsWith("<data"))
     //    assertTrue(actualString.endsWith(">word</data>"))
-  
+
     val infoset = <data xmlns={ example }>word</data>
     TestUtils.testUnparsing(testSchema, infoset, "*word")
   }
@@ -707,7 +706,7 @@ class TestDsomCompiler extends Logging {
     //    val actualString = actual.result.toString
     //    assertTrue(actualString.startsWith("<data"))
     //    assertTrue(actualString.endsWith(">37</data>"))
-  
+
     val infoset = <data xmlns={ example }>37</data>
     TestUtils.testUnparsing(testSchema, infoset, "37!")
   }
@@ -721,7 +720,7 @@ class TestDsomCompiler extends Logging {
     //    val actualString = actual.result.toString
     //    assertTrue(actualString.startsWith("<data"))
     //    assertTrue(actualString.endsWith(">37</data>"))
-  
+
     val infoset = <data xmlns={ example }>37</data>
     TestUtils.testUnparsing(testSchema, infoset, "*37!")
   }
@@ -759,7 +758,7 @@ class TestDsomCompiler extends Logging {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
-  
+
       <xs:element name="list" type="tns:example1">
         <xs:annotation>
           <xs:appinfo source={ dfdl }>
@@ -778,7 +777,7 @@ class TestDsomCompiler extends Logging {
     //    val actualString = actual.result.toString
     //    assertTrue(actualString.startsWith("<list"))
     //    assertTrue(actualString.endsWith("><somedata>50.93</somedata><moredata>XYZ</moredata><anddata>42</anddata></list>"))
-  
+
     val infoset = <list xmlns={ example }><somedata>50.93</somedata><moredata>XYZ</moredata><anddata>42</anddata></list>
     TestUtils.testUnparsing(testSchema, infoset, "50.93^%XYZ^42")
   }
@@ -992,7 +991,7 @@ class TestDsomCompiler extends Logging {
     //        val actualString = actual.result.toString
     //        assertTrue(actualString.startsWith("<data"))
     //        assertTrue(actualString.endsWith(">15</data>"))
-  
+
     val infoset = <data xmlns={ example }>15</data>
     val bytes = List[Byte](0, 0, 0, 15).toArray
     TestUtils.testUnparsingBinary(testSchema, infoset, bytes)
@@ -1007,7 +1006,7 @@ class TestDsomCompiler extends Logging {
     //        val actualString = actual.result.toString
     //        assertTrue(actualString.startsWith("<data"))
     //        assertTrue(actualString.endsWith(">15</data>"))
-  
+
     val infoset = <data xmlns={ example }>15</data>
     val bytes = List[Byte](15, 0, 0, 0).toArray
     TestUtils.testUnparsingBinary(testSchema, infoset, bytes)
@@ -1050,14 +1049,14 @@ class TestDsomCompiler extends Logging {
           <xs:pattern value="3"/>
         </xs:restriction>
       </xs:simpleType>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
     val Seq(schemaDoc, _) = schema.schemaDocuments
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.forRoot()
-  
+
     assertEquals(1, decl.patternValues.length)
     val (_, pattern) = decl.patternValues(0)
     assertEquals("1|2|3", pattern.toString())
@@ -1089,19 +1088,19 @@ class TestDsomCompiler extends Logging {
           <xs:pattern value="9"/>
         </xs:restriction>
       </xs:simpleType>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
     val Seq(schemaDoc, _) = schema.schemaDocuments
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.forRoot()
-  
+
     assertEquals(3, decl.patternValues.length)
     val (_, st1) = decl.patternValues(0)
     val (_, st2) = decl.patternValues(1)
     val (_, st3) = decl.patternValues(2)
-  
+
     assertEquals("1|2|3", st1.toString())
     assertEquals("4|5|6", st2.toString())
     assertEquals("7|8|9", st3.toString())
@@ -1159,7 +1158,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1167,35 +1166,35 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, _: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     assertEquals(1, elemsFollowingOne.length)
     assertEquals("two", elemsFollowingOne(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     assertEquals(1, elemsFollowingTwo.length)
     assertEquals("three", elemsFollowingTwo(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     assertEquals(1, elemsFollowingThree.length)
     val seqFollowingThree = elemsFollowingThree(0).asInstanceOf[Sequence]
-  
+
     val Seq(four: ElementBase) = seqFollowingThree.allSelfContainedTermsTerminatedByRequiredElement
     assertEquals("four", four.name)
-  
+
   }
 
   /**
@@ -1251,7 +1250,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1259,31 +1258,31 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, _: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     assertEquals(1, elemsFollowingOne.length)
     assertEquals("two", elemsFollowingOne(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     assertEquals(2, elemsFollowingTwo.length)
     assertEquals("three", elemsFollowingTwo(0).asInstanceOf[ElementBase].name)
     val seqFollowingThree = elemsFollowingTwo(1).asInstanceOf[Sequence]
     val Seq(four: ElementBase) = seqFollowingThree.groupMembers
     assertEquals("four", four.name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     assertEquals(1, elemsFollowingThree.length)
     val seqFollowingThree2 = elemsFollowingThree(0).asInstanceOf[Sequence]
@@ -1343,7 +1342,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1351,35 +1350,35 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, _: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     assertEquals(2, elemsFollowingOne.length)
     assertEquals("two", elemsFollowingOne(0).asInstanceOf[ElementBase].name)
     assertEquals("three", elemsFollowingOne(1).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     assertEquals(1, elemsFollowingTwo.length)
     assertEquals("three", elemsFollowingTwo(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     assertEquals(1, elemsFollowingThree.length)
     val seqFollowingThree = elemsFollowingThree(0).asInstanceOf[Sequence]
     val Seq(four: ElementBase) = seqFollowingThree.groupMembers
     assertEquals("four", four.name)
-  
+
   }
 
   /**
@@ -1434,7 +1433,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1442,34 +1441,34 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, _: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     assertEquals(1, elemsFollowingOne.length)
     assertEquals("two", elemsFollowingOne(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     assertEquals(1, elemsFollowingTwo.length)
     assertEquals("three", elemsFollowingTwo(0).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     assertEquals(1, elemsFollowingThree.length)
     val seqFollowingThree = elemsFollowingThree(0).asInstanceOf[Sequence]
     val Seq(four: ElementBase) = seqFollowingThree.groupMembers
     assertEquals("four", four.name)
-  
+
   }
 
   /**
@@ -1530,7 +1529,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1538,22 +1537,22 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, seq: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val Seq(four: ElementBase) = seq.groupMembers
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     val Seq(eTwo: ElementBase, eThree: ElementBase, seqFollowingThree: Sequence) = one.possibleNextTerms
     assertEquals(3, elemsFollowingOne.length)
@@ -1561,23 +1560,23 @@ class TestDsomCompiler extends Logging {
     assertEquals("three", eThree.name)
     val Seq(eFour: ElementBase) = seqFollowingThree.groupMembers
     assertEquals("four", eFour.name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     val Seq(eThree_2: ElementBase, seqFollowingThree_2: Sequence) = two.possibleNextTerms
     assertEquals(2, elemsFollowingTwo.length)
     assertEquals("three", eThree_2.name)
     val Seq(eFour_2: ElementBase) = seqFollowingThree_2.groupMembers
     assertEquals("four", eFour_2.name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     val Seq(seqFollowingThree_3: Sequence) = three.possibleNextTerms
     assertEquals(1, elemsFollowingThree.length)
     val Seq(eFour_3: ElementBase) = seqFollowingThree_3.groupMembers
     assertEquals("four", eFour_3.name)
-  
+
     val elemsFollowingFour = four.possibleNextTerms
     assertEquals(0, elemsFollowingFour.length)
-  
+
   }
 
   /**
@@ -1638,7 +1637,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -1646,22 +1645,22 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase, seq: Sequence) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val Seq(four: ElementBase) = seq.groupMembers
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     val Seq(two_1: ElementBase, three_1: ElementBase, seqFollowingThree_1: Sequence) = one.possibleNextTerms
     val Seq(four_1: ElementBase) = seqFollowingThree_1.groupMembers
@@ -1669,23 +1668,23 @@ class TestDsomCompiler extends Logging {
     assertEquals("two", two_1.name)
     assertEquals("three", three_1.name)
     assertEquals("four", four_1.name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     val Seq(three_2: ElementBase, seqFollowingThree_2: Sequence) = two.possibleNextTerms
     val Seq(four_2: ElementBase) = seqFollowingThree_2.groupMembers
     assertEquals(2, elemsFollowingTwo.length)
     assertEquals("three", three_2.name)
     assertEquals("four", four_2.name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     val Seq(seqFollowingThree_3: Sequence) = three.possibleNextTerms
     val Seq(four_3: ElementBase) = seqFollowingThree_3.groupMembers
     assertEquals(1, elemsFollowingThree.length)
     assertEquals("four", four_3.name)
-  
+
     val elemsFollowingFour = four.possibleNextTerms
     assertEquals(0, elemsFollowingFour.length)
-  
+
   }
 
   //  /**
@@ -2313,7 +2312,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-  
+
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -2321,32 +2320,32 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val root = declf.forRoot()
     val rootCT = root.complexType
-  
+
     // Verify that nothing follows the root, as it is the root.
     val elemsFollowingRoot = root.possibleNextTerms
     assertEquals(0, elemsFollowingRoot.length)
-  
+
     val rootCTSeq = rootCT.sequence //... which is a sequence
-  
+
     // Verify that nothing follows the sequence of the root.
     val elemsFollowingRootSeq = rootCTSeq.possibleNextTerms
     assertEquals(0, elemsFollowingRootSeq.length)
-  
+
     val Seq(one: ElementBase, two: ElementBase, three: ElementBase) =
       rootCTSeq.groupMembers // has an element and a sub-sequence as its children.
-  
+
     val elemsFollowingOne = one.possibleNextTerms
     assertEquals(3, elemsFollowingOne.length)
     assertEquals("one", elemsFollowingOne(0).asInstanceOf[ElementBase].name)
     assertEquals("two", elemsFollowingOne(1).asInstanceOf[ElementBase].name)
     assertEquals("three", elemsFollowingOne(2).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingTwo = two.possibleNextTerms
     assertEquals(3, elemsFollowingTwo.length)
     assertEquals("one", elemsFollowingTwo(0).asInstanceOf[ElementBase].name)
     assertEquals("two", elemsFollowingTwo(1).asInstanceOf[ElementBase].name)
     assertEquals("three", elemsFollowingTwo(2).asInstanceOf[ElementBase].name)
-  
+
     val elemsFollowingThree = three.possibleNextTerms
     assertEquals(3, elemsFollowingThree.length)
     assertEquals("one", elemsFollowingThree(0).asInstanceOf[ElementBase].name)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -101,6 +101,12 @@ final class MStackOfMaybe[T <: AnyRef] {
     else One(m)
   }
 
+  @inline final def bottom: Maybe[T] = {
+    val m = delegate.bottom
+    if (m eq null) Nope
+    else One(m)
+  }
+
   @inline final def isEmpty = delegate.isEmpty
 
   def clear() = delegate.clear()
@@ -138,6 +144,7 @@ final class MStackOf[T <: AnyRef] {
   @inline final def push(t: T) = delegate.push(t)
   @inline final def pop: T = delegate.pop.asInstanceOf[T]
   @inline final def top: T = delegate.top.asInstanceOf[T]
+  @inline final def bottom: T = delegate.bottom.asInstanceOf[T]
   @inline final def isEmpty = delegate.isEmpty
   def clear() = delegate.clear()
   def toList = delegate.toList
@@ -167,7 +174,7 @@ object MStackOfAnyRef {
  * things.
  */
 protected abstract class MStack[@specialized T] private[util] (
-    arrayAllocator: (Int) => Array[T], nullValue: T) {
+  arrayAllocator: (Int) => Array[T], nullValue: T) {
 
   private var index = 0
   private var table: Array[T] = null
@@ -260,6 +267,8 @@ protected abstract class MStack[@specialized T] private[util] (
    *  @return the element on top of the stack.
    */
   @inline final def top: T = table(index - 1).asInstanceOf[T]
+
+  @inline final def bottom: T = table(0).asInstanceOf[T]
 
   @inline final def isEmpty: Boolean = index == 0
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -298,7 +298,8 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
       //
       val compiledExpr = try {
         val hostForDiags = new DebuggerHost()
-        val ce = eCompilers.JBoolean.compileExpression(debuggerQName,
+        val ce = eCompilers.JBoolean.compileExpression(
+          debuggerQName,
           NodeInfo.Boolean, expression, processor.context.namespaces, context.dpathCompileInfo, false,
           hostForDiags, context.dpathCompileInfo)
         val warnings = hostForDiags.getDiagnostics.filterNot(_.isError)
@@ -456,9 +457,9 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     debugPrintln(bos.toString("UTF-8"))
   }
 
-  /**********************************/
+/**********************************/
   /**          Commands            **/
-  /**********************************/
+/**********************************/
 
   abstract class DebugCommand {
     val name: String
@@ -1043,7 +1044,8 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
         val isEvaluatedAbove = false
         try {
           val hostForDiags = new DebuggerHost()
-          val compiledExpression = eCompilers.AnyRef.compileExpression(debuggerQName,
+          val compiledExpression = eCompilers.AnyRef.compileExpression(
+            debuggerQName,
             NodeInfo.AnyType, expressionWithBraces, namespaces, context.dpathCompileInfo,
             isEvaluatedAbove, hostForDiags, context.dpathElementCompileInfo)
           val res = compiledExpression.evaluate(state)
@@ -1494,27 +1496,10 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
         val desc = "display the current infoset"
         val longDesc = desc
 
-        def getInfoset(currentNode: InfosetItem) = {
-          val rootNode =
-            if (currentNode.isInstanceOf[InfosetElement]) {
-
-              var tmpNode = currentNode.asInstanceOf[DIElement]
-              var parent = tmpNode.diParent
-              while (parent ne null) {
-                tmpNode = parent
-                parent = tmpNode.diParent
-              }
-              tmpNode
-            } else {
-              currentNode
-            }
-          rootNode.asInstanceOf[DIDocument]
-        }
-
         def act(args: Seq[String], prestate: StateForDebugger, state: ParseOrUnparseState, processor: Processor): DebugState.Type = {
           debugPrintln("%s:".format(name))
 
-          val infoset = getInfoset(state.infoset)
+          val infoset = state.infoset.toRootDoc
           if (infoset.getRootElement != null) {
             val bos = new java.io.ByteArrayOutputStream()
             val xml = new XMLTextInfosetOutputter(bos, true)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -146,7 +146,7 @@ final case class ConstantExpression[+T <: AnyRef](
     value
   }
   override def run(dstate: DState) = dstate.setCurrentValue(value)
- 
+
   final def evaluateForwardReferencing(state: ParseOrUnparseState, whereBlockedLocation: Suspension): Maybe[T] = {
     // whereBlockedLocation is ignored since a constant expression cannot block.
     whereBlockedLocation.setDone
@@ -299,7 +299,7 @@ class DPathCompileInfo(
  * structures are created which reference these.
  */
 class DPathElementCompileInfo(
-  @TransientParam parentArg: => Option[DPathCompileInfo],
+  @TransientParam parentArg: => Option[DPathElementCompileInfo],
   @TransientParam variableMap: => VariableMap,
   @TransientParam elementChildrenCompileInfoArg: => Seq[DPathElementCompileInfo],
   namespaces: scala.xml.NamespaceBinding,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -66,7 +66,7 @@ sealed trait DINode {
     }
   }
   def isSimple: Boolean
-  
+
   def asComplex: DIComplex = {
     this match {
       case diComplex: DIComplex => diComplex
@@ -158,8 +158,8 @@ case class InfosetWrongNodeType(expectedType: String, val node: DINode)
 case class InfosetNoSuchChildElementException(val diComplex: DIComplex, val info: DPathElementCompileInfo)
   extends ProcessingError("Expression Evaluation", Nope, Nope, "Child element %s does not exist.", info.namedQName)
   with InfosetException with RetryableException
-  
-case class InfosetNoNextSiblingException(val diSimple:DISimple, val info:DPathElementCompileInfo)
+
+case class InfosetNoNextSiblingException(val diSimple: DISimple, val info: DPathElementCompileInfo)
   extends ProcessingError("Expression Evaluation", Nope, Nope, "Element %s does not have a nextSibling", info.namedQName)
   with InfosetException with RetryableException
 
@@ -836,11 +836,11 @@ sealed trait DIElement
     case _ => false
   }
 
-  def toRootDoc: DIComplex = toRootDoc1(this)
+  def toRootDoc: DIDocument = toRootDoc1(this)
 
-  private def toRootDoc1(orig: DIElement): DIComplex = {
+  private def toRootDoc1(orig: DIElement): DIDocument = {
     if (isRootDoc) this.asInstanceOf[DIDocument]
-    else if (isRoot) diParent
+    else if (isRoot) diParent.asInstanceOf[DIDocument]
     else {
       parent match {
         case null =>
@@ -961,7 +961,7 @@ final class DIArray(
       }
     }
   }
-  
+
   override def isSimple = false
   override def isComplex = false
 
@@ -1593,7 +1593,7 @@ final class DIDocument(erd: ElementRuntimeData, tunable: DaffodilTunables)
       nameToChildNodeLookup.put(node.namedQName, ab)
     }
     child.setParent(this)
-    if(root == null)
+    if (root == null)
       root = child.asInstanceOf[DIElement]
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -370,7 +370,7 @@ class DataProcessor(val ssrd: SchemaSetRuntimeData)
     Assert.invariant(state.arrayIndexStack.length == 1)
     Assert.invariant(state.groupIndexStack.length == 1)
     Assert.invariant(state.childIndexStack.length == 1)
-    Assert.invariant(state.currentInfosetNodeStack.isEmpty)
+    Assert.invariant(state.currentInfosetNodeMaybe.isEmpty)
     Assert.invariant(state.escapeSchemeEVCache.isEmpty)
     //
     // All the DOS that precede the last one

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
@@ -28,5 +28,5 @@ object TestNilled {
 class TestNilled {
   import TestNilled._
 
-  @Test def test_nilled_ES_optional() = { runner.trace.runOneTest("nilled_ES_optional") }
+  @Test def test_nilled_ES_optional() = { runner.runOneTest("nilled_ES_optional") }
 }


### PR DESCRIPTION
This is incremental progress toward getting rid of the backpointers that prevent structure sharing in the Daffodil schema compiler.

There's some commits which are small cleanups. The last commit eliminates the backpointers from all simple type objects to the objects that reference them. This eliminates the Factory vs. Instance distinction for simple types (so far). 

I would like to try to carry out this task of fixing the schema compiler's algorithmic/data-structure flaws incrementally, by a number of smaller change sets like this one. 