### PR TITLE
Enable schema validation of attribute- and short-form properties

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives2.scala
@@ -33,7 +33,7 @@ class TestPrimitives2 {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
-      <xs:element name="e1" nillable="true" dfdl:nilKind="literalValue" dfdl:lengthKind="delimited" type="xs:string" dfdl:nilValue="%WSP;nil%NL; foobar" dfdl:outputNewline="%LF;"/>,
+      <xs:element name="e1" nillable="true" dfdl:nilKind="literalValue" dfdl:lengthKind="delimited" type="xs:string" dfdl:nilValue="%WSP;nil%NL; foobar" dfdl:outputNewLine="%LF;"/>,
       elementFormDefault = "unqualified")
     val infoset = <ex:e1 xmlns:ex={ example } xmlns:xsi={ XMLUtils.XSI_NAMESPACE.toString() } xsi:nil="true"/>
     TestUtils.testUnparsing(sch, infoset, " nil\u000a")
@@ -43,7 +43,7 @@ class TestPrimitives2 {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
-      <xs:element name="e1" dfdl:nilValue="start%WSP;bla%%WSP;;;;foo%WSP*;bar%WSP+;baz%ES;quux%NL;boo%%baz%%NL;end" dfdl:outputNewline="%LF;" nillable="true" dfdl:nilKind="literalValue" dfdl:lengthKind="delimited" type="xs:string"/>,
+      <xs:element name="e1" dfdl:nilValue="start%WSP;bla%%WSP;;;;foo%WSP*;bar%WSP+;baz%ES;quux%NL;boo%%baz%%NL;end" dfdl:outputNewLine="%LF;" nillable="true" dfdl:nilKind="literalValue" dfdl:lengthKind="delimited" type="xs:string"/>,
       elementFormDefault = "unqualified")
     val infoset = <ex:e1 xmlns:ex={ example } xmlns:xsi={ XMLUtils.XSI_NAMESPACE.toString() } xsi:nil="true"/>
     TestUtils.testUnparsing(sch, infoset, "start bla%WSP;;;;foobar bazquux\u000aboo%baz%NL;end")

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
@@ -556,51 +556,25 @@ this to validate when we load a DFDL Schema.
 
   <xsd:attributeGroup name="anyOther">
     <!--
-      
-      IBM's DFDL Schemas have ibm-specific attributes on them that we 
-      need to tolerate. Users may want to decorate their DFDL schemas with
-      other non-native and non-DFDL attributes and annotation sub-elements.
-      
-      So the behavior here has been switched back to the XSD Default behavior
-      which is lax validation allowing any other attribute to appear.
-      
-      The problem: this disables ability to catch certain typographical errors.
-      In fact a bunch of our negative tests will have to be fixed, as they are 
-      counting on errors from validation of these typos and mistakes and 
-      that sort of thing.
-      
-      A common error is to forget the dfdl: prefix on 
-      a short form dfdl property binding, or to include the dfdl: prefix
-      one on a long-form format annotation. This will no longer be caught by 
-      the validator. 
-      
-      We will have to build explicit checking for this into Daffodil's traversal
-      of the schema. 
-      
-      -->
-    <xsd:anyAttribute namespace="##other" processContents="lax"/> 
-    <!-- <xsd:anyAttribute namespace="##other" processContents="strict"/> -->
+    IBM's DFDL Schemas have ibm-specific attributes on them that we 
+    need to tolerate. Users may want to decorate their DFDL schemas with
+    other non-native and non-DFDL attributes and annotation sub-elements.
+    
+    The default XSD behavior (commented out below) is to allow any additional
+    attributes on a schema by performing lax validation on anything not in the
+    XSD namespace.
+    
+    The problem: since DFDL short form properties are not in the XSD namespace,
+    they are not validated. This means common typographical errors or forgetting
+    the dfdl: prefix are often not caught.
 
