### PR TITLE
Add debugger infosetParents config option and update trace mode

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/TraceDebuggerRunner.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/TraceDebuggerRunner.scala
@@ -18,11 +18,12 @@
 package org.apache.daffodil.debugger
 
 class TraceDebuggerRunner extends InteractiveDebuggerRunner {
-  val traceIter = Seq("display info parser",
+  val traceIter = Seq(
+    "set infosetParents 1",
+    "display info parser",
     "display info bitPosition",
     "display info data",
-    // "display info infoset", // entire infoset
-    "display eval ..", // by default, just this node's parent on down.
+    "display info infoset",
     "display info diff",
     "trace").iterator
 


### PR DESCRIPTION
This new config option determines how many parent elements to include
when running the "info infoset" debugger command. A value of -1 will
show the entire inforset, which is the current and default behavior. A
value of zero or more will show 0 or more parent elements, in addition
to the current element.

Also modify the trace mode commands to set this property to "1" to show
a single parent and use "info infoset" so show the infoset. This
replaces the "eval .." command which gave unfriendly results going past
the root element.

DAFFODIL-1931