### PR TITLE
Incremental progress on Daffodil 1444 schema compiler space/speed issue.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
@@ -79,6 +79,7 @@ final class ProcessorFactory(val sset: SchemaSet)
   with HavingRootSpec {
 
   final override def enclosingComponentDef: Option[SchemaComponent] = None
+  final override def enclosingComponentDefs = Seq()
 
   lazy val (generateParser, generateUnparser) = {
     val (context, policy) = tunable.parseUnparsePolicy match {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/AnnotatedSchemaComponent.scala
@@ -186,10 +186,6 @@ trait AnnotatedSchemaComponent
   with AnnotatedMixin
   with OverlapCheckMixin {
 
-  requiredEvaluations(annotationObjs)
-  requiredEvaluations(nonDefaultPropertySources)
-  requiredEvaluations(defaultPropertySources)
-
   /**
    * Since validation of extra attributes on XML Schema elements is
    * normally lax validation, we can't count on validation of DFDL schemas

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -114,8 +114,6 @@ abstract class ChoiceTermBase(
   requiredEvaluations(branchesAreNotIVCElements)
   requiredEvaluations(modelGroupRuntimeData.preSerialization)
 
-  protected final override lazy val myPeers = choicePeers
-
   final protected lazy val optionChoiceDispatchKeyRaw = findPropertyOption("choiceDispatchKey")
   final protected lazy val choiceDispatchKeyRaw = requireProperty(optionChoiceDispatchKeyRaw)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ComplexTypes.scala
@@ -69,7 +69,7 @@ final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaD
   extends SchemaComponentFactory(xmlArg, schemaDocumentArg)
   with GlobalNonElementComponentMixin {
 
-  def forElement(elementDecl: ElementDeclMixin) = new GlobalComplexTypeDef(xml, schemaDocument, elementDecl)
+  def forElement(elementDecl: ElementDeclMixin) = new GlobalComplexTypeDef(xml, schemaDocument, elementDecl, this)
 
   override lazy val namedQName = QName.createGlobal(name, targetNamespace, xml.scope)
 }
@@ -80,7 +80,8 @@ final class GlobalComplexTypeDefFactory(xmlArg: Node, schemaDocumentArg: SchemaD
 final class GlobalComplexTypeDef(
   xmlArg: Node,
   schemaDocumentArg: SchemaDocument,
-  val elementDecl: ElementDeclMixin)
+  val elementDecl: ElementDeclMixin,
+  override val factory: GlobalComplexTypeDefFactory)
   extends ComplexTypeBase(xmlArg, schemaDocumentArg)
   with GlobalNonElementComponentMixin
   with NestingTraversesToReferenceMixin {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -74,6 +74,7 @@ final class DFDLSchemaFile(
   lazy val schemaSource = schemaSourceArg
 
   final override protected def enclosingComponentDef = None
+  final override protected def enclosingComponentDefs = Seq()
 
   private var validationDiagnostics_ : Seq[Diagnostic] = Nil
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -119,8 +119,8 @@ trait ElementBase
 
   def complexType: ComplexTypeBase
 
-  lazy final val optSimpleType = if (isSimpleType) Some(simpleType) else None
-  lazy final val optComplexType = if (isComplexType) Some(complexType) else None
+  def optSimpleType: Option[SimpleTypeBase]
+  def optComplexType: Option[ComplexTypeBase]
 
   /**
    * Irrespective of whether the type of this element is immediate or

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementRef.scala
@@ -51,6 +51,8 @@ abstract class AbstractElementRef(
   def isSimpleType: Boolean = this.referencedElement.isSimpleType
   def simpleType: SimpleTypeBase = this.referencedElement.simpleType
   def primType: NodeInfo.PrimType = this.referencedElement.primType
+  def optSimpleType = this.referencedElement.optSimpleType
+  def optComplexType = this.referencedElement.optComplexType
 
   override lazy val optReferredToComponent = Some(referencedElement)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDecl.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDecl.scala
@@ -22,15 +22,19 @@ import scala.xml.Node
 final class GlobalElementDecl(
   xmlArg: Node,
   schemaDocument: SchemaDocument,
-  elementRefArg: => AbstractElementRef)
+  elementRefArg: => AbstractElementRef,
+  override val factory: GlobalElementDeclFactory)
   extends AnnotatedSchemaComponentImpl(xmlArg, schemaDocument)
   with GlobalElementComponentMixin
-  with ElementDeclMixin
+  with ElementDeclFactoryDelegatingMixin
   with NestingTraversesToReferenceMixin
   with ResolvesProperties {
+
   //   global elements combined with element references referring to them can
   //   be multiple occurring (aka arrays) hence, we have to have things
   //   that take root and referenced situation into account.
+
+  final override def delegate = factory
 
   lazy val elementRef = elementRefArg
   override lazy val dpathCompileInfo = elementRef.dpathElementCompileInfo

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
@@ -32,18 +32,21 @@ import scala.xml.Node
  */
 class GlobalElementDeclFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
   extends SchemaComponentFactory(xmlArg, schemaDocumentArg)
-  with GlobalElementComponentMixin {
+  with GlobalElementComponentMixin
+  with ElementDeclFactoryImplMixin {
+
+  override def optReferredToComponent: Option[AnnotatedSchemaComponent] = None
 
   def forRoot() = asRoot // cache. Not a new one every time.
 
   private lazy val asRoot = {
-    lazy val ged = new GlobalElementDecl(xml, schemaDocument, root)
+    lazy val ged = new GlobalElementDecl(xml, schemaDocument, root, this)
     lazy val root: Root = new Root(xml, schemaDocument, namedQName, ged)
     root
   }
 
   def forElementRef(eRef: AbstractElementRef) = {
-    new GlobalElementDecl(xml, schemaDocument, eRef)
+    new GlobalElementDecl(xml, schemaDocument, eRef, this)
   }
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
@@ -34,14 +34,14 @@ final class GlobalGroupDefFactory(defXML: Node, schemaDocument: SchemaDocument)
         val list = contents.collect {
           case groupXML @ <sequence>{ _* }</sequence> => {
             lazy val gref: SequenceGroupRef = new SequenceGroupRef(gdef, refXML, refLexicalParent, position, isHidden)
-            lazy val gdef: GlobalSequenceGroupDef = new GlobalSequenceGroupDef(defXML, groupXML, schemaDocument, gref)
+            lazy val gdef: GlobalSequenceGroupDef = new GlobalSequenceGroupDef(defXML, groupXML, schemaDocument, gref, this)
             gref.groupDef
             gdef.groupRef
             (gref, gdef)
           }
           case groupXML @ <choice>{ _* }</choice> =>
             lazy val gref: ChoiceGroupRef = new ChoiceGroupRef(gdef, refXML, refLexicalParent, position, isHidden)
-            lazy val gdef: GlobalChoiceGroupDef = new GlobalChoiceGroupDef(defXML, groupXML, schemaDocument, gref)
+            lazy val gdef: GlobalChoiceGroupDef = new GlobalChoiceGroupDef(defXML, groupXML, schemaDocument, gref, this)
             gref.groupDef
             gdef.groupRef
             (gref, gdef)
@@ -108,7 +108,8 @@ sealed abstract class GlobalGroupDef(
   defXML: Node,
   groupXML: Node,
   schemaDocumentArg: SchemaDocument,
-  grefArg: => GroupRef)
+  grefArg: => GroupRef,
+  override val factory: GlobalGroupDefFactory)
   extends AnnotatedSchemaComponentImpl(groupXML, schemaDocumentArg)
   with GroupDefLike
   with GlobalNonElementComponentMixin
@@ -136,12 +137,16 @@ sealed abstract class GlobalGroupDef(
   final override lazy val referringComponent = Some(groupRef.asModelGroup)
 }
 
-final class GlobalSequenceGroupDef(defXMLArg: Node, seqXML: Node, schemaDocument: SchemaDocument, gref: => SequenceGroupRef)
-  extends GlobalGroupDef(defXMLArg, seqXML, schemaDocument, gref)
+final class GlobalSequenceGroupDef(
+  defXMLArg: Node, seqXML: Node, schemaDocument: SchemaDocument, gref: => SequenceGroupRef,
+  factory: GlobalGroupDefFactory)
+  extends GlobalGroupDef(defXMLArg, seqXML, schemaDocument, gref, factory)
   with SequenceDefMixin
 
-final class GlobalChoiceGroupDef(defXMLArg: Node, choiceXML: Node, schemaDocument: SchemaDocument, gref: => ChoiceGroupRef)
-  extends GlobalGroupDef(defXMLArg, choiceXML, schemaDocument, gref)
+final class GlobalChoiceGroupDef(
+  defXMLArg: Node, choiceXML: Node, schemaDocument: SchemaDocument, gref: => ChoiceGroupRef,
+  factory: GlobalGroupDefFactory)
+  extends GlobalGroupDef(defXMLArg, choiceXML, schemaDocument, gref, factory)
   with ChoiceDefMixin {
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/InitiatedTerminatedMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/InitiatedTerminatedMixin.scala
@@ -46,8 +46,6 @@ trait InitiatedTerminatedMixin
    */
   lazy val hasInitiator = {
     val hasOne = initiatorExpr.isKnownNonEmpty
-    if (parentSaysInitiatedContent)
-      schemaDefinitionUnless(hasOne, "Enclosing group has initiatedContent='yes', but initiator is not defined.")
     hasOne
   }
 
@@ -63,10 +61,10 @@ trait InitiatedTerminatedMixin
     res
   }
 
-  lazy val initiatorDiscriminator = prod("initiatorDiscriminator", parentSaysInitiatedContent) { InitiatedContent(this) }
+  private lazy val initiatorDiscriminator = prod("initiatorDiscriminator", parentSaysInitiatedContent) { InitiatedContent(this) }
 
   lazy val initiatorRegion = prod("initiatorRegion", hasInitiator) { initiatorItself ~ initiatorDiscriminator }
-  lazy val initiatorItself = delimMTA ~ Initiator(this)
+  private lazy val initiatorItself = delimMTA ~ Initiator(this)
 
   lazy val terminatorRegion = prod("terminatorRegion", hasTerminator) { delimMTA ~ Terminator(this) }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/LocalElementDecl.scala
@@ -25,7 +25,7 @@ sealed abstract class LocalElementDeclBase(
   final override val position: Int)
   extends ElementBase
   with LocalElementComponentMixin
-  with ElementDeclMixin
+  with ElementDeclNonFactoryDelegatingMixin
   with NestingLexicalMixin {
 
   requiredEvaluations(minOccurs, maxOccurs)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Root.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Root.scala
@@ -17,11 +17,13 @@
 
 package org.apache.daffodil.dsom
 
+import scala.collection.mutable
+import scala.xml.Node
+import scala.xml.UnprefixedAttribute
+
 import org.apache.daffodil.grammar.RootGrammarMixin
 import org.apache.daffodil.xml.NamedQName
 import org.apache.daffodil.xml.XMLUtils
-import scala.xml.Node
-import scala.xml.UnprefixedAttribute
 
 /**
  * Root is a special kind of ElementRef that has no enclosing group.
@@ -45,4 +47,103 @@ final class Root(defXML: Node, parentArg: SchemaDocument,
   override lazy val referencedElement = globalElementDecl
 
   lazy val rootParseUnparsePolicy = defaultParseUnparsePolicy
+
+  /**
+   * For any given global schema component, tells us what schema components contain
+   * references to it, and if that reference is from a sequence or choice, the index of
+   * the group member within that sequence/choice.
+   *
+   * This is intended to be used when compilation needs to understand
+   * the context where an object is referenced. This allows the various referencing contexts
+   * to be known, without making copies of schema components for each such context.
+   */
+  lazy val refMap: Map[SchemaComponentFactory, Seq[(String, Seq[RefSpec])]] = {
+    val refEntries: Seq[(SchemaComponentFactory, Seq[RefSpec])] =
+      refTargets.groupBy { _.to }.toSeq
+    val m: Seq[(SchemaComponentFactory, Seq[(String, Seq[RefSpec])])] = refEntries.map {
+      case (to, seq) => (to, seq.groupBy { _.from.shortSchemaComponentDesignator }.toSeq)
+    }
+    m.toMap
+  }
+
+  lazy val refPairsMap: Map[SchemaComponentFactory, Seq[String]] = {
+    refMap.toSeq.map {
+      case (to, seq: Seq[(String, _)]) => (to, seq.map { case (sscd, _) => sscd }.toSeq)
+    }.toMap
+  }
+
+  private lazy val allComponentsSet = new mutable.HashSet[SchemaComponent]
+
+  private def allSchemaComponents(component: SchemaComponent, optIndex: Option[Int]): Unit = {
+    if (allComponentsSet.contains(component)) {
+      // ok
+    } else {
+      allComponentsSet.add(component)
+      component match {
+        case er: ElementBase => er.typeDef match {
+          case std: SimpleTypeDefBase => //ok
+          case ctd: ComplexTypeBase => allSchemaComponents(ctd, None)
+          case _ => // ok
+        }
+        case ct: ComplexTypeBase => allSchemaComponents(ct.modelGroup, None)
+        case mg: ModelGroup => mg.groupMembers.foreach { gm =>
+          allSchemaComponents(gm, Some(gm.position))
+        }
+      }
+    }
+  }
+
+  final lazy val allComponents = {
+    allSchemaComponents(this, None)
+    allComponentsSet.toSeq
+  }
+
+  final lazy val numComponents =
+    allComponents.length
+
+  final lazy val allComponentSSCDs =
+    allComponents.map { _.shortSchemaComponentDesignator }.distinct
+
+  final lazy val numUniqueComponents =
+    allComponentSSCDs.length
+
+  final lazy val refTargets: Seq[RefSpec] = {
+    allComponents.collect {
+      case er: AbstractElementRef => {
+        val ed = er.referencedElement
+        RefSpec(er, ed.factory, er.position) +:
+          ed.optNamedComplexType.map { gctd => RefSpec(ed, gctd.factory, 1) }.toSeq
+      }
+      case ed: LocalElementDecl => {
+        ed.optNamedComplexType.map { gctd => RefSpec(ed, gctd.factory, 1) }.toSeq
+      }
+      case gr: GroupRef => Seq(RefSpec(gr, gr.groupDef.factory, gr.asModelGroup.position))
+    }.flatten
+  }
+
+  lazy val allERefs = allComponents.filter {
+    case er: ElementRef => true
+    case _ => false
+  }.map { _.shortSchemaComponentDesignator }.distinct
+
+  lazy val allGRefs = allComponents.filter {
+    case _: GroupRef => true
+    case _ => false
+  }.map { _.shortSchemaComponentDesignator }.distinct
+
+  lazy val allCTRefs = {
+    val cts = allComponents.collect {
+      case e: ElementBase if (e.optComplexType.isDefined && e.complexType.isInstanceOf[GlobalComplexTypeDef]) => e.complexType
+    }
+    val ctsIDs = cts.map { _.shortSchemaComponentDesignator }.distinct
+    ctsIDs
+  }
+}
+
+case class RefSpec(from: SchemaComponent, to: SchemaComponentFactory, index: Int) {
+
+  override def toString = "RefSpec(from=" +
+    from.shortSchemaComponentDesignator + ", to=" +
+    to.shortSchemaComponentDesignator + ", " + index +
+    ")"
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -181,9 +181,9 @@ trait DelimitedRuntimeValuedPropertiesMixin
   extends TermRuntimeValuedPropertiesMixin
   with RawDelimitedRuntimeValuedPropertiesMixin { decl: Term =>
 
-  lazy val isLengthKindDelimited = {
+  private lazy val isLengthKindDelimited = {
     this match {
-      case mg: ModelGroup => mg.enclosingElement.get.lengthKind == LengthKind.Delimited
+      case mg: ModelGroup => false
       case eb: ElementBase => eb.lengthKind == LengthKind.Delimited
     }
   }
@@ -440,7 +440,7 @@ trait ElementRuntimeValuedPropertiesMixin
     res
   }
 
-  final lazy val maybeUnparseTargetLengthInBitsEv:Maybe[UnparseTargetLengthInBitsEv] = {
+  final lazy val maybeUnparseTargetLengthInBitsEv: Maybe[UnparseTargetLengthInBitsEv] = {
     if (this.isSimpleType && this.simpleType.optRepTypeElement.isDefined) {
       this.simpleType.optRepTypeElement.get.maybeUnparseTargetLengthInBitsEv
     } else {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponentFactory.scala
@@ -39,14 +39,6 @@ abstract class SchemaComponentFactory(
     this(xml, Option(lexicalParent))
 }
 
-abstract class AnnotatedSchemaComponentFactory(
-  final override val xml: Node,
-  final override val optLexicalParent: Option[SchemaComponent])
-  extends AnnotatedSchemaComponent
-  with NestingLexicalMixin {
-
-}
-
 trait SchemaFileLocatableImpl
   extends SchemaFileLocatable {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
@@ -53,6 +53,7 @@ import org.apache.daffodil.xml.XMLUtils
 trait SchemaDocumentMixin { self: SchemaComponent =>
 
   protected final override def enclosingComponentDef: Option[SchemaComponent] = None
+  protected final override def enclosingComponentDefs = Seq()
 
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -94,7 +94,10 @@ final class SchemaSet(
   override lazy val schemaSet = this
   // These things are needed to satisfy the contract of being a schema component.
   final override protected def enclosingComponentDef = None
+  final override protected def enclosingComponentDefs = Seq()
+
   override lazy val schemaDocument = Assert.usageError("schemaDocument should not be called on SchemaSet")
+  override lazy val xmlSchemaDocument = Assert.usageError("xmlSchemaDocument should not be called on SchemaSet")
 
   override lazy val lineAttribute: Option[String] = None
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -97,8 +97,6 @@ abstract class SequenceGroupTermBase(
 
   protected def apparentXMLChildren: Seq[Node]
 
-  final override lazy val myPeers = sequencePeers
-
   final override lazy val hasDelimiters = hasInitiator || hasTerminator || hasSeparator
 
   protected def hiddenGroupRefOption: PropertyLookupResult
@@ -419,8 +417,6 @@ final class ChoiceBranchImpliedSequence(rawGM: Term)
   protected def optReferredToComponent: Option[AnnotatedSchemaComponent] = None
 
   def modelGroupRuntimeData: ModelGroupRuntimeData = sequenceRuntimeData
-
-  protected def myPeers: Option[Seq[ModelGroup]] = None
 
   def xmlChildren: Seq[scala.xml.Node] = Seq(xml)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
@@ -102,6 +102,9 @@ trait Term
   with TermEncodingMixin
   with EscapeSchemeRefMixin {
 
+  requiredEvaluations(annotationObjs)
+  requiredEvaluations(nonDefaultPropertySources)
+  requiredEvaluations(defaultPropertySources)
   requiredEvaluations(termChecks)
 
   private lazy val termChecks = {
@@ -233,8 +236,6 @@ trait Term
 
   final val tID = UUID.randomUUID()
 
-  lazy val someEnclosingComponent = enclosingComponent.getOrElse(Assert.invariantFailed("All terms except a root element have an enclosing component."))
-
   /** Overridden as false for elements with dfdl:inputValueCalc property. */
   lazy val isRepresented = true
 
@@ -335,7 +336,14 @@ trait Term
           // but if we have a CT as our parent, the group around the element whose type
           // that is, isn't "immediately enclosing".
         }
-        case _ => Assert.invariantFailed("immediatelyEnclosingModelGroup called on " + this + "with lexical parent " + lexicalParent)
+        case qe: QuasiElementDeclBase => {
+          //
+          // If your lexical parent is a Quasi-element, then your model group is
+          // the one surrounding the quasi-element.
+          //
+          qe.immediatelyEnclosingModelGroup
+        }
+        case _ => Assert.invariantFailed("immediatelyEnclosingModelGroup called on " + this + " with lexical parent " + lexicalParent)
       }
       res
     }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/AlignedMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/AlignedMixin.scala
@@ -127,6 +127,8 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
     LengthExact(trailingSkipInBits)
   }
 
+  private lazy val unaligned = AlignmentMultipleOf(1)
+
   private lazy val priorAlignmentApprox: AlignmentMultipleOf = {
     if (this.isInstanceOf[Root] || this.isInstanceOf[QuasiElementDeclBase]) {
       AlignmentMultipleOf(0) // root and quasi elements are aligned with anything
@@ -179,7 +181,10 @@ trait AlignedMixin extends GrammarMixin { self: Term =>
         csa
       }.toSeq
       val priorAlignmentsApprox = priorSibsAlignmentsApprox ++ parentAlignmentApprox ++ arraySelfAlignment
-      priorAlignmentsApprox.reduce(_ * _)
+      if (priorAlignmentsApprox.isEmpty)
+        unaligned
+      else
+        priorAlignmentsApprox.reduce(_ * _)
     }
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
@@ -30,7 +30,7 @@ trait SequenceGrammarMixin extends GrammarMixin { self: SequenceTermBase =>
     else sequenceContent
   }
 
-  final lazy val sequenceContent = {
+  private lazy val sequenceContent = {
     import columnConstants._
     self.sequenceKind match {
       case Ordered__ => orderedSequence
@@ -61,7 +61,7 @@ trait SequenceGrammarMixin extends GrammarMixin { self: SequenceTermBase =>
   /**
    * Constants to make the lookup tables below more readable without using fragile whitespace
    */
-  object columnConstants {
+  private object columnConstants {
     val UNB = -1 // UNBOUNDED
     val ZER = 0
     val ONE = 1
@@ -100,7 +100,7 @@ trait SequenceGrammarMixin extends GrammarMixin { self: SequenceTermBase =>
    * algorithm. For arrays these SequenceChild objects enable processing exactly one array instance at
    * a time, orchestrated by the surrounding sequence's processor.
    */
-  protected def sequenceChild(child: Term, groupIndex: Int): SequenceChild = {
+  private def sequenceChild(child: Term, groupIndex: Int): SequenceChild = {
     import columnConstants._
 
     val (max, min, ock) = child match {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -405,6 +405,7 @@ class TestDsomCompiler extends Logging {
 
     val sset = new SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
+    val root = sset.root
     val Seq(sd, _) = sch.schemaDocuments
 
     // No annotations
@@ -440,10 +441,10 @@ class TestDsomCompiler extends Logging {
     // Tests overlapping properties
     // because these unit tests are outside the normal framework,
     // we sometimes have to demand things in order for errors to be noticed.
-    assertTrue(gs3.isError)
-    val msgs = gs3.getDiagnostics.mkString("\n").toLowerCase
+    assertTrue(root.isError)
+    val msgs = root.getDiagnostics.mkString("\n").toLowerCase
     assertTrue(msgs.contains("overlap"))
-    assertTrue(msgs.contains("alignmentUnits".toLowerCase))
+    assertTrue(msgs.contains("initiator".toLowerCase))
   }
 
   @Test def test_group_references {
@@ -490,9 +491,9 @@ class TestDsomCompiler extends Logging {
     myGlobal3.asInstanceOf[GlobalSequenceGroupDef]
 
     // Tests overlapping properties
-    assertTrue(e5ctgref.isError)
+    assertTrue(e5.isError)
 
-    val msg = e5ctgref.getDiagnostics.mkString("\n").toLowerCase
+    val msg = e5.getDiagnostics.mkString("\n").toLowerCase
     val res = msg.contains("overlap")
     if (!res) println(msg)
     assertTrue(res)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
@@ -1,0 +1,651 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.dsom
+
+import scala.xml.{ XML, Utility, Node }
+import org.junit.Test
+import org.apache.daffodil.compiler._
+import org.apache.daffodil.Implicits._;
+import org.apache.daffodil.schema.annotation.props.gen.{ YesNo, TextNumberRep, SeparatorPosition, Representation, OccursCountKind, NilKind, LengthKind, ChoiceLengthKind, ByteOrder, BinaryNumberRep, AlignmentUnits }
+import org.apache.daffodil.schema.annotation.props.AlignmentType
+import org.apache.daffodil.util.{ Misc, Logging }
+import org.apache.daffodil.xml.XMLUtils
+import junit.framework.Assert._
+import org.apache.daffodil.api.Diagnostic
+import org.apache.daffodil.util._
+import org.junit.Test
+import org.apache.daffodil.schema.annotation.props.Found
+
+class TestRefMap extends Logging {
+
+  val xsd = XMLUtils.XSD_NAMESPACE
+  val dfdl = XMLUtils.dfdlAppinfoSource // XMLUtils.DFDL_NAMESPACE
+  val xsi = XMLUtils.XSI_NAMESPACE
+  val example = XMLUtils.EXAMPLE_NAMESPACE
+
+  @Test def testRefMapEmpty() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(1, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(1, numEntries)
+    val numRefPairs = root.refPairsMap.size
+    assertEquals(1, numRefPairs) // good proxy for schema size
+    val rootDecl = root.referencedElement
+    val rootRefPair = refMap.get(rootDecl.factory)
+    assertTrue(rootRefPair.isDefined)
+    val Seq((fromSSCD, refSpecs)) = rootRefPair.get
+    assertEquals(root.shortSchemaComponentDesignator, fromSSCD)
+    val Seq(RefSpec(rootRef, to, 1)) = refSpecs
+    assertEquals(root, rootRef)
+    assertEquals(rootDecl.factory, to)
+  }
+
+  @Test def testRefMapComplex1() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:sequence>
+          <xs:element name="e" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+        </xs:sequence>
+      </xs:complexType>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(4, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(2, numEntries)
+    val numRefPairs = root.refPairsMap.size
+    assertEquals(2, numRefPairs) // good proxy for schema size
+    val rootDecl = root.referencedElement
+    val rootRefPair = refMap.get(rootDecl.factory)
+    assertTrue(rootRefPair.isDefined)
+    val Seq((fromSSCD, refSpecs)) = rootRefPair.get
+    assertEquals(root.shortSchemaComponentDesignator, fromSSCD)
+    val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
+    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef.factory)
+    assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
+  }
+
+  @Test def testRefMapGroupRefSeq1() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:group ref="ex:g"/>
+      </xs:complexType>
+      <xs:group name="g">
+        <xs:sequence>
+          <xs:element name="e" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+        </xs:sequence>
+      </xs:group>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(4, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(3, numEntries)
+    val numRefPairs = root.refPairsMap.size
+    assertEquals(3, numRefPairs) // good proxy for schema size
+    val rootDecl = root.referencedElement
+    val rootRefPair = refMap.get(rootDecl.factory)
+    assertTrue(rootRefPair.isDefined)
+    val Seq((fromSSCD, refSpecs)) = rootRefPair.get
+    assertEquals(root.shortSchemaComponentDesignator, fromSSCD)
+    val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
+    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef.factory)
+    assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
+    val gref = rootDecl.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
+    val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef.factory).get
+    assertEquals(gref.shortSchemaComponentDesignator, grefSSCD)
+    assertEquals(4, root.numComponents)
+    assertEquals(4, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapGroupRefChoice1() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:group ref="ex:g"/>
+      </xs:complexType>
+      <xs:group name="g">
+        <xs:choice>
+          <xs:element name="e" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          <xs:element name="f" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+        </xs:choice>
+      </xs:group>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(5, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(3, numEntries)
+    val numRefPairs = root.refPairsMap.size
+    assertEquals(3, numRefPairs) // good proxy for schema size
+    val rootDecl = root.referencedElement
+    val rootRefPair = refMap.get(rootDecl.factory)
+    assertTrue(rootRefPair.isDefined)
+    val Seq((fromSSCD, refSpecs)) = rootRefPair.get
+    assertEquals(root.shortSchemaComponentDesignator, fromSSCD)
+    val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
+    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef.factory)
+    assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
+    val gref = rootDecl.complexType.modelGroup.asInstanceOf[ChoiceGroupRef]
+    val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef.factory).get
+    assertEquals(gref.shortSchemaComponentDesignator, grefSSCD)
+    assertEquals(5, root.numComponents)
+    assertEquals(5, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapGroupRefNest1() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:group ref="ex:g"/>
+      </xs:complexType>
+      <xs:group name="g">
+        <xs:choice>
+          <xs:element name="e" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          <xs:element name="f" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          <xs:element ref="ex:r1"/>
+        </xs:choice>
+      </xs:group>
+      <xs:element name="r1" type="ex:ct1"/>
+      <xs:complexType name="ct1">
+        <xs:sequence dfdl:hiddenGroupRef="ex:g1"/>
+      </xs:complexType>
+      <xs:group name="g1">
+        <xs:choice>
+          <xs:element name="e1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          <xs:element name="f1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+        </xs:choice>
+      </xs:group>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(10, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(6, numEntries)
+    val numRefPairs = root.refPairsMap.size
+    assertEquals(6, numRefPairs) // good proxy for schema size
+    val rootDecl = root.referencedElement
+    val rootRefPair = refMap.get(rootDecl.factory)
+    assertTrue(rootRefPair.isDefined)
+    val Seq((fromSSCD, refSpecs)) = rootRefPair.get
+    assertEquals(root.shortSchemaComponentDesignator, fromSSCD)
+    val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
+    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef.factory)
+    assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
+    val gref = rootDecl.complexType.modelGroup.asInstanceOf[ChoiceGroupRef]
+    val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef.factory).get
+    assertEquals(gref.shortSchemaComponentDesignator, grefSSCD)
+    assertEquals(10, root.numComponents)
+    assertEquals(10, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion1() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:sequence>
+          <xs:group ref="ex:g"/>
+          <xs:group ref="ex:g"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:group name="g">
+        <xs:choice>
+          <xs:element ref="ex:r1"/>
+          <xs:element ref="ex:r1"/>
+        </xs:choice>
+      </xs:group>
+      <xs:element name="r1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(25, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(4, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(6, numRefPairs) // good proxy for schema size
+    val allGRefs = root.allGRefs
+    assertEquals(2, allGRefs.size)
+    val allERefsCount = root.allERefs.size
+    assertEquals(2, allERefsCount)
+    val allCTRefsCount = root.allCTRefs.size
+    assertEquals(1, allCTRefsCount)
+    assertEquals(25, root.numComponents)
+    assertEquals(11, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion2() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r" type="ex:ct"/>
+      <xs:complexType name="ct">
+        <xs:sequence>
+          <xs:group ref="ex:g"/>
+          <xs:group ref="ex:g"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:group name="g">
+        <xs:choice>
+          <xs:element ref="ex:r1"/>
+          <xs:element ref="ex:r1"/>
+        </xs:choice>
+      </xs:group>
+      <xs:element name="r1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:r2"/>
+            <xs:element ref="ex:r2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="r2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(57, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(5, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(8, numRefPairs)
+    assertEquals(57, root.numComponents)
+    assertEquals(15, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion3() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="r">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:r1"/>
+            <xs:element ref="ex:r1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="r1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:r2"/>
+            <xs:element ref="ex:r2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="r2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:r3"/>
+            <xs:element ref="ex:r3"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="r3">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f1" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(61, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(4, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(7, numRefPairs)
+    assertEquals(61, root.numComponents)
+    assertEquals(17, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion4() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="e5">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e4"/>
+            <xs:element ref="ex:e4"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e4">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e3"/>
+            <xs:element ref="ex:e3"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e3">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e2"/>
+            <xs:element ref="ex:e2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e1"/>
+            <xs:element ref="ex:e1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(125, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(5, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(9, numRefPairs)
+    assertEquals(125, root.numComponents)
+    assertEquals(21, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion5() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="e6">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e5"/>
+            <xs:element ref="ex:e5"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e5">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e4"/>
+            <xs:element ref="ex:e4"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e4">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e3"/>
+            <xs:element ref="ex:e3"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e3">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e2"/>
+            <xs:element ref="ex:e2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e1"/>
+            <xs:element ref="ex:e1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(253, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(6, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(11, numRefPairs)
+    assertEquals(253, root.numComponents)
+    assertEquals(25, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion6() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="e7">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e6"/>
+            <xs:element ref="ex:e6"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e6">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e5"/>
+            <xs:element ref="ex:e5"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e5">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e4"/>
+            <xs:element ref="ex:e4"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e4">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e3"/>
+            <xs:element ref="ex:e3"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e3">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e2"/>
+            <xs:element ref="ex:e2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e1"/>
+            <xs:element ref="ex:e1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(509, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(7, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(13, numRefPairs)
+    assertEquals(509, root.numComponents)
+    assertEquals(29, root.numUniqueComponents)
+  }
+
+  @Test def testRefMapExplosion7() {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="e8">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e7"/>
+            <xs:element ref="ex:e7"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e7">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e6"/>
+            <xs:element ref="ex:e6"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e6">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e5"/>
+            <xs:element ref="ex:e5"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e5">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e4"/>
+            <xs:element ref="ex:e4"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e4">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e3"/>
+            <xs:element ref="ex:e3"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e3">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e2"/>
+            <xs:element ref="ex:e2"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="ex:e1"/>
+            <xs:element ref="ex:e1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="e1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="e0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+            <xs:element name="f0" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>)
+    val compiler = Compiler()
+    val sset = compiler.compileNode(testSchema).sset
+    val root = sset.root
+    val comps = root.allComponents
+    assertEquals(1021, comps.length)
+    val refMap = root.refMap
+    val numEntries = refMap.size
+    assertEquals(8, numEntries)
+    val refPairsMap = root.refPairsMap.toSeq
+    val numRefPairs = refPairsMap.map { _._2.length }.sum
+    assertEquals(15, numRefPairs)
+    assertEquals(1021, root.numComponents)
+    assertEquals(33, root.numUniqueComponents)
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -217,10 +217,6 @@ class DPathCompileInfo(
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
   override def toString = "DPathCompileInfo(%s)".format(path)
-  /**
-   * The immediate containing parent.
-   */
-  final lazy val immediateEnclosingCompileInfo: Option[DPathCompileInfo] = parent
 
   /**
    * The contract here supports the semantics of ".." in paths.
@@ -237,7 +233,7 @@ class DPathCompileInfo(
     eci match {
       case None => None
       case Some(eci) => {
-        val eci2 = eci.immediateEnclosingCompileInfo
+        val eci2 = eci.parent
         eci2 match {
           case None => None
           case Some(ci) => {
@@ -258,7 +254,7 @@ class DPathCompileInfo(
   final lazy val elementCompileInfo: Option[DPathElementCompileInfo] = this match {
     case e: DPathElementCompileInfo => Some(e)
     case d: DPathCompileInfo => {
-      val eci = d.immediateEnclosingCompileInfo
+      val eci = d.parent
       eci match {
         case None => None
         case Some(ci) => {
@@ -413,39 +409,6 @@ class DPathElementCompileInfo(
     retryMatchesERD
   }
 
-  /**
-   * Returns a subset of the possibles which are truly ambiguous siblings.
-   * Does not find all such, but if any exist, it finds some ambiguous
-   * Siblings. Only returns empty Seq if there are no ambiguous siblings.
-   */
-  //      private def ambiguousModelGroupSiblings(possibles: Seq[DPathElementCompileInfo]) : Seq[DPathElementCompileInfo] = {
-  //        val ambiguityLists: Seq[Seq[DPathElementCompileInfo]] = possibles.tails.toSeq.map{
-  //          possiblesList =>
-  //          if (possiblesList.isEmpty) Nil
-  //          else {
-  //            val one = possiblesList.head
-  //            val rest = possiblesList.tail
-  //            val ambiguousSiblings = modelGroupSiblings(one, rest)
-  //            val allAmbiguous =
-  //                if (ambiguousSiblings.isEmpty) Nil
-  //            else one +: ambiguousSiblings
-  //            allAmbiguous
-  //          }
-  //        }
-  //          val firstAmbiguous = ambiguityLists
-  //          ambiguityLists.head
-  //        }
-
-  /**
-   * Returns others that are direct siblings of a specific one.
-   *
-   * Direct siblings means they have the same parent, but that parent
-   * cannot be a choice.
-   */
-  //  private def modelGroupSiblings(one: DPathElementCompileInfo, rest: Seq[DPathElementCompileInfo]): Seq[DPathElementCompileInfo] = {
-  //    rest.filter(r => one.immediateEnclosingCompileInfo eq r.immediateEnclosingCompileInfo &&
-  //        one.immediateEnclosingCompileInfo
-  //  }
   /**
    * Issues a good diagnostic with suggestions about near-misses on names
    * like missing prefixes.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -251,16 +251,6 @@ sealed trait DITerm {
 
   def trd: TermRuntimeData
   final def termRuntimeData = trd
-
-  protected final def dafPrefix = {
-    val ee = trd.dpathCompileInfo.immediateEnclosingCompileInfo.getOrElse {
-      trd.dpathCompileInfo
-    }
-    val pre = ee.namespaces.getPrefix(XMLUtils.dafintURI.uri.toString())
-    Assert.invariant(pre ne null)
-    pre
-  }
-
 }
 
 /**

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -463,9 +463,18 @@
 
     <xs:element name="e31" dfdl:lengthKind="delimited" dfdl:terminator=")">
       <xs:complexType>
+        <!-- 
+          a sequence doesn't have a lengthKind, so the check for trailingSkip 
+          with lengthKind 'delimited' won't fail a check on the sequence here.
+          -->
         <xs:sequence dfdl:alignment="8" dfdl:alignmentUnits="bits" dfdl:leadingSkip="0" dfdl:trailingSkip="8">
           <xs:element name="s1" type="xs:string" dfdl:lengthKind="delimited" dfdl:encoding="ascii" dfdl:alignment="8" dfdl:terminator=":"/>
-          <xs:element name="s2" type="xs:string" dfdl:lengthKind="delimited" dfdl:encoding="ascii" dfdl:alignment="8" dfdl:terminator=":"/>
+          <!-- 
+            this element violates the requirement that when trailingSkip is non-zero and
+            lengthKind is 'delimited' there must be a terminator.
+           -->
+          <xs:element name="s2" type="xs:string" dfdl:lengthKind="delimited" dfdl:encoding="ascii" dfdl:alignment="8" 
+            dfdl:trailingSkip="8"/>
         </xs:sequence>
       </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Has features to allow navigation of multiple backpointers from referenced components to the places referencing them.

This enables sharing in the future once the code that is depending on non-shared schema components is moved.

Also deprecates the unitary backpointers that prevent sharing, but does not remove them.

Tests demonstrate exponential growth of number of schema components being compiled. So this sharing improvement is critical. 