-
-    <!-- need some wildcard to allow xml:lang, xml:space etc. which do appear in 
-      schemas sometimes -->
-      
-    <!-- Daffodil augments schemas with dafint:file dafint:line and dafint:col -->
-          
-    <!-- Daffodil extensions to DFDL intended for end-users use the dafext namespace -->
-          
-    <!-- Not important to validate these, and we need to tolerate
-      Other attributes from other DFDL implementations -->
-     
-     <!-- <xsd:anyAttribute 
-    namespace="http://www.w3.org/XML/1998/namespace 
-    urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:int 
-    urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext
-    http://www.ibm.com/schema/extensions"
-      processContents="lax"
-    /> -->
-
-
+    So instead, we reference an attributeGroup that has the same anyAttribute line,
+    but is in a schema with a dfdl target namespace. This means we will perform lax
+    validation for attributes not in the dfdl namespace, but all dfdl properties
+    will be strictly validated.
+    -->
+    <!-- <xsd:anyAttribute namespace="##other" processContents="lax"/> -->
+    <xsd:attributeGroup ref="dfdl:anyOther" />
   </xsd:attributeGroup>
 
   <xsd:complexType name="topLevelComplexType">
@@ -1019,6 +993,7 @@ this to validate when we load a DFDL Schema.
         <!-- DFDL -->
         <xsd:attributeGroup ref="dfdl:SequenceAGQualified" />
         <xsd:attributeGroup ref="dfdl:SeparatorAGQualified" />
+        <xsd:attributeGroup ref="dfdl:LayeringAGQualified" />
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
@@ -1379,13 +1354,19 @@ this to validate when we load a DFDL Schema.
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:choice minOccurs="0" maxOccurs="unbounded">
-        <xsd:any processContents="lax" />
         <!--
-           strict so tooling will check DFDL annotations 
-          <xsd:any namespace="http://www.ogf.org/dfdl/dfdl-1.0/" processContents="strict"/>
-          <xsd:any namespace="##targetNamespace" processContents="lax"/>
-          <xsd:any namespace="##other" processContents="lax"/>
+          Some users may want to provide appinfo annotations specific to their
+          use-case in addition to the DFDL annotations. Normal XML schema allows
+          any elements with lax validation using the commented out line below.
+          However, we want to perform extra validation on the dfdl elements. So
+          the DFDLAppInfoGroup defines all the DFDL specific attribute-form
+          elements that are allowed in an xs:appinfo and what attributes they may
+          have. The dfdl:anyOther group reference is used to allow elements from any
+          other namespace with lax validation.
         -->
+        <!--<xsd:any processContents="lax" />-->
+        <xsd:group ref="dfdl:DFDLAppInfoGroup" />
+        <xsd:group ref="dfdl:anyOther" />
       </xsd:choice>
       <xsd:attribute name="source" type="xsd:anyURI" />
       <xsd:attributeGroup ref="sub:anyOther" />
@@ -1757,11 +1738,19 @@ this to validate when we load a DFDL Schema.
     </xsd:annotation>
   </xsd:element>
 
-  <xsd:element name="enumeration" id="enumeration" type="sub:noFixedFacet">
+  <xsd:element name="enumeration" id="enumeration">
     <xsd:annotation>
       <xsd:documentation
         source="http://www.w3.org/TR/xmlschema-2/#element-enumeration" />
     </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="sub:facet">
+          <xsd:attributeGroup ref="dfdl:RepValuesAGQualified" />
+          <xsd:attributeGroup ref="sub:anyOther" />
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
   </xsd:element>
 
   <!--

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -33,6 +33,41 @@
 
   <xsd:attribute name="ref" type="xsd:QName" />
 
