### PR TITLE
Incremental progress on schema compilation space/speed issue.

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -460,7 +460,7 @@ class TestCLIdebugger {
       shell.sendLine("condition 1 fn:count(../cell) eq 3") // ../cell is wrong. Needs to be ../tns:cell
 
       shell.sendLine("continue")
-      shell.expect(allOf(contains("Schema Definition Error"), contains("{}cell"), contains("{http://www.example.org/example1/}cell")))
+      shell.expect(allOf(contains("Schema Definition Error"), contains("{}cell"), contains("tns:cell")))
 
       shell.sendLine("quit")
     } finally {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
@@ -173,6 +173,9 @@ final class ProcessorFactory(val sset: SchemaSet)
         variables,
         validationMode,
         sset.typeCalcMap)
+      if (rootElem.numComponents > rootElem.numUniqueComponents)
+        log(LogLevel.Info, "Compiler: component counts: unique %s, actual %s.",
+          rootElem.numUniqueComponents, rootElem.numComponents)
       val dataProc = new DataProcessor(ssrd)
       if (dataProc.isError) {
         // NO longer printing anything here. Callers must do this.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/DFDLExpressionParser.scala
@@ -46,7 +46,8 @@ import org.apache.daffodil.xml.QNameRegex
  * save it. So hopefully that discards all the state of the combinator
  * stuff as well.
  */
-class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
+class DFDLPathExpressionParser[T <: AnyRef](
+  qn: NamedQName,
   nodeInfoKind: NodeInfo.Kind,
   namespaces: NamespaceBinding,
   context: DPathCompileInfo,
@@ -54,7 +55,7 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
   host: OOLAGHost) extends RegexParsers {
 
   def compile(expr: String): CompiledExpression[T] = {
-    val tree = getExpressionTree(expr, host)
+    val tree = getExpressionTree(expr)
 
     val recipe = tree.compiledDPath // if we cannot get one this will fail by throwing out of here.
 
@@ -119,7 +120,7 @@ class DFDLPathExpressionParser[T <: AnyRef](qn: NamedQName,
       r
     }
 
-  def getExpressionTree(expr: String, host: OOLAGHost): WholeExpression = {
+  def getExpressionTree(expr: String): WholeExpression = {
     // This wrapping of phrase() prevents a memory leak in the scala parser
     // combinators in scala 2.10. See the following bug for more information:
     //

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/CompiledExpression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/CompiledExpression.scala
@@ -53,7 +53,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     nodeInfoKind: NodeInfo.Kind,
     exprOrLiteral: String,
     namespaces: NamespaceBinding,
-    compileInfoWherePropertyWasLocated: DPathCompileInfo,
+    compileInfoWhereExpressionWasLocated: DPathCompileInfo,
     isEvaluatedAbove: Boolean,
     host: OOLAGHost,
     compileInfo: DPathCompileInfo): CompiledExpression[T] = {
@@ -65,7 +65,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
           nodeInfoKind,
           exprOrLiteral,
           namespaces,
-          compileInfoWherePropertyWasLocated,
+          compileInfoWhereExpressionWasLocated,
           isEvaluatedAbove,
           host,
           compileInfo)
@@ -75,9 +75,8 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
           nodeInfoKind,
           exprOrLiteral,
           namespaces,
-          compileInfoWherePropertyWasLocated,
-          isEvaluatedAbove,
-          host)
+          compileInfoWhereExpressionWasLocated,
+          isEvaluatedAbove)
       }
     res
   }
@@ -145,13 +144,13 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     val isEvaluatedAbove = false
     val exprOrLiteral = property.value
     val namespacesForNamespaceResolution = property.location.namespaces
-    val compileInfoWherePropertyWasLocated = propertyCompileInfo(property)
+    val compileInfoWhereExpressionWasLocated = propertyCompileInfo(property)
     val compiled1 = compileExpression(
       qn,
       staticNodeInfoKind,
       exprOrLiteral,
       namespacesForNamespaceResolution,
-      compileInfo,
+      compileInfoWhereExpressionWasLocated,
       isEvaluatedAbove,
       host,
       compileInfo)
