### PR TITLE
Remove GitHub Actions linux dependency step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,15 +36,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1.0.0
 
-      - name: Install Dependencies (Linux)
-        run: |
-          echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-          sudo apt-get -y update
-          sudo apt-get -y install rpm sbt
-        shell: bash
-        if: runner.os == 'Linux'
-
       - name: Install Dependencies (Windows)
         run: |
           choco install sbt


### PR DESCRIPTION
We currently run apt-get to install linux dependencies like RPM and SBT
as part of our Github Actions workflow. Unfortunately, GitHub has
updated their container to include a Microsoft repository that is buggy
and started breaking builds everyone's builds that ran apt. We could
remove just this buggy repo, but other repos could always break in the
future.

Fortunately, it the GitHub Actions container now includes SBT and RPM by
default, so our dependencies are already met. So remove the Install
Linux Dependencies step so we never have to worry about random
repositories breaking our build.

DAFFODIL-2253