+  <!--
+    This attribute group is a way to allow any attribute that is NOT in the
+    dfdl namespace to be used in elements. This anyAttribute matches non-dfdl
+    namespace attributes because the targetNamespace in this file is the dfdl
+    namespace, and the "namespace" attribute is "##other". The
+    processContexts="lax" says that these non-dfdl namespace attributes will be
+    validated if a schema for them can be found, but otherwise validation for
+    them will be skipped. This can be used to allow for DFDL schema authors to
+    use custom namespace attributes/annotations in their DFDL schemas without
+    us needing to know about them.
+
+    This means that by default, dfdl namespace attributes will not be allowed
+    at all. However, if we add dfdl namespace definitions alongside this
+    attribute group, those dfdl namespace attributes WILL be allowed and
+    strictly validated using standard XML schema validation rules. This has the
+    effect of strictly validating dfdl namespace attributes, but being lax
+    about all other attributes.
+  -->
+  <xsd:attributeGroup name="anyOther">
+    <xsd:anyAttribute namespace="##other" processContents="lax" />
+  </xsd:attributeGroup>
+
+  <!--
+    This works the same way as the anyOther attributeGroup defined above,
+    except it applies to elements instead of attributes (xs:any vs
+    xs:anyAttribute). See the description above for how this group works to
+    enable strict validation of dfdl namespace elements and lax validation of
+    other elements.
+  -->
+  <xsd:group name="anyOther">
+    <xsd:sequence>
+      <xsd:any namespace="##other" processContents="lax" />
+    </xsd:sequence>
+  </xsd:group>
+
   <xsd:attributeGroup name="BaseAG">
     <xsd:attribute name="ref" type="xsd:QName" />
     <xsd:anyAttribute namespace="http://www.ibm.com/xmlns/dfdl/testData" processContents="lax"/> 
@@ -647,6 +682,8 @@
   </xsd:attributeGroup>
 
   <xsd:attributeGroup name="CommonAGQualified">
+    <xsd:attribute form="qualified" name="bitOrder"
+      type="dfdl:BitOrderEnum"/>
     <xsd:attribute form="qualified" name="byteOrder"
       type="dfdl:ByteOrderEnum_Or_DFDLExpression" />
     <xsd:attribute form="qualified" name="encoding"

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
@@ -31,6 +31,25 @@
   <xsd:import namespace="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext" schemaLocation="org/apache/daffodil/xsd/dafext.xsd" />
   <xsd:include schemaLocation="DFDL_part2_attributes.xsd" />
 
+  <!-- all the dfdl: elements that can appear inside an xs:appinfo element -->
+  <xsd:group name="DFDLAppInfoGroup">
+    <xsd:choice>
+      <xsd:element ref="dfdl:assert" />
+      <xsd:element ref="dfdl:choice" />
+      <xsd:element ref="dfdl:defineEscapeScheme" />
+      <xsd:element ref="dfdl:defineFormat" />
+      <xsd:element ref="dfdl:defineVariable" />
+      <xsd:element ref="dfdl:discriminator" />
+      <xsd:element ref="dfdl:element" />
+      <xsd:element ref="dfdl:enumeration" />
+      <xsd:element ref="dfdl:format" />
+      <xsd:element ref="dfdl:group" />
+      <xsd:element ref="dfdl:newVariableInstance" />
+      <xsd:element ref="dfdl:sequence" />
+      <xsd:element ref="dfdl:setVariable" />
+      <xsd:element ref="dfdl:simpleType" />
+    </xsd:choice>
+  </xsd:group>
 
   <!-- ======================================================== -->
   <!-- DFDL Format definition types -->

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
@@ -160,7 +160,7 @@
     <xs:element name="inputTypeCalc_unionOfKeysetValueCalcs_01">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="byte" type="tns:_1through100_union_to_string" maxOccurs="unbounded" dfdl:occursCoundKind="parsed"/>
+          <xs:element name="byte" type="tns:_1through100_union_to_string" maxOccurs="unbounded" dfdl:occursCountKind="parsed"/>
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -168,7 +168,7 @@
     <xs:element name="inputTypeCalc_unionOfKeysetValueCalcs_02">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="byte" maxOccurs="unbounded" dfdl:occursCoundKind="parsed">
