### PR TITLE
Sick of NPE. lexicalParent is now optLexicalParent and is Option type

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
@@ -110,8 +110,12 @@ trait ResolvesProperties
 /** Convenience class for implemening AnnotatedSchemaComponent trait */
 abstract class AnnotatedSchemaComponentImpl(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent)
-  extends AnnotatedSchemaComponent
+  final override val optLexicalParent: Option[SchemaComponent])
+  extends AnnotatedSchemaComponent {
+
+  def this(xml: Node, lexicalParent: SchemaComponent) =
+    this(xml, Option(lexicalParent))
+}
 
 /**
  * Shared characteristics of any annotated schema component.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -101,7 +101,7 @@ trait ChoiceDefMixin
 
 abstract class ChoiceTermBase(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent,
+  final override val optLexicalParent: Option[SchemaComponent],
   final override val position: Int)
   extends ModelGroup(position)
   with Choice_AnnotationMixin
@@ -369,7 +369,7 @@ abstract class ChoiceTermBase(
 }
 
 final class Choice(xmlArg: Node, lexicalParent: SchemaComponent, position: Int)
-  extends ChoiceTermBase(xmlArg, lexicalParent, position)
+  extends ChoiceTermBase(xmlArg, Option(lexicalParent), position)
   with ChoiceDefMixin {
 
   override lazy val optReferredToComponent = None

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLAnnotation.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLAnnotation.scala
@@ -33,13 +33,15 @@ import org.apache.daffodil.util.Misc
  * and Import objects which represent those statements in a schema,
  * the proxy DFDLSchemaFile object, etc.
  *
+ *
  */
 abstract class DFDLAnnotation(xmlArg: Node, annotatedSCArg: AnnotatedSchemaComponent)
   extends SchemaComponent
   with NestingLexicalMixin {
 
   final override val xml = xmlArg
-  final override def lexicalParent = annotatedSCArg
+
+  final override val optLexicalParent = Option(annotatedSCArg)
 
   final lazy val annotatedSC = annotatedSCArg
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -663,10 +663,12 @@ trait ElementBase
   }
 
   final lazy val isParentUnorderedSequence: Boolean = {
-    lexicalParent match {
-      case s: SequenceTermBase if !s.isOrdered => true
-      case _ => false
-    }
+    optLexicalParent.map { lp =>
+      lp match {
+        case s: SequenceTermBase if !s.isOrdered => true
+        case _ => false
+      }
+    }.getOrElse(false)
   }
 
   private def getImplicitAlignmentInBits(thePrimType: PrimType, theRepresentation: Representation): Int = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
