### PR TITLE
DAFFODIL-2200. xs:import problems with xsd files provided in daffodil-lib

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
@@ -39,11 +39,12 @@ this to validate when we load a DFDL Schema.
    "http://www.w3.org/2001/XMLSchema"
   -->
 
-  <xsd:import namespace="http://www.ogf.org/dfdl/dfdl-1.0/" />
+  <xsd:import namespace="http://www.ogf.org/dfdl/dfdl-1.0/"
+    schemaLocation="DFDL_part3_model.xsd" />
 
   <xsd:import namespace="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
     schemaLocation="dfdlx.xsd" />
-    
+
   <xsd:import namespace="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:int"
     schemaLocation="dafint.xsd"/>
 

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
@@ -27,8 +27,8 @@
   attributeFormDefault="unqualified"
   elementFormDefault="qualified">
 
-  <xs:import namespace="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:int" schemaLocation="xsd/dafint.xsd" />
-  <xs:import namespace="http://www.ogf.org/dfdl/dfdl-1.0/" schemaLocation="xsd/DFDL_part3_model.xsd" />
+  <xs:import namespace="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:int" schemaLocation="dafint.xsd" />
+  <xs:import namespace="http://www.ogf.org/dfdl/dfdl-1.0/" schemaLocation="DFDL_part3_model.xsd" />
 
   <!-- dfdl:property="..." extension values. Extension properties must start with dfdlx: -->
 


### PR DESCRIPTION
Jira had reported 2 issues:
1. schemaLocation attributes should just be the filenames
2. missing schemaLocation in XMLSchema_for_DFDL.xsd when importing dfdl namespace.

Issue 1 was not seen and probably fixed by another jira in the past.

This PR addresses issue 2.