### PR TITLE
Daffodil 2250 cleanup runtime data vs. compile info

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLEscapeScheme.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLEscapeScheme.scala
@@ -86,7 +86,7 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
     val qn = this.qNameForProperty("escapeCharacter")
     val expr = ExpressionCompilers.String.compileProperty(qn, NodeInfo.NonEmptyString, escapeCharacterRaw, this,
       defES.pointOfUse.dpathCompileInfo)
-    val ev = new EscapeCharEv(expr, runtimeData)
+    val ev = new EscapeCharEv(expr, ci)
     ev.compile(tunable)
     ev
   }.value
@@ -98,9 +98,9 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
       case found @ Found(v, loc, _, _) => {
         val typeIfStaticallyKnown = NodeInfo.String
         val typeIfRuntimeKnown = NodeInfo.NonEmptyString
-        val expr = ExpressionCompilers.String.compileDelimiter(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, found, this,
-          defES.pointOfUse.dpathCompileInfo)
-        val ev = new EscapeEscapeCharEv(expr, runtimeData)
+        val ci = defES.pointOfUse.dpathCompileInfo
+        val expr = ExpressionCompilers.String.compileDelimiter(qn, typeIfStaticallyKnown, typeIfRuntimeKnown, found, this, ci)
+        val ev = new EscapeEscapeCharEv(expr, ci)
         ev.compile(tunable)
         One(ev)
       }
