### PR TITLE
Simplify how we show text differences when a TDML test fails

### DIFF
--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
@@ -33,8 +33,8 @@ class TestXMLUtils {
     val diffs = XMLUtils.computeTextDiff("", d1, d2, None)
     val Seq((p, a, b)) = diffs
     assertEquals(".charAt(1)", p)
-    assertEquals("a(%#x0061;)", a)
-    assertEquals("b(%#x0062;)", b)
+    assertEquals("a", a)
+    assertEquals("b", b)
   }
 
   @Test def testDiff1() {
@@ -43,8 +43,8 @@ class TestXMLUtils {
     val diffs = XMLUtils.computeDiff(d1, d2)
     val Seq((p1, a, b)) = diffs
     assertEquals("d.charAt(1)", p1)
-    assertEquals("a(%#x0061;)", a)
-    assertEquals("b(%#x0062;)", b)
+    assertEquals("a", a)
+    assertEquals("b", b)
   }
 
   @Test def testDiff2() {
@@ -53,8 +53,8 @@ class TestXMLUtils {
     val diffs = XMLUtils.computeDiff(d1, d2)
     val Seq((p1, a, b)) = diffs
     assertEquals("a/d[2].charAt(1)", p1)
-    assertEquals("x(%#x0078;)", a)
-    assertEquals("y(%#x0079;)", b)
+    assertEquals("x", a)
+    assertEquals("y", b)
   }
 
   @Test def testDiff3() {
@@ -63,11 +63,11 @@ class TestXMLUtils {
     val diffs = XMLUtils.computeDiff(d1, d2)
     val Seq((p1, e, f), (p2, x, y)) = diffs
     assertEquals("a/e[1].charAt(1)", p1)
-    assertEquals("e(%#x0065;)", e)
-    assertEquals("f(%#x0066;)", f)
+    assertEquals("e", e)
+    assertEquals("f", f)
     assertEquals("a/d[2].charAt(3)", p2)
-    assertEquals("x(%#x0078;)", x)
-    assertEquals("y(%#x0079;)", y)
+    assertEquals("x", x)
+    assertEquals("y", y)
 
   }
 


### PR DESCRIPTION
We previously found every character that differed and showed its path,
index, and expected/actual characters. But when an XML element contains
a lot of text (e.g. hexBinary blob) with a lot of differences, this
character by character diff is not very helpful and consumed a lot
memory to build the output string. This easily leads to an OutOfMemory
exception.

Instead, when showing the diff of two XML text elements, only show the
index of the first diff plus some following characters for context. This
should be useful enough in most cases to figure out where things when
off the rails while keep memory usage low, even on large diffs.

Also change the diff output to show the actual infoset before the
differences summary. Displaying the actual infoset after the diff made
it very difficult to find the summary of differences when big infosets
were involved.

DAFFODIL-2118