### PR TITLE
Modify inspectPure to be aware of pending events

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -152,22 +152,28 @@ abstract class InfosetInputter
     val res = priorOpKind match {
       case Advance => {
         priorOpKind = InspectPure
-        next() //advance the input stream so nextElementErd is pointing to the correct place
-        val eventKind = getEventType() match {
-          case StartElement  => StartKind
-          case EndElement    => EndKind
-          case StartDocument => StartKind
-          case EndDocument   => EndKind
-        }
-        accessor.kind = eventKind
-        if (eventKind == StartKind) {
-          accessor.erd = nextElementErd()
-          accessor.node = null
-        }else{
-          //accessor.kind == EndKind
-          val node = nodeStack.top
-          accessor.node=node
-          accessor.erd=node.erd
+        if (isPending) {
+          accessor.kind = pendingStartOrEnd(pendingCurIndex)
+          accessor.node = pendingNodes(pendingCurIndex)
+          accessor.erd = accessor.node.erd
+        } else {
+          next() //advance the input stream so nextElementErd is pointing to the correct place
+          val eventKind = getEventType() match {
+            case StartElement  => StartKind
+            case EndElement    => EndKind
+            case StartDocument => StartKind
+            case EndDocument   => EndKind
+          }
+          accessor.kind = eventKind
+          if (eventKind == StartKind) {
+            accessor.erd = nextElementErd()
+            accessor.node = null
+          } else {
+            //accessor.kind == EndKind
+            val node = nodeStack.top
+            accessor.node = node
+            accessor.erd = node.erd
+          }
         }
         true
       }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
@@ -349,6 +349,19 @@
           </xs:complexType>
         </xs:element>
 
+    <xs:element name="arrayWithFollowingOVC">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="Arr" type="xs:string" minOccurs="0" maxOccurs="2"
+            dfdl:length="1" dfdl:lengthKind="explicit" />
+          <xs:element name="OVC" type="xs:string" dfdl:outputValueCalc="{ ../ex:Arr[1] }"
+            dfdl:length="1" dfdl:lengthKind="explicit" />
+          <xs:element name="End" type="xs:string"
+            dfdl:length="1" dfdl:lengthKind="explicit" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
 	</tdml:defineSchema>
 
 	<tdml:unparserTestCase name="binaryIntegerBigEndian"
@@ -799,6 +812,22 @@
         <tdml:error>dfdl:outputValueCalc cannot be defined on complexType elements.</tdml:error>
       </tdml:errors>
 
+    </tdml:unparserTestCase>
+
+    <tdml:unparserTestCase name="arrayWithFollowingOVC"
+      root="arrayWithFollowingOVC" model="outputValueCalc-Embedded.dfdl.xsd"
+      description="An OVC element that follows an array" roundTrip="false">
+      <tdml:infoset>
+        <tdml:dfdlInfoset>
+          <ex:arrayWithFollowingOVC xmlns:ex="http://example.com">
+            <Arr>1</Arr>
+            <Arr>2</Arr>
+            <OVC>8</OVC>
+            <End>9</End>
+          </ex:arrayWithFollowingOVC>
+        </tdml:dfdlInfoset>
+      </tdml:infoset>
+      <tdml:document>1219</tdml:document>
     </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -87,4 +87,7 @@ class TestOutputValueCalc {
   @Test def test_refSimpleTypeElemWithOvc() { runner.runOneTest("refSimpleTypeElemWithOvc") }
   @Test def test_refComplexTypeElemNoOvc() { runner.runOneTest("refComplexTypeElemNoOvc") }
   @Test def test_refComplexTypeElemWithOvc() { runner.runOneTest("refComplexTypeElemWithOvc") }
+
+  // DAFFODIL-2167
+  @Test def test_arrayWithFollowingOVC() { runner.runOneTest("arrayWithFollowingOVC") }
 }


### PR DESCRIPTION
When unparsing, there are some cases where Daffodil will read multiple
events and cache future events in a buffer, called pending events. The
inspectPure function wasn't aware of these pending events and so it
would always try to read an event, which resulted in it returning events
after the current pending.

This modifies inspectPure so that if there are pending events, it just
returns the first one instead of reading more events.

DAFFODIL-2167