### PR TITLE
Specify the appropriate shell for installing GitHub Actions dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,16 +42,18 @@ jobs:
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
           sudo apt-get -y update
           sudo apt-get -y install rpm sbt
+        shell: bash
         if: runner.os == 'Linux'
 
       - name: Install Dependencies (Windows)
         run: |
           choco install sbt
-          # choco doesn't update PATH, and SBT isn't in any of the default
-          # PATHs, and Github Actions doesn't have a built in way to modify
-          # PATH. So add a link to sbt in a directory that is in PATH and that
-          # should always exist (bit of a hack).
+          REM choco doesn't update PATH, and SBT isn't in any of the default
+          REM PATHs, and Github Actions doesn't have a built in way to modify
+          REM PATH. So add a link to sbt in a directory that is in PATH and that
+          REM should always exist (bit of a hack).
           mklink "C:\ProgramData\Chocolatey\bin\sbt" "C:\Program Files (x86)\sbt\bin\sbt"
+        shell: cmd
         if: runner.os == 'Windows'
 
       - name: Install Java

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -606,9 +606,7 @@ class TestCLIparsing {
 
     try {
       //val expected = """<tns:hcp2 xmlns:tns="http://www.example.org/example1/">12</tns:hcp2>"""
-      val cmdLinux = String.format("echo -ne '12' | %s parse -s %s -r hcp2 -p /", Util.binPath, testSchemaFile)
-      val cmdWindows = String.format("echo 12| %s parse -s %s -r hcp2 -p /", Util.binPath, testSchemaFile)
-      val cmd = if (Util.isWindows) cmdWindows else cmdLinux
+      val cmd = String.format(Util.echoN("12") + "| %s parse -s %s -r hcp2 -p /", Util.binPath, testSchemaFile)
 
       shell.sendLine(cmd)
       shell.expect(contains("<tns:hcp2 xmlns:tns=\"http://www.example.org/example1/\">"))

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
@@ -41,7 +41,9 @@ class TestCLIUdfs {
           val filePath = fp.toString
           val indexOfOrg = filePath.indexOfSlice("org")
           if (indexOfOrg >= 0) {
-            val prefix = filePath.splitAt(indexOfOrg)._1
+            // use index - 1 to remove trailing slash, which can cause
+            // accidental escaping on windows
+            val prefix = filePath.splitAt(indexOfOrg - 1)._1
             Some(prefix)
           } else None
       }.toList.distinct
@@ -59,7 +61,7 @@ class TestCLIUdfs {
     val shell = Util.start("")
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r fn_func", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r fn_func", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expect(
         allOf(
@@ -87,7 +89,7 @@ class TestCLIUdfs {
     val shell = Util.startIncludeErrors("")
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -118,12 +120,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaForNonExistentClass))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -151,12 +153,12 @@ class TestCLIUdfs {
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
     val dafClassPath =
-      testUdfsPaths.mkString(":")
+      testUdfsPaths.mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -183,12 +185,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -218,12 +220,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -254,12 +256,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -293,12 +295,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -342,12 +344,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func1", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -393,12 +395,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s parse -s %s -r user_func2", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s parse -s %s -r user_func2", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -427,12 +429,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s parse -s %s -r user_func3", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s parse -s %s -r user_func3", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(1, contains("[error] Schema Definition Error: User Defined Function 'ssudf:rev-words' Error: UDF PE!"))
 
@@ -456,12 +458,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -491,12 +493,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -527,12 +529,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,
@@ -564,12 +566,12 @@ class TestCLIUdfs {
 
     val dafClassPath =
       (testUdfsPaths :+ Util.daffodilPath(metaInfForSomeUdfA))
-        .mkString(":")
+        .mkString(java.io.File.pathSeparator)
 
     val shell = Util.startIncludeErrors("", envp = Map("DAFFODIL_CLASSPATH" -> dafClassPath))
 
     try {
-      val cmd = String.format("echo -n strng| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
+      val cmd = String.format(Util.echoN("strng") + "| %s -v parse -s %s -r user_func3", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
       shell.expectIn(
         1,


### PR DESCRIPTION
GitHub Actions seems to have changed the default shell on Windows from
cmd.exe to powershell. We relied on the cmd.exe 'mklink' built-in to add
sbt to the PATH on windows, but that doesn't work in powershell. Ensure
we use cmd.exe for this step.

Also switch to REM for comments in the windows script. YAML does not
treat hashes as comments inside multi-line scalars, so they end being
fed directly to cmd.exe. Change them to cmd.exe style comments.

DAFFODIL-2225