### PR TITLE
Adds hex/utf-8 data dump on left over data

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -533,10 +533,10 @@ class TestCLIparsing {
       val cmd = String.format("echo 0,1,2| %s parse -P parserThatDoesNotExist", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       if (Util.isWindows) {
-	    shell.expect(contains("parserThatDoesNotExist (The system cannot find the file specified)"))
-	  } else {
+        shell.expect(contains("parserThatDoesNotExist (The system cannot find the file specified)"))
+      } else {
         shell.expect(contains("parserThatDoesNotExist (No such file or directory)"))
-	  }
+      }
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {
@@ -816,6 +816,8 @@ class TestCLIparsing {
       val cmd = String.format("echo 0,1,2,3,,,,| %s -t parse -s %s", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(1, contains("Left over data. Consumed 56 bit(s) with at least"))
+      shell.expectIn(1, contains("Data (UTF-8) starting at byte 8 is: ("))
+      shell.expectIn(1, contains("Data (Hex) starting at byte 8 is: ("))
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {
@@ -833,6 +835,8 @@ class TestCLIparsing {
       val cmd = String.format("echo 1,2,3,4,,,| %s parse -s %s -r matrix", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expect(contains("Left over data. Consumed 56 bit(s) with at least"))
+      shell.expect(contains("Data (UTF-8) starting at byte 8 is: ("))
+      shell.expect(contains("Data (Hex) starting at byte 8 is: ("))
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDump.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDump.scala
@@ -460,4 +460,28 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
+  @Test def testDumpTextLine7() {
+    val data = """da8b f090 a487 f48b be8b be7a 1234
+      4567 f48b 8018 0156 dada
+      0000 0101 0817 dead beef cc7a"""
+      .replaceAll("\\s+", "").grouped(2)
+      .map { Integer.parseInt(_, 16).toByte }.toArray
+    val bs = new BS(data)
+    val lengthInbits = data.length * 8
+    val dumpString = Dump.dump(Dump.TextOnly(Some("utf-8")), 0, lengthInbits, bs).mkString("\n")
+    val uUnknown = 0xfffd
+    val arrayOfDecodedChars1 =
+      Array(0x068b, 0x10907, 0x10bf8b, uUnknown, 0x007a)
+    val arrayOfDecodedChars2 = Array(0x0034, 0x0045, 0x0067, uUnknown)
+    val arrayOfDecodedChars3 = Array(0x0056, uUnknown, uUnknown)
+    val arrayOfDecodedChars4 = Array(0x07ad, uUnknown, uUnknown, uUnknown, 0x007a)
+    val expected =
+      s"""${arrayOfDecodedChars1.map(Character.toChars(_).mkString).mkString}␒""" +
+        s"""${arrayOfDecodedChars2.map(Character.toChars(_).mkString).mkString}␘␁""" +
+        s"""${arrayOfDecodedChars3.map(Character.toChars(_).mkString).mkString}␀␀␁␁␈␗""" +
+        s"""${arrayOfDecodedChars4.map(Character.toChars(_).mkString).mkString}"""
+        .replace("\r\n", "\n")
+    assertEquals(expected, dumpString)
+  }
+
 }


### PR DESCRIPTION
- Fixes dumpTextLine to decode whole characters rather than per byte
in keeping with the updates to converToCharRepr
- Limited to 8 bytes displayed and decoded
- Uses Java utf-8 decoder
- 1 based indexing

DAFFODIL 1387