### PR TITLE
Daffodil 2165 type calc double functions

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -301,7 +301,8 @@ trait ElementBase
       optPrimType,
       schemaFileLocation,
       tunable,
-      schemaSet.typeCalcMap)
+      schemaSet.typeCalcMap,
+      runtimeData)
     eci
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.oolag.OOLAG._
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.xml.GetAttributesMixin
 import org.apache.daffodil.schema.annotation.props.PropTypes
+import org.apache.daffodil.util.Maybe
 
 abstract class SchemaComponentImpl(
   final override val xml: Node,
@@ -71,11 +72,10 @@ trait SchemaComponent
       path,
       schemaFileLocation,
       tunable,
-      schemaSet.typeCalcMap)
+      schemaSet.typeCalcMap,
+      runtimeData)
 
   /**
-   * ALl non-terms get runtimeData from this definition. All Terms
-   * which are elements and model-groups) override this.
    *
    * The Term class has a generic termRuntimeData => TermRuntimeData
    * function (useful since all Terms share things like having charset encoding)
@@ -84,7 +84,7 @@ trait SchemaComponent
    *
    * There is also VariableRuntimeData and SchemaSetRuntimeData.
    */
-  lazy val runtimeData: RuntimeData = nonTermRuntimeData // overrides in ModelGroup, ElementBase
+  lazy val runtimeData: RuntimeData = nonTermRuntimeData // overrides in ModelGroup, ElementBase, SimpleTypes
 
   final def nonTermRuntimeData = LV('nonTermRuntimeData) {
     new NonTermRuntimeData(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -258,11 +258,7 @@ case class TypeValueCalc(e: ElementBase)
   extends Terminal(e, e.hasRepType) {
 
   private lazy val simpleTypeDefBase = e.simpleType.asInstanceOf[SimpleTypeDefBase]
-  private lazy val typeCalculator = {
-    val a = simpleTypeDefBase
-    val b = simpleTypeDefBase.optTypeCalculator
-    simpleTypeDefBase.optTypeCalculator.get
-  }
+  private lazy val typeCalculator = simpleTypeDefBase.optTypeCalculator.get
   private lazy val repTypeRuntimeData = simpleTypeDefBase.optRepTypeElement.get.elementRuntimeData
   private lazy val repTypeParser = simpleTypeDefBase.optRepTypeElement.get.enclosedElement.parser
   private lazy val repTypeUnparser = simpleTypeDefBase.optRepTypeElement.get.enclosedElement.unparser

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
@@ -113,9 +113,9 @@ case class DState(val maybeSsrd: Maybe[SchemaSetRuntimeData]) {
    * (eg. to the runtime stack), and replaces the below fields.
    * At the end of the computation, it should restore the below fields.
    */
-  var logicalValue: Maybe[(AnyRef, NodeInfo.Kind)] = Maybe.Nope
+  var logicalValue: Maybe[AnyRef] = Maybe.Nope
 
-  var repValue: Maybe[(AnyRef, NodeInfo.Kind)] = Maybe.Nope
+  var repValue: Maybe[AnyRef] = Maybe.Nope
 
   /**
    * The currentValue is used when we have a value that is not

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.dsom
 
-import scala.runtime.ScalaRunTime.stringOf
+import scala.runtime.ScalaRunTime.stringOf // for printing arrays properly.
 
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.api.UnqualifiedPathStepPolicy
@@ -29,6 +29,7 @@ import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.exceptions.HasSchemaFileLocation
 import org.apache.daffodil.exceptions.SchemaFileLocation
 import org.apache.daffodil.processors.ParseOrUnparseState
+import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.Suspension
 import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 import org.apache.daffodil.processors.VariableMap
@@ -205,7 +206,8 @@ class DPathCompileInfo(
   val path: String,
   override val schemaFileLocation: SchemaFileLocation,
   val tunable: DaffodilTunables,
-  @TransientParam typeCalcMapArg: => TypeCalcMap)
+  @TransientParam typeCalcMapArg: => TypeCalcMap,
+  val lexicalContextRuntimeData: RuntimeData)
   extends ImplementsThrowsSDE with PreSerialization
   with HasSchemaFileLocation {
 
@@ -316,8 +318,9 @@ class DPathElementCompileInfo(
   val optPrimType: Option[PrimType],
   sfl: SchemaFileLocation,
   override val tunable: DaffodilTunables,
-  typeCalcMap: TypeCalcMap)
-  extends DPathCompileInfo(parentArg, variableMap, namespaces, path, sfl, tunable, typeCalcMap)
+  typeCalcMap: TypeCalcMap,
+  lexicalContextRuntimeData: RuntimeData)
+  extends DPathCompileInfo(parentArg, variableMap, namespaces, path, sfl, tunable, typeCalcMap, lexicalContextRuntimeData)
   with HasSchemaFileLocation {
 
   lazy val elementChildrenCompileInfo = elementChildrenCompileInfoArg

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/NextElementResolver.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/NextElementResolver.scala
@@ -51,6 +51,8 @@ trait NextElementResolver extends Serializable {
   //
   def nextElement(nqn: NamedQName, hasNamespace: Boolean): ElementRuntimeData =
     nextElement(nqn.local, if (hasNamespace) nqn.namespace.toStringOrNullIfNoNS else null, hasNamespace)
+    
+  def allPossibleNextElements: Seq[ElementRuntimeData]
 }
 
 sealed abstract class ResolverType(val name: String) extends Serializable
@@ -66,10 +68,12 @@ class NoNextElement(schemaFileLocation: SchemaFileLocation, resolverType: Resolv
   }
 
   override def toString() = "NoNextElement"
+  
+  override val allPossibleNextElements = Seq()
 
 }
 
-class OnlyOnePossibilityForNextElement(schemaFileLocation: SchemaFileLocation, nextERD: ElementRuntimeData, resolverType: ResolverType)
+class OnlyOnePossibilityForNextElement(schemaFileLocation: SchemaFileLocation, val nextERD: ElementRuntimeData, resolverType: ResolverType)
   extends NextElementResolver {
 
   override def nextElement(local: String, namespace: String, hasNamespace: Boolean): ElementRuntimeData = {
@@ -95,6 +99,8 @@ class OnlyOnePossibilityForNextElement(schemaFileLocation: SchemaFileLocation, n
   }
 
   override def toString() = "OnlyOne(" + nextERD.namedQName + ")"
+  
+  override lazy val allPossibleNextElements = Seq(nextERD)
 }
 
 /**
@@ -163,4 +169,6 @@ class SeveralPossibilitiesForNextElement(loc: SchemaFileLocation, nextERDMap: Ma
   }
 
   override def toString() = "Several(" + nextERDMap.keySet.mkString(", ") + ")"
+  
+  override lazy val allPossibleNextElements = nextERDMap.values.toSeq
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -240,7 +240,8 @@ final class SimpleTypeRuntimeData(
   @TransientParam tunableArg: => DaffodilTunables,
   @TransientParam repTypeRuntimeDataArg: => Option[SimpleTypeRuntimeData],
   @TransientParam repValueSetArg: => Option[RepValueSet[AnyRef]],
-  @TransientParam typeCalculatorArg: => Option[TypeCalculator[AnyRef,AnyRef]]
+  @TransientParam typeCalculatorArg: => Option[TypeCalculator[AnyRef,AnyRef]],
+  @TransientParam optRepPrimTypeArg: => Option[PrimType]
 ) extends NonTermRuntimeData(variableMapArg, schemaFileLocationArg, diagnosticDebugNameArg,
   pathArg, namespacesArg, tunableArg) {
 
@@ -262,6 +263,7 @@ final class SimpleTypeRuntimeData(
   lazy val repTypeRuntimeData = repTypeRuntimeDataArg
   lazy val repValueSet = repValueSetArg
   lazy val typeCalculator = typeCalculatorArg
+  lazy val optRepPrimType = optRepPrimTypeArg
 
   override def preSerialization: Unit = {
     super.preSerialization
@@ -281,6 +283,7 @@ final class SimpleTypeRuntimeData(
     repTypeRuntimeData
     repValueSet
     typeCalculator
+    optRepPrimType
   }
 
   @throws(classOf[java.io.IOException])

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc_malformed.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc_malformed.tdml
@@ -18,7 +18,8 @@
 
 <tdml:testSuite xmlns:ex="http://example.com" xmlns="http://example.com"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions" >
 
   <tdml:defineSchema name="inputTypeCalc-Embedded.dfdl.xsd">
 
@@ -28,7 +29,7 @@
       terminator="" occursCountKind="parsed" ignoreCase="no"
       textNumberRep="standard" representation="text" />
 
-    <xs:element name="keysetValue_00" type="tns:keysetValue_01">
+    <xs:element name="keysetValue_00" type="tns:keysetValue_01" />
 
     <xs:element name="keysetValue_01">
       <xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
@@ -49,65 +49,63 @@
       <xs:restriction base="xs:string"/>
     </xs:simpleType>
 
-    <!--
-    <xs:element name="typeCalcDispatch_typeError_baseline" type="xs:string" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcString('tns:intToString', 0) }" />
-    -->
-    <xs:element name="typeCalcDispatch_typeError_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcString('tns:intToString', 0) }" />
-    <xs:element name="typeCalcDispatch_typeError_02" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:intToString', 0) }" />
-    <xs:element name="typeCalcDispatch_typeError_03" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:stringToInt', 0) }" />
-    <!--
-    <xs:element name="typeCalcDispatch_typeError_baseline" type="xs:string" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcString('tns:stringToInt', 0) }" />
-    -->
-    <xs:element name="typeCalcDispatch_typeError_04" type="xs:int" dfdl:inputValueCalc="{ dfdlx:outputTypeCalcString('tns:stringToInt', 0) }" />
-    <xs:element name="typeCalcDispatch_typeError_05" type="xs:int" dfdl:inputValueCalc="{ dfdlx:outputTypeCalcInt('tns:stringToInt', 0) }" />
-    <xs:element name="typeCalcDispatch_typeError_06" type="xs:int" dfdl:inputValueCalc="{ dfdlx:outputTypeCalcInt('tns:intToString', 0) }" />
+    <xs:element name="typeCalcDispatch_typeError_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:intToString', 0) }" />
+    <xs:element name="typeCalcDispatch_typeError_02" type="xs:int" dfdl:inputValueCalc="{ dfdlx:outputTypeCalc('tns:stringToInt', 0) }" />
 
-    <xs:element name="typeCalcDispatch_typeError_07" dfdlx:parseUnparsePolicy="unparseOnly">
+    <xs:element name="typeCalcDispatch_typeError_03" dfdlx:parseUnparsePolicy="unparseOnly">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="raw" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSiblingInt() }" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly"/>
+          <xs:element name="raw" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly"/>
           <xs:element name="stringToInt" type="stringToInt" dfdlx:parseUnparsePolicy="unparseOnly" dfdl:inputValueCalc="{ 0 }"/>
         </xs:sequence>
       </xs:complexType>
+    </xs:element>
+
+    <xs:element name="typeCalcDispatch_typeError_04" dfdlx:parseUnparsePolicy="unparseOnly">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="raw" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly"/>
+          <xs:element name="stringToInt" type="stringToInt" dfdlx:parseUnparsePolicy="unparseOnly" dfdl:inputValueCalc="{ 0 }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="typeCalcDispatch_typeError_05">
+      <xs:simpleType dfdlx:repType="tns:string8" dfdlx:inputTypeCalc="{ dfdlx:repTypeValue() }">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="typeCalcDispatch_typeError_06">
+      <xs:simpleType dfdlx:repType="tns:string8" dfdlx:inputTypeCalc="{ dfdlx:repTypeValue() }">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="typeCalcDispatch_typeError_07" dfdlx:parseUnparsePolicy="unparseOnly" >
+      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValue() }">
+        <xs:restriction base="xs:string"/>
+      </xs:simpleType>
     </xs:element>
 
     <xs:element name="typeCalcDispatch_typeError_08" dfdlx:parseUnparsePolicy="unparseOnly">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="raw" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSiblingString() }" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly"/>
-          <xs:element name="stringToInt" type="stringToInt" dfdlx:parseUnparsePolicy="unparseOnly" dfdl:inputValueCalc="{ 0 }"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-    <xs:element name="typeCalcDispatch_typeError_09">
-      <xs:simpleType dfdlx:repType="tns:string8" dfdlx:inputTypeCalc="{ dfdlx:repTypeValueString() }">
-        <xs:restriction base="xs:int"/>
-      </xs:simpleType>
-    </xs:element>
-
-    <xs:element name="typeCalcDispatch_typeError_10">
-      <xs:simpleType dfdlx:repType="tns:string8" dfdlx:inputTypeCalc="{ dfdlx:repTypeValueInt() }">
-        <xs:restriction base="xs:int"/>
-      </xs:simpleType>
-    </xs:element>
-
-    <xs:element name="typeCalcDispatch_typeError_11" dfdlx:parseUnparsePolicy="unparseOnly" >
-      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValueInt() }">
+      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValue() }">
         <xs:restriction base="xs:string"/>
       </xs:simpleType>
     </xs:element>
 
-    <xs:element name="typeCalcDispatch_typeError_12" dfdlx:parseUnparsePolicy="unparseOnly">
-      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValueString() }">
-        <xs:restriction base="xs:string"/>
+    <xs:element name="repTypeValue_bad_context_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:repTypeValue() }"/>
+    <xs:element name="repTypeValue_bad_context_02" dfdlx:parseUnparsePolicy="unparseOnly">
+      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ dfdlx:repTypeValue() }" dfdlx:inputTypeCalc="{ 0 }">
+        <xs:restriction base="xs:int"/>
       </xs:simpleType>
     </xs:element>
-
-    <xs:element name="repTypeValue_bad_context_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:repTypeValueString() }"/>
-    <xs:element name="repTypeValue_bad_context_02" type="xs:int" dfdl:inputValueCalc="{ dfdlx:repTypeValueInt() }"/>
-    <xs:element name="logicalTypeValue_bad_context_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:logicalTypeValueString() }"/>
-    <xs:element name="logicalTypeValue_bad_context_02" type="xs:int" dfdl:inputValueCalc="{ dfdlx:logicalTypeValueInt() }"/>
+    <xs:element name="logicalTypeValue_bad_context_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:logicalTypeValue() }"/>
+    <xs:element name="logicalTypeValue_bad_context_02">
+      <xs:simpleType dfdlx:repType="tns:uint8" dfdlx:inputTypeCalc="{ dfdlx:logicalTypeValue() }" dfdlx:outputTypeCalc="{ 0 }">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+    </xs:element>
 
     <xs:element name="nonexistant_reptype_01">
       <xs:simpleType dfdlx:repType="tns:nonExistant" dfdlx:inputTypeCalc="{ 0 }">
@@ -119,13 +117,54 @@
       <xs:restriction base="xs:int"/>
     </xs:simpleType>
 
-    <xs:element name="nonexistantOutputTypeCalc_01" type="xs:int" dfdl:inputValueCalc="{dfdlx:outputTypeCalcInt('tns:inputConversionOnly', 7)}"/>
+    <xs:element name="nonexistantOutputTypeCalc_01" type="xs:int" dfdl:inputValueCalc="{dfdlx:outputTypeCalc('tns:inputConversionOnly', 7)}"/>
 
     <xs:simpleType name="outputConversionOnly" dfdlx:repType="tns:uint8" dfdlx:outputTypeCalc="{ 1 }">
       <xs:restriction base="xs:int"/>
     </xs:simpleType>
 
-    <xs:element name="nonexistantInputTypeCalc_01" type="xs:int" dfdl:inputValueCalc="{dfdlx:inputTypeCalcInt('tns:outputConversionOnly', 7)}"/>
+    <xs:element name="nonexistantInputTypeCalc_01" type="xs:int" dfdl:inputValueCalc="{dfdlx:inputTypeCalc('tns:outputConversionOnly', 7)}"/>
+
+    <xs:element name="nextSibling_01" dfdlx:parseUnparsePolicy="unparseOnly" >
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="raw" type="xs:int" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" dfdlx:parseUnparsePolicy="unparseOnly" />
+          <xs:choice>
+            <xs:element name="a" type="tns:intToString" dfdlx:parseUnparsePolicy="unparseOnly" />
+            <xs:element name="b" type="tns:stringToInt" dfdlx:parseUnparsePolicy="unparseOnly" />
+          </xs:choice>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="nextSibling_02" dfdlx:parseUnparsePolicy="unparseOnly" >
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="raw" type="xs:int" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" dfdlx:parseUnparsePolicy="unparseOnly" />
+          <xs:choice>
+            <xs:element name="a" type="tns:intToString" dfdlx:parseUnparsePolicy="unparseOnly" />
+            <xs:element name="b" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly" />
+          </xs:choice>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="nextSibling_03" dfdlx:parseUnparsePolicy="unparseOnly" >
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="raw" type="xs:int" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" dfdlx:parseUnparsePolicy="unparseOnly" />
+          <xs:element name="b" type="tns:uint8" dfdlx:parseUnparsePolicy="unparseOnly" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="nextSibling_04" dfdlx:parseUnparsePolicy="unparseOnly" >
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="raw" type="xs:int" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }" dfdlx:parseUnparsePolicy="unparseOnly" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
 
   </tdml:defineSchema>
 
@@ -153,30 +192,6 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>tns:intToString has a destination type of String, but its usage requires Int</tdml:error>
-    </tdml:errors>
-  </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_03"
-    root="typeCalcDispatch_typeError_03" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>tns:stringToInt has a source type of String, but its usage requires Int</tdml:error>
-    </tdml:errors>
-  </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_04"
-    root="typeCalcDispatch_typeError_04" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Cannot convert 'a' from String type to Long</tdml:error>
     </tdml:errors>
     <tdml:warnings>
@@ -185,52 +200,34 @@
     </tdml:warnings>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_05"
-    root="typeCalcDispatch_typeError_05" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>tns:stringToInt has a source type of String, but its usage requires Int</tdml:error>
-    </tdml:errors>
-  </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_06"
-    root="typeCalcDispatch_typeError_06" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>tns:intToString has a destination type of String, but its usage requires Int</tdml:error>
-    </tdml:errors>
-  </tdml:parserTestCase>
-
-  <tdml:unparserTestCase name="typeCalcDispatch_typeError_07"
-    root="typeCalcDispatch_typeError_07" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:unparserTestCase name="typeCalcDispatch_typeError_03"
+    root="typeCalcDispatch_typeError_03" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <typeCalcDispatch_typeError_07>
+        <typeCalcDispatch_typeError_03>
           <stringToInt>0</stringToInt>
-        </typeCalcDispatch_typeError_07>
+        </typeCalcDispatch_typeError_03>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>The type calculator defined by stringToInt has a source type of String, but its usage requires Int</tdml:error>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Cannot convert</tdml:error>
+      <tdml:error>from String type to Long</tdml:error>
     </tdml:errors>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>expected type (Int)</tdml:warning>
+    </tdml:warnings>
   </tdml:unparserTestCase>
 
-  <tdml:unparserTestCase name="typeCalcDispatch_typeError_08"
-    root="typeCalcDispatch_typeError_08" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:unparserTestCase name="typeCalcDispatch_typeError_04"
+    root="typeCalcDispatch_typeError_04" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <typeCalcDispatch_typeError_08>
+        <typeCalcDispatch_typeError_04>
           <stringToInt>0</stringToInt>
-        </typeCalcDispatch_typeError_08>
+        </typeCalcDispatch_typeError_04>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:errors>
@@ -242,8 +239,8 @@
     </tdml:warnings>
   </tdml:unparserTestCase>
 
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_09"
-    root="typeCalcDispatch_typeError_09" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:parserTestCase name="typeCalcDispatch_typeError_05"
+    root="typeCalcDispatch_typeError_05" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:document>
     <tdml:documentPart type="text">a</tdml:documentPart>
     </tdml:document>
@@ -254,35 +251,49 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="typeCalcDispatch_typeError_10"
-    root="typeCalcDispatch_typeError_10" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:parserTestCase name="typeCalcDispatch_typeError_06"
+    root="typeCalcDispatch_typeError_06" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:document>
     <tdml:documentPart type="text">a</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Reptype is a(n) String type, where Integer is expected</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Cannot convert</tdml:error>
+      <tdml:error>From String type to Long</tdml:error>
     </tdml:errors>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>manually cast</tdml:warning>
+      <tdml:warning>Expected type (Int)</tdml:warning>
+    </tdml:warnings>
   </tdml:parserTestCase>
 
-  <tdml:unparserTestCase name="typeCalcDispatch_typeError_11"
-    root="typeCalcDispatch_typeError_11" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:unparserTestCase name="typeCalcDispatch_typeError_07"
+    root="typeCalcDispatch_typeError_07" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <typeCalcDispatch_typeError_11>a</typeCalcDispatch_typeError_11>
+        <typeCalcDispatch_typeError_07>a</typeCalcDispatch_typeError_07>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>logical type is a(n) String type, where Integer is expected</tdml:error>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Cannot convert</tdml:error>
+      <tdml:error>From String type to Long</tdml:error>
     </tdml:errors>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>manually cast</tdml:warning>
+      <tdml:warning>Expected type (Int)</tdml:warning>
+    </tdml:warnings>
   </tdml:unparserTestCase>
 
-  <tdml:unparserTestCase name="typeCalcDispatch_typeError_12"
-    root="typeCalcDispatch_typeError_12" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+  <tdml:unparserTestCase name="typeCalcDispatch_typeError_08"
+    root="typeCalcDispatch_typeError_08" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <typeCalcDispatch_typeError_12>a</typeCalcDispatch_typeError_12>
+        <typeCalcDispatch_typeError_08>a</typeCalcDispatch_typeError_08>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:errors>
@@ -298,20 +309,22 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>dfdlx:repTypeValueString() may only be called from within a dfdlx:inputTypeCalc annotation</tdml:error>
+      <tdml:error>dfdlx:repTypeValue() can only be defined on a simple type</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="repTypeValue_bad_context_02"
+  <tdml:unparserTestCase name="repTypeValue_bad_context_02"
     root="repTypeValue_bad_context_02" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
-    <tdml:document>
-    <tdml:documentPart type="byte"></tdml:documentPart>
-    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <repTypeValue_bad_context_02>0</repTypeValue_bad_context_02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>dfdlx:repTypeValueInt() may only be called from within a dfdlx:inputTypeCalc annotation</tdml:error>
+      <tdml:error>dfdlx:repTypeValue() may only be called from within dfdlx:inputTypeCalc</tdml:error>
     </tdml:errors>
-  </tdml:parserTestCase>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="logicalTypeValue_bad_context_01"
     root="logicalTypeValue_bad_context_01" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
@@ -320,18 +333,18 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>dfdlx:logicalTypeValueString() may only be called from within a dfdlx:outputTypeCalc annotation</tdml:error>
+      <tdml:error>dfdlx:logicalTypeValue() can only be defined on a simple type</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="logicalTypeValue_bad_context_02"
     root="logicalTypeValue_bad_context_02" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
     <tdml:document>
-    <tdml:documentPart type="byte"></tdml:documentPart>
+    <tdml:documentPart type="byte">00</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>dfdlx:logicalTypeValueInt() may only be called from within a dfdlx:outputTypeCalc annotation</tdml:error>
+      <tdml:error>dfdlx:logicalTypeValue() may only be called from within dfdlx:outputTypeCalc</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -377,7 +390,7 @@
       dfdlx:parseUnparsePolicy="parseOnly"
       />
 
-     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:nonExistant', 0) }"/>
+     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:nonExistant', 0) }"/>
 
   </tdml:defineSchema>
 
@@ -405,7 +418,7 @@
      <xs:simpleType name="nonExistantTypeCalc">
        <xs:restriction base="xs:int"/>
      </xs:simpleType>
-     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:nonExistantTypeCalc', 0) }"/>
+     <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:nonExistantTypeCalc', 0) }"/>
 
   </tdml:defineSchema>
 
@@ -420,5 +433,77 @@
       <tdml:error>does not have a repType</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="nextSibling_01"
+    root="nextSibling_01" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <nextSibling_01>
+          <raw>0</raw>
+          <a>a</a>
+        </nextSibling_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
+      <tdml:error>all the possible next siblings have the same repType</tdml:error>
+      <tdml:error>potential next siblings a and b</tdml:error>
+      <tdml:error>have repTypes Int and String</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="nextSibling_02"
+    root="nextSibling_02" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <nextSibling_02>
+          <raw>0</raw>
+          <a>a</a>
+        </nextSibling_02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
+      <tdml:error>potential next sibling</tdml:error>
+      <tdml:error>{http://example.com}b</tdml:error>
+      <tdml:error>does not define a type calculator</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="nextSibling_03"
+    root="nextSibling_03" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <nextSibling_03>
+          <raw>0</raw>
+          <b>0</b>
+        </nextSibling_03>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
+      <tdml:error>potential next sibling</tdml:error>
+      <tdml:error>{http://example.com}b</tdml:error>
+      <tdml:error>does not define a type calculator</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="nextSibling_04"
+    root="nextSibling_04" model="inputTypeCalcFunctionErrors-Embedded.dfdl.xsd" description="Extensions - inputTypeCalc errors">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <nextSibling_04>
+          <raw>0</raw>
+        </nextSibling_04>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdlx:outputTypeCalcNextSibling() called where no next sibling exists</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctions.tdml
@@ -50,19 +50,19 @@
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 
-  <xs:simpleType name="AbstractIntToMulitiply2" dfdlx:repType="xs:int" dfdlx:inputTypeCalc="{ dfdlx:repTypeValueInt() * 2 }">
+  <xs:simpleType name="AbstractIntToMulitiply2" dfdlx:repType="xs:int" dfdlx:inputTypeCalc="{ dfdlx:repTypeValue() * 2 }">
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 
-  <xs:simpleType name="AbstractStringToPrefixedString" dfdlx:repType="xs:string" dfdlx:inputTypeCalc="{ fn:concat('x',dfdlx:repTypeValueString()) }">
+  <xs:simpleType name="AbstractStringToPrefixedString" dfdlx:repType="xs:string" dfdlx:inputTypeCalc="{ fn:concat('x',dfdlx:repTypeValue()) }">
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
 
-  <xs:simpleType name="AbstractMulitiply2FromInt" dfdlx:repType="xs:int" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValueInt() * 2 }">
+  <xs:simpleType name="AbstractMulitiply2FromInt" dfdlx:repType="xs:int" dfdlx:outputTypeCalc="{ dfdlx:logicalTypeValue() * 2 }">
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 
-  <xs:simpleType name="AbstractPrefixedStringFromInt" dfdlx:repType="xs:string" dfdlx:outputTypeCalc="{ fn:concat('x',xs:string(dfdlx:logicalTypeValueInt())) }">
+  <xs:simpleType name="AbstractPrefixedStringFromInt" dfdlx:repType="xs:string" dfdlx:outputTypeCalc="{ fn:concat('x',xs:string(dfdlx:logicalTypeValue())) }">
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 
@@ -73,27 +73,27 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:element name="inputTypeCalcInt_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:AbstractIntTo1', 7) }" />
-  <xs:element name="inputTypeCalcString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcString('tns:AbstractIntToXYZ', 7) }" />
+  <xs:element name="inputTypeCalcInt_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:AbstractIntTo1', 7) }" />
+  <xs:element name="inputTypeCalcString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:AbstractIntToXYZ', 7) }" />
 
   <xs:element name="outputTypeCalcInt_01">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="inner" type="tns:uint8" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcInt('tns:Abstract1FromInt', 7) }" />
+        <xs:element name="inner" type="tns:uint8" dfdl:outputValueCalc="{ dfdlx:outputTypeCalc('tns:Abstract1FromInt', 7) }" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="outputTypeCalcString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:outputTypeCalcString('tns:AbstractXYZFromInt', 7) }" />
-  <xs:element name="repTypeValueInt_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcInt('tns:AbstractIntToMulitiply2', 7) }" />
-  <xs:element name="repTypeValueString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:inputTypeCalcString('tns:AbstractStringToPrefixedString', 'y') }" />
+  <xs:element name="outputTypeCalcString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:outputTypeCalc('tns:AbstractXYZFromInt', 7) }" />
+  <xs:element name="repTypeValueInt_01" type="xs:int" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:AbstractIntToMulitiply2', 7) }" />
+  <xs:element name="repTypeValueString_01" type="xs:string" dfdl:inputValueCalc="{ dfdlx:inputTypeCalc('tns:AbstractStringToPrefixedString', 'y') }" />
   <xs:element name="logicalTypeValueInt_01" dfdlx:parseUnparsePolicy="parseOnly" type="xs:int" 
-    dfdl:inputValueCalc="{ dfdlx:outputTypeCalcInt('tns:AbstractMulitiply2FromInt', 7) }" />
+    dfdl:inputValueCalc="{ dfdlx:outputTypeCalc('tns:AbstractMulitiply2FromInt', 7) }" />
   <xs:element name="logicalTypeValueString_01" dfdlx:parseUnparsePolicy="parseOnly" type="xs:string" 
-    dfdl:inputValueCalc="{ dfdlx:outputTypeCalcString('tns:AbstractPrefixedStringFromInt', 7) }" />
+    dfdl:inputValueCalc="{ dfdlx:outputTypeCalc('tns:AbstractPrefixedStringFromInt', 7) }" />
   <xs:element name="outputTypeCalcNextSiblingInt_01">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="raw" type="tns:uint8" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSiblingInt() }"/>
+        <xs:element name="raw" type="tns:uint8" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }"/>
         <xs:element name="logic" type="tns:AbstractMulitiply2FromInt" dfdl:inputValueCalc="{ 0 }"/>
       </xs:sequence>
     </xs:complexType>
@@ -101,13 +101,13 @@
   <xs:element name="outputTypeCalcNextSiblingString_01">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="raw" type="xs:string" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSiblingString() }"/>
+        <xs:element name="raw" type="xs:string" dfdl:outputValueCalc="{ dfdlx:outputTypeCalcNextSibling() }"/>
         <xs:element name="logic" type="tns:AbstractXYZFromInt" dfdl:inputValueCalc="{ 0 }"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="abstractIntToStringByKeyset_01" type="xs:string" dfdl:inputValueCalc="{dfdlx:inputTypeCalcString('AbstractIntToStringByKeyset',0)}"/>
+  <xs:element name="abstractIntToStringByKeyset_01" type="xs:string" dfdl:inputValueCalc="{dfdlx:inputTypeCalc('AbstractIntToStringByKeyset',0)}"/>
 
   </tdml:defineSchema>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -85,14 +85,14 @@ class TestInputTypeValueCalc {
   @Test def test_typeCalcDispatch_typeError_06() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_06") }
   @Test def test_typeCalcDispatch_typeError_07() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_07") }
   @Test def test_typeCalcDispatch_typeError_08() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_08") }
-  @Test def test_typeCalcDispatch_typeError_09() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_09") }
-  @Test def test_typeCalcDispatch_typeError_10() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_10") }
-  @Test def test_typeCalcDispatch_typeError_11() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_11") }
-  @Test def test_typeCalcDispatch_typeError_12() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_12") }
   @Test def test_repTypeValue_bad_context_01() { fnErrRunner.runOneTest("repTypeValue_bad_context_01") }
   @Test def test_repTypeValue_bad_context_02() { fnErrRunner.runOneTest("repTypeValue_bad_context_02") }
   @Test def test_logicalTypeValue_bad_context_01() { fnErrRunner.runOneTest("logicalTypeValue_bad_context_01") }
   @Test def test_logicalTypeValue_bad_context_02() { fnErrRunner.runOneTest("logicalTypeValue_bad_context_02") }
+  @Test def test_nextSibling_01() { fnErrRunner.runOneTest("nextSibling_01") }
+  @Test def test_nextSibling_02() { fnErrRunner.runOneTest("nextSibling_02") }
+  @Test def test_nextSibling_03() { fnErrRunner.runOneTest("nextSibling_03") }
+  @Test def test_nextSibling_04() { fnErrRunner.runOneTest("nextSibling_04") }
   @Test def test_nonexistant_reptype_01() { fnErrRunner.runOneTest("nonexistant_reptype_01") }
   @Test def test_nonexistantOutputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantOutputTypeCalc_01") }
   @Test def test_nonexistantInputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantInputTypeCalc_01") }


### PR DESCRIPTION
The scope expanded a bit beyond the original idea. This de-specializes all of the type-calc functions and instead infers the return type at compile time.