@@ -38,7 +38,7 @@ abstract class AbstractElementRef(
   with NestingLexicalMixin {
 
   override lazy val xml = xmlArg
-  final override lazy val lexicalParent = parentArg
+  final override lazy val optLexicalParent = Option(parentArg)
   final override lazy val position = positionArg
 
   requiredEvaluations(referencedElement)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupRef.scala
@@ -59,13 +59,13 @@ trait GroupRef { self: ModelGroup =>
  * right part of the schema.
  */
 final class GroupRefFactory(refXMLArg: Node, val refLexicalParent: SchemaComponent, position: Int, isHidden: Boolean)
-  extends SchemaComponentFactory(refXMLArg, refLexicalParent.schemaDocument)
+  extends SchemaComponentFactory(refXMLArg, Some(refLexicalParent.schemaDocument))
   with HasRefMixin {
 
   final def qname = this.refQName
 
   lazy val groupRef = LV('groupRef) {
-    val gdefFactory = lexicalParent.schemaSet.getGlobalGroupDef(qname).getOrElse {
+    val gdefFactory = schemaSet.getGlobalGroupDef(qname).getOrElse {
       SDE("Referenced group definition not found: %s", this.ref)
     }
     val (gref, _) = gdefFactory.forGroupRef(refXMLArg, refLexicalParent, position, isHidden)
@@ -105,7 +105,7 @@ final class ChoiceGroupRef(
   refLexicalParent: SchemaComponent,
   positionArg: Int,
   isHiddenArg: Boolean)
-  extends ChoiceTermBase(refXML, refLexicalParent, positionArg)
+  extends ChoiceTermBase(refXML, Option(refLexicalParent), positionArg)
   with GroupRef {
 
   requiredEvaluations(groupDef)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/IIBase.scala
@@ -126,7 +126,7 @@ object IIUtils {
 abstract class IIBase( final override val xml: Node, xsdArg: XMLSchemaDocument, val seenBefore: IIMap)
   extends SchemaComponent
   with NestingLexicalMixin {
-  final override def lexicalParent = xsdArg
+  final override def optLexicalParent = Option(xsdArg)
 
   /**
    * An import/include requires only that we can access the

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
@@ -21,7 +21,7 @@ import scala.xml.Node
 
 sealed abstract class LocalElementDeclBase(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent,
+  final override val optLexicalParent: Option[SchemaComponent],
   final override val position: Int)
   extends ElementBase
   with LocalElementComponentMixin
@@ -35,7 +35,7 @@ class LocalElementDecl(
   xml: Node,
   lexicalParent: SchemaComponent,
   position: Int)
-  extends LocalElementDeclBase(xml, lexicalParent, position)
+  extends LocalElementDeclBase(xml, Option(lexicalParent), position)
 
 /**
  * A QuasiElement is similar to a LocalElement except it will have no
@@ -49,7 +49,7 @@ class LocalElementDecl(
 sealed abstract class QuasiElementDeclBase(
   xml: Node,
   lexicalParent: SchemaComponent)
-  extends LocalElementDeclBase(xml, lexicalParent, -1) {
+  extends LocalElementDeclBase(xml, Option(lexicalParent), -1) {
 
   override lazy val isQuasiElement = true
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
@@ -22,7 +22,7 @@ import org.apache.daffodil.exceptions.Assert
 trait NestingMixin {
 
   /** The lexically enclosing schema component */
-  def lexicalParent: SchemaComponent
+  def optLexicalParent: Option[SchemaComponent]
 
   /**
    * Define this for schema components that have back-references to ref
@@ -56,8 +56,7 @@ trait NestingMixin {
 trait NestingLexicalMixin
   extends NestingMixin {
 
-  override protected def enclosingComponentDef =
-    if (lexicalParent eq null) None else Some(lexicalParent)
+  override protected def enclosingComponentDef = optLexicalParent
 
 }
 
@@ -70,7 +69,8 @@ trait NestingTraversesToReferenceMixin
   def referringComponent: Option[SchemaComponent]
 
   final override protected def enclosingComponentDef: Option[SchemaComponent] = {
-    Assert.invariant(lexicalParent.isInstanceOf[SchemaDocument]) // global things have schema documents as their parents.
+    Assert.invariant(optLexicalParent.isDefined &&
+      optLexicalParent.get.isInstanceOf[SchemaDocument]) // global things have schema documents as their parents.
     referringComponent
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ReptypeMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ReptypeMixins.scala
@@ -32,7 +32,7 @@ trait HasOptRepTypeMixinImpl extends SchemaComponent with HasOptRepTypeMixin {
   override lazy val optRepTypeElement: Option[RepTypeQuasiElementDecl] =
     optRepTypeDef.map(repType => {
       val xmlElem = Elem(null, "QuasiElementForTypeCalc", new UnprefixedAttribute("type", repType.namedQName.toAttributeNameString, Null), namespaces, true)
-      new RepTypeQuasiElementDecl(xmlElem, lexicalParent)
+      new RepTypeQuasiElementDecl(xmlElem, optLexicalParent.get)
     })
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -36,8 +36,12 @@ import org.apache.daffodil.schema.annotation.props.PropTypes
 
 abstract class SchemaComponentImpl(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent)
-  extends SchemaComponent
+  final override val optLexicalParent: Option[SchemaComponent])
+  extends SchemaComponent {
+
+  def this(xml: Node, lexicalParent: SchemaComponent) =
+    this(xml, Option(lexicalParent))
+}
 
 /**
  * The core root class of the DFDL Schema object model.
@@ -54,12 +58,10 @@ trait SchemaComponent
   with PropTypes {
 
   def xml: Node
-  def lexicalParent: SchemaComponent
-  final lazy val optLexicalParent = Option(lexicalParent) // Option because Option(null) == None. We want that.
 
-  override def oolagContextViaArgs = Option(lexicalParent) // Option because Option(null) == None. We want that.
+  override def oolagContextViaArgs = optLexicalParent
 
-  def tunable: DaffodilTunables = lexicalParent.tunable
+  lazy val tunable: DaffodilTunables = optLexicalParent.get.tunable
 
   lazy val dpathCompileInfo: DPathCompileInfo =
     new DPathCompileInfo(
@@ -209,7 +211,7 @@ trait SchemaComponent
  * the 'schema'.
  */
 final class Schema(val namespace: NS, schemaDocs: Seq[SchemaDocument], schemaSetArg: SchemaSet)
-  extends SchemaComponentImpl(<fake/>, schemaSetArg) {
+  extends SchemaComponentImpl(<fake/>, Option(schemaSetArg)) {
 
   requiredEvaluations(schemaDocuments)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
@@ -31,15 +31,17 @@ import scala.xml.Node
  */
 abstract class SchemaComponentFactory(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent)
+  final override val optLexicalParent: Option[SchemaComponent])
   extends SchemaComponent
   with NestingLexicalMixin {
 
+  def this(xml: Node, lexicalParent: SchemaComponent) =
+    this(xml, Option(lexicalParent))
 }
 
 abstract class AnnotatedSchemaComponentFactory(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent)
+  final override val optLexicalParent: Option[SchemaComponent])
   extends AnnotatedSchemaComponent
   with NestingLexicalMixin {
 
@@ -50,7 +52,7 @@ trait SchemaFileLocatableImpl
 
   def xml: scala.xml.Node
   def schemaFile: Option[DFDLSchemaFile]
-  def lexicalParent: SchemaComponent
+  def optLexicalParent: Option[SchemaComponent]
 
   /**
    * Annotations can contain expressions, so we need to be able to compile them.
@@ -63,7 +65,7 @@ trait SchemaFileLocatableImpl
     val attrText = xml.attribute(XMLUtils.INT_NS, XMLUtils.LINE_ATTRIBUTE_NAME).map { _.text }
     if (attrText.isDefined) {
       attrText
-    } else if (lexicalParent != null) lexicalParent.lineAttribute
+    } else if (optLexicalParent.isDefined) optLexicalParent.get.lineAttribute
     else None
   }
 
@@ -79,14 +81,14 @@ trait SchemaFileLocatableImpl
 trait CommonContextMixin
   extends NestingMixin { self: OOLAGHost with ThrowsSDE =>
 
-  def lexicalParent: SchemaComponent
+  def optLexicalParent: Option[SchemaComponent]
 
-  lazy val schemaFile: Option[DFDLSchemaFile] = lexicalParent.schemaFile
-  lazy val schemaSet: SchemaSet = lexicalParent.schemaSet
-  def schemaDocument: SchemaDocument = lexicalParent.schemaDocument
-  lazy val xmlSchemaDocument: XMLSchemaDocument = lexicalParent.xmlSchemaDocument
-  lazy val schema: Schema = lexicalParent.schema
-  def uriString: String = lexicalParent.uriString
+  lazy val schemaFile: Option[DFDLSchemaFile] = optLexicalParent.flatMap { _.schemaFile }
+  lazy val schemaSet: SchemaSet = optLexicalParent.get.schemaSet
+  def schemaDocument: SchemaDocument = optLexicalParent.get.schemaDocument
+  lazy val xmlSchemaDocument: XMLSchemaDocument = optLexicalParent.get.xmlSchemaDocument
+  lazy val schema: Schema = optLexicalParent.get.schema
+  def uriString: String = optLexicalParent.get.uriString
 
   def xml: scala.xml.Node
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
@@ -182,7 +182,8 @@ final class SchemaDocument(xmlSDoc: XMLSchemaDocument)
   with SeparatorSuppressionPolicyMixin {
 
   final override val xml = xmlSDoc.xml
-  final override def lexicalParent = xmlSDoc
+  final override def optLexicalParent = Option(xmlSDoc)
+  final override lazy val xmlSchemaDocument = xmlSDoc
 
   override lazy val optReferredToComponent = None
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -70,14 +70,14 @@ final class SchemaSet(
   val validateDFDLSchemas: Boolean,
   checkAllTopLevelArg: Boolean,
   tunableArg: DaffodilTunables)
-  extends SchemaComponentImpl(<schemaSet/>, null)
+  extends SchemaComponentImpl(<schemaSet/>, None)
   with SchemaSetIncludesAndImportsMixin {
 
   private lazy val processorFactory = pfArg // insure this by name arg is evaluated exactly once.
 
   lazy val root = rootElement(processorFactory.flatMap { _.rootSpec })
 
-  override def tunable =
+  override lazy val tunable =
     tunableArg
 
   requiredEvaluations(isValid)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -48,7 +48,7 @@ import org.apache.daffodil.exceptions.Assert
  */
 abstract class SequenceTermBase(
   final override val xml: Node,
-  final override val lexicalParent: SchemaComponent,
+  final override val optLexicalParent: Option[SchemaComponent],
   final override val position: Int)
   extends ModelGroup(position)
   with SequenceGrammarMixin {
@@ -86,7 +86,7 @@ abstract class SequenceGroupTermBase(
   xml: Node,
   lexicalParent: SchemaComponent,
   position: Int)
-  extends SequenceTermBase(xml, lexicalParent, position)
+  extends SequenceTermBase(xml, Option(lexicalParent), position)
   with Sequence_AnnotationMixin
   with SequenceRuntimeValuedPropertiesMixin
   with SeparatorSuppressionPolicyMixin
@@ -356,7 +356,7 @@ class Sequence(xmlArg: Node, lexicalParent: SchemaComponent, position: Int)
  * handled as a degenerate sequence having only one element decl within it.
  */
 final class ChoiceBranchImpliedSequence(rawGM: Term)
-  extends SequenceTermBase(rawGM.xml, rawGM.lexicalParent, rawGM.position)
+  extends SequenceTermBase(rawGM.xml, rawGM.optLexicalParent, rawGM.position)
   with GroupDefLike {
 
   override def separatorSuppressionPolicy: SeparatorSuppressionPolicy = SeparatorSuppressionPolicy.TrailingEmptyStrict

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -217,7 +217,7 @@ trait ElementBaseGrammarMixin
       <element name={ name + " (prefixLength)" } type={ prefixLengthType.toQNameString }/>
         .copy(scope = prefixLengthTypeGSTD.xml.scope)
     val detachedElementDecl =
-      new PrefixLengthQuasiElementDecl(detachedNode, prefixLengthTypeGSTD.lexicalParent)
+      new PrefixLengthQuasiElementDecl(detachedNode, prefixLengthTypeGSTD.optLexicalParent.get)
 
     val prefixedLengthKind = detachedElementDecl.lengthKind
     prefixedLengthKind match {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -123,7 +123,7 @@ case class InitiatedContent(
 }
 
 case class SetVariable(stmt: DFDLSetVariable)
-  extends ExpressionEvaluatorBase(stmt.lexicalParent) {
+  extends ExpressionEvaluatorBase(stmt.annotatedSC) {
 
   val baseName = "SetVariable[" + stmt.varQName.local + "]"
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
@@ -73,7 +73,7 @@ class TestPropertyRuntime {
 
 }
 
-class HasMixin extends SchemaComponentImpl(<foo/>, null)
+class HasMixin extends SchemaComponentImpl(<foo/>, None)
   with TheExamplePropMixin
   with NestingLexicalMixin {
 


### PR DESCRIPTION
This small change is another incremental improvement. I was getting NPE quite a bit due to things running up the DSOM object taxonomy looking for the root which has lexicalParent pointer of null.

I've converted this to an Option type. So you can still get bad behavior of course, it's just that you get a bit more type-safety in the code. 