+          <xs:element name="byte" maxOccurs="unbounded" dfdl:occursCountKind="parsed">
             <xs:complexType>
               <xs:choice dfdl:choiceBranchKeyKind="byType" dfdl:choiceDispatchKeyKind="byType">
                 <xs:element name="a" type="tns:_1through100_union_to_string"/>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
@@ -28,8 +28,11 @@
   <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
 
   <!-- 
-    If you comment out the import below, then the other annotations are ignored.
-    Buf it this is allowed to import, you get an SDE on the attribute decls in it.
+    Daffodil ignores the imported schema because it does not define the dfdl
+    namespace. This is good since it has things like attribute declarations
+    that aren't allowed in a dfdl schema. This means we will never be able to
+    validate annotation defined inside that namespace, but that's fine since
+    Daffodil ignores them anyways.
     -->
   <xs:import namespace="urn:otherAnnotationLanguage" schemaLocation="otherAnnotationLanguage.xsd" />
 
@@ -39,12 +42,17 @@
     </xs:appinfo>
   </xs:annotation>
 
-  <xs:element name="r1" type="xs:string" dfdl:lengthKind="delimited">
+  <xs:element name="r1" type="xs:string">
     <xs:annotation>
       <xs:appinfo source="urn:otherAnnotationLanguage">
         <oth:otherAnnotation oth:otherAnnotationAttribute="other"/>
       </xs:appinfo>
+      <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/">
+        <dfdl:element lengthKind="delimited"/>
+      </xs:appinfo>
     </xs:annotation>
   </xs:element>
+
+  <xs:element name="r2" type="xs:string" dfdl:lengthKind="delimited" oth:otherAnnotationAttribute="other" />
   
 </schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testImportOtherAnnotationSchema.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testImportOtherAnnotationSchema.tdml
@@ -28,14 +28,21 @@
   
 
   <tdml:parserTestCase name="importOtherAnnotationSchema1" root="r1" model="schemaWithOtherAnnotations.dfdl.xsd">
+    <tdml:document>foo</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tns:r1>foo</tns:r1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-  <tdml:document>foo</tdml:document>
-  <tdml:infoset>
-    <tdml:dfdlInfoset>
-      <tns:r1>foo</tns:r1>
-    </tdml:dfdlInfoset>
-  </tdml:infoset>
-
-</tdml:parserTestCase>
+  <tdml:parserTestCase name="importOtherAnnotationSchema2" root="r2" model="schemaWithOtherAnnotations.dfdl.xsd">
+    <tdml:document>foo</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tns:r2>foo</tns:r2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/dfdl_xsdl_subset/DFDLSubset.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/dfdl_xsdl_subset/DFDLSubset.tdml
@@ -103,8 +103,9 @@
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>minOccurs' is not allowed to appear in element 'xs:sequence'</tdml:error>
-      <tdml:error>maxOccurs' is not allowed to appear in element 'xs:sequence'</tdml:error>
+      <tdml:error>minOccurs</tdml:error>
+      <tdml:error>cannot appear in</tdml:error>
+      <tdml:error>sequence</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -658,7 +658,7 @@
       </xs:complexType>
     </xs:element>
 
-    <xs:simpleType name="reffed" dfdl:separator="{ /ex:elem/ex:header/ex:sep }" dfdl:terminator="{ /ex:elem/ex:header/ex:term }">
+    <xs:simpleType name="reffed" dfdl:terminator="{ /ex:elem/ex:header/ex:term }">
       <xs:restriction base="xs:string"/>
     </xs:simpleType>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -225,7 +225,7 @@
     <xs:element name="e12">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="bits" type="xs:unsignedByte" dfdl:represenation="binary" dfdl:leadingSkip="0" dfdl:alignment="1" 
