### PR TITLE
Pass findPropertyOption through a ChoiceBranchImpliedSequence to the underlying Term

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -382,6 +382,8 @@ final class ChoiceBranchImpliedSequence(rawGM: Term)
 
   override def checkHiddenSequenceIsDefaultableOrOVC: Unit = ()
 
+  override def findPropertyOption(pname: String): PropertyLookupResult = rawGM.findPropertyOption(pname)
+
   override lazy val sequenceRuntimeData: SequenceRuntimeData = {
     new SequenceRuntimeData(
       schemaSet.variableMap,

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/PropertyScoping.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/PropertyScoping.scala
@@ -120,8 +120,7 @@ trait FindPropertyMixin extends PropTypes {
   
   val propCache = new scala.collection.mutable.LinkedHashMap[String, PropertyLookupResult]
 
-  final def findPropertyOption(pname: String): PropertyLookupResult = {
-
+  def findPropertyOption(pname: String): PropertyLookupResult = {
     val propCacheResult = propCache.get(pname)
     val propRes =
       propCacheResult match {


### PR DESCRIPTION
The ChoiceCombinator asks all of its child Terms for the choiceBranchKey
property (and other properties related to direct dispatch) to build the
dispatch mappings. This means that property lookup results are cached on
the implied sequence instead of on the Term that the properties actually
appear. This leads to the Term thinking the property wasn't used because
its access didn't appear it its cache, and leads it an incorrect
warning.

Instead, pass through the findPropertyOption function to the underlying
Term so that look ups happen and are cached on the Term, getting rid of
the false warnings.

DAFFODIL-2162