### PR TITLE
Daffodil 2146 enum support fix1

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -1234,7 +1234,7 @@ abstract class LiteralExpressionBase(value: Any)
   }
 
   override lazy val compiledDPath: CompiledDPath = {
-    new CompiledDPath(Literal(litValue) +: conversions)
+    new CompiledDPath(Literal(Numbers.asAnyRef(litValue)) +: conversions)
   }
 
   override lazy val inherentType = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -560,7 +560,7 @@ final class EnumerationDefFactory(
 
   Assert.invariant(xml.label == "enumeration")
 
-  override lazy val optRepType = parentType.optRepTypeDef
+  override lazy val optRepType = parentType.optRepType
 
   lazy val enumValueRaw: String = (xml \ "@value").head.text
   lazy val enumValueCooked: AnyRef = parentType.primType.fromXMLString(enumValueRaw)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
@@ -329,13 +329,20 @@ object Numbers {
     }
   }
 
+  @inline 
   def asAnyRef(n: Any): AnyRef = {
-    n match {
-      // case bi: BigInt => bi.bigInteger
-      // case bd: BigDecimal => bd.bigDecimal
-      case ar: AnyRef => ar
-      case b: Boolean => JBoolean.valueOf(b)
-      case _ => asNumber(n)
-    }
+    n.asInstanceOf[AnyRef]
+    /*
+     * Attempting to match on the type is pointless.
+     * Simply doing the match will box the value, so
+     * it will always match against AnyRef
+     */
+//    n match {
+//      // case bi: BigInt => bi.bigInteger
+//      // case bd: BigDecimal => bd.bigDecimal
+//      case ar: AnyRef => ar
+//      case b: Boolean => JBoolean.valueOf(b)
+//      case _ => asNumber(n)
+//    }
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DAFFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DAFFunctions.scala
@@ -127,9 +127,9 @@ case class DAFLookAhead(recipes: List[CompiledDPath])
       val ans: AnyRef = if (bitSize > 63) {
         dis.getUnsignedBigInt(bitSize, pstate)
       } else if (bitSize == 0) {
-        new JLong(0)
+        JLong.valueOf(0)
       } else {
-        new JLong(dis.getUnsignedLong(bitSize, pstate).longValue)
+        JLong.valueOf(dis.getUnsignedLong(bitSize, pstate).longValue)
       }
       dis.resetPos(mark)
       ans

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
@@ -180,7 +180,7 @@ case class VRef(vrd: VariableRuntimeData, context: ThrowsSDE)
 
 }
 
-case class Literal(v: Any) extends RecipeOp {
+case class Literal(v: AnyRef) extends RecipeOp {
   override def run(dstate: DState) {
     dstate.setCurrentValue(v)
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
@@ -190,11 +190,18 @@ case class DState(val maybeSsrd:Maybe[SchemaSetRuntimeData]) {
     else _currentValue
   }
 
-  def setCurrentValue(v: Any) {
-    Assert.invariant(!v.isInstanceOf[(Any, Any)])
+  def setCurrentValue(v: AnyRef) {
+    _currentValue = v
+    _currentNode = null
+  }  
+  def setCurrentValue(v: Long) {
     _currentValue = asAnyRef(v)
     _currentNode = null
-  }
+  }  
+  def setCurrentValue(v: Boolean) {
+    _currentValue = asAnyRef(v)
+    _currentNode = null
+  }  
 
   def booleanValue: Boolean = currentValue.asInstanceOf[Boolean]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
@@ -23,6 +23,7 @@ import scala.xml.NodeSeq.seqToNodeSeq
 import org.apache.daffodil.exceptions.Assert
 import java.lang.{ Integer => JInt, Long => JLong, Double => JDouble, Boolean => JBoolean }
 import java.math.{ BigInteger => JBigInt, BigDecimal => JBigDecimal }
+import org.apache.daffodil.util.Numbers
 
 trait CompareOpBase {
   def operate(v1: AnyRef, v2: AnyRef): AnyRef
@@ -91,10 +92,10 @@ case class BooleanOp(op: String, left: CompiledDPath, right: CompiledDPath)
 case class NegateOp(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe) {
   override def run(dstate: DState) {
     recipe.run(dstate)
-    val value = dstate.currentValue match {
-      case i: JInt => i * -1
-      case l: JLong => l * (-1L)
-      case d: JDouble => d * -1.0
+    val value: AnyRef = dstate.currentValue match {
+      case i: JInt => Numbers.asAnyRef(i * -1)
+      case l: JLong => Numbers.asAnyRef(l * (-1L))
+      case d: JDouble => Numbers.asAnyRef(d * -1.0)
       case bi: JBigInt => bi.negate()
       case bd: JBigDecimal => bd.negate()
       case bi: BigInt => bi.underlying().negate()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TypeCalculator.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TypeCalculator.scala
@@ -98,7 +98,7 @@ abstract class TypeCalculator[A <: AnyRef, B <: AnyRef](val srcType: NodeInfo.Ki
       //      throw FNErrorFunctionException(Maybe(context.schemaFileLocation), dstate.contextLocation, err.get)
     }
 
-    dstate.setCurrentValue(ans)
+    dstate.setCurrentValue(ans.get)
 
   }
   def outputTypeCalcRun(dstate: DState, x: B, xType: NodeInfo.Kind): Unit = {
@@ -111,7 +111,7 @@ abstract class TypeCalculator[A <: AnyRef, B <: AnyRef](val srcType: NodeInfo.Ki
       throw diag
     }
 
-    dstate.setCurrentValue(ans)
+    dstate.setCurrentValue(ans.get)
 
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctions.tdml
@@ -67,6 +67,13 @@
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 
+  <xs:simpleType name="AbstractIntToStringByKeyset" dfdl:repType="xs:int">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="one" dfdl:repValues="1"/>
+      <xs:enumeration value="zero" dfdl:repValues="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:element name="inputTypeCalcInt_01" type="xs:int" dfdl:inputValueCalc="{ dfdl:inputTypeCalcInt('tns:AbstractIntTo1', 7) }" />
   <xs:element name="inputTypeCalcString_01" type="xs:string" dfdl:inputValueCalc="{ dfdl:inputTypeCalcString('tns:AbstractIntToXYZ', 7) }" />
   <xs:element name="outputTypeCalcInt_01">
@@ -99,6 +106,8 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name="abstractIntToStringByKeyset_01" type="xs:string" dfdl:inputValueCalc="{dfdl:inputTypeCalcString('AbstractIntToStringByKeyset',0)}"/>
 
   </tdml:defineSchema>
 
@@ -256,6 +265,21 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="abstractIntToStringByKeyset_01"
+    root="abstractIntToStringByKeyset_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc keysetValue transform">
+
+    <tdml:document>
+    <tdml:documentPart type="byte">
+    </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <abstractIntToStringByKeyset_01>zero</abstractIntToStringByKeyset_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -75,6 +75,7 @@ class TestInputTypeValueCalc {
   @Test def test_logicalTypeValueString_01() { fnRunner.runOneTest("logicalTypeValueString_01") }
   @Test def test_outputTypeCalcNextSiblingInt_01() { fnRunner.runOneTest("outputTypeCalcNextSiblingInt_01") }
   @Test def test_outputTypeCalcNextSiblingString_01() { fnRunner.runOneTest("outputTypeCalcNextSiblingString_01") }
+  @Test def test_abstractIntToStringByKeyset_01() { fnRunner.runOneTest("abstractIntToStringByKeyset_01") }
 
   @Test def test_typeCalcDispatch_typeError_01() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_01") }
   @Test def test_typeCalcDispatch_typeError_02() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_02") }


### PR DESCRIPTION
There were 2 minor bugs this fixes:

1) Enumerations assumed that any repType has a corresponding typeDef. This is not true when the repType is a primitive type
2) The type calculators set the current value to Maybe(...)

In the processes of fixing this, I slightly refactored the code to catch the error that led to (2) as a type error at compile time. Our DPath interperator is still largly type-unsafe, which I would like to fix at somepoint.

In looking into this, I also discovered that our Numbers.asAnyRef function is largly useless. I updated the code so that it is less misleading about what it is actually doing by turning it into a .asInstanceOf[AnyRef] call, which turns out to be exactly what was going on. I think we might want to remove the asAnyRef function entirely and box manually where nessasary, but did not feel like pulling at that string either.