### PR TITLE
Remove the emptyElementParsePolicy warning

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/ByHandMixins.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/ByHandMixins.scala
@@ -441,10 +441,15 @@ trait EmptyElementParsePolicyMixin extends PropertyMixin {
       // prop is not required AND not defined so use tunable value
       // but issue warning (which can be suppressed)
       val defaultEmptyElementParsePolicy = this.tunable.defaultEmptyElementParsePolicy
-      SDW(
-        WarnID.EmptyElementParsePolicyError,
-        "Property 'dfdlx:emptyElementParsePolicy' is required but not defined, using tunable '%s' by default.",
-        defaultEmptyElementParsePolicy)
+      // This property is an extension, so we don't want to require users to
+      // add this property just to silence this warning, especially since the
+      // property might change in the future. So silently use a default without
+      // outputting a warning. We may want to turn this warning on when the
+      // property makes its way into the official DFDL spec.
+      //SDW(
+      //  WarnID.EmptyElementParsePolicyError,
+      //  "Property 'dfdlx:emptyElementParsePolicy' is required but not defined, using tunable '%s' by default.",
+      //  defaultEmptyElementParsePolicy)
       defaultEmptyElementParsePolicy
     }
   }


### PR DESCRIPTION
This property is a new extension that most schemas will not have. And if
they do not have it, it results in a lot of warnings, seems almost one
for every element. For now, just remove this warning so that users
aren't spammed with it and forced to add an extension property to hide
the warning. If this extension becomes part of the spec, we can reenable
the warning then.

DAFFODIL-2150