@@ -116,8 +116,8 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
 
   final lazy val escapeSchemeParseEv: EscapeSchemeParseEv = {
     val espev = escapeKind match {
-      case EscapeKind.EscapeBlock => new EscapeSchemeBlockParseEv(escapeBlockStart, escapeBlockEnd, optionEscapeEscapeCharacterEv, runtimeData)
-      case EscapeKind.EscapeCharacter => new EscapeSchemeCharParseEv(escapeCharacterEv, optionEscapeEscapeCharacterEv, runtimeData)
+      case EscapeKind.EscapeBlock => new EscapeSchemeBlockParseEv(escapeBlockStart, escapeBlockEnd, optionEscapeEscapeCharacterEv, ci)
+      case EscapeKind.EscapeCharacter => new EscapeSchemeCharParseEv(escapeCharacterEv, optionEscapeEscapeCharacterEv, ci)
     }
     espev.compile(tunable)
     espev
@@ -125,8 +125,8 @@ final class DFDLEscapeScheme(node: Node, decl: AnnotatedSchemaComponent, defES: 
 
   final lazy val escapeSchemeUnparseEv: EscapeSchemeUnparseEv = {
     val esuev = escapeKind match {
-      case EscapeKind.EscapeBlock => new EscapeSchemeBlockUnparseEv(escapeBlockStart, escapeBlockEnd, optionEscapeEscapeCharacterEv, optionExtraEscapedCharacters, generateEscapeBlock, runtimeData)
-      case EscapeKind.EscapeCharacter => new EscapeSchemeCharUnparseEv(escapeCharacterEv, optionEscapeEscapeCharacterEv, optionExtraEscapedCharacters, runtimeData)
+      case EscapeKind.EscapeBlock => new EscapeSchemeBlockUnparseEv(escapeBlockStart, escapeBlockEnd, optionEscapeEscapeCharacterEv, optionExtraEscapedCharacters, generateEscapeBlock, ci)
+      case EscapeKind.EscapeCharacter => new EscapeSchemeCharUnparseEv(escapeCharacterEv, optionEscapeEscapeCharacterEv, optionExtraEscapedCharacters, ci)
     }
     esuev.compile(tunable)
     esuev

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -81,6 +81,11 @@ trait SchemaComponent
   }
 
   /**
+   * Abbreviation. We use this very often.
+   */
+  final def ci = dpathCompileInfo
+
+  /**
    * All non-terms get runtimeData from this definition. All Terms
    * which are elements and model-groups) override this.
    *

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -243,7 +243,7 @@ abstract class SequenceGroupTermBase(
         maybeLayerLengthInBytesEv,
         Maybe.toMaybe(optionLayerLengthUnits),
         maybeLayerBoundaryMarkEv,
-        termRuntimeData)
+        dpathCompileInfo)
       lt.compile(tunable)
       Maybe.One(lt)
     }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Term.scala
@@ -113,6 +113,11 @@ trait Term
   }
 
   /**
+   * Abbreviation analogous to trd, tci is the compile-time counterpart.
+   */
+  final def tci = dpathCompileInfo
+
+  /**
    * Used to recursively go through Terms and look for DFDL properties that
    * have not been accessed and record it as a warning. This function uses the
    * property cache state to determine which properties have been access, so

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/BitOrderMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/BitOrderMixin.scala
@@ -23,6 +23,7 @@ import org.apache.daffodil.processors.CheckByteAndBitOrderEv
 import org.apache.daffodil.processors.CheckBitOrderAndCharsetEv
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.dsom.{ Binary, NoText }
+import org.apache.daffodil.dsom.ElementBase
 
 trait BitOrderMixin extends GrammarMixin with ByteOrderAnalysisMixin { self: Term =>
 
@@ -73,6 +74,11 @@ trait BitOrderMixin extends GrammarMixin with ByteOrderAnalysisMixin { self: Ter
         (isArray && !hasUniformBitOrderThroughout)))
   }
 
+  private lazy val maybeByteOrderEv = self match {
+    case eb: ElementBase => eb.maybeByteOrderEv
+    case _ => Maybe.Nope
+  }
+
   lazy val maybeCheckByteAndBitOrderEv = {
     //
     // TODO: Performance: could be improved, as there are situations where byteOrder
@@ -83,7 +89,8 @@ trait BitOrderMixin extends GrammarMixin with ByteOrderAnalysisMixin { self: Ter
       Maybe.Nope
     else {
       val checkByteAndBitOrder = {
-        val ev = new CheckByteAndBitOrderEv(termRuntimeData, defaultBitOrder)
+        val ev = new CheckByteAndBitOrderEv(ci, defaultBitOrder,
+          maybeByteOrderEv)
         ev.compile(tunable)
         ev
       }
@@ -97,7 +104,7 @@ trait BitOrderMixin extends GrammarMixin with ByteOrderAnalysisMixin { self: Ter
       Maybe.Nope
     else {
       val checkBitOrderAndCharset = {
-        val ev = new CheckBitOrderAndCharsetEv(termRuntimeData, defaultBitOrder, charsetEv)
+        val ev = new CheckBitOrderAndCharsetEv(ci, defaultBitOrder, charsetEv)
         ev.compile(tunable)
         ev
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Grammar.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/Grammar.scala
@@ -27,15 +27,6 @@ import org.apache.daffodil.compiler.ForParser
 import org.apache.daffodil.processors.unparsers.NadaUnparser
 import org.apache.daffodil.processors.parsers.NadaParser
 
-abstract class UnaryGram(context: Term, rr: => Gram) extends NamedGram(context) {
-  private lazy val r = rr
-
-  final override lazy val gram = {
-    if (r.isEmpty) EmptyGram
-    else this
-  }
-}
-
 /**
  * BinaryGram isn't really 'binary' it's n-ary. It is called binary because it comes from
  * the binary grammar operations ~ and |, but in the abstract syntax tree we want

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDateTime.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesDateTime.scala
@@ -127,13 +127,13 @@ abstract class ConvertTextCalendarPrimBase(e: ElementBase, guard: Boolean)
   }
 
   private lazy val localeEv = {
-    val ev = new CalendarLanguageEv(e.calendarLanguage, e.erd)
+    val ev = new CalendarLanguageEv(e.calendarLanguage, e.eci)
     ev.compile(e.tunable)
     ev
   }
 
   private lazy val calendarEv = {
-    val cev = new CalendarEv(localeEv, calendarTz, firstDay, calendarDaysInFirstWeek, calendarCheckPolicy, e.erd)
+    val cev = new CalendarEv(localeEv, calendarTz, firstDay, calendarDaysInFirstWeek, calendarCheckPolicy, e.eci)
     cev.compile(e.tunable)
     cev
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesLengthKind.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesLengthKind.scala
@@ -130,7 +130,7 @@ abstract class StringDelimited(e: ElementBase)
 
   // TODO: move out of parser and into the dsom
   lazy val fieldDFAParseEv = {
-    val ev = new FieldDFAParseEv(escapeSchemeParseEvOpt, context.runtimeData)
+    val ev = new FieldDFAParseEv(escapeSchemeParseEvOpt, context.dpathCompileInfo)
     ev.compile(context.tunable)
     ev
   }
@@ -138,9 +138,9 @@ abstract class StringDelimited(e: ElementBase)
   val textDelimitedParser = {
     val isBlockEscapeScheme = es.isDefined && es.get.escapeKind == EscapeKind.EscapeBlock
     if (isBlockEscapeScheme) {
-      new TextDelimitedParserWithEscapeBlock(justificationTrim, parsingPadChar, e.elementRuntimeData)
+      new TextDelimitedParserWithEscapeBlock(justificationTrim, parsingPadChar, e.erd)
     } else {
-      new TextDelimitedParser(justificationTrim, parsingPadChar, e.elementRuntimeData)
+      new TextDelimitedParser(justificationTrim, parsingPadChar, e.erd)
     }
   }
 
@@ -165,7 +165,7 @@ abstract class StringDelimited(e: ElementBase)
 
   override lazy val unparser: DaffodilUnparser =
     new StringDelimitedUnparser(
-      e.elementRuntimeData,
+      e.erd,
       escapeSchemeUnparseEvOpt,
       isDelimRequired)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
@@ -96,14 +96,14 @@ class UnorderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceC
 
   override lazy val parser: Parser = {
 
-    lazy val choiceParser = new ChoiceParser(srd, parsers.toVector, unordered=true)
+    lazy val choiceParser = new ChoiceParser(srd, parsers.toVector, unordered = true)
 
     sq.hasSeparator match {
       case true => {
         lazy val groupHelper = new NonPositionalGroupSeparatedSequenceChildParseResultHelper(
           srd,
           NonPositional,
-          true,  // Due to the nature of UOSeqs, could potentially be empty
+          true, // Due to the nature of UOSeqs, could potentially be empty
           false) // and does not have required syntax
 
         lazy val groupParser = new GroupSeparatedUnorderedSequenceChildParser(
@@ -121,7 +121,7 @@ class UnorderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceC
       case false => {
         lazy val groupHelper = new GroupUnseparatedSequenceChildParseResultHelper(
           srd,
-          true,  // Due to the nature of UOSeqs, could potentially be empty
+          true, // Due to the nature of UOSeqs, could potentially be empty
           false) // and does not have required syntax
 
         lazy val groupParser = new ScalarUnorderedUnseparatedSequenceChildParser(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -41,7 +41,7 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
 
   final lazy val choiceDispatchKeyEv = {
     Assert.invariant(isDirectDispatch)
-    val ev = new ChoiceDispatchKeyEv(choiceDispatchKeyExpr, modelGroupRuntimeData)
+    val ev = new ChoiceDispatchKeyEv(choiceDispatchKeyExpr, ci)
     ev.compile(tunable)
     ev
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
@@ -120,6 +120,11 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
   }
 
   final override lazy val dpathCompileInfo = dpathElementCompileInfo
+  
+  /**
+   * Just an abbrev. analogous to erd, trd, etc.
+   */
+  final def eci = dpathElementCompileInfo
 
   /**
    * This is the compile info for this element term.
@@ -143,7 +148,8 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
       tunable.unqualifiedPathStepPolicy,
       schemaSet.typeCalcMap,
       runtimeData,
-      shortSchemaComponentDesignator)
+      shortSchemaComponentDesignator,
+      isOutputValueCalc)
     eci
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StringLiteralForUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StringLiteralForUnparser.scala
@@ -26,11 +26,13 @@ import org.apache.daffodil.processors.ParseOrUnparseState
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.cookers.EntityReplacer
+import org.apache.daffodil.dsom.DPathCompileInfo
 
-class NilStringLiteralForUnparserEv(trd: TermRuntimeData,
+class NilStringLiteralForUnparserEv(
+  tci: DPathCompileInfo,
   maybeOutputNewLineEv: Maybe[OutputNewLineEv],
   stringLiteralRaw: String)
-  extends Evaluatable[String](trd)
+  extends Evaluatable[String](tci)
   with InfosetCachedEvaluatable[String] {
 
   override lazy val runtimeDependencies = maybeOutputNewLineEv.toList
@@ -61,7 +63,8 @@ class NilStringLiteralForUnparserEv(trd: TermRuntimeData,
         // there are no NL entities. There is only a single chunk.
         chunks.head
       } else {
-        trd.schemaDefinitionUnless(maybeOutputNewLineEv.isDefined,
+        tci.schemaDefinitionUnless(
+          maybeOutputNewLineEv.isDefined,
           "Property dfdl:outputNewLine is required, but it is not defined.")
         val nl = maybeOutputNewLineEv.get.evaluate(state)
         val sl = chunks.mkString(nl)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -225,6 +225,8 @@ class DPathCompileInfo(
     variableMap
   }
 
+  def diagnosticDebugName = path
+
   @throws(classOf[java.io.IOException])
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
@@ -292,7 +294,8 @@ class DPathElementCompileInfo(
   override val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy,
   typeCalcMap: TypeCalcMap,
   lexicalContextRuntimeData: RuntimeData,
-  val sscd: String)
+  val sscd: String,
+  val isOutputValueCalc: Boolean)
   extends DPathCompileInfo(parentsArg, variableMap, namespaces, path, sfl,
     unqualifiedPathStepPolicy,
     typeCalcMap, lexicalContextRuntimeData) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -54,6 +54,7 @@ import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.api.DaffodilTunables
 import java.util.HashMap
 import org.apache.daffodil.dsom.DPathElementCompileInfo
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 sealed trait DINode {
 
@@ -169,7 +170,7 @@ case class InfosetNoNextSiblingException(val diSimple: DISimple, val info: DPath
   extends ProcessingError("Expression Evaluation", Nope, Nope, "Element %s does not have a nextSibling", info.namedQName)
   with InfosetException with RetryableException
 
-case class InfosetNoInfosetException(val rd: Maybe[RuntimeData])
+case class InfosetNoInfosetException(val rd: Maybe[DPathCompileInfo])
   extends ProcessingError("Expression Evaluation", Nope, Nope, "There is no infoset%s", (if (rd.isEmpty) "." else " for path %s.".format(rd.get.path)))
   with InfosetException with RetryableException
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
@@ -45,6 +45,7 @@ import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 object AISPayloadArmoringTransformer {
   val iso8859 = StandardCharsets.ISO_8859_1
@@ -142,7 +143,7 @@ class AISPayloadArmoringOutputStream(jos: java.io.OutputStream)
       val dis = InputSourceDataInputStream(ba)
       val finfo = new FormatInfoForAISDecode()
       val cb = CharBuffer.allocate(256)
-      while( { val numDecoded = dec.decode(dis, finfo, cb); numDecoded > 0 } ) {
+      while ({ val numDecoded = dec.decode(dis, finfo, cb); numDecoded > 0 }) {
         cb.flip()
         IOUtils.write(cb, jos, iso8859)
         cb.clear()
@@ -161,12 +162,13 @@ class AISPayloadArmoringOutputStream(jos: java.io.OutputStream)
 object AISPayloadArmoringTransformerFactory
   extends LayerTransformerFactory("aisPayloadArmor") {
 
-  override def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer = {
+    tci: DPathCompileInfo): LayerTransformer = {
 
     val xformer = new AISPayloadArmoringTransformer()
     xformer

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
@@ -32,6 +32,7 @@ import org.apache.daffodil.processors.charset.BitsCharset
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv: LayerBoundaryMarkEv)
   extends LayerTransformer() {
@@ -72,24 +73,29 @@ class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv:
 object Base64MIMETransformerFactory
   extends LayerTransformerFactory("base64_MIME") {
 
-  override def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer = {
+    tci: DPathCompileInfo): LayerTransformer = {
 
-    trd.schemaDefinitionUnless(scala.util.Properties.isJavaAtLeast("1.8"),
+    tci.schemaDefinitionUnless(
+      scala.util.Properties.isJavaAtLeast("1.8"),
       "Base64 layer support requires Java 8 (aka Java 1.8).")
 
-    trd.schemaDefinitionUnless(maybeLayerBoundaryMarkEv.isDefined,
+    tci.schemaDefinitionUnless(
+      maybeLayerBoundaryMarkEv.isDefined,
       "Property dfdlx:layerBoundaryMark was not defined.")
-    trd.schemaDefinitionUnless(maybeLayerLengthKind.isEmpty ||
-      (maybeLayerLengthKind.get eq LayerLengthKind.BoundaryMark),
+    tci.schemaDefinitionUnless(
+      maybeLayerLengthKind.isEmpty ||
+        (maybeLayerLengthKind.get eq LayerLengthKind.BoundaryMark),
       "Only dfdlx:layerLengthKind 'boundaryMark' is supported, but '%s' was specified",
       maybeLayerLengthKind.get.toString)
 
-    trd.schemaDefinitionUnless(maybeLayerCharsetEv.isDefined,
+    tci.schemaDefinitionUnless(
+      maybeLayerCharsetEv.isDefined,
       "Property dfdlx:layerEncoding must be defined.")
 
     val xformer = new Base64MIMETransformer(maybeLayerCharsetEv.get, maybeLayerBoundaryMarkEv.get)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 /**
  * An input stream wrapper that re-orders bytes according to wordsize.
@@ -148,7 +149,7 @@ class ByteSwapOutputStream(wordsize: Int, jos: OutputStream)
     Assert.usage(!closed)
     stack.push(bInt.toByte)
     if (stack.size() == wordsize) {
-      while(!stack.isEmpty()) {
+      while (!stack.isEmpty()) {
         jos.write(stack.pop())
       }
     }
@@ -193,14 +194,16 @@ class ByteSwapTransformer(wordsize: Int, layerLengthInBytesEv: LayerLengthInByte
 sealed abstract class ByteSwapTransformerFactory(wordsize: Int, name: String)
   extends LayerTransformerFactory(name) {
 
-  override def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer = {
+    tci: DPathCompileInfo): LayerTransformer = {
 
-    trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,
+    tci.schemaDefinitionUnless(
+      maybeLayerLengthKind.isDefined,
       "The propert dfdlx:layerLengthKind must be defined.")
 
     val xformer =
@@ -209,7 +212,8 @@ sealed abstract class ByteSwapTransformerFactory(wordsize: Int, name: String)
           new ByteSwapTransformer(wordsize, maybeLayerLengthInBytesEv.get)
         }
         case x =>
-          trd.SDE("Property dfdlx:layerLengthKind can only be 'explicit', but was '%s'",
+          tci.SDE(
+            "Property dfdlx:layerLengthKind can only be 'explicit', but was '%s'",
             x.toString)
       }
     xformer
@@ -221,4 +225,3 @@ sealed abstract class ByteSwapTransformerFactory(wordsize: Int, name: String)
  */
 object FourByteSwapTransformerFactory
   extends ByteSwapTransformerFactory(4, "fourbyteswap")
-

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -27,6 +27,7 @@ import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
   extends LayerTransformer() {
@@ -57,12 +58,13 @@ class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
 object GZIPTransformerFactory
   extends LayerTransformerFactory("gzip") {
 
-  override def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer = {
+    tci: DPathCompileInfo): LayerTransformer = {
 
     val xformer = new GZIPTransformer(maybeLayerLengthInBytesEv.get)
     xformer

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
@@ -40,6 +40,7 @@ import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
 import passera.unsigned.ULong
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 /**
  * Factory for a layer transformer.
@@ -53,12 +54,13 @@ abstract class LayerTransformerFactory(nom: String)
 
   val name = nom.toUpperCase()
 
-  def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer
+    tci: DPathCompileInfo): LayerTransformer
 }
 
 /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
@@ -34,6 +34,7 @@ import java.io.InputStream
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.schema.annotation.props.Enum
 import org.apache.daffodil.io.RegexLimitingStream
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 /*
  * This and related classes implement so called "line folding" from
@@ -155,14 +156,16 @@ class LineFoldedTransformerImplicit(mode: LineFoldMode)
 sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: String)
   extends LayerTransformerFactory(name) {
 
-  override def newInstance(maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
     maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    trd: TermRuntimeData): LayerTransformer = {
+    tci: DPathCompileInfo): LayerTransformer = {
 
-    trd.schemaDefinitionUnless(maybeLayerLengthKind.isDefined,
+    tci.schemaDefinitionUnless(
+      maybeLayerLengthKind.isDefined,
       "The property dfdlx:layerLengthKind must be defined.")
 
     val xformer =
@@ -174,7 +177,8 @@ sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: Str
           new LineFoldedTransformerImplicit(mode)
         }
         case x =>
-          trd.SDE("Property dfdlx:layerLengthKind can only be 'implicit' or 'boundaryMark', but was '%s'",
+          tci.SDE(
+            "Property dfdlx:layerLengthKind can only be 'implicit' or 'boundaryMark', but was '%s'",
             x.toString)
       }
     xformer
@@ -472,4 +476,3 @@ class LineFoldedOutputStream(mode: LineFoldMode, jos: OutputStream)
     }
   }
 }
-

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvBinaryFloat.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvBinaryFloat.scala
@@ -20,11 +20,11 @@ package org.apache.daffodil.processors
 import org.apache.daffodil.schema.annotation.props.gen._
 import org.apache.daffodil.dsom._
 
-class BinaryFloatRepEv(expr: CompiledExpression[String], erd: ElementRuntimeData)
+class BinaryFloatRepEv(expr: CompiledExpression[String], eci: DPathElementCompileInfo)
   extends EvaluatableConvertedExpression[String, BinaryFloatRep](
     expr,
     BinaryFloatRep,
-    erd)
+    eci)
   with InfosetCachedEvaluatable[BinaryFloatRep] {
 
   override lazy val runtimeDependencies = Vector()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvByteOrder.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvByteOrder.scala
@@ -20,15 +20,16 @@ package org.apache.daffodil.processors
 import org.apache.daffodil.schema.annotation.props.gen._
 import org.apache.daffodil.dsom._
 import org.apache.daffodil.equality._
+import org.apache.daffodil.util.Maybe
 
 /**
  * Runtime valued properties that are enums would all work like ByteOrder here.
  */
-class ByteOrderEv(override val expr: CompiledExpression[String], erd: ElementRuntimeData)
+class ByteOrderEv(override val expr: CompiledExpression[String], eci: DPathElementCompileInfo)
   extends EvaluatableConvertedExpression[String, ByteOrder](
     expr,
     ByteOrder,
-    erd)
+    eci)
   with InfosetCachedEvaluatable[ByteOrder] {
   override lazy val runtimeDependencies = Vector()
 
@@ -43,7 +44,8 @@ class Ok private () extends Serializable {
 }
 object Ok extends Ok()
 
-class CheckByteAndBitOrderEv(t: TermRuntimeData, bitOrder: BitOrder)
+class CheckByteAndBitOrderEv(t: DPathCompileInfo, bitOrder: BitOrder,
+  maybeByteOrderEv: Maybe[ByteOrderEv])
   extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 
@@ -51,9 +53,9 @@ class CheckByteAndBitOrderEv(t: TermRuntimeData, bitOrder: BitOrder)
 
   override final protected def compute(state: ParseOrUnparseState): Ok = {
     t match {
-      case erd: ElementRuntimeData => {
-        if (erd.maybeByteOrderEv.isDefined) {
-          val byteOrderEv = erd.maybeByteOrderEv.get
+      case eci: DPathElementCompileInfo => {
+        if (maybeByteOrderEv.isDefined) {
+          val byteOrderEv = maybeByteOrderEv.get
           val byteOrder = byteOrderEv.evaluate(state)
           bitOrder match {
             case BitOrder.MostSignificantBitFirst => // ok
@@ -70,7 +72,7 @@ class CheckByteAndBitOrderEv(t: TermRuntimeData, bitOrder: BitOrder)
   }
 }
 
-class CheckBitOrderAndCharsetEv(t: TermRuntimeData, bitOrder: BitOrder, charsetEv: CharsetEv)
+class CheckBitOrderAndCharsetEv(t: DPathCompileInfo, bitOrder: BitOrder, charsetEv: CharsetEv)
   extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvCalendarLanguage.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvCalendarLanguage.scala
@@ -24,7 +24,6 @@ import com.ibm.icu.util.TimeZone
 import com.ibm.icu.util.ULocale
 import org.apache.daffodil.cookers.Converter
 
-
 object LocaleConverter extends Converter[String, ULocale] {
 
   val regex = "([A-Za-z]{1,8}([-_][A-Za-z0-9]{1,8})*)"
@@ -43,22 +42,23 @@ object LocaleConverter extends Converter[String, ULocale] {
   }
 }
 
-class CalendarLanguageEv(calendarLanguageExpr: CompiledExpression[String], erd: ElementRuntimeData)
+class CalendarLanguageEv(calendarLanguageExpr: CompiledExpression[String], eci: DPathElementCompileInfo)
   extends EvaluatableConvertedExpression[String, ULocale](
     calendarLanguageExpr,
     LocaleConverter,
-    erd)
+    eci)
   with InfosetCachedEvaluatable[ULocale] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class CalendarEv(localeEv: CalendarLanguageEv,
+class CalendarEv(
+  localeEv: CalendarLanguageEv,
   calendarTz: Option[TimeZone],
   firstDay: Int,
   calendarDaysInFirstWeek: Int,
   calendarCheckPolicy: Boolean,
-  erd: ElementRuntimeData)
-  extends Evaluatable[Calendar](erd)
+  eci: DPathElementCompileInfo)
+  extends Evaluatable[Calendar](eci)
   with InfosetCachedEvaluatable[Calendar] {
 
   override lazy val runtimeDependencies = Seq(localeEv)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvDelimiters.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvDelimiters.scala
@@ -37,7 +37,6 @@ trait DelimiterEvMixin[+T <: AnyRef]
 
   def expr: CompiledExpression[String]
   def converter: Converter[String, List[String]]
-  def trd: TermRuntimeData
 
   override final def toBriefXML(depth: Int = -1) = if (this.isConstant) this.constValue.toString else expr.toBriefXML(depth)
 
@@ -45,15 +44,19 @@ trait DelimiterEvMixin[+T <: AnyRef]
     val expressionResult = eval(expr, state)
 
     val converterResult = state match {
-      case cs: CompileState => converter.convertConstant(expressionResult, trd, false)
-      case _ => converter.convertRuntime(expressionResult, trd, false)
+      case cs: CompileState => converter.convertConstant(expressionResult, ci, false)
+      case _ => converter.convertRuntime(expressionResult, ci, false)
     }
     converterResult
   }
 }
 
-abstract class DelimiterParseEv(delimType: DelimiterTextType.Type, override val expr: CompiledExpression[String], ignoreCase: Boolean, override val trd: TermRuntimeData)
-  extends Evaluatable[Array[DFADelimiter]](trd)
+abstract class DelimiterParseEv(
+  delimType: DelimiterTextType.Type,
+  override val expr: CompiledExpression[String],
+  ignoreCase: Boolean,
+  override val ci: DPathCompileInfo)
+  extends Evaluatable[Array[DFADelimiter]](ci)
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
@@ -68,13 +71,17 @@ abstract class DelimiterParseEv(delimType: DelimiterTextType.Type, override val 
     if (converterResult.length == 1 && converterResult(0) == "") {
       Array()
     } else {
-      CreateDelimiterDFA(delimType, trd, converterResult, ignoreCase)
+      CreateDelimiterDFA(delimType, ci, converterResult, ignoreCase)
     }
   }
 }
 
-abstract class DelimiterUnparseEv(delimType: DelimiterTextType.Type, override val expr: CompiledExpression[String], outputNewLine: OutputNewLineEv, override val trd: TermRuntimeData)
-  extends Evaluatable[Array[DFADelimiter]](trd)
+abstract class DelimiterUnparseEv(
+  delimType: DelimiterTextType.Type,
+  override val expr: CompiledExpression[String],
+  outputNewLine: OutputNewLineEv,
+  override val ci: DPathCompileInfo)
+  extends Evaluatable[Array[DFADelimiter]](ci)
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
@@ -90,43 +97,43 @@ abstract class DelimiterUnparseEv(delimType: DelimiterTextType.Type, override va
       Array()
     } else {
       val onl = outputNewLine.evaluate(state)
-      CreateDelimiterDFA(delimType, trd, converterResult, onl)
+      CreateDelimiterDFA(delimType, ci, converterResult, onl)
     }
   }
 }
 
-class InitiatorParseEv(expr: CompiledExpression[String], ignoreCase: Boolean, trd: TermRuntimeData)
-  extends DelimiterParseEv(DelimiterTextType.Initiator, expr, ignoreCase, trd) {
+class InitiatorParseEv(expr: CompiledExpression[String], ignoreCase: Boolean, tci: DPathCompileInfo)
+  extends DelimiterParseEv(DelimiterTextType.Initiator, expr, ignoreCase, tci) {
 
   override val converter = InitiatorCooker
 }
 
-class InitiatorUnparseEv(expr: CompiledExpression[String], outputNewLine: OutputNewLineEv, trd: TermRuntimeData)
-  extends DelimiterUnparseEv(DelimiterTextType.Initiator, expr, outputNewLine, trd) {
+class InitiatorUnparseEv(expr: CompiledExpression[String], outputNewLine: OutputNewLineEv, tci: DPathCompileInfo)
+  extends DelimiterUnparseEv(DelimiterTextType.Initiator, expr, outputNewLine, tci) {
 
   override val converter = InitiatorCooker
 }
 
-class TerminatorParseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, ignoreCase: Boolean, trd: TermRuntimeData)
-  extends DelimiterParseEv(DelimiterTextType.Terminator, expr, ignoreCase, trd) {
+class TerminatorParseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, ignoreCase: Boolean, tci: DPathCompileInfo)
+  extends DelimiterParseEv(DelimiterTextType.Terminator, expr, ignoreCase, tci) {
 
   override val converter = if (isLengthKindDelimited) TerminatorCookerNoES else TerminatorCooker
 }
 
-class TerminatorUnparseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, outputNewLine: OutputNewLineEv, trd: TermRuntimeData)
-  extends DelimiterUnparseEv(DelimiterTextType.Terminator, expr, outputNewLine, trd) {
+class TerminatorUnparseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, outputNewLine: OutputNewLineEv, tci: DPathCompileInfo)
+  extends DelimiterUnparseEv(DelimiterTextType.Terminator, expr, outputNewLine, tci) {
 
   override val converter = if (isLengthKindDelimited) TerminatorCookerNoES else TerminatorCooker
 }
 
-class SeparatorParseEv(expr: CompiledExpression[String], ignoreCase: Boolean, trd: TermRuntimeData)
-  extends DelimiterParseEv(DelimiterTextType.Separator, expr, ignoreCase, trd) {
+class SeparatorParseEv(expr: CompiledExpression[String], ignoreCase: Boolean, tci: DPathCompileInfo)
+  extends DelimiterParseEv(DelimiterTextType.Separator, expr, ignoreCase, tci) {
 
   override val converter = SeparatorCooker
 }
 
-class SeparatorUnparseEv(expr: CompiledExpression[String], outputNewLine: OutputNewLineEv, trd: TermRuntimeData)
-  extends DelimiterUnparseEv(DelimiterTextType.Separator, expr, outputNewLine, trd) {
+class SeparatorUnparseEv(expr: CompiledExpression[String], outputNewLine: OutputNewLineEv, tci: DPathCompileInfo)
+  extends DelimiterUnparseEv(DelimiterTextType.Separator, expr, outputNewLine, tci) {
 
   override val converter = SeparatorCooker
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvElement.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvElement.scala
@@ -42,10 +42,10 @@ import org.apache.daffodil.util.Numbers
 
 sealed trait LengthEv extends Evaluatable[JLong]
 
-class ExplicitLengthEv(expr: CompiledExpression[JLong], rd: RuntimeData)
+class ExplicitLengthEv(expr: CompiledExpression[JLong], ci: DPathCompileInfo)
   extends EvaluatableExpression[JLong](
     expr,
-    rd)
+    ci)
   with LengthEv
   with InfosetCachedEvaluatable[JLong] {
   override lazy val runtimeDependencies = Vector()
@@ -68,8 +68,8 @@ class ExplicitLengthEv(expr: CompiledExpression[JLong], rd: RuntimeData)
   }
 }
 
-class ImplicitLengthEv(lengthValue: Long, rd: ElementRuntimeData)
-  extends Evaluatable[JLong](rd)
+class ImplicitLengthEv(lengthValue: Long, ci: DPathElementCompileInfo)
+  extends Evaluatable[JLong](ci)
   with LengthEv
   with NoCacheEvaluatable[JLong] {
 
@@ -125,10 +125,11 @@ class ImplicitLengthEv(lengthValue: Long, rd: ElementRuntimeData)
  * In that case, the access to the infoset throws particular exceptions
  * descended from the RetryableException trait.
  */
-sealed abstract class LengthInBitsEvBase(rd: TermRuntimeData,
+sealed abstract class LengthInBitsEvBase(
+  ci: DPathCompileInfo,
   val lengthUnits: LengthUnits,
   val lengthKind: LengthKind)
-  extends Evaluatable[MaybeJULong](rd)
+  extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
   protected def maybeCharsetEv: Maybe[CharsetEv]
@@ -164,12 +165,13 @@ sealed abstract class LengthInBitsEvBase(rd: TermRuntimeData,
  * textOutputMinLength for unparsing of Explicit length elements.
  * See ElementTargetLengthInBitsEv.
  */
-class LengthInBitsEv(lengthUnits: LengthUnits,
+class LengthInBitsEv(
+  lengthUnits: LengthUnits,
   lengthKind: LengthKind,
   override val maybeCharsetEv: Maybe[CharsetEv],
   val lengthEv: LengthEv,
-  rd: TermRuntimeData)
-  extends LengthInBitsEvBase(rd, lengthUnits, lengthKind) {
+  ci: DPathCompileInfo)
+  extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
   override lazy val runtimeDependencies = maybeCharsetEv.toList :+ lengthEv
 
@@ -185,11 +187,12 @@ class LengthInBitsEv(lengthUnits: LengthUnits,
  *
  * Hence, we have to compute this similarly at runtime.
  */
-class MinLengthInBitsEv(lengthUnits: LengthUnits,
+class MinLengthInBitsEv(
+  lengthUnits: LengthUnits,
   lengthKind: LengthKind,
   override val maybeCharsetEv: Maybe[CharsetEv],
-  minLen: Long, rd: TermRuntimeData)
-  extends LengthInBitsEvBase(rd, lengthUnits, lengthKind) {
+  minLen: Long, ci: DPathCompileInfo)
+  extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
   override lazy val runtimeDependencies = maybeCharsetEv.toList
 
@@ -210,8 +213,8 @@ class MinLengthInBitsEv(lengthUnits: LengthUnits,
 class UnparseTargetLengthInBitsEv(
   val lengthInBitsEv: LengthInBitsEv,
   minLengthInBitsEv: MinLengthInBitsEv,
-  rd: RuntimeData)
-  extends Evaluatable[MaybeJULong](rd)
+  ci: DPathCompileInfo)
+  extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
   override lazy val runtimeDependencies = Vector(this.lengthInBitsEv, this.minLengthInBitsEv)
@@ -246,8 +249,8 @@ class UnparseTargetLengthInCharactersEv(
   val lengthEv: LengthEv,
   val charsetEv: CharsetEv,
   minLen: Long,
-  rd: ElementRuntimeData)
-  extends Evaluatable[MaybeJULong](rd)
+  ci: DPathElementCompileInfo)
+  extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
   override lazy val runtimeDependencies = Vector(this.lengthEv, charsetEv)
@@ -271,28 +274,28 @@ class UnparseTargetLengthInCharactersEv(
   }
 }
 
-class OccursCountEv(expr: CompiledExpression[JLong], rd: ElementRuntimeData)
+class OccursCountEv(expr: CompiledExpression[JLong], ci: DPathElementCompileInfo)
   extends EvaluatableExpression[JLong](
     expr,
-    rd)
+    ci)
   with InfosetCachedEvaluatable[JLong] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class OutputNewLineEv(expr: CompiledExpression[String], rd: TermRuntimeData)
+class OutputNewLineEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](
     expr,
     OutputNewLineCooker,
-    rd)
+    ci)
   with InfosetCachedEvaluatable[String] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class ChoiceDispatchKeyEv(expr: CompiledExpression[String], rd: TermRuntimeData)
+class ChoiceDispatchKeyEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](
     expr,
     ChoiceDispatchKeyCooker,
-    rd)
+    ci)
   with InfosetCachedEvaluatable[String] {
   override lazy val runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvFieldDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvFieldDFA.scala
@@ -20,10 +20,10 @@ package org.apache.daffodil.processors
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.processors.dfa.DFAField
 import org.apache.daffodil.processors.dfa.CreateFieldDFA
+import org.apache.daffodil.dsom.DPathCompileInfo
 
-
-class FieldDFAParseEv(val escapeSchemeEv: Maybe[EscapeSchemeParseEv], rd: RuntimeData)
-  extends Evaluatable[DFAField](rd)
+class FieldDFAParseEv(val escapeSchemeEv: Maybe[EscapeSchemeParseEv], ci: DPathCompileInfo)
+  extends Evaluatable[DFAField](ci)
   with InfosetCachedEvaluatable[DFAField] {
 
   override lazy val runtimeDependencies = escapeSchemeEv.toList

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
@@ -29,23 +29,23 @@ import org.apache.daffodil.layers.LayerTransformerFactory
 /*
  * Layering-related Evaluatables
  */
-final class LayerTransformEv(override val expr: CompiledExpression[String], trd: TermRuntimeData)
+final class LayerTransformEv(override val expr: CompiledExpression[String], tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](
     expr,
     UpperCaseTokenCooker, // cooker insures upper-case and trimmed of whitespace.
-    trd)
+    tci)
   with NoCacheEvaluatable[String]
 
-final class LayerEncodingEv(override val expr: CompiledExpression[String], trd: TermRuntimeData)
-  extends EncodingEvBase(expr, trd)
+final class LayerEncodingEv(override val expr: CompiledExpression[String], tci: DPathCompileInfo)
+  extends EncodingEvBase(expr, tci)
 
-final class LayerCharsetEv(layerEncodingEv: LayerEncodingEv, override val trd: TermRuntimeData)
-  extends CharsetEvBase(layerEncodingEv, trd)
+final class LayerCharsetEv(layerEncodingEv: LayerEncodingEv, override val ci: DPathCompileInfo)
+  extends CharsetEvBase(layerEncodingEv, ci)
 
-final class LayerLengthInBytesEv(override val expr: CompiledExpression[JLong], override val rd: TermRuntimeData)
+final class LayerLengthInBytesEv(override val expr: CompiledExpression[JLong], override val ci: DPathCompileInfo)
   extends EvaluatableExpression[JLong](
     expr,
-    rd)
+    ci)
   with NoCacheEvaluatable[JLong] {
   override lazy val runtimeDependencies = Vector()
 
@@ -58,10 +58,10 @@ final class LayerLengthInBytesEv(override val expr: CompiledExpression[JLong], o
   }
 }
 
-final class LayerBoundaryMarkEv(override val expr: CompiledExpression[String], override val rd: TermRuntimeData)
+final class LayerBoundaryMarkEv(override val expr: CompiledExpression[String], override val ci: DPathCompileInfo)
   extends EvaluatableExpression[String](
     expr,
-    rd)
+    ci)
   with NoCacheEvaluatable[String] {
   override lazy val runtimeDependencies = Vector()
 }
@@ -73,8 +73,8 @@ final class LayerTransformerEv(
   maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
   maybeLayerLengthUnits: Maybe[LayerLengthUnits],
   maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-  trd: TermRuntimeData)
-  extends Evaluatable[LayerTransformer](trd)
+  ci: DPathCompileInfo)
+  extends Evaluatable[LayerTransformer](ci)
   with NoCacheEvaluatable[LayerTransformer] {
 
   override lazy val runtimeDependencies = layerTransformEv +:
@@ -89,13 +89,13 @@ final class LayerTransformerEv(
   override def compute(state: State): LayerTransformer = {
     val layerTransform = layerTransformEv.evaluate(state)
     val factory = LayerTransformerFactory.find(layerTransform, state)
-    val xformer = factory.newInstance(maybeLayerCharsetEv,
+    val xformer = factory.newInstance(
+      maybeLayerCharsetEv,
       maybeLayerLengthKind,
       maybeLayerLengthInBytesEv,
       maybeLayerLengthUnits,
       maybeLayerBoundaryMarkEv,
-      trd)
+      ci)
     xformer
   }
 }
-

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
@@ -24,38 +24,38 @@ import org.apache.daffodil.cookers.TextStandardExponentRepCooker
 import org.apache.daffodil.cookers.TextBooleanTrueRepCooker
 import org.apache.daffodil.cookers.TextStandardDecimalSeparatorCooker
 
-class TextStandardDecimalSeparatorEv(expr: CompiledExpression[String], trd: TermRuntimeData)
+class TextStandardDecimalSeparatorEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, List[String]](
     expr,
     TextStandardDecimalSeparatorCooker,
-    trd)
+    tci)
   with InfosetCachedEvaluatable[List[String]] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], trd: TermRuntimeData)
