### PR TITLE
Code improvements to restrict scoped property lookup to only terms.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDecl.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GlobalElementDecl.scala
@@ -28,17 +28,10 @@ final class GlobalElementDecl(
   with GlobalElementComponentMixin
   with ElementDeclFactoryDelegatingMixin
   with NestingTraversesToReferenceMixin
-  with ResolvesProperties // 
-    // Technically, this is not a term, so shouldn't resolve scoped properties
-  // and doesn't take into account combining ref with def properties.
-  // But we need to get one local property: dfdl:choiceBranchKey. In order to 
-  // enforce that it is NOT specified on global defs/decls.
-  // So we mixin ResolvesProperties, but shouldn't use it except to probe dfdl:choiceBranchKey
-  {
-
-  //   global elements combined with element references referring to them can
-  //   be multiple occurring (aka arrays) hence, we have to have things
-  //   that take root and referenced situation into account.
+  // Below needed so we can insure some properties are
+  // NOT on global element decls that are allowed on local element decls.
+  // Such as dfdl:choiceBranchKey
+  with ResolvesLocalProperties {
 
   final override def delegate = factory
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/GroupDef.scala
@@ -111,12 +111,7 @@ sealed abstract class GlobalGroupDef(
   with GroupDefLike
   with GlobalNonElementComponentMixin
   with NestingTraversesToReferenceMixin
-  with ResolvesProperties // 
-    // Technically, this is not a term, so shouldn't resolve scoped properties
-  // and doesn't take into account combining ref with def properties.
-  // But we need to get one local property: dfdl:choiceBranchKey. In order to 
-  // enforce that it is NOT specified on global defs/decls.
-  // So we mixin ResolvesProperties, but shouldn't use it except to probe dfdl:choiceBranchKey
+  with ResolvesLocalProperties // for dfdl:choiceBranchKey
   {
 
   requiredEvaluations(groupMembers)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaDocument.scala
@@ -177,13 +177,7 @@ final class XMLSchemaDocument(
  */
 final class SchemaDocument(xmlSDoc: XMLSchemaDocument)
   extends AnnotatedSchemaComponent
-  with SchemaDocumentMixin
-  with ResolvesProperties //
-  // Technically, this is not a term, so shouldn't resolve scoped properties
-  // This is mixed in to satisfy the contract of FindPropertyMixin, which requires
-  // a lookup method that is defined in ResolveProperties.
-  with Format_AnnotationMixin
-  with SeparatorSuppressionPolicyMixin {
+  with SchemaDocumentMixin {
 
   final override val xml = xmlSDoc.xml
   final override def optLexicalParent = Option(xmlSDoc)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -40,6 +40,7 @@ import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.processors.SeparatorUnparseEv
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.runtime1.ChoiceBranchImpliedSequenceRuntime1Mixin
+import org.apache.daffodil.schema.annotation.props.FindPropertyMixin
 
 /**
  * Base for anything sequence-like.
@@ -260,12 +261,7 @@ abstract class SequenceGroupTermBase(
 trait SequenceDefMixin
   extends AnnotatedSchemaComponent
   with GroupDefLike
-  with ResolvesProperties //
-  // Technically, this is not a term, so shouldn't resolve scoped properties
-  // and doesn't take into account combining ref with def properties.
-  // But we need to get one local property: dfdl:hiddenGroupRef.
-  // So we mixin ResolvesProperties, but shouldn't use it except to obtain dfdl:hiddenGroupRef.
-  {
+  with FindPropertyMixin {
 
   protected final def isMyFormatAnnotation(a: DFDLAnnotation) = a.isInstanceOf[DFDLSequence]
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -75,7 +75,8 @@ sealed trait SimpleTypeBase extends TypeBase
  * but the element will still have an optRepValueSet for another source (eg. children elements)
  */
 sealed trait HasRepValueAttributes extends AnnotatedSchemaComponent
-  with ResolvesProperties {
+  with ResolvesLocalProperties // for repValues, repValueRanges, repType
+  {
 
   def optRepType: Option[SimpleTypeBase]
   def optRepValueSet: Option[RepValueSet[AnyRef]]
@@ -556,8 +557,7 @@ final class EnumerationDefFactory(
   parentType: SimpleTypeDefBase)
   extends SchemaComponentFactory(xml, parentType.schemaDocument)
   with NestingLexicalMixin
-  with HasRepValueAttributes
-  with ResolvesProperties {
+  with HasRepValueAttributes {
 
   Assert.invariant(xml.label == "enumeration")
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
@@ -94,7 +94,7 @@ trait HasTermCheck {
  */
 trait Term
   extends AnnotatedSchemaComponent
-  with ResolvesProperties
+  with ResolvesScopedProperties
   with ResolvesDFDLStatementMixin
   with TermRuntimeValuedPropertiesMixin
   with TermGrammarMixin

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -64,11 +64,8 @@ class TestDsomCompiler extends Logging {
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.forRoot()
 
-    schemaDoc.defaultFormat
-    val tnr = schemaDoc.textNumberRep
+    val tnr = decl.textNumberRep
     assertEquals(TextNumberRep.Standard, tnr)
-    val tnr2 = decl.textNumberRep
-    assertEquals(TextNumberRep.Standard, tnr2)
   }
 
   @Test def testSchemaValidationSubset() {


### PR DESCRIPTION
A cleanup which prevents a class of errors where you lookup properties not on an object that actually has full visibility to scoping. 

This cleanup is helpful in some of the refactoring for DAFFODIL-1444 (schema compiler space/speed)

DAFFODIL-2244