### PR TITLE
Replaces arrayIndex with occursIndex

### DIFF
--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/debugger/1330
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/debugger/1330
@@ -1,4 +1,4 @@
-display info arrayIndex
+display info occursIndex
 break element.cell
 info breakpoints
 continue

--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/debugger/1331
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/debugger/1331
@@ -3,7 +3,7 @@ break element.cell
 condition 1 dfdl:occursIndex() mod 2 = 1
 condition 2 dfdl:occursIndex() mod 2 = 0
 info breakpoints
-display info arrayIndex
+display info occursIndex
 continue
 continue
 continue

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -255,29 +255,29 @@ class TestCLIdebugger {
       shell.sendLine("info breakpoints")
       shell.expect(contains("2: cell   { dfdl:occursIndex() mod 2 eq 0 }"))
 
-      shell.sendLine("display info arrayIndex")
+      shell.sendLine("display info occursIndex")
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 1"))
+      shell.expect(contains("occursIndex: 1"))
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 2"))
+      shell.expect(contains("occursIndex: 2"))
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 3"))
+      shell.expect(contains("occursIndex: 3"))
 
       shell.sendLine("disable breakpoint 2")
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 5"))
+      shell.expect(contains("occursIndex: 5"))
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 7"))
+      shell.expect(contains("occursIndex: 7"))
 
       shell.sendLine("enable breakpoint 2")
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 8"))
+      shell.expect(contains("occursIndex: 8"))
 
       shell.sendLine("disable breakpoint 1")
       shell.sendLine("disable breakpoint 2")
@@ -480,7 +480,7 @@ class TestCLIdebugger {
       shell.sendLine(cmd)
       shell.expect(contains("(debug)"))
 
-      shell.sendLine("display info arrayIndex")
+      shell.sendLine("display info occursIndex")
       shell.expect(contains("(debug)"))
       shell.sendLine("break cell")
       shell.expect(contains("(debug)"))
@@ -488,10 +488,10 @@ class TestCLIdebugger {
       shell.expect(contains("1: cell"))
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 1"))
+      shell.expect(contains("occursIndex: 1"))
 
       shell.sendLine("continue")
-      shell.expect(contains("arrayIndex: 2"))
+      shell.expect(contains("occursIndex: 2"))
 
       shell.sendLine("disable breakpoint 1")
       shell.sendLine("info breakpoints")

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -1189,7 +1189,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
                         |multiple times to display multiple pieces of information.
                         |
                         |Example: info data infoset""".stripMargin
-      override val subcommands = Seq(InfoArrayIndex, InfoBitLimit, InfoBitPosition, InfoBreakpoints, InfoChildIndex, InfoData, InfoDelimiterStack, InfoDiff, InfoDiscriminator, InfoDisplays, InfoFoundDelimiter, InfoGroupIndex, InfoInfoset, InfoParser, InfoUnparser, InfoPath)
+      override val subcommands = Seq(InfoBitLimit, InfoBitPosition, InfoBreakpoints, InfoChildIndex, InfoData, InfoDelimiterStack, InfoDiff, InfoDiscriminator, InfoDisplays, InfoFoundDelimiter, InfoGroupIndex, InfoInfoset, InfoOccursIndex, InfoParser, InfoUnparser, InfoPath)
 
       override def validate(args: Seq[String]) {
         if (args.size == 0) {
@@ -1229,9 +1229,9 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
         }
       }
 
-      object InfoArrayIndex extends DebugCommand with DebugCommandValidateZeroArgs {
-        val name = "arrayIndex"
-        override lazy val short = "ai"
+      object InfoOccursIndex extends DebugCommand with DebugCommandValidateZeroArgs {
+        val name = "occursIndex"
+        override lazy val short = "oi"
         val desc = "display the current array limit"
         val longDesc = desc
         def act(args: Seq[String], prestate: StateForDebugger, state: ParseOrUnparseState, processor: Processor): DebugState.Type = {
@@ -1396,7 +1396,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
             case (prestate: StateForDebugger, state: ParseOrUnparseState) => {
               if (prestate.bytePos != state.bytePos) { debugPrintln("position (bytes): %d -> %d".format(prestate.bytePos, state.bytePos), "  "); diff = true }
               if (prestate.bitLimit0b != state.bitLimit0b) { debugPrintln("bitLimit: %d -> %d".format(prestate.bitLimit0b, state.bitLimit0b), "  "); diff = true }
-              if (prestate.arrayPos != state.arrayPos) { debugPrintln("arrayIndex: %d -> %d".format(prestate.arrayPos, state.arrayPos), "  "); diff = true }
+              if (prestate.arrayPos != state.arrayPos) { debugPrintln("occursIndex: %d -> %d".format(prestate.arrayPos, state.arrayPos), "  "); diff = true }
               if (prestate.groupPos != state.groupPos) { debugPrintln("groupIndex: %d -> %d".format(prestate.groupPos, state.groupPos), "  "); diff = true }
               if (prestate.childPos != state.childPos) { debugPrintln("childIndex: %d -> %d".format(prestate.childPos, state.childPos), "  "); diff = true }
             }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -257,7 +257,7 @@ abstract class OrderedSequenceParserBase(
 
     var wasThrow = true
     try {
-      checkN(pstate, parser) // check if arrayIndex exceeds tunable limit.
+      checkN(pstate, parser) // check if occursIndex exceeds tunable limit.
 
       if (hasPoU) pstate.pushDiscriminator
       val priorPos = pstate.bitPos0b

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -338,7 +338,7 @@ class UStateForSuspension(
   dos: DirectOrBufferedDataOutputStream,
   vbox: VariableBox,
   override val currentInfosetNode: DINode,
-  arrayIndex: Long,
+  occursIndex: Long,
   escapeSchemeEVCacheMaybe: Maybe[MStackOfMaybe[EscapeSchemeUnparserHelper]],
   delimiterStackMaybe: Maybe[MStackOf[DelimiterStackUnparseNode]],
   override val prior: UStateForSuspension,
@@ -375,7 +375,7 @@ class UStateForSuspension(
 
   override def arrayIndexStack = die
   override def moveOverOneArrayIndexOnly() = die
-  override def arrayPos = arrayIndex
+  override def arrayPos = occursIndex
 
   override def groupIndexStack = die
   override def moveOverOneGroupIndexOnly() = die


### PR DESCRIPTION
Now the debugger uses "info occursIndex" instead of "info arrayIndex"

DAFFODIL 1478