### PR TITLE
Fixes DAFFODIL-2142

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
@@ -70,15 +70,12 @@ trait GroupDefLike
 
   /** Returns the group members that are elements or model groups. */
   final lazy val groupMembers: Seq[Term] = LV('groupMembers) {
-    //
-    // So we have to flatMap, so that we can tolerate annotation objects (like documentation objects).
-    // and our ModelGroup factory has to return Nil for annotations and Text nodes.
-    //
     val positions = List.range(1, goodXmlChildren.length + 1) // range is exclusive on 2nd arg. So +1.
     val pairs = goodXmlChildren zip positions
-    pairs.flatMap {
+    pairs.map {
       case (n, i) =>
-        TermFactory(n, this, i)
+        val t = TermFactory(n, this, i)
+        t
     }
   }.value
 
@@ -86,13 +83,13 @@ trait GroupDefLike
    * XML is full of uninteresting text nodes. We just want the element children, not all children.
    */
   private def removeNonInteresting(child: Node) = {
-    val childList: List[Node] = child match {
-      case _: Text => Nil
-      case _: Comment => Nil
-      case <annotation>{ _* }</annotation> => Nil
-      case _ => List(child)
+    val childElem: Option[Node] = child match {
+      case _: Text => None
+      case _: Comment => None
+      case <annotation>{ _* }</annotation> => None
+      case _ => Some(child)
     }
-    childList
+    childElem
   }
 }
 

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -421,6 +421,7 @@
           <xs:enumeration value="ignoreImport" />
           <xs:enumeration value="ignoreDFDLProperty" />
           <xs:enumeration value="inconsistentLengthKind" />
+          <xs:enumeration value="invalidAnnotationPoint" />
           <xs:enumeration value="multipleChoiceBranches" />
           <xs:enumeration value="namespaceDifferencesOnly" />
           <xs:enumeration value="noEmptyDefault" />

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/annotations/annotations.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/annotations/annotations.tdml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite suiteName="annotations" xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tns="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  defaultRoundTrip="true">
+
+  <defineSchema name="as1">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <xs:element name="inElementContainerPassingAssert">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:assert>
+            {fn:true()}
+          </dfdl:assert>
+        </xs:appinfo>
+      </xs:annotation>
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="inElementContainerFailingAssert">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:assert>
+            {fn:false()}
+          </dfdl:assert>
+        </xs:appinfo>
+        <xs:appinfo>Hello, otherInfo</xs:appinfo>
+      </xs:annotation>
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="inComplexTypeContainer">
+      <xs:complexType>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:assert>
+              {fn:false()}
+            </dfdl:assert>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="inComplexTypeContainerMutltipleAi">
+      <xs:complexType>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:assert>
+              {fn:false()}
+            </dfdl:assert>
+          </xs:appinfo>
+          <xs:appinfo source="http://www.w3.org/2001/XMLSchema">Hello, appInfo</xs:appinfo>
+          <xs:appinfo>Hello, otherInfo</xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="noAnnotationComplexType">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="noDFDLAnnotationComplexType">
+      <xs:complexType>
+        <xs:annotation>
+          <xs:appinfo source="http://www.w3.org/2001/XMLSchema">Hello, appInfo</xs:appinfo>
+          <xs:appinfo>Hello, otherInfo</xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{42}" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </defineSchema>
+
+
+  <!--
+    Test name: annotationInElementPass
+    Schema: as1
+    Purpose: This document contains an annotation with a passing assert wrapped in an element.
+    The annotation should be properly recognized and thus return a proper element.
+  -->
+
+  <parserTestCase name="annotationInElementPass" root="inElementContainerPassingAssert"
+    model="as1" description="Passing Assert processed for annotation in element" roundTrip="false">
+    <document />
+    <infoset>
+      <dfdlInfoset>
+        <tns:inElementContainerPassingAssert>
+          <e1>42</e1>
+        </tns:inElementContainerPassingAssert>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <!--
+    Test name: annotationInElementFail
+    Schema: as1
+    Purpose: This document contains an annotation with a failing assert wrapped in an element.
+    The annotation should be properly recognized and thus return an Assertion error.
+  -->
+
+  <parserTestCase name="annotationInElementFail" root="inElementContainerFailingAssert"
+    model="as1" description="Failing Assert processed for annotation in element" roundTrip="false">
+    <document />
+    <errors>
+      <error>Assertion</error>
+    </errors>
+  </parserTestCase>
+
+  <!--
+    Test name: annotationInComplexTypeFail
+    Schema: as1
+    Purpose: This document contains an annotation with a failing DFDL assert wrapped in an complexType.
+    Since complexTypes are not DFDL annotation points, the DFDL annotation will be ignored with a warning.
+  -->
+
+  <parserTestCase name="annotationInComplexTypeWarn" root="inComplexTypeContainer"
+    model="as1" description="Annotation in ComplexType ignored with warning" roundTrip="false">
+    <document />
+    <warnings>
+      <warning>Schema Definition Warning</warning>
+      <warning>complexType is not a valid annotation point. Annotation ignored.</warning>
+    </warnings>
+    <infoset>
+      <dfdlInfoset>
+        <tns:inComplexTypeContainer>
+          <e1>42</e1>
+        </tns:inComplexTypeContainer>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <!--
+    Test name: multipleAppsInfosWarn
+    Schema: as1
+    Purpose: This document contains a complexType with a multi appInfo annotation. One of the appInfos
+    contains a failing DFDL assert. Since complexTypes are not DFDL annotation points, the DFDL annotation
+    should be ignored with a warning.
+  -->
+
+  <parserTestCase name="multipleAppsInfosWarn" root="inComplexTypeContainerMutltipleAi"
+    model="as1" description="Annotation in ComplexType ignored with warning" roundTrip="false">
+    <document />
+    <warnings>
+      <warning>Schema Definition Warning</warning>
+      <warning>complexType is not a valid annotation point. Annotation ignored.</warning>
+    </warnings>
+    <infoset>
+      <dfdlInfoset>
+        <tns:inComplexTypeContainerMutltipleAi>
+          <e1>42</e1>
+        </tns:inComplexTypeContainerMutltipleAi>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <!--
+    Test name: noAnnotationsInCTPass
+    Schema: as1
+    Purpose: This document contains a complexType without an annotation.
+    There should be no warning.
+  -->
+
+  <parserTestCase name="noAnnotationsInCTPass" root="noAnnotationComplexType" model="as1"
+    description="No annotation in ComplexType. No warning" roundTrip="false">
+    <document />
+    <infoset>
+      <dfdlInfoset>
+        <tns:noAnnotationComplexType>
+          <e1>42</e1>
+        </tns:noAnnotationComplexType>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <!--
+    Test name: noDFDLAnnotationsInCTPass
+    Schema: as1
+    Purpose: This document contains a complexType with multiple annotation but no DFDL annotations.
+    There should be no warning.
+  -->
+
+  <parserTestCase name="noDFDLAnnotationsInCTPass" root="noDFDLAnnotationComplexType" model="as1"
+    description="No DFDL annotation in ComplexType. Other annotations ignored without warning" roundTrip="false">
+    <document />
+    <infoset>
+      <dfdlInfoset>
+        <tns:noDFDLAnnotationComplexType>
+          <e1>42</e1>
+        </tns:noDFDLAnnotationComplexType>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section07.annotations
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestAnnotations {
+  val testDir = "/org/apache/daffodil/section07/annotations/"
+  val runner = Runner(testDir, "annotations.tdml", validateTDMLFile = false)
+
+  @AfterClass def tearDown {
+    runner.reset
+  }
+}
+
+class TestAnnotations {
+
+  import TestAnnotations._
+
+  @Test def test_annotationInElementPass() { runner.runOneTest("annotationInElementPass") }
+  @Test def test_annotationInElementFail() { runner.runOneTest("annotationInElementFail") }
+
+  //DAFFODIL-2142
+  @Test def test_annotationInComplexTypeWarn() { runner.runOneTest("annotationInComplexTypeWarn") }
+  @Test def test_multipleAppsInfosWarn() { runner.runOneTest("multipleAppsInfosWarn") }
+  @Test def test_noAnnotationsInCTPass() { runner.runOneTest("noAnnotationsInCTPass") }
+  @Test def test_noDFDLAnnotationsInCTPass() { runner.runOneTest("noAnnotationsInCTPass") }
+
+}


### PR DESCRIPTION
-- adds warning for annotation in complexType instead of silently dropping it
-- moves checks for non-Model groups to complexTypes