### PR TITLE
Fix unused properties related to implied choice sequences

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -344,26 +344,6 @@ abstract class ChoiceTermBase(
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharset)
   }
-
-  /**
-   * Examines all the children. Those that are non-scalar elements are
-   * encapsulated with a ChoiceBranchImpliedSequence, which is a kind of
-   * Sequence base.
-   *
-   * Thereafter daffodil can depend on the invariant that every recurring element is contained
-   * inside a sequence, and that sequence describes everything about how that
-   * element's occurrences are separated.
-   */
-  final lazy val groupMembersWithImpliedSequences = {
-    val rawGMs = groupMembers
-    val wrappedGMs = rawGMs.map {
-      gm =>
-        if (gm.isScalar) gm
-        else
-          new ChoiceBranchImpliedSequence(gm)
-    }
-    wrappedGMs
-  }
 }
 
 final class Choice(xmlArg: Node, lexicalParent: SchemaComponent, position: Int)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
@@ -69,7 +69,7 @@ trait GroupDefLike
   private lazy val goodXmlChildren = LV('goodXMLChildren) { xmlChildren.flatMap { removeNonInteresting(_) } }.value
 
   /** Returns the group members that are elements or model groups. */
-  final lazy val groupMembers: Seq[Term] = LV('groupMembers) {
+  lazy val groupMembers: Seq[Term] = LV('groupMembers) {
     val positions = List.range(1, goodXmlChildren.length + 1) // range is exclusive on 2nd arg. So +1.
     val pairs = goodXmlChildren zip positions
     pairs.map {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -358,6 +358,8 @@ final class ChoiceBranchImpliedSequence(rawGM: Term)
   extends SequenceTermBase(rawGM.xml, rawGM.optLexicalParent, rawGM.position)
   with SequenceDefMixin {
 
+  override final lazy val groupMembers: Seq[Term] = Seq(rawGM)
+
   override def separatorSuppressionPolicy: SeparatorSuppressionPolicy = SeparatorSuppressionPolicy.TrailingEmptyStrict
 
   override def sequenceKind: SequenceKind = SequenceKind.Ordered


### PR DESCRIPTION
When a ChoiceBranchImpliedSequence was created, because groupMembers was
not overridden, it would actually create a complete duplicate of all the
children terms because that's what the ModelGroup groupMembers that it
inherits does. This meant that properties would be cached on different
terms than we checked for unused properties, which lead to warnings.

This overrides groupMembers for ChoiceBranchImpliedSequence so that it
does not create new terms, but is instead just a sequence of the Term it
wraps. This allows all the same behavior provided by the implied
sequence, but 1) removes the duplicate Terms and 2) allows correct
caching/checking of unused properties.

DAFFODIL-2163