+class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](
     expr,
     TextStandardGroupingSeparatorCooker,
-    trd)
+    tci)
   with InfosetCachedEvaluatable[String] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class TextStandardExponentRepEv(expr: CompiledExpression[String], trd: TermRuntimeData)
+class TextStandardExponentRepEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](
     expr,
     TextStandardExponentRepCooker,
-    trd)
+    tci)
   with InfosetCachedEvaluatable[String] {
   override lazy val runtimeDependencies = Vector()
 }
 
-class TextBooleanTrueRepEv(exprT: CompiledExpression[String], falseRepEv: TextBooleanFalseRepEv, mustBeSameLength: Boolean, trd: TermRuntimeData)
+class TextBooleanTrueRepEv(exprT: CompiledExpression[String], falseRepEv: TextBooleanFalseRepEv, mustBeSameLength: Boolean, tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, List[String]](
     exprT,
     TextBooleanTrueRepCooker,
-    trd)
+    tci)
   with InfosetCachedEvaluatable[List[String]] {
   override lazy val runtimeDependencies = Vector()
 
@@ -71,7 +71,7 @@ class TextBooleanTrueRepEv(exprT: CompiledExpression[String], falseRepEv: TextBo
       if (trueLength != falseLength ||
         textBooleanTrueReps.exists(x => x.length != trueLength) ||
         textBooleanFalseReps.exists(x => x.length != falseLength)) {
-        trd.schemaDefinitionError("If dfdl:lengthKind is 'explicit' or 'implicit' and either dfdl:textPadKind or dfdl:textTrimKind  is 'none' then both dfdl:textBooleanTrueRep and dfdl:textBooleanFalseRep must have the same length.")
+        tci.schemaDefinitionError("If dfdl:lengthKind is 'explicit' or 'implicit' and either dfdl:textPadKind or dfdl:textTrimKind  is 'none' then both dfdl:textBooleanTrueRep and dfdl:textBooleanFalseRep must have the same length.")
       }
       textBooleanTrueReps
     } else {
@@ -80,11 +80,11 @@ class TextBooleanTrueRepEv(exprT: CompiledExpression[String], falseRepEv: TextBo
   }
 }
 
-class TextBooleanFalseRepEv(expr: CompiledExpression[String], trd: TermRuntimeData)
+class TextBooleanFalseRepEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, List[String]](
     expr,
     TextBooleanFalseRepCooker,
-    trd)
+    tci)
   with InfosetCachedEvaluatable[List[String]] {
   override lazy val runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -63,6 +63,7 @@ import org.apache.daffodil.processors.dfa.Registers
 import org.apache.daffodil.processors.dfa.RegistersPool
 import org.apache.daffodil.processors.dfa.RegistersPool
 import org.apache.daffodil.processors.dfa.RegistersPool
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 /**
  * Trait mixed into the PState.Mark object class and the ParseOrUnparseState
@@ -131,7 +132,7 @@ abstract class ParseOrUnparseState protected (
   protected var variableBox: VariableBox,
   var diagnostics: List[Diagnostic],
   var dataProc: Maybe[DataProcessor],
-  override val tunable: DaffodilTunables) extends DFDL.State
+  val tunable: DaffodilTunables) extends DFDL.State
   with StateForDebugger
   with ThrowsSDE
   with SavesErrorsAndWarnings
@@ -139,8 +140,7 @@ abstract class ParseOrUnparseState protected (
   with EncoderDecoderMixin
   with Logging
   with FormatInfo
-  with SetProcessorMixin
-  with HasTunable {
+  with SetProcessorMixin {
 
   def this(vmap: VariableMap, diags: List[Diagnostic], dataProc: Maybe[DataProcessor], tunable: DaffodilTunables) =
     this(new VariableBox(vmap), diags, dataProc, tunable)
@@ -544,8 +544,8 @@ abstract class ParseOrUnparseState protected (
  *  inconsistent with constant-value are attempted to be extracted from the state. By "blow up" it throws
  *  a structured set of exceptions, typically children of InfosetException or VariableException.
  */
-final class CompileState(trd: RuntimeData, maybeDataProc: Maybe[DataProcessor], tunable: DaffodilTunables)
-  extends ParseOrUnparseState(trd.variableMap, Nil, maybeDataProc, tunable) {
+final class CompileState(tci: DPathCompileInfo, maybeDataProc: Maybe[DataProcessor], tunable: DaffodilTunables)
+  extends ParseOrUnparseState(tci.variableMap, Nil, maybeDataProc, tunable) {
 
   def arrayPos: Long = 1L
   def bitLimit0b: MaybeULong = MaybeULong.Nope
@@ -561,7 +561,7 @@ final class CompileState(trd: RuntimeData, maybeDataProc: Maybe[DataProcessor], 
     if (infoset_.isDefined)
       infoset_.value
     else
-      throw new InfosetNoInfosetException(One(trd)) // for expressions evaluated in debugger, default expressions for top-level variable decls.
+      throw new InfosetNoInfosetException(One(tci)) // for expressions evaluated in debugger, default expressions for top-level variable decls.
 
   def currentNode = Maybe(infoset.asInstanceOf[DINode])
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -810,7 +810,8 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
       null, // override val unqualifiedPathStepPolicy : UnqualifiedPathStepPolicy,
       null, // typeCalcMap: TypeCalcMap,
       null, // lexicalContextRuntimeData: RuntimeData,
-      null), // val sscd: String),
+      null, // val sscd: String),
+      false), // val hasOutputValueCalc: Boolean
     null, // SchemaFileLocation
     local, // diagnosticDebugName: String,
     local, // pathArg: => String,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/CreateDelimiterDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/CreateDelimiterDFA.scala
@@ -30,6 +30,7 @@ import org.apache.daffodil.processors.WSPDelim
 import org.apache.daffodil.processors.WSPPlusDelim
 import org.apache.daffodil.processors.WSPStarDelim
 import org.apache.daffodil.processors.parsers.DelimiterTextType
+import org.apache.daffodil.dsom.DPathCompileInfo
 
 object CreateDelimiterDFA {
 
@@ -37,65 +38,65 @@ object CreateDelimiterDFA {
    * Constructs an Array of states reflecting the delimiters only.
    * StateNum is offset by stateOffset
    */
-  protected def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiter: Seq[DelimBase], delimiterStr: String, outputNewLine: String): DFADelimiter = {
+  protected def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiter: Seq[DelimBase], delimiterStr: String, outputNewLine: String): DFADelimiter = {
 
     val allStates: ArrayBuffer[State] = ArrayBuffer.empty
 
     buildTransitions(delimiter, allStates, false)
 
     val unparseValue = delimiter.map { _.unparseValue(outputNewLine) }.mkString
-    new DFADelimiterImplUnparse(delimType, allStates.reverse.toArray, delimiterStr, unparseValue, rd.schemaFileLocation)
+    new DFADelimiterImplUnparse(delimType, allStates.reverse.toArray, delimiterStr, unparseValue, ci.schemaFileLocation)
   }
 
   /**
    * Constructs an Array of states reflecting the delimiters only.
    * StateNum is offset by stateOffset
    */
-  protected def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiter: Seq[DelimBase], delimiterStr: String, ignoreCase: Boolean): DFADelimiter = {
+  protected def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiter: Seq[DelimBase], delimiterStr: String, ignoreCase: Boolean): DFADelimiter = {
 
     val allStates: ArrayBuffer[State] = ArrayBuffer.empty
 
     buildTransitions(delimiter, allStates, ignoreCase)
 
-    new DFADelimiterImpl(delimType, allStates.reverse.toArray, delimiterStr, rd.schemaFileLocation)
+    new DFADelimiterImpl(delimType, allStates.reverse.toArray, delimiterStr, ci.schemaFileLocation)
   }
 
   /**
    * Converts a String to a DFA representing
    * that string
    */
-  def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiterStr: String, ignoreCase: Boolean): DFADelimiter = {
+  def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiterStr: String, ignoreCase: Boolean): DFADelimiter = {
     val d = new Delimiter()
     d.compileDelimiter(delimiterStr, ignoreCase)
     val db = d.delimBuf
-    apply(delimType, rd, db, delimiterStr, ignoreCase)
+    apply(delimType, ci, db, delimiterStr, ignoreCase)
   }
 
   /**
    * Converts a String to a DFA representing
    * that string
    */
-  def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiterStr: String, outputNewLine: String): DFADelimiter = {
+  def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiterStr: String, outputNewLine: String): DFADelimiter = {
     val d = new Delimiter()
     d.compileDelimiter(delimiterStr, false)
     val db = d.delimBuf
-    apply(delimType, rd, db, delimiterStr, outputNewLine)
+    apply(delimType, ci, db, delimiterStr, outputNewLine)
   }
 
   /**
    * Converts a Seq of String to a Seq of
    * DFA's representing each String with outputNewLine.
    */
