### PR TITLE
Emit SDE when a type calculator attempts to use an undefined type.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
@@ -17,14 +17,20 @@
 
 package org.apache.daffodil.dpath
 
-import org.apache.daffodil.exceptions._
-import org.apache.daffodil.dsom._
-import scala.xml.NamespaceBinding
-import org.apache.daffodil.xml._
-import scala.util.parsing.input.CharSequenceReader
+import java.math.{ BigDecimal => JBigDecimal }
+import java.math.{ BigInteger => JBigInt }
+
 import scala.util.parsing.combinator.RegexParsers
-import java.math.{ BigDecimal => JBigDecimal, BigInteger => JBigInt }
-import org.apache.daffodil.oolag.OOLAG._
+import scala.util.parsing.input.CharSequenceReader
+import scala.xml.NamespaceBinding
+
+import org.apache.daffodil.dsom.CompiledExpression
+import org.apache.daffodil.dsom.ConstantExpression
+import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.oolag.OOLAG.OOLAGHost
+import org.apache.daffodil.xml.NamedQName
+import org.apache.daffodil.xml.QNameRegex
 
 /**
  * Parses DPath expressions. Most real analysis is done later. This is

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -300,7 +300,8 @@ trait ElementBase
       namedQName,
       optPrimType,
       schemaFileLocation,
-      tunable)
+      tunable,
+      schemaSet.typeCalcMap)
     eci
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -62,7 +62,7 @@ trait SchemaComponent
   override def oolagContextViaArgs = optLexicalParent
 
   lazy val tunable: DaffodilTunables = optLexicalParent.get.tunable
-
+  
   lazy val dpathCompileInfo: DPathCompileInfo =
     new DPathCompileInfo(
       enclosingComponent.map { _.dpathCompileInfo },
@@ -70,7 +70,8 @@ trait SchemaComponent
       namespaces,
       path,
       schemaFileLocation,
-      tunable)
+      tunable,
+      schemaSet.typeCalcMap)
 
   /**
    * ALl non-terms get runtimeData from this definition. All Terms

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -40,6 +40,7 @@ import org.apache.daffodil.processors.TypeCalculator
 import scala.collection.immutable.Map
 import scala.collection.immutable.HashMap
 import org.apache.daffodil.compiler.ProcessorFactory
+import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 
 /**
  * A schema set is exactly that, a set of schemas. Each schema has
@@ -173,11 +174,10 @@ final class SchemaSet(
 
   lazy val globalSimpleTypeDefs: Seq[GlobalSimpleTypeDef] = schemas.flatMap(_.globalSimpleTypeDefs)
 
-  lazy val typeCalcMap: Map[GlobalQName, TypeCalculator[AnyRef, AnyRef]] = {
+  lazy val typeCalcMap: TypeCalcMap = {
     val factories = globalSimpleTypeDefs
     val withCalc = factories.filter(_.optTypeCalculator.isDefined)
     val mappings = withCalc.map(st => (st.globalQName, st.optTypeCalculator.get))
-
     mappings.toMap
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXTypeCalcFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXTypeCalcFunctions.scala
@@ -44,11 +44,10 @@ trait TypeCalculatorNamedDispatch { self: FNTwoArgs =>
    */
   def getCalculator(arg1: AnyRef, dstate: DState, expectedInputType: NodeInfo.Kind, expectedOutputType: NodeInfo.Kind, requireInputCalc: Boolean = false, requireOutputCalc: Boolean = false): TypeCalculator[AnyRef, AnyRef] = {
     val qn = arg1.asInstanceOf[String]
-    val runtimeData = dstate.runtimeData.get
-    val refType = QName.resolveRef(qn, runtimeData.namespaces, runtimeData.tunable).get.toGlobalQName
-    val maybeCalc = dstate.maybeSsrd.get.typeCalculators.get(refType)
+    val refType = QName.resolveRef(qn, dstate.compileInfo.namespaces, dstate.compileInfo.tunable).get.toGlobalQName
+    val maybeCalc = dstate.typeCalculators.get(refType)
     if (!maybeCalc.isDefined) {
-      throw FNErrorFunctionException(Maybe(runtimeData.schemaFileLocation), dstate.contextLocation, s"Simple type ${refType} does not exist or does not have a repType")
+      dstate.SDE("Simple type %s does not exist or does not have a repType", refType)
     }
     val calc = maybeCalc.get
     if (!expectedInputType.isSubtypeOf(calc.srcType)) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
@@ -36,6 +36,8 @@ import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.util.Misc
 import org.apache.daffodil.dpath.NodeInfo.PrimType
 import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.xml.GlobalQName
+import org.apache.daffodil.processors.TypeCalculator
 
 class CompiledDPath(val ops: RecipeOp*) extends Serializable {
 
@@ -72,7 +74,9 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
    * TODO: constant folding really should operate on sub-expressions of expressions
    * so that part of an expression can be constant, not necessarily the whole thing.
    */
-  def runExpressionForConstant(sfl: SchemaFileLocation, compileInfo: DPathCompileInfo): Option[AnyRef] = {
+  def runExpressionForConstant(
+      sfl: SchemaFileLocation, 
+      compileInfo: DPathCompileInfo ): Option[AnyRef] = {
 
     //
     // we use a special dummy dstate here that errors out via throw

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/ExpressionCompiler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/ExpressionCompiler.scala
@@ -22,6 +22,7 @@ import org.apache.daffodil.xml.NamedQName
 import scala.xml.NamespaceBinding
 import java.lang.{ Long => JLong, Boolean => JBoolean }
 import org.apache.daffodil.oolag.OOLAG._
+import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 
 trait ExpressionCompilerBase[T <: AnyRef] {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
@@ -23,6 +23,7 @@ import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.processors.unparsers.Unparser
 import org.apache.daffodil.processors.parsers.Parser
 import org.apache.daffodil.xml.GlobalQName
+import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 
 final class SchemaSetRuntimeData(
   val parser: Parser,
@@ -31,7 +32,7 @@ final class SchemaSetRuntimeData(
   val elementRuntimeData: ElementRuntimeData,
   var variables: VariableMap,
   var validationMode: ValidationMode.Type,
-  val typeCalculators: Map[GlobalQName, TypeCalculator[AnyRef, AnyRef]])
+  val typeCalculators: TypeCalcMap)
   extends Serializable with ThrowsSDE {
 
   def tunable = elementRuntimeData.tunable

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/lookAhead/lookAhead.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/lookAhead/lookAhead.tdml
@@ -299,7 +299,7 @@
     </tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Look-ahead distance of 520 bits exceeds implementation defined limit of 512 bits</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -321,7 +321,7 @@
     </tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Look-ahead distance of 513 bits exceeds implementation defined limit of 512 bits</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
@@ -136,7 +136,8 @@
     </tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Cannot convert 'a' from String type to Long</tdml:error>
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
@@ -175,7 +176,8 @@
     </tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Cannot convert 'a' from String type to Long</tdml:error>
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
@@ -246,12 +248,10 @@
     <tdml:documentPart type="text">a</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>parse Error</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Cannot convert</tdml:error>
+      <tdml:error>from String type to Long</tdml:error>
     </tdml:errors>
-    <tdml:warnings>
-      <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String) should be manually cast to the expected type (Int)</tdml:warning>
-    </tdml:warnings>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="typeCalcDispatch_typeError_10"
@@ -285,10 +285,6 @@
         <typeCalcDispatch_typeError_12>a</typeCalcDispatch_typeError_12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String) should be manually cast to the expected type (Int)</tdml:warning>
-    </tdml:warnings>
     <tdml:errors>
       <tdml:error>Unparse Error</tdml:error>
       <tdml:error>Cannot convert 'a' from String type to Long</tdml:error>
@@ -369,6 +365,59 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>tns:outputConversionOnly does not define an inputValueCalc</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="nonexistantTypeCalcType_01.dfdl.xsd">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit"
+      lengthUnits="bytes" encoding="UTF-8" separator="" initiator=""
+      terminator="" occursCountKind="parsed" ignoreCase="no"
+      textNumberRep="standard" representation="binary" 
+      dfdlx:parseUnparsePolicy="parseOnly"
+      />
+
+     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:nonExistant', 0) }"/>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nonexistantTypeCalcType_01"
+    root="root" model="nonexistantTypeCalcType_01.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:document>
+    <tdml:documentPart type="byte"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>tns:nonExistant</tdml:error>
+      <tdml:error>does not exist</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="nonexistantTypeCalcType_02.dfdl.xsd">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit"
+      lengthUnits="bytes" encoding="UTF-8" separator="" initiator=""
+      terminator="" occursCountKind="parsed" ignoreCase="no"
+      textNumberRep="standard" representation="binary" 
+      dfdlx:parseUnparsePolicy="parseOnly"
+      />
+
+     <xs:simpleType name="nonExistantTypeCalc">
+       <xs:restriction base="xs:int"/>
+     </xs:simpleType>
+     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:nonExistantTypeCalc', 0) }"/>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nonexistantTypeCalcType_02"
+    root="root" model="nonexistantTypeCalcType_02.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:document>
+    <tdml:documentPart type="byte"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>tns:nonExistant</tdml:error>
+      <tdml:error>does not have a repType</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -96,5 +96,7 @@ class TestInputTypeValueCalc {
   @Test def test_nonexistant_reptype_01() { fnErrRunner.runOneTest("nonexistant_reptype_01") }
   @Test def test_nonexistantOutputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantOutputTypeCalc_01") }
   @Test def test_nonexistantInputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantInputTypeCalc_01") }
+  @Test def test_nonexistantTypeCalcType_01() { fnErrRunner.runOneTest("nonexistantTypeCalcType_01") }
+  @Test def test_nonexistantTypeCalcType_02() { fnErrRunner.runOneTest("nonexistantTypeCalcType_02") }
 
 }


### PR DESCRIPTION
This lays down the infrastructure which allows the DPath
interperator to lookup type calculators at compile time,
which will allow us to make their return type dependent on
the calculator they are using, instead of their functin name.

DAFFODIL-2148