### PR TITLE
Fixes OVC on elements of complex type

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -105,6 +105,7 @@ trait ElementBase
     val optOVC = findPropertyOption("outputValueCalc")
     schemaDefinitionWhen(optOVC.isDefined && isOptional, "dfdl:outputValueCalc cannot be defined on optional elements.")
     schemaDefinitionWhen(optOVC.isDefined && isArray, "dfdl:outputValueCalc cannot be defined on array elements.")
+    schemaDefinitionWhen(optOVC.isDefined && isComplexType, "dfdl:outputValueCalc cannot be defined on complexType elements.")
     // This should be an SDE, but is very useful for unit tests to be able to specify OVC on a single global element
     // self.schemaDefinitionWhen(optOVC.isDefined && self.isInstanceOf[GlobalElementDecl], "dfdl:outputValueCalc cannot be defined on global elements.")
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
@@ -315,6 +315,40 @@
 			</xs:complexType>
 		</xs:element>
 
+        <xs:element name="refSimpleElementWithOvc">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="ex:st1" dfdl:outputValueCalc="{1}"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="st1" type="xs:int"/>
+
+        <xs:element name="refComplexElementNoOvc">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="ex:ct1"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="refComplexElementWithOvc">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="ex:ct1" dfdl:outputValueCalc="{1}"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="ct1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="e1" type="xs:int"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
 	</tdml:defineSchema>
 
 	<tdml:unparserTestCase name="binaryIntegerBigEndian"
@@ -708,4 +742,63 @@
 	    </tdml:errors>
 
 	</tdml:unparserTestCase>
+
+    <tdml:unparserTestCase name="refSimpleTypeElemWithOvc"
+      root="refSimpleElementWithOvc" model="outputValueCalc-Embedded.dfdl.xsd"
+      description="An element referencing a simpleType Elem with an OVC" roundTrip="false">
+      <tdml:infoset>
+        <tdml:dfdlInfoset>
+          <ex:refSimpleElementWithOvc>
+            <ex:st1>9</ex:st1>
+          </ex:refSimpleElementWithOvc>
+        </tdml:dfdlInfoset>
+      </tdml:infoset>
+
+      <tdml:document>
+        <tdml:documentPart type="text">1</tdml:documentPart>
+      </tdml:document>
+
+    </tdml:unparserTestCase>
+
+    <tdml:unparserTestCase name="refComplexTypeElemNoOvc"
+      root="refComplexElementNoOvc" model="outputValueCalc-Embedded.dfdl.xsd"
+      description="An element referencing a complexType Elem with no OVC" roundTrip="false">
+      <tdml:infoset>
+        <tdml:dfdlInfoset>
+          <ex:refComplexElementNoOvc>
+            <ex:ct1>
+              <e1>2</e1>
+            </ex:ct1>
+          </ex:refComplexElementNoOvc>
+        </tdml:dfdlInfoset>
+      </tdml:infoset>
+
+      <tdml:document>
+        <tdml:documentPart type="text">2</tdml:documentPart>
+      </tdml:document>
+
+    </tdml:unparserTestCase>
+
+    <tdml:unparserTestCase name="refComplexTypeElemWithOvc"
+      root="refComplexElementWithOvc" model="outputValueCalc-Embedded.dfdl.xsd"
+      description="An element referencing a complexType Elem with an OVC" roundTrip="false">
+      <tdml:infoset>
+        <tdml:dfdlInfoset>
+          <ex:refComplexElementWithOvc>
+            <ex:ct1>
+              <e1>2</e1>
+            </ex:ct1>
+          </ex:refComplexElementWithOvc>
+        </tdml:dfdlInfoset>
+      </tdml:infoset>
+
+      <tdml:document />
+
+      <tdml:errors>
+        <tdml:error>Schema Definition Error</tdml:error>
+        <tdml:error>dfdl:outputValueCalc cannot be defined on complexType elements.</tdml:error>
+      </tdml:errors>
+
+    </tdml:unparserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -82,4 +82,9 @@ class TestOutputValueCalc {
   @Test def test_ovcStringLSBF1() { runner3.runOneTest("rStringLSBF1") }
 
   @Test def test_ovcBitOrderChange() { runner3.runOneTest("ovc_bitOrderChange") }
+
+  // DAFFODIL-1701
+  @Test def test_refSimpleTypeElemWithOvc() { runner.runOneTest("refSimpleTypeElemWithOvc") }
+  @Test def test_refComplexTypeElemNoOvc() { runner.runOneTest("refComplexTypeElemNoOvc") }
+  @Test def test_refComplexTypeElemWithOvc() { runner.runOneTest("refComplexTypeElemWithOvc") }
 }


### PR DESCRIPTION
Rather than a huge trace, we get a schema definition error if an outputValueCalc is put on element of complex type

DAFFODIL-1701