### PR TITLE
Switch to OpenJDK on TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ scala:
   - 2.12.6
   - 2.11.12
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - oraclejdk11
+  - openjdk8
+  - openjdk9
+  - openjdk11
 sudo: required
 dist: trusty
 


### PR DESCRIPTION
TravisCI downloads the OracleJDK from oracles website. Periodially
Oracle changes something and builds start to break. Since OracleJDK and
OpenJDK are virtually the same (except OpenJDK is easier to install)
switch to OpenJDK for TravisCI builds.

DAFFODIL-2166