### PR TITLE
Allow globals with no referringComponents

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
@@ -125,7 +125,7 @@ trait NestingTraversesToReferenceMixin
    */
   lazy val referringComponents: Seq[(String, Seq[RefSpec])] = {
     schemaSet.root.refMap.get(this.factory) match {
-      case None => Assert.invariantFailed("There are no references to this component: " + this)
+      case None => Seq()
       case Some(seq) => seq
     }
   }


### PR DESCRIPTION
DAFFODIL-2197

Was preventing VMF from working on 2.5.0 branch. 