+          <xs:element name="bits" type="xs:unsignedByte" dfdl:representation="binary" dfdl:leadingSkip="0" dfdl:alignment="1" 
             dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="4"/>
           <xs:element name="string" type="xs:string" dfdl:representation="text" dfdl:lengthKind="explicit" dfdl:length="4" dfdl:encoding="utf-8" dfdl:leadingSkip="0"
             dfdl:lengthUnits="bytes" dfdl:alignment="8" dfdl:alignmentUnits="bits">
@@ -238,7 +238,7 @@
       <xs:complexType>
         <xs:sequence>
           <xs:element name="bits" type="xs:unsignedByte" 
-            dfdl:terminator="TERM" dfdl:represenation="binary" dfdl:leadingSkip="0" dfdl:alignment="1" 
+            dfdl:terminator="TERM" dfdl:representation="binary" dfdl:leadingSkip="0" dfdl:alignment="1" 
             dfdl:alignmentUnits="bits" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="4"/>
           <xs:element name="string" type="xs:string" dfdl:representation="text" dfdl:lengthKind="explicit" dfdl:length="4" dfdl:encoding="utf-8" dfdl:leadingSkip="0"
             dfdl:lengthUnits="bytes" dfdl:alignment="8" dfdl:alignmentUnits="bits">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils-unparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils-unparse.tdml
@@ -33,14 +33,14 @@
     <xs:element name="doc6" dfdl:lengthKind="delimited" nillable="true" type="xsd:string" dfdl:outputNewLine="%CR;%LF;" dfdl:nilValue="%NL;"/>
     <xs:element name="doc7" dfdl:lengthKind="delimited" nillable="true" type="xsd:string" dfdl:outputNewLine="%LF;" dfdl:nilValue="%NL;"/>
 
-    <xs:simpleType name="type" dfdl:nilValue="NIL" dfdl:lengthKind="delimited">
+    <xs:simpleType name="type" dfdl:lengthKind="delimited">
         <xs:restriction base="xs:string"/>
     </xs:simpleType>
 
     <xs:element name="doc8">
         <xs:complexType>
             <xs:sequence dfdl:separator=",">
-                <xs:element name="e1" type="ex:type" nillable="true" minOccurs="2" maxOccurs="10"/>
+                <xs:element name="e1" type="ex:type" nillable="true" minOccurs="2" maxOccurs="10" dfdl:nilValue="NIL" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -316,9 +316,7 @@
 
     <xs:element name="e">
       <xs:complexType>
-        <xs:sequence dfdl:separator=",">
-          <xs:element name="elem" dfdl:hiddenGroupRef=""/>
-        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="" />
       </xs:complexType>
     </xs:element>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
@@ -602,7 +602,7 @@
       <xs:complexType>
         <xs:sequence>
           <xs:element name="num" type="xs:int" />
-          <xs:element name="invalid" type="xs:int" dfdl:minOccurs="0" dfdl:inputValueCalc="{ ../ex:num }" />
+          <xs:element name="invalid" type="xs:int" minOccurs="0" dfdl:inputValueCalc="{ ../ex:num }" />
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -610,7 +610,7 @@
     <xs:element name="ivc_25">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="a" type="xs:int" dfdl:minOccurs="2" dfdl:maxOccurs="5" dfdl:inputValueCalc="{ 5 }"/>
+          <xs:element name="a" type="xs:int" minOccurs="2" maxOccurs="5" dfdl:inputValueCalc="{ 5 }"/>
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -1310,7 +1310,9 @@
 
     <tdml:document>5</tdml:document>
     <tdml:errors>
-      <tdml:error>Placeholder</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>inputValueCalc</tdml:error>
+      <tdml:error>array</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -1325,7 +1327,9 @@
 
     <tdml:document/>
     <tdml:errors>
-      <tdml:error>Placeholder</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>inputValueCalc</tdml:error>
+      <tdml:error>array</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -83,7 +83,7 @@
     <xs:element name="e1">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="seq" dfdl:separator=",">