-  def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiters: Seq[String], outputNewLine: String): Array[DFADelimiter] = {
-    delimiters.map(d => apply(delimType, rd, d, outputNewLine)).toArray
+  def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiters: Seq[String], outputNewLine: String): Array[DFADelimiter] = {
+    delimiters.map(d => apply(delimType, ci, d, outputNewLine)).toArray
   }
 
   /**
    * Converts a Seq of String to a Seq of
    * DFA's representing each String.
    */
-  def apply(delimType: DelimiterTextType.Type, rd: RuntimeData, delimiters: Seq[String], ignoreCase: Boolean): Array[DFADelimiter] = {
-    delimiters.map(d => apply(delimType, rd, d, ignoreCase)).toArray
+  def apply(delimType: DelimiterTextType.Type, ci: DPathCompileInfo, delimiters: Seq[String], ignoreCase: Boolean): Array[DFADelimiter] = {
+    delimiters.map(d => apply(delimType, ci, d, ignoreCase)).toArray
   }
 
   /**
@@ -127,7 +128,8 @@ object CreateDelimiterDFA {
     theState
   }
 
-  private def buildTransitions(delim: Seq[DelimBase],
+  private def buildTransitions(
+    delim: Seq[DelimBase],
     allStates: ArrayBuffer[State], ignoreCase: Boolean): State = {
     assert(!delim.isEmpty)
     buildTransitions(null, delim.reverse, allStates, ignoreCase)
@@ -142,7 +144,8 @@ object CreateDelimiterDFA {
       return nextState
     }
 
-    val currentState = getState(delim(0),
+    val currentState = getState(
+      delim(0),
       if (nextState == null) DFA.FinalState else nextState.stateNum,
       delim.length - 1, allStates, ignoreCase)
     val rest = delim.tail


### PR DESCRIPTION
No functional change here. Just a cleanup. 

Lots of places in the code are using the RuntimeData objects that have no need of anything there beyond just the CompileInfo part of it. This change just decouples that code from anything we change about the RuntimeData objects. 

DAFFODIL-2250