@@ -164,7 +163,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
         runtimeNodeInfoKind,
         exprOrLiteral,
         namespacesForNamespaceResolution,
-        compileInfo,
+        compileInfoWhereExpressionWasLocated,
         isEvaluatedAbove,
         host,
         compileInfo)
@@ -195,7 +194,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     nodeInfoKind: NodeInfo.Kind,
     exprOrLiteral: String,
     namespaces: NamespaceBinding,
-    compileInfoWherePropertyWasLocated: DPathCompileInfo,
+    compileInfoWhereExpressionWasLocated: DPathCompileInfo,
     isEvaluatedAbove: Boolean,
     host: OOLAGHost,
     compileInfo: DPathCompileInfo): CompiledExpression[T] = {
@@ -205,7 +204,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     val expr = exprOrLiteral.trim
     if (!expr.endsWith("}")) {
       val msg = "'%s' is an unterminated expression. Add missing closing brace, or escape opening brace with another opening brace."
-      compileInfoWherePropertyWasLocated.SDE(msg, exprOrLiteral)
+      compileInfoWhereExpressionWasLocated.SDE(msg, exprOrLiteral)
     }
 
     val compiler = new DFDLPathExpressionParser[T](
@@ -224,9 +223,8 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     nodeInfoKind: NodeInfo.Kind,
     exprOrLiteral: String,
     namespaces: NamespaceBinding,
-    compileInfoWherePropertyWasLocated: DPathCompileInfo,
-    isEvaluatedAbove: Boolean,
-    host: OOLAGHost): CompiledExpression[T] = {
+    compileInfoWhereExpressionWasLocated: DPathCompileInfo,
+    isEvaluatedAbove: Boolean): CompiledExpression[T] = {
 
     // This string is not a real expression, we need to convert it to it's
     // logical type and set it as a constant expression. Not compilation
@@ -237,7 +235,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     val maybePrimType = PrimType.fromNodeInfo(nodeInfoKind)
     if (maybePrimType.isEmpty) {
       val msg = "No known primitive type to convert logical value to: %s"
-      compileInfoWherePropertyWasLocated.SDE(msg, nodeInfoKind)
+      compileInfoWhereExpressionWasLocated.SDE(msg, nodeInfoKind)
     }
 
     // remove the leading escape curly brace if it exists
@@ -250,7 +248,7 @@ class ExpressionCompiler[T <: AnyRef] extends ExpressionCompilerBase[T] {
     } catch {
       case e: Exception => {
         val msg = "Unable to convert logical value \"%s\" to %s: %s"
-        compileInfoWherePropertyWasLocated.SDE(msg, exprOrLiteral, nodeInfoKind, e.getMessage)
+        compileInfoWhereExpressionWasLocated.SDE(msg, exprOrLiteral, nodeInfoKind, e.getMessage)
       }
     }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDeclFactory.scala
@@ -48,5 +48,4 @@ class GlobalElementDeclFactory(xmlArg: Node, schemaDocumentArg: SchemaDocument)
   def forElementRef(eRef: AbstractElementRef) = {
     new GlobalElementDecl(xml, schemaDocument, eRef, this)
   }
-
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -34,8 +34,6 @@ import org.apache.daffodil.processors.RepValueSet
 import org.apache.daffodil.processors.TypeCalculator
 import org.apache.daffodil.processors.TypeCalculatorCompiler
 import org.apache.daffodil.processors.RepValueSetCompiler
-import org.apache.daffodil.dpath.NodeInfo.SignedIntegerKind
-import org.apache.daffodil.dpath.NodeInfo.SignedInteger
 import org.apache.daffodil.dpath.NodeInfo.Numeric
 import org.apache.daffodil.dpath.NodeInfo.PrimType.UnsignedInt
 import org.apache.daffodil.cookers.RepValueCooker

--- a/daffodil-core/src/test/resources/test/example-of-most-dfdl-constructs.dfdl.xml
+++ b/daffodil-core/src/test/resources/test/example-of-most-dfdl-constructs.dfdl.xml
@@ -153,6 +153,7 @@
             </xsd:appinfo>
           </annotation>
         </element>
+        <element ref="ex:obscure"/>
       </sequence>
     </complexType>
   </element>
@@ -231,6 +232,10 @@
           </restriction>
         </simpleType>
       </element>
+      
+      <group ref="ex:myGlobal3"/>
+      <group ref="ex:myGlobal2"/>
+      <group ref="ex:myGlobal1"/>
     </choice>
   </group>
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -279,7 +279,7 @@ class TestDsomCompiler extends Logging {
     assertEquals("hiddenGroup", ggd2.namedQName.local)
 
     //Explore LocalSimpleTypeDef
-    val Seq(c1: LocalElementDecl, _: LocalElementDecl, c3: LocalElementDecl) = cgr.groupMembers
+    val Seq(c1: LocalElementDecl, _: LocalElementDecl, c3: LocalElementDecl, rest @ _*) = cgr.groupMembers
     val ist = c3.asInstanceOf[LocalElementDecl].immediateType.get.asInstanceOf[LocalSimpleTypeDef]
     val istBase = ist.optRestriction.get.baseQName.toQNameString
     assertEquals("tns:aType", istBase)
@@ -312,7 +312,7 @@ class TestDsomCompiler extends Logging {
     val Seq(_: ElementRef, gr: GroupRef) = seq1.groupMembers
     val cgd = gr.groupDef.asInstanceOf[GlobalChoiceGroupDef]
     val cgr = cgd.groupRef.asInstanceOf[ChoiceGroupRef]
-    val Seq(_, cd2: LocalElementDecl, _) = cgd.groupMembers // Children nodes of Choice-node, there are 3
+    val Seq(_, cd2: LocalElementDecl, rest @ _*) = cgd.groupMembers // Children nodes of Choice-node, there are 3
 
     // val Seq(a1: DFDLChoice) = ch1.annotationObjs // Obtain the annotation object that is a child
     // of the group node.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps.scala
@@ -235,6 +235,10 @@ case object LongToUnsignedLong extends Converter {
   }
 }
 
+case object NumericToDouble extends Converter {
+  override def computeValue(a: AnyRef, dstate: DState): AnyRef = asDouble(a)
+}
+
 case object StringToBoolean extends Converter {
   override def computeValue(a: AnyRef, dstate: DState): AnyRef = {
     val str = a.asInstanceOf[String]

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps2.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps2.scala
@@ -28,13 +28,8 @@ import org.apache.daffodil.calendar.DFDLDateTimeConversion
 import org.apache.daffodil.calendar.DFDLTime
 import org.apache.daffodil.calendar.DFDLTimeConversion
 
-case object AnyAtomicToString extends Converter {
-  override def computeValue(a: AnyRef, dstate: DState): AnyRef = {
-    a match {
-      case c: DFDLCalendar => c.toString
-      case _ => a.asInstanceOf[String]
-    }
-  }
+case object AnyAtomicToString extends ToString {
+  val name = "AnyAtomicToString"
 }
 
 case object StringToDate extends Converter {
@@ -79,7 +74,7 @@ case object StringToTime extends Converter {
   }
 }
 
-case object StringToHexBinary extends Converter with HexBinaryKind{
+case object StringToHexBinary extends Converter with HexBinaryKind {
   val name = "StringToHexBinary"
 
   override def computeValue(a: AnyRef, dstate: DState): AnyRef = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
@@ -36,7 +36,8 @@ import org.apache.daffodil.processors.parsers.DoSDEMixin
 import org.apache.daffodil.processors.parsers.PState
 
 class ExpressionEvaluationException(e: Throwable, s: ParseOrUnparseState)
-  extends ProcessingError("Expression Evaluation",
+  extends ProcessingError(
+    "Expression Evaluation",
     One(s.schemaFileLocation),
     Nope,
     Maybe(e),
@@ -168,9 +169,9 @@ final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kin
       case unfin: InfosetNodeNotFinalException =>
         whereBlockedInfo.block(unfin.node, unfin.node.erd.dpathElementCompileInfo, 0, unfin)
       case noChild: InfosetNoSuchChildElementException =>
-        whereBlockedInfo.block(noChild.diComplex, noChild.info, 0, noChild)
+        whereBlockedInfo.block(noChild.diComplex, noChild.nqn, 0, noChild)
       case noSibling: InfosetNoNextSiblingException =>
-        whereBlockedInfo.block(noSibling.diSimple, noSibling.info, 0 , noSibling)
+        whereBlockedInfo.block(noSibling.diSimple, noSibling.info, 0, noSibling)
       case noArrayIndex: InfosetArrayIndexOutOfBoundsException =>
         whereBlockedInfo.block(noArrayIndex.diArray, noArrayIndex.diArray.erd.dpathElementCompileInfo, noArrayIndex.index, noArrayIndex)
       case nd: InfosetNoDataException if nd.erd.outputValueCalcExpr.isDefined => {
@@ -192,7 +193,7 @@ final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kin
   override def run(dstate: DState) {
     recipe.run(dstate)
   }
-  
+
   private def processForwardExpressionResults(dstate: DState): AnyRef = {
     val v: AnyRef = {
       dstate.currentNode match {
@@ -334,8 +335,8 @@ final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kin
             case NodeInfo.NonEmptyString => {
               Assert.invariant(value.isInstanceOf[String])
               if (value.asInstanceOf[String].length == 0) {
-                val e = new RuntimeSchemaDefinitionError(ci.schemaFileLocation, state, "Non-empty string required." )
-                doSDE(e,state)
+                val e = new RuntimeSchemaDefinitionError(ci.schemaFileLocation, state, "Non-empty string required.")
+                doSDE(e, state)
               }
               value
             }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/typeCalcFunctionErrors.tdml
@@ -180,7 +180,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String) should be manually cast to the expected type (Int)</tdml:warning>
+      <tdml:warning>result type (String) should be manually cast to the expected type (Int)</tdml:warning>
     </tdml:warnings>
   </tdml:parserTestCase>
 
@@ -196,7 +196,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String) should be manually cast to the expected type (Int)</tdml:warning>
+      <tdml:warning>result type (String) should be manually cast to the expected type (Int)</tdml:warning>
     </tdml:warnings>
   </tdml:parserTestCase>
 
@@ -216,7 +216,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>result type (String)</tdml:warning>
       <tdml:warning>expected type (Int)</tdml:warning>
     </tdml:warnings>
   </tdml:unparserTestCase>
@@ -235,7 +235,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String) should be manually cast to the expected type (Int)</tdml:warning>
+      <tdml:warning>result type (String) should be manually cast to the expected type (Int)</tdml:warning>
     </tdml:warnings>
   </tdml:unparserTestCase>
 
@@ -263,7 +263,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>result type (String)</tdml:warning>
       <tdml:warning>manually cast</tdml:warning>
       <tdml:warning>Expected type (Int)</tdml:warning>
     </tdml:warnings>
@@ -283,7 +283,7 @@
     </tdml:errors>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>Expression result type (String)</tdml:warning>
+      <tdml:warning>result type (String)</tdml:warning>
       <tdml:warning>manually cast</tdml:warning>
       <tdml:warning>Expected type (Int)</tdml:warning>
     </tdml:warnings>
@@ -448,7 +448,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
       <tdml:error>all the possible next siblings have the same repType</tdml:error>
-      <tdml:error>potential next siblings a and b</tdml:error>
+      <tdml:error>potential next siblings ex:a and ex:b</tdml:error>
       <tdml:error>have repTypes Int and String</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
@@ -467,7 +467,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
       <tdml:error>potential next sibling</tdml:error>
-      <tdml:error>{http://example.com}b</tdml:error>
+      <tdml:error>ex:b</tdml:error>
       <tdml:error>does not define a type calculator</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
@@ -486,7 +486,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>dfdlx:outputTypeCalcNextSibling</tdml:error>
       <tdml:error>potential next sibling</tdml:error>
-      <tdml:error>{http://example.com}b</tdml:error>
+      <tdml:error>ex:b</tdml:error>
       <tdml:error>does not define a type calculator</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -2053,7 +2053,7 @@
     </tdml:infoset>
     <tdml:warnings>
       <tdml:warning>Schema Definition Warning</tdml:warning>
-      <tdml:warning>two is an optional element or a variable-occurrence array and its alignment (1) is not the same as three's alignment (4)</tdml:warning>
+      <tdml:warning>ex:two is an optional element or a variable-occurrence array and its alignment (1) is not the same as ex:three's alignment (4)</tdml:warning>
     </tdml:warnings>
   </tdml:parserTestCase>
   
@@ -2078,7 +2078,7 @@
   </tdml:infoset>
   <tdml:warnings>
     <tdml:warning>Schema Definition Warning</tdml:warning>
-    <tdml:warning>one is an optional element or a variable-occurrence array and its alignment (1) is not the same as two's alignment (2)</tdml:warning>
+    <tdml:warning>ex:one is an optional element or a variable-occurrence array and its alignment (1) is not the same as ex:two's alignment (2)</tdml:warning>
   </tdml:warnings>
   </tdml:parserTestCase>
   
@@ -2125,7 +2125,7 @@
   </tdml:infoset>
   <tdml:warnings>
     <tdml:warning>Schema Definition Warning</tdml:warning>
-    <tdml:warning>one is an optional element or a variable-occurrence array and its alignment (1) is not the same as two's alignment (2)</tdml:warning>
+    <tdml:warning>ex:one is an optional element or a variable-occurrence array and its alignment (1) is not the same as ex:two's alignment (2)</tdml:warning>
   </tdml:warnings>
   </tdml:parserTestCase>
   

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1838,7 +1838,7 @@
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Expression result type</tdml:error>
+      <tdml:error>result type</tdml:error>
       <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Double</tdml:error>
       <tdml:error>Int</tdml:error>
@@ -1880,7 +1880,7 @@
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Expression result type</tdml:error>
+      <tdml:error>result type</tdml:error>
       <tdml:error>must be manually cast</tdml:error>
       <tdml:error>String</tdml:error>
       <tdml:error>Boolean</tdml:error>
@@ -1894,7 +1894,7 @@
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Expression result type</tdml:error>
+      <tdml:error>result type</tdml:error>
       <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Int</tdml:error>
       <tdml:error>String</tdml:error>
@@ -1908,7 +1908,7 @@
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Expression result type</tdml:error>
+      <tdml:error>result type</tdml:error>
       <tdml:error>must be manually cast</tdml:error>
       <tdml:error>Double</tdml:error>
       <tdml:error>Float</tdml:error>
@@ -2012,7 +2012,10 @@
       <tdml:documentPart type="text">abcd</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error />
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Relative path</tdml:error>
+      <tdml:error>past root</tdml:error>
+      <tdml:error>../../ex:reps * /ex:e1/ex:scale</tdml:error>
     </tdml:errors>
 
     <!-- <tdml:infoset> <tdml:dfdlInfoset> <ex:e1> <ex:reps>2</ex:reps> <ex:scale>2</ex:scale>
@@ -7200,7 +7203,7 @@
     config="cfg_errorOnResultCoercion">
     <tdml:document></tdml:document>
       <tdml:errors>
-        <tdml:error>Expression result type</tdml:error>
+        <tdml:error>result type</tdml:error>
         <tdml:error>Decimal</tdml:error>
         <tdml:error>must be manually cast</tdml:error>
         <tdml:error>Double</tdml:error>
@@ -7211,7 +7214,7 @@
     config="cfg_errorOnResultCoercion">
     <tdml:document></tdml:document>
       <tdml:errors>
-        <tdml:error>Expression result type</tdml:error>
+        <tdml:error>result type</tdml:error>
         <tdml:error>Decimal</tdml:error>
         <tdml:error>must be manually cast</tdml:error>
         <tdml:error>Float</tdml:error>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions3.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions3.tdml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite
+ suiteName="expressions3"
+ xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+ xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+ xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+ xmlns:ex="http://example.com"
+ xmlns:fn="http://www.w3.org/2005/xpath-functions"
+ defaultRoundTrip="true"
+ defaultConfig="yesAutoCoercion">
+
+  <tdml:defineConfig name="noAutoCoercion">
+    <daf:tunables>
+      <daf:allowExpressionResultCoercion>false</daf:allowExpressionResultCoercion>
+    </daf:tunables>
+  </tdml:defineConfig>
+  
+  <tdml:defineConfig name="yesAutoCoercion">
+    <daf:tunables>
+      <daf:allowExpressionResultCoercion>true</daf:allowExpressionResultCoercion>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_1" model="s1.dfdl.xsd" root="r"
+    description="Polymorphic path expression">
+    <tdml:document>1|a|2|b</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression ../foo/bar</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <!-- 
+      Line numbers below are fragile. If s1.dfdl.xsd is edited these will 
+      change. They are supposed to be the lines where the two local element 'bar'
+      are declared.
+       -->
+      <tdml:error>element bar in expression ../foo/bar with xs:int type at Location line 76</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:string type at Location line 62</tdml:error>
+      <tdml:error>s1.dfdl.xsd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="s2a" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+
+    <xs:group name="g">
+      <!-- 
+        The path expression below is depending on the ability to 
+        compile polymorphically. The expression ../foo/hdr is always an int.
+        The expression ../foo/bar is a string, or an integer depending on 
+        the context. 
+       -->
+      <xs:sequence>
+      <xs:choice dfdl:choiceDispatchKey="{ 
+         xs:string(if (../foo/hdr eq 1) 
+           then xs:int( fn:round( xs:double( ../foo/bar) ) )
+           else xs:int( fn:round( xs:double( ../foo/bar) ) + 1 ) )}">
+        <xs:element name="c1" type="xs:string" dfdl:choiceBranchKey="1" />
+        <xs:element name="c2" type="xs:string" dfdl:choiceBranchKey="2" />
+      </xs:choice>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|">
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar" type="xs:float" />
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar" type="xs:int" />
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+ </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_2a" model="s2a" root="r"
+    description="Polymorphic path expression">
+    <tdml:document>1|1|a|2|1|b</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression ../foo/bar</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:int type at Location</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:float type at Location</tdml:error>
+    </tdml:errors>   
+  </tdml:parserTestCase>
+  
+  <tdml:defineSchema name="s2b" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+
+    <xs:group name="g">
+      <!-- 
+        The path expression below is depending on the ability to 
+        compile polymorphically. The expression ../foo/hdr is always an int.
+        The expression ../foo/bar is a string, or an integer depending on 
+        the context. 
+       -->
+      <xs:sequence>
+      <xs:choice dfdl:choiceDispatchKey="{ 
+         xs:string(if (../foo/hdr eq 1) 
+           then xs:int( ../foo/bar )
+           else xs:int( ../foo/bar + 1 ) )}">
+        <xs:element name="c1" type="xs:string" dfdl:choiceBranchKey="1" />
+        <xs:element name="c2" type="xs:string" dfdl:choiceBranchKey="2" />
+      </xs:choice>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|">
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar" type="xs:float" />
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar" type="xs:int" />
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+ </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_2b" model="s2b" root="r"
+    description="Polymorphic path expression">
+    <tdml:document>1|1|a|2|1|b</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression ../foo/bar</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:int type at Location</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:float type at Location</tdml:error>
+    </tdml:errors> 
+  </tdml:parserTestCase>
+    
+  
+  <tdml:defineSchema name="s3" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+
+    <xs:group name="g">
+      <!-- 
+        The path expression below is depending on the ability to 
+        compile polymorphically. The expression ../foo/hdr is always an int.
+        The expression ../foo/bar is a string, or a complex type depending on 
+        the context. So this shouldn't compile since you can't do math on 
+        a complex type. 
+       -->
+      <xs:sequence>
+      <xs:choice dfdl:choiceDispatchKey="{ 
+         xs:string(if (../foo/hdr eq 1) 
+           then xs:int( ../foo/bar )
+           else xs:int( ../foo/bar + 1 ) )}">
+        <xs:element name="c1" type="xs:string" dfdl:choiceBranchKey="1" />
+        <xs:element name="c2" type="xs:string" dfdl:choiceBranchKey="2" />
+      </xs:choice>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|">
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar" type="xs:float" />
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="|">
+                      <xs:element name="hdr" type="xs:int"/>
+                      <xs:element name="bar">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="quux" type="xs:int" />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:group ref="ex:g" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+ </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_3" model="s3" root="r"
+    description="Polymorphic path expression">
+    <tdml:document>1|1|a|2|1|b</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression ../foo/bar</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with complex type at Location</tdml:error>
+      <tdml:error>element bar in expression ../foo/bar with xs:float type at Location</tdml:error>
+    </tdml:errors> 
+  </tdml:parserTestCase>
+  
+  
+  <tdml:defineSchema name="s4" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <dfdl:defineVariable name="myVar" type="xs:double"/>
+
+  <xs:group name="g">
+    <xs:sequence>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:setVariable ref="ex:myVar">{ ./foo }</dfdl:setVariable>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:sequence dfdl:separator="|">
+        <xs:element name="hdr" type="xs:int" />
+        <xs:choice>
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:int" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:decimal" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_4" model="s4" root="r"
+    description="Polymorphic path expression - This test shows that int and 
+    decimal polymorphically are converted to decimal, not double, 
+    because int is a subtype of decimal. This is shown by getting an error 
+    when the decimal will not be auto-coerced to the type of the variable, which 
+    is double."
+    config="noAutoCoercion">
+    <tdml:document></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression foo</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <tdml:error>element foo in expression foo with xs:int type at Location</tdml:error>
+      <tdml:error>element foo in expression foo with xs:decimal type at Location</tdml:error>
+      <tdml:error>dfdl:setVariable</tdml:error>
+    </tdml:errors> 
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="s5" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <dfdl:defineVariable name="myVar" type="xs:double"/>
+
+  <xs:group name="g">
+    <xs:sequence>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:setVariable ref="ex:myVar">{ ./foo }</dfdl:setVariable>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:sequence dfdl:separator="|">
+        <xs:element name="hdr" type="xs:int" />
+        <xs:choice>
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:int" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:decimal" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e3">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:float" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_5" model="s5" root="r"
+    description="Polymorphic path expression - This test shows that int, float, and 
+    decimal polymorphically are converted to double."
+    config="noAutoCoercion">
+    <tdml:document>1|1</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Feature not yet implemented</tdml:error>
+      <tdml:error>Expression foo</tdml:error>
+      <tdml:error>inconsistent</tdml:error>
+      <tdml:error>element foo in expression foo with xs:int type at Location</tdml:error>
+      <tdml:error>element foo in expression foo with xs:decimal type at Location</tdml:error>
+      <tdml:error>element foo in expression foo with xs:float type at Location</tdml:error>
+      <tdml:error>dfdl:setVariable</tdml:error>
+    </tdml:errors> 
+  </tdml:parserTestCase>
+  
+    <tdml:defineSchema name="s6" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <dfdl:defineVariable name="myVar" type="xs:double"/>
+
+  <xs:group name="g">
+    <xs:sequence>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:setVariable ref="ex:myVar">{ ./foo }</dfdl:setVariable>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:sequence dfdl:separator="|">
+        <xs:element name="hdr" type="xs:int" />
+        <xs:choice>
+          <xs:element name="e1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:int" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="e2">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="foo" type="xs:int" maxOccurs="unbounded" />
+                <xs:group ref="ex:g" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_polymorphic_expr_6" model="s6" root="r"
+    description="Polymorphic path expression - Mixture of array and non-array"
+    config="noAutoCoercion">
+    <tdml:document>1|1</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Path step is ambiguous</tdml:error>
+      <tdml:error>foo</tdml:error>
+      <tdml:error>can be to an array or a non-array</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  
+  <tdml:defineSchema name="arraySchema" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|">
+          <xs:element name="e1" type="xs:string" minOccurs="3" maxOccurs="3">
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:assert>{ if (dfdl:occursIndex() eq 1) then fn:true() else ( .[1] eq '1' ) }</dfdl:assert>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="rx">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|">
+          <xs:element name="e1" type="xs:string" minOccurs="1" maxOccurs="3">
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:assert>{ .[1] eq '42' }</dfdl:assert>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+            
+ </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_array_self_expr1" model="arraySchema" root="r">
+    <tdml:document>1|2|3</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:r>
+          <e1>1</e1><e1>2</e1><e1>3</e1>
+        </ex:r>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="test_array_self_expr2" model="arraySchema" root="rx">
+    <tdml:document>1</tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Assertion failed</tdml:error>
+      <tdml:error>42</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+</tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/s1.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/s1.dfdl.xsd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema elementFormDefault="unqualified"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  targetNamespace="http://example.com"
+  xmlns:ex="http://example.com"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:group name="g">
+      <!-- 
+        The path expression below is going to have different type
+        elements for the different instances of this group in the 
+        final schema. 
+        
+        Ultimately they all are converted to string.
+       -->
+    <xs:sequence>
+      <xs:choice dfdl:choiceDispatchKey="{ ../foo/bar }">
+        <xs:element name="c1" type="xs:string" dfdl:choiceBranchKey="1" />
+        <xs:element name="c2" type="xs:string" dfdl:choiceBranchKey="2" />
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:sequence dfdl:separator="|">
+        <xs:element name="e1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="foo">
+                <xs:complexType>
+                  <xs:sequence dfdl:separator="|">
+                    <xs:element name="bar" type="xs:string" />
+                    <xs:group ref="ex:g" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="e2">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="foo">
+                <xs:complexType>
+                  <xs:sequence dfdl:separator="|">
+                    <xs:element name="bar" type="xs:int" />
+                    <xs:group ref="ex:g" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -3891,7 +3891,7 @@
     <tdml:errors>
       <tdml:error>Runtime Schema Definition Error</tdml:error>
       <tdml:error>Value length unknown</tdml:error>
-      <tdml:error>{http://example.com}x</tdml:error>
+      <tdml:error>ex:x</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -4087,7 +4087,7 @@
     <tdml:errors>
       <tdml:error>Runtime Schema Definition Error</tdml:error>
       <tdml:error>Content length unknown</tdml:error>
-      <tdml:error>{http://example.com}x</tdml:error>
+      <tdml:error>ex:x</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section23.dfdl_expressions
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestDFDLExpressions3 {
+
+  val testDir = "org/apache/daffodil/section23/dfdl_expressions/"
+  val runner = Runner(testDir, "expressions3.tdml")
+
+  @AfterClass def shutdown = {
+    runner.reset
+  }
+}
+
+class TestDFDLExpressions3 {
+  import TestDFDLExpressions3._
+
+  @Test def test_polymorphic_expr_1() { runner.runOneTest("test_polymorphic_expr_1") }
+  @Test def test_polymorphic_expr_2a() { runner.runOneTest("test_polymorphic_expr_2a") }
+  @Test def test_polymorphic_expr_2b() { runner.runOneTest("test_polymorphic_expr_2b") }
+  @Test def test_polymorphic_expr_3() { runner.runOneTest("test_polymorphic_expr_3") }
+  @Test def test_polymorphic_expr_4() { runner.runOneTest("test_polymorphic_expr_4") }
+  @Test def test_polymorphic_expr_5() { runner.runOneTest("test_polymorphic_expr_5") }
+  @Test def test_polymorphic_expr_6() { runner.runOneTest("test_polymorphic_expr_6") }
+
+  // DAFFODIL-2182
+  // @Test def test_array_self_expr1() { runner.runOneTest("test_array_self_expr1") }
+  @Test def test_array_self_expr2() { runner.runOneTest("test_array_self_expr2") }
+
+}


### PR DESCRIPTION
This change set reorganizes expression compilation so that
expressions are compiled taking all possible contexts where the expression
is reused into account, rather than compiling a separate copy for each
expression location.

This does NOT yet eliminate the excessive copying of objects in the
schema compiler. It does eliminate expressions from the set of things
preventing copy-elimination by removing the problem caused by
up-and-out relative paths.

DAFFODIL-1444