+          <xs:element name="seq">
             <xs:complexType>
               <xs:sequence>
                 <xs:element name="item" type="xs:int" minOccurs="1" maxOccurs="10"/>
@@ -830,7 +830,7 @@
 
     <xs:element name="e46">
       <xs:complexType>
-        <xs:sequence dfdl:separatorPosition="infix" dfdl:seperator=",">
+        <xs:sequence>
           <xs:element name="hexBinary1" type="xs:hexBinary"
             dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
             dfdl:length="3" dfdl:encoding="ISO-8859-1"/>
@@ -846,10 +846,10 @@
       <xs:complexType>
         <xs:sequence>
           <xs:element name="hexBinary1" type="xs:hexBinary"
-            dfdl:lengthKind="explicit" dfdl:lenghtUnits="bytes"
+            dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
             dfdl:length="3" dfdl:encoding="ISO-8859-1"/>
           <xs:element name="hexBinary2" type="xs:hexBinary"
-            dfdl:lengthKind="explicit" dfdl:lenghtUnits="bytes"
+            dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
             dfdl:length="3" dfdl:encoding="ISO-8859-1"/>
           <xs:element name="notEqual" type="xs:boolean" dfdl:inputValueCalc="{ ../ex:hexBinary1 ne ../ex:hexBinary2 }"/>
         </xs:sequence>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
@@ -23,7 +23,7 @@ import org.junit.AfterClass
 
 object TestImportOtherAnnotationSchema {
   val testDir = "/org/apache/daffodil/section00/general/"
-  val runner = Runner(testDir, "testImportOtherAnnotationSchema.tdml", validateDFDLSchemas = false)
+  val runner = Runner(testDir, "testImportOtherAnnotationSchema.tdml")
 
   @AfterClass def shutDown {
     runner.reset
@@ -36,5 +36,6 @@ class TestImportOtherAnnotationSchema {
 
   //DFDL-1907
   @Test def test_importOtherAnnotationSchema1() { runner.runOneTest("importOtherAnnotationSchema1") }
+  @Test def test_importOtherAnnotationSchema2() { runner.runOneTest("importOtherAnnotationSchema2") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -24,7 +24,7 @@ import org.junit.AfterClass
 object TestLengthKindPrefixed {
   private val testDir = "/org/apache/daffodil/section12/lengthKind/"
 
-  val runner = Runner(testDir, "PrefixedTests.tdml")
+  val runner = Runner(testDir, "PrefixedTests.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
 
   @AfterClass def shutDown {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -130,7 +130,7 @@ class TestInputValueCalc {
   //@Test def test_InputValueCalc_circular_ref() { runner.runOneTest("InputValueCalc_circular_ref") }
   
   //DFDL-1024
-  //@Test def test_InputValueCalc_optional_elem() { runner.runOneTest("InputValueCalc_optional_elem") }
-  //@Test def test_InputValueCalc_array_elem() { runner.runOneTest("InputValueCalc_array_elem") }
+  @Test def test_InputValueCalc_optional_elem() { runner.runOneTest("InputValueCalc_optional_elem") }
+  @Test def test_InputValueCalc_array_elem() { runner.runOneTest("InputValueCalc_array_elem") }
   //@Test def test_InputValueCalc_global_elem() { runner.runOneTest("InputValueCalc_global_elem") }
 }


### PR DESCRIPTION
- Use xs:anyAttribute and xs:any defined in the DFDL namespace to enable
  validation for attribute-form and short-form properties. Other
  namespaces use lax validation and will mostly likely just be ignored,
  but could still be validated if the other namespace schema defines the
  dfdl namespace and is a valid DFDL schema.
- Fix XML Schema for DFDL to allow for repValues in xs:enumerations,
  layering properties in xs:sequences, and short form dfdl:bitOrder.
- Fix tests that used incorrect properties or had typos that are now
  checked.

DAFFODIL-598, DAFFODIL-1024