### PR TITLE
Fixes and tests twoPass Mac LE bug

### DIFF
--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
@@ -75,9 +75,10 @@ class TDMLInfosetInputter(val scalaInputter: ScalaXMLInfosetInputter, others: Se
         true
       } else {
         if (i.isInstanceOf[JsonInfosetInputter]) {
-          // the json infoset inputter maintains CRLF, but XML converts CRLF to
-          // LF. So if this is Json, then compare with the CRLF converted to LF
-          res == st.replace("\r\n", "\n")
+          // the json infoset inputter maintains CRLF/CR, but XML converts CRLF/CR to
+          // LF. So if this is Json, then compare with the CRLF/CR converted to LF
+          val replaced = st.replace("\r\n", "\n").replace("\r", "\n")
+          res == replaced
         } else {
           false
         }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
@@ -143,6 +143,106 @@ class TestTDMLRoundTrips {
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("test1")
   }
+  /**
+   * Tests windows style (CRLF) line endings for two pass
+   */
+  @Test def testTwoPass2() {
+
+    val testSuite =
+      <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+        <ts:defineSchema name="s">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="ex:GeneralFormat"/>
+          <xs:element name="all">
+            <xs:complexType>
+              <xs:sequence dfdl:separator="//%NL;">
+                <xs:element name="r" dfdl:lengthKind="implicit" dfdl:occursCountKind="parsed" maxOccurs="unbounded">
+                  <xs:complexType>
+                    <xs:sequence dfdl:separator="; ,">
+                      <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                      <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </ts:defineSchema>
+        <ts:parserTestCase ID="test1" name="test1" root="all" model="s" roundTrip="twoPass">
+          <ts:document>
+            <ts:documentPart type="text" replaceDFDLEntities="true"><![CDATA[Text,One%CR;%LF;New Line//%CR;%LF;Text following,Two%CR;%LF;New Line//%CR;%LF;]]></ts:documentPart>
+          </ts:document>
+          <ts:infoset>
+            <ts:dfdlInfoset>
+              <ex:all>
+                <ex:r>
+                  <foo>Text</foo>
+                  <bar><![CDATA[One
+New Line]]></bar>
+                </ex:r>
+                <ex:r>
+                  <foo>Text following</foo>
+                  <bar><![CDATA[Two
+New Line]]></bar>
+                </ex:r>
+              </ex:all>
+            </ts:dfdlInfoset>
+          </ts:infoset>
+        </ts:parserTestCase>
+      </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    ts.runOneTest("test1")
+  }
+
+  /**
+   * Tests mac style (CR) line endings for two pass
+   */
+  @Test def testTwoPass3() {
+
+    val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
+                      <ts:defineSchema name="s">
+                        <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+                        <dfdl:format ref="ex:GeneralFormat"/>
+                        <xs:element name="all">
+                          <xs:complexType>
+                            <xs:sequence dfdl:separator="//%NL;">
+                              <xs:element name="r" dfdl:occursCountKind="parsed" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:sequence dfdl:separator="; ,">
+                                    <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited"/>
+                                    <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited"/>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </ts:defineSchema>
+                      <ts:parserTestCase ID="test1" name="test1" root="all" model="s" roundTrip="twoPass">
+                        <ts:document>
+                          <ts:documentPart type="text" replaceDFDLEntities="true"><![CDATA[Text,One%CR;New Line//%CR;%LF;Text following,Two%CR;New Line//%CR;%LF;]]></ts:documentPart>
+                        </ts:document>
+                        <ts:infoset>
+                          <ts:dfdlInfoset>
+                            <ex:all>
+                              <ex:r>
+                                <foo>Text</foo>
+                                <bar><![CDATA[One
+New Line]]></bar>
+                              </ex:r>
+                              <ex:r>
+                                <foo>Text following</foo>
+                                <bar><![CDATA[Two
+New Line]]></bar>
+                              </ex:r>
+                            </ex:all>
+                          </ts:dfdlInfoset>
+                        </ts:infoset>
+                      </ts:parserTestCase>
+                    </ts:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    ts.runOneTest("test1")
+  }
 
   def nPassNotNeededTDML(passesEnum: String) =
     <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">


### PR DESCRIPTION
Fixes bug where data containing CRs aren't replaced with LFs during
twoPass testing.

DAFFODIL-2209