### PR TITLE
Adds bitawareness to left over data dump

### DIFF
--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://www.example.org/example1/" xmlns:tns="http://www.example.org/example1/"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:format alignment="1"
+          alignmentUnits="bytes" binaryFloatRep="ieee" binaryNumberRep="binary"
+          byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" encodingErrorPolicy="replace"
+          documentFinalTerminatorCanBeMissing="no" emptyValueDelimiterPolicy="both"
+          encoding="US-ASCII" escapeSchemeRef="" ignoreCase="no"
+          initiatedContent="no" initiator="" leadingSkip="0" lengthKind="delimited"
+          lengthUnits="bytes" occursCountKind="parsed" representation="text"
+          separator="" separatorPosition="infix" separatorSuppressionPolicy="anyEmpty"
+          sequenceKind="ordered" terminator="" textNumberCheckPolicy="lax"
+          textNumberRep="standard" textStandardBase="10"
+          textStringJustification="left" textTrimKind="none" trailingSkip="0"
+          utf16Width="fixed" textStandardDecimalSeparator="."
+          textStandardGroupingSeparator="," textStandardExponentRep="E"
+          textStandardZeroRep="0" textStandardInfinityRep="Inf"
+          textStandardNaNRep="NaN" textNumberPattern="#,##0.###;-#,##0.###"
+          textNumberRounding="explicit" textNumberRoundingMode="roundUnnecessary"
+          textNumberRoundingIncrement="0"
+          calendarPatternKind='implicit' calendarFirstDayOfWeek='Sunday'
+          calendarDaysInFirstWeek='4' calendarTimeZone='UTC'
+          calendarCheckPolicy='strict' calendarLanguage='en' textPadKind="none"
+          fillByte="%SP;" textBidi="no" floating="no"
+          truncateSpecifiedLengthString="yes"/>
+      </appinfo>
+    </annotation>
+
+    <xs:element name="msbFullByte" dfdl:lengthKind='implicit' dfdl:alignmentUnits="bits" dfdl:representation="binary">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="A" type="xs:int" dfdl:length="3" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" />
+          <xs:element name="B" type="xs:int" dfdl:length="13" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+
+    <xs:element name="msbPartialByte" dfdl:lengthKind='implicit' dfdl:alignmentUnits="bits" dfdl:representation="binary">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="A" type="xs:int" dfdl:length="3" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" />
+          <xs:element name="B" type="xs:int" dfdl:length="7" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="lsbPartialByte" dfdl:lengthKind='implicit' dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:byteOrder="littleEndian" dfdl:bitOrder="leastSignificantBitFirst">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="A" type="xs:int" dfdl:length="3" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:byteOrder="littleEndian" dfdl:bitOrder="leastSignificantBitFirst" dfdl:lengthUnits="bits" />
+          <xs:element name="B" type="xs:int" dfdl:length="7" dfdl:alignmentUnits="bits" dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:byteOrder="littleEndian" dfdl:bitOrder="leastSignificantBitFirst" dfdl:lengthUnits="bits"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+</schema>

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -816,8 +816,8 @@ class TestCLIparsing {
       val cmd = String.format("echo 0,1,2,3,,,,| %s -t parse -s %s", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(1, contains("Left over data. Consumed 56 bit(s) with at least"))
-      shell.expectIn(1, contains("Data (UTF-8) starting at byte 8 is: ("))
-      shell.expectIn(1, contains("Data (Hex) starting at byte 8 is: ("))
+      shell.expectIn(1, contains("Left over data (Hex) starting at byte 8 is: ("))
+      shell.expectIn(1, contains("Left over data (UTF-8) starting at byte 8 is: ("))
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {
@@ -835,8 +835,64 @@ class TestCLIparsing {
       val cmd = String.format("echo 1,2,3,4,,,| %s parse -s %s -r matrix", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expect(contains("Left over data. Consumed 56 bit(s) with at least"))
-      shell.expect(contains("Data (UTF-8) starting at byte 8 is: ("))
-      shell.expect(contains("Data (Hex) starting at byte 8 is: ("))
+      shell.expect(contains("Left over data (Hex) starting at byte 8 is: ("))
+      shell.expect(contains("Left over data (UTF-8) starting at byte 8 is: ("))
+      shell.sendLine("exit")
+      shell.expect(eof)
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Parsing_BitParse_LSBPartialByte_leftOverData() {
+    val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
+    val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+    val shell = Util.start("", true)
+
+    try {
+      val cmd = String.format("echo -n stri| %s parse -s %s -r lsbPartialByte", Util.binPath, testSchemaFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("Left over data. Consumed 10 bit(s) with at least 16 bit(s) remaining."
+        + "\nLeft over data starts with partial byte. Left over data (Binary) at byte 2 is: (0b011101xx)"
+        + "\nLeft over data (Hex) starting at byte 3 is: (0x7269...)"
+        + "\nLeft over data (UTF-8) starting at byte 3 is: (ri...)"))
+      shell.sendLine("exit")
+      shell.expect(eof)
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Parsing_BitParse_MSBPartialByte_leftOverData() {
+    val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
+    val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+    val shell = Util.start("", true)
+
+    try {
+      val cmd = String.format("echo -n stri| %s parse -s %s -r msbPartialByte", Util.binPath, testSchemaFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("Left over data. Consumed 10 bit(s) with at least 16 bit(s) remaining."
+        + "\nLeft over data starts with partial byte. Left over data (Binary) at byte 2 is: (0bxx110100)"
+        + "\nLeft over data (Hex) starting at byte 3 is: (0x7269...)"
+        + "\nLeft over data (UTF-8) starting at byte 3 is: (ri...)"))
+      shell.sendLine("exit")
+      shell.expect(eof)
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Parsing_BitParse_MSBFullByte_leftOverData() {
+    val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
+    val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+    val shell = Util.start("", true)
+
+    try {
+      val cmd = String.format("echo -n stri| %s parse -s %s -r msbFullByte", Util.binPath, testSchemaFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("Left over data. Consumed 16 bit(s) with at least 16 bit(s) remaining."
+        + "\nLeft over data (Hex) starting at byte 3 is: (0x7269...)"
+        + "\nLeft over data (UTF-8) starting at byte 3 is: (ri...)"))
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -204,7 +204,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     // eventually combine that into the array.
     inputSource.get(array, 0, bytesToFill)
 
-    if (isUnaligned) { 
+    if (isUnaligned) {
       // If we are not aligned, then we need to shift all the bits we just got
       // to the left, based on the bitOffset and the bitOrder. Do that shift
       // here.
@@ -237,7 +237,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
           if (isMSBF)
             (curBits << curShift) | (nxtBits >> nxtShift)
           else
-            (curBits >> curShift) | (nxtBits << nxtShift) 
+            (curBits >> curShift) | (nxtBits << nxtShift)
         Bits.asSignedByte(newByte)
       }
 
@@ -313,7 +313,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
   // used by the below function to get up to 8 bytes of data
   private val longArray = new Array[Byte](8)
 
-  /**    
+  /**
    * This method returns an unsigned long created from bitLengthFrom1To64 bits
    * of data.
    *
@@ -723,7 +723,6 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     }
   }
 
-
   private val charIterator = new InputSourceDataInputStreamCharIterator(this)
   def asIteratorChar: CharIterator = {
     val ci = charIterator
@@ -758,7 +757,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
   def futureData(nBytesRequested: Int): ByteBuffer = {
     // threadCheck()
     if (!areDebugging)
-       throw new IllegalStateException("Must be debugging.")
+      throw new IllegalStateException("Must be debugging.")
     Assert.usage(nBytesRequested >= 0)
 
     if (nBytesRequested == 0) return ByteBuffer.allocate(0).asReadOnlyBuffer()
@@ -777,7 +776,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
 
 }
 
-class InputSourceDataInputStreamCharIteratorState  {
+class InputSourceDataInputStreamCharIteratorState {
   var bitPositionAtLastFetch0b = 0L
 
   // CharBuffer and LongBuffer for some amount of cache lookahead
@@ -812,7 +811,7 @@ class InputSourceDataInputStreamCharIteratorState  {
 
 class InputSourceDataInputStreamCharIterator(dis: InputSourceDataInputStream) extends DataInputStream.CharIterator {
 
-  private var finfo : FormatInfo = null
+  private var finfo: FormatInfo = null
 
   override def reset(): Unit = {
     dis.cst.charIteratorState.clear()


### PR DESCRIPTION
If a parse partially consumes a byte, the left over data dump prints
the rest of the consumed bytes as binary output(0bxx101011/0b101010xx)
depending on bitOrder with the x's representing already consumed bytes

Sample Output:
[warning] Left over data. Consumed 10 bit(s) with at least 16 bit(s) remaining.
Left over data (Hex) at byte 2 is: (0b011101xx)
Left over data (Hex) starting at byte 3 is: (0x7269...)
Left over data (UTF-8) starting at byte 3 is: (ri...)

DAFFODIL-2173