### PR TITLE
Purge scala.math.{BigInt BigDecimal}

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -1338,16 +1338,10 @@ abstract class LiteralExpressionBase(value: Any)
   lazy val litValue:DataValuePrimitive = value match {
     case s: String => s
     case i: Int => i
-    case i: BigInt => {
-      Assert.usageError("Expected java.math.BigInteger but received BigInt.")
-    }
     case i: JBigInt => {
       if (Numbers.isValidInt(i)) i.intValue()
       else if (Numbers.isValidLong(i)) i.longValue()
       else i
-    }
-    case bd: BigDecimal => {
-      Assert.usageError("Expected java.math.BigDecimal but received scala BigDecimal.")
     }
     case bd: JBigDecimal => {
       // since we got a JBigDecimal, we know it at least wasn't parsed
@@ -1376,9 +1370,7 @@ abstract class LiteralExpressionBase(value: Any)
   override lazy val inherentType = {
     litValue.getAnyRef match {
       case s: String => NodeInfo.String
-      case i: BigInt => Assert.usageError("Expected java.math.BigInteger but got BigInt.")
       case i: JBigInt => NodeInfo.Integer
-      case d: BigDecimal => Assert.usageError("Expected java.math.BigDecimal but got package.BigDecimal.")
       case d: JBigDecimal => NodeInfo.Decimal
       case df: JDouble => NodeInfo.Double
       case l: JLong => NodeInfo.Long

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RestrictionUnion.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RestrictionUnion.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.dsom
 
-import java.math.{BigInteger => JBigInt}
+import java.math.{BigInteger => JBigInt, BigDecimal => JBigDecimal}
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.exceptions.UnsuppressableException
 import scala.xml.Node
@@ -297,20 +297,20 @@ final class Union(val xmlArg: Node, simpleTypeDef: SimpleTypeDefBase)
 }
 
 sealed trait TypeChecks { self: Restriction =>
-  protected def dateToBigDecimal(date: String, format: String, dateType: String, context: ThrowsSDE): java.math.BigDecimal = {
+  protected def dateToBigDecimal(date: String, format: String, dateType: String, context: ThrowsSDE): JBigDecimal = {
     val df = new SimpleDateFormat(format)
     df.setCalendar(new GregorianCalendar())
     df.setTimeZone(TimeZone.GMT_ZONE)
     val bd = try {
       val dt = df.parse(date)
-      new java.math.BigDecimal(dt.getTime())
+      new JBigDecimal(dt.getTime())
     } catch {
       case s: scala.util.control.ControlThrowable => throw s
       case u: UnsuppressableException => throw u
       case e1: Exception => {
         try {
           // Could already be a BigDecimal
-          new java.math.BigDecimal(date)
+          new JBigDecimal(date)
         } catch {
           case s: scala.util.control.ControlThrowable => throw s
           case u: UnsuppressableException => throw u
@@ -321,16 +321,16 @@ sealed trait TypeChecks { self: Restriction =>
     bd
   }
 
-  private def convertStringToBigDecimal(value: String, primType: PrimType, context: ThrowsSDE): java.math.BigDecimal = {
+  private def convertStringToBigDecimal(value: String, primType: PrimType, context: ThrowsSDE): JBigDecimal = {
     primType match {
       case PrimType.DateTime => dateToBigDecimal(value, "uuuu-MM-dd'T'HH:mm:ss.SSSSSSxxx", PrimType.DateTime.toString(), context)
       case PrimType.Date => dateToBigDecimal(value, "uuuu-MM-ddxxx", PrimType.Date.toString(), context)
       case PrimType.Time => dateToBigDecimal(value, "HH:mm:ss.SSSSSSxxx", PrimType.Time.toString(), context)
-      case _ => new java.math.BigDecimal(value)
+      case _ => new JBigDecimal(value)
     }
   }
 
-  def checkRangeReturnsValue(value: String, primType: PrimType, theContext: ThrowsSDE): (Boolean, Option[BigDecimal]) = {
+  def checkRangeReturnsValue(value: String, primType: PrimType, theContext: ThrowsSDE): (Boolean, Option[JBigDecimal]) = {
     // EmptyString is only valid for hexBinary and String
     if ((value == null | value.length() == 0)) {
       return primType match {
@@ -349,8 +349,8 @@ sealed trait TypeChecks { self: Restriction =>
 
     // Check Boolean, and the Numeric types.
     (value.toLowerCase(), primType) match {
-      case ("true", PrimType.Boolean) => (true, Some(BigDecimal(1)))
-      case ("false", PrimType.Boolean) => (true, Some(BigDecimal(0)))
+      case ("true", PrimType.Boolean) => (true, Some(JBigDecimal.ONE))
+      case ("false", PrimType.Boolean) => (true, Some(JBigDecimal.ZERO))
       case (x, PrimType.Boolean) => theContext.SDE("%s is not a valid Boolean value. Expected 'true' or 'false'.", x)
       case (_, _) => {
         // Perform conversions once
@@ -403,49 +403,49 @@ sealed trait TypeChecks { self: Restriction =>
     boolResult
   }
 
-  protected def isNumInRange(num: java.math.BigDecimal, min: java.math.BigDecimal,
-    max: java.math.BigDecimal): Boolean = {
+  protected def isNumInRange(num: JBigDecimal, min: JBigDecimal,
+    max: JBigDecimal): Boolean = {
     val checkMin = num.compareTo(min)
     if (checkMin < 0) { return false } // num less than min
     val checkMax = num.compareTo(max)
     if (checkMax > 0) { return false } // num greater than max
     true
   }
-  protected def isInByteRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Byte.MinValue.toLong.toString())
-    val max = new java.math.BigDecimal(Byte.MaxValue.toLong.toString())
+  protected def isInByteRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Byte.MinValue.toLong.toString())
+    val max = new JBigDecimal(Byte.MaxValue.toLong.toString())
     isNumInRange(value, min, max)
   }
-  protected def isInShortRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Short.MinValue.toLong.toString())
-    val max = new java.math.BigDecimal(Short.MaxValue.toLong.toString())
+  protected def isInShortRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Short.MinValue.toLong.toString())
+    val max = new JBigDecimal(Short.MaxValue.toLong.toString())
     isNumInRange(value, min, max)
   }
-  protected def isInIntRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Int.MinValue.toString())
-    val max = new java.math.BigDecimal(Int.MaxValue.toString())
+  protected def isInIntRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Int.MinValue.toString())
+    val max = new JBigDecimal(Int.MaxValue.toString())
     isNumInRange(value, min, max)
   }
-  protected def isInIntegerRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Int.MinValue.toString())
+  protected def isInIntegerRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Int.MinValue.toString())
     // Unbounded Integer
     val checkMin = value.compareTo(min)
     if (checkMin < 0) { return false } // num less than min
     true
   }
-  protected def isInLongRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Long.MinValue.toString())
-    val max = new java.math.BigDecimal(Long.MaxValue.toString())
+  protected def isInLongRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Long.MinValue.toString())
+    val max = new JBigDecimal(Long.MaxValue.toString())
     isNumInRange(value, min, max)
   }
-  protected def isInDoubleRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Double.MinValue.toString())
-    val max = new java.math.BigDecimal(Double.MaxValue.toString())
+  protected def isInDoubleRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Double.MinValue.toString())
+    val max = new JBigDecimal(Double.MaxValue.toString())
     isNumInRange(value, min, max)
   }
-  protected def isInFloatRange(value: java.math.BigDecimal): Boolean = {
-    val min = new java.math.BigDecimal(Float.MinValue.toString())
-    val max = new java.math.BigDecimal(Float.MaxValue.toString())
+  protected def isInFloatRange(value: JBigDecimal): Boolean = {
+    val min = new JBigDecimal(Float.MinValue.toString())
+    val max = new JBigDecimal(Float.MaxValue.toString())
     isNumInRange(value, min, max)
   }
 
@@ -467,45 +467,45 @@ sealed trait TypeChecks { self: Restriction =>
    *
    * See http://stackoverflow.com/questions/35435691/bigdecimal-precision-and-scale
    */
-  protected def isInDecimalRange(value: java.math.BigDecimal): Boolean = {
+  protected def isInDecimalRange(value: JBigDecimal): Boolean = {
     true
   }
-  protected def isInNegativeIntegerRange(value: java.math.BigDecimal, context: ThrowsSDE): Boolean = {
+  protected def isInNegativeIntegerRange(value: JBigDecimal, context: ThrowsSDE): Boolean = {
     // TODO: NegativeInteger not supported in DFDL v1.0
-    val min = new java.math.BigDecimal(Int.MinValue.toString())
-    // val max = new java.math.BigDecimal(Int.MaxValue.toString())
+    val min = new JBigDecimal(Int.MinValue.toString())
+    // val max = new JBigDecimal(Int.MaxValue.toString())
     val isNegative = value.signum == -1
     if (!isNegative) context.SDE("Expected a negative integer for this value.")
     val checkMin = value.compareTo(min)
     if (checkMin < 0) context.SDE("Value (%s) was found to be more negative than allowed by Int.MinValue.", value.intValue())
     true
   }
-  protected def isInNonNegativeIntegerRange(value: java.math.BigDecimal): Boolean = {
+  protected def isInNonNegativeIntegerRange(value: JBigDecimal): Boolean = {
     // Should be treated as unsigned Integer (unbounded)
-    // val min = java.math.BigDecimal.ZERO
+    // val min = JBigDecimal.ZERO
     val isNegative = value.signum == -1
     if (isNegative) return false
     true
   }
-  protected def isInUnsignedXXXRange(value: java.math.BigDecimal, numBits: Int, typeName: String): Boolean = {
+  protected def isInUnsignedXXXRange(value: JBigDecimal, numBits: Int, typeName: String): Boolean = {
     Assert.usage(numBits <= 64, "isInUnsignedXXXRange: numBits must be <= 64.")
-    // val min = java.math.BigDecimal.ZERO
-    val max = new java.math.BigDecimal(JBigInt.ONE.shiftLeft(numBits)).subtract(new java.math.BigDecimal(1))
+    // val min = JBigDecimal.ZERO
+    val max = new JBigDecimal(JBigInt.ONE.shiftLeft(numBits)).subtract(new JBigDecimal(1))
     val isNegative = value.signum == -1
     if (isNegative) return false
     val checkMax = value.compareTo(max)
     if (checkMax > 0) return false
     true
   }
-  protected def isInUnsignedLongRange(value: java.math.BigDecimal): Boolean =
+  protected def isInUnsignedLongRange(value: JBigDecimal): Boolean =
     isInUnsignedXXXRange(value, 64, "ulong")
 
-  protected def isInUnsignedIntRange(value: java.math.BigDecimal): Boolean =
+  protected def isInUnsignedIntRange(value: JBigDecimal): Boolean =
     isInUnsignedXXXRange(value, 32, "uint")
 
-  protected def isInUnsignedShortRange(value: java.math.BigDecimal): Boolean =
+  protected def isInUnsignedShortRange(value: JBigDecimal): Boolean =
     isInUnsignedXXXRange(value, 16, "ushort")
 
-  protected def isInUnsignedByteRange(value: java.math.BigDecimal): Boolean =
+  protected def isInUnsignedByteRange(value: JBigDecimal): Boolean =
     isInUnsignedXXXRange(value, 8, "ubyte")
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
@@ -147,7 +147,7 @@ class TestDFDLExpressionTree extends Parsers {
       val List(n1, n2, n3) = steps
       val u @ Up(None) = n1; assertNotNull(u)
       val u2 @ Up(Some(PredicateExpression(LiteralExpression(two: JBigInt)))) = n2; assertNotNull(u2)
-      assertEquals(BigDecimal(2), BigDecimal(two))
+      assertEquals(JBigInt.valueOf(2), two)
       val n3p @ NamedStep("bookstore", None) = n3; assertNotNull(n3p)
     }
   }
@@ -244,8 +244,8 @@ class TestDFDLExpressionTree extends Parsers {
   @Test def testAddConstants() {
     testExpr(dummySchema, "{ 1 + 2 }") { actual =>
       val a @ WholeExpression(_, AdditiveExpression("+", List(LiteralExpression(one: JBigInt), LiteralExpression(two: JBigInt))), _, _, _) = actual; assertNotNull(a)
-      assertEquals(BigDecimal(1), BigDecimal(one))
-      assertEquals(BigDecimal(2), BigDecimal(two))
+      assertEquals(JBigInt.valueOf(1), one)
+      assertEquals(JBigInt.valueOf(2), two)
     }
   }
 
@@ -257,10 +257,9 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_numbers1() = {
     testExpr(dummySchema, "{ 0. }") { actual: Expression =>
-      val res = BigDecimal("0.0")
-      val a @ WholeExpression(_, LiteralExpression(actualRes), _, _, _) = actual; assertNotNull(a)
-      val bd = BigDecimal(actualRes.asInstanceOf[JBigDecimal])
-      assertEquals(res, bd)
+      val res = JBigDecimal.ZERO
+      val a @ WholeExpression(_, LiteralExpression(actualRes: JBigDecimal), _, _, _) = actual; assertNotNull(a)
+      assertEquals(res, actualRes)
     }
   }
 
@@ -287,14 +286,14 @@ class TestDFDLExpressionTree extends Parsers {
     }
 
     testExpr(dummySchema, "{ 0 }") { actual =>
-      val res = scala.math.BigInt(0)
+      val res = JBigInt.ZERO
       val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _) = actual; assertNotNull(a)
-      assertEquals(res, BigInt(actualRes))
+      assertEquals(res, actualRes)
     }
     testExpr(dummySchema, "{ 9817239872193792873982173948739879128370982398723897921370 }") { actual =>
-      val res = scala.math.BigInt("9817239872193792873982173948739879128370982398723897921370")
+      val res = new JBigInt("9817239872193792873982173948739879128370982398723897921370")
       val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _) = actual; assertNotNull(a)
-      assertEquals(res, BigInt(actualRes))
+      assertEquals(res, actualRes)
     }
 
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -17,27 +17,29 @@
 
 package org.apache.daffodil.dsom
 
+import java.math.{ BigInteger => JBigInt }
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.LongBuffer
 
-import junit.framework.Assert._
-import org.junit.Test
-import org.junit.After
 import org.apache.daffodil.api.DaffodilTunables
-import org.apache.daffodil.util.Misc
-import org.apache.daffodil.schema.annotation.props.gen.BitOrder
-import org.apache.daffodil.io.InputSourceDataInputStream
-import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import org.apache.daffodil.io.DataInputStream
 import org.apache.daffodil.io.FormatInfo
-import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.schema.annotation.props.gen.BinaryFloatRep
-import org.apache.daffodil.util.MaybeInt
-import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
-import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
+import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
+import org.apache.daffodil.schema.annotation.props.gen.BinaryFloatRep
+import org.apache.daffodil.schema.annotation.props.gen.BitOrder
+import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
+import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
+import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.MaybeInt
+import org.apache.daffodil.util.Misc
+import org.junit.After
+import org.junit.Test
+
+import junit.framework.Assert.assertEquals
 
 // Do no harm number 16 of 626 fail in regression, 154 in total of 797
 
@@ -190,27 +192,27 @@ class TestBinaryInput_01 {
   @Test
   def testBufferLongBigEndianExtraction() {
     val (dis, finfo) = fromString("Harrison", BE, msbFirst)
-    assertEquals(BigInt(5215575679192756078L), getBigInt(finfo, dis, 0, 64))
+    assertEquals(JBigInt.valueOf(5215575679192756078L), getBigInt(finfo, dis, 0, 64))
   }
 
   @Test
   def testBufferLongLittleEndianExtraction() {
     val (dis, finfo) = fromString("Harrison", LE, msbFirst)
-    assertEquals(BigInt(7957705963315814728L), getBigInt(finfo, dis, 0, 64))
+    assertEquals(JBigInt.valueOf(7957705963315814728L), getBigInt(finfo, dis, 0, 64))
   }
 
   @Test
   def testBufferBigIntBigEndianExtraction() {
     val (dis, finfo) = fromString("Something in the way she moves, ", BE, msbFirst)
     val bigInt = getBigInt(finfo, dis, 0, 256)
-    assertEquals(BigInt("37738841482167102822784581157237036764884875846207476558974346160344516471840"),
+    assertEquals(new JBigInt("37738841482167102822784581157237036764884875846207476558974346160344516471840"),
       bigInt)
   }
 
   @Test
   def testBufferBigIntLittleEndianExtraction() {
     val (dis, finfo) = fromString("Something in the way she moves, ", LE, msbFirst)
-    assertEquals(BigInt("14552548861771956163454220823873430243364312915206513831353612029437431082835"),
+    assertEquals(new JBigInt("14552548861771956163454220823873430243364312915206513831353612029437431082835"),
       getBigInt(finfo, dis, 0, 256))
   }
 
@@ -302,7 +304,7 @@ class TestBinaryInput_01 {
   }
 
   @Test def testOneBit3LSBFirst() {
-    val (dis, finfo) = fromBytes(BigInt(0xE4567A).toByteArray, LE, lsbFirst)
+    val (dis, finfo) = fromBytes(JBigInt.valueOf(0xE4567A).toByteArray, LE, lsbFirst)
 
     val bit1 = getLong(finfo, dis, 13, 12)
     assertEquals(0x2B7, bit1)

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStream.scala
@@ -17,14 +17,15 @@
 
 package org.apache.daffodil.io
 
+import java.math.{ BigInteger => JBigInt }
 import java.util.regex.Matcher
-
-import passera.unsigned.ULong
 
 import org.apache.daffodil.exceptions.ThinThrowable
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.util.Poolable
+
+import passera.unsigned.ULong
 
 /*
  * TODO:
@@ -353,7 +354,7 @@ trait DataInputStream
    * It is recommended that getUnsignedLong be used for any bit length 64 or less, as
    * that method does not require a heap allocated object to represent the value.
    */
-  def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt
+  def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt
 
   /**
    * Constructs a big integer from the data. The current bit order and byte order are used.
@@ -373,7 +374,7 @@ trait DataInputStream
    * It is recommended that getSignedLong be used for any bit length 64 or less, as
    * that method does not require a heap allocated object to represent the value.
    */
-  def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt
+  def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt
 
   /**
    * Float and Double

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStream.scala
@@ -24,6 +24,7 @@ import java.io.File
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.util.Logging
 import org.apache.daffodil.util.Maybe
+import java.math.{BigInteger => JBigInt}
 
 sealed abstract class ZeroLengthStatus
 object ZeroLengthStatus {
@@ -176,7 +177,7 @@ trait DataOutputStream extends DataStreamCommon
    * It is a usage error if bitLengthFrom1 is not greater than or equal to 1.
    *
    */
-  def putBigInt(bigInt: BigInt, bitLengthFrom1: Int, signed: Boolean, finfo: FormatInfo): Boolean
+  def putBigInt(bigInt: JBigInt, bitLengthFrom1: Int, signed: Boolean, finfo: FormatInfo): Boolean
 
   /**
    * If bitLengthFrom1 bits are available to be written before bitLimit0b (if

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -18,21 +18,21 @@
 package org.apache.daffodil.io
 
 import java.io.InputStream
+import java.math.{ BigInteger => JBigInt }
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.LongBuffer
 
-import passera.unsigned.ULong
-
-import org.apache.daffodil.equality._
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import org.apache.daffodil.util.Bits
+import org.apache.daffodil.util.MStackOf
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.MaybeULong
-import org.apache.daffodil.util.MStackOf
 import org.apache.daffodil.util.Pool
+
+import passera.unsigned.ULong
 
 /**
  * Factory for creating this type of DataInputStream
@@ -471,12 +471,12 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     }
   }
 
-  def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt = {
+  def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt = {
     // threadCheck()
     Assert.usage(bitLengthFrom1 >= 1)
 
     if (bitLengthFrom1 <= 64) {
-      BigInt(getSignedLong(bitLengthFrom1, finfo))
+      JBigInt.valueOf(getSignedLong(bitLengthFrom1, finfo))
     } else {
       val bytes = getByteArray(bitLengthFrom1, finfo)
       val fragmentLength = bitLengthFrom1 % 8
@@ -489,11 +489,11 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
         val shift = 8 - fragmentLength
         bytes(0) = ((bytes(0) << shift).toByte >> shift).toByte
       }
-      BigInt(bytes)
+      new JBigInt(bytes)
     }
   }
 
-  def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt = {
+  def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt = {
     Assert.usage(bitLengthFrom1 >= 1)
     val bytes = getByteArray(bitLengthFrom1, finfo)
     val fragmentLength = bitLengthFrom1 % 8
@@ -501,7 +501,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
       adjustBigIntArrayWithFragmentByte(bytes, fragmentLength, finfo)
     }
 
-    BigInt(1, bytes)
+    new JBigInt(1, bytes)
   }
 
   /**

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
@@ -17,10 +17,12 @@
 
 package org.apache.daffodil.io
 
-import org.apache.daffodil.util.Misc
+import java.math.{ BigInteger => JBigInt }
+
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.MaybeULong
+import org.apache.daffodil.util.Misc
 
 /**
  * When unparsing, we reuse all the DFA logic to identify delimiters within
@@ -67,9 +69,9 @@ final class StringDataInputStreamForUnparse
   override def futureData(nBytesRequested: Int): java.nio.ByteBuffer = doNotUse
   override def getBinaryDouble(finfo: FormatInfo): Double = doNotUse
   override def getBinaryFloat(finfo: FormatInfo): Float = doNotUse
-  override def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt = doNotUse
+  override def getSignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt = doNotUse
   override def getSignedLong(bitLengthFrom1To64: Int, finfo: FormatInfo): Long = doNotUse
-  override def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): BigInt = doNotUse
+  override def getUnsignedBigInt(bitLengthFrom1: Int, finfo: FormatInfo): JBigInt = doNotUse
   override def getUnsignedLong(bitLengthFrom1To64: Int, finfo: FormatInfo): passera.unsigned.ULong = doNotUse
   override def getByteArray(bitLengthFrom1: Int, finfo: FormatInfo): Array[Byte] = doNotUse
   override def getByteArray(bitLengthFrom1: Int, finfo: FormatInfo, array: Array[Byte]): Unit = doNotUse

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -20,9 +20,7 @@ package org.apache.daffodil.io
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.util.regex.Pattern
-
-import scala.BigInt
-import scala.math.BigInt.int2bigInt
+import java.math.{BigInteger => JBigInt}
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -298,7 +296,7 @@ class TestInputSourceDataInputStream {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
-    val expected = BigInt(1)
+    val expected = JBigInt.ONE
     assertTrue(expected =:= ml)
   }
 
@@ -306,24 +304,24 @@ class TestInputSourceDataInputStream {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(40, finfo)
     assertEqualsTyped[Long](40, dis.bitPos0b)
-    val expected = BigInt(0xFFFFFFC1C2C3C4C5L)
-    assertEqualsTyped[BigInt](expected, ml)
+    val expected = JBigInt.valueOf(0xFFFFFFC1C2C3C4C5L)
+    assertEqualsTyped[JBigInt](expected, ml)
   }
 
   @Test def testUnsignedBigInt1 {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(2, finfo)
     assertEqualsTyped(2, dis.bitPos0b)
-    val expected = BigInt(3)
-    assertEqualsTyped[BigInt](expected, ml)
+    val expected = JBigInt.valueOf(3)
+    assertEqualsTyped[JBigInt](expected, ml)
   }
 
   @Test def testUnsignedBigInt2 {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(40, finfo)
     assertEqualsTyped(40, dis.bitPos0b)
-    val expected = BigInt(0xC1C2C3C4C5L)
-    assertEqualsTyped[BigInt](expected, ml)
+    val expected = JBigInt.valueOf(0xC1C2C3C4C5L)
+    assertEqualsTyped[JBigInt](expected, ml)
   }
 
   @Test def testUnsignedBigInt3 {
@@ -334,7 +332,7 @@ class TestInputSourceDataInputStream {
     finfo.byteOrder = ByteOrder.LittleEndian
     finfo.bitOrder = BitOrder.LeastSignificantBitFirst
     val mbi = dis.getUnsignedBigInt(dat.length * 4, finfo)
-    val expected = BigInt(dat.reverse, 16)
+    val expected = new JBigInt(dat.reverse, 16)
     val expectedHex = "%x".format(expected)
     val actualHex = "%x".format(mbi)
     assertEqualsTyped[String](expectedHex, actualHex)
@@ -343,12 +341,12 @@ class TestInputSourceDataInputStream {
   @Test def testUnsignedBigInt4 {
     val expectedHex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
     assertEqualsTyped(720, expectedHex.length)
-    val expected = BigInt(expectedHex, 16)
-    val valueWithExtraLSByte = expected << 8
-    assertEqualsTyped[Long](0, (valueWithExtraLSByte & 0xFF).toInt)
+    val expected = new JBigInt(expectedHex, 16)
+    val valueWithExtraLSByte = expected.shiftLeft(8)
+    assertEqualsTyped[Long](0, (valueWithExtraLSByte.and(JBigInt.valueOf(0xFF))).intValue())
     assertEqualsTyped[Long](0x77, (valueWithExtraLSByte.toByteArray.dropRight(1).last & 0xFF).toInt)
-    val valueWith3BitsInLSByte = valueWithExtraLSByte >> 3
-    assertEqualsTyped[Long](0xE0, (valueWith3BitsInLSByte & 0xFF).toInt)
+    val valueWith3BitsInLSByte = valueWithExtraLSByte.shiftRight(3)
+    assertEqualsTyped[Long](0xE0, (valueWith3BitsInLSByte.and(JBigInt.valueOf(0xFF))).intValue())
     val valueWith3BitsInLSByteAsHexAsHexBytesLittleEndian = valueWith3BitsInLSByte.toByteArray.toList.reverse :+ 0.toByte
     val dat = valueWith3BitsInLSByteAsHexAsHexBytesLittleEndian.toArray
     assertEqualsTyped[Long](361, dat.length)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
@@ -98,8 +98,6 @@ object Numbers {
       case s: JShort => s.toInt
       case i: JInt => return i
       case l: JLong => l.toInt
-      case bi: BigInt => bi.toInt
-      case bd: BigDecimal => bd.toInt
       case bi: JBigInt => bi.intValue()
       case bd: JBigDecimal => bd.intValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Int. %s of type %s".format(
@@ -115,8 +113,6 @@ object Numbers {
       case s: JShort => s.toByte
       case i: JInt => i.toByte
       case l: JLong => l.toByte
-      case bi: BigInt => bi.toByte
-      case bd: BigDecimal => bd.toByte
       case bi: JBigInt => bi.byteValue()
       case bd: JBigDecimal => bd.byteValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Byte. %s of type %s".format(
@@ -132,8 +128,6 @@ object Numbers {
       case s: JShort => return s
       case i: JInt => i.toShort
       case l: JLong => l.toShort
-      case bi: BigInt => bi.toShort
-      case bd: BigDecimal => bd.toShort
       case bi: JBigInt => bi.shortValue()
       case bd: JBigDecimal => bd.shortValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Short. %s of type %s".format(
@@ -150,8 +144,6 @@ object Numbers {
       case d: JDouble => d.toLong
       case f: JFloat => f.toLong
       case l: JLong => return l
-      case bi: BigInt => bi.toLong
-      case bd: BigDecimal => bd.toLong
       case bi: JBigInt => bi.longValue()
       case bd: JBigDecimal => bd.longValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Long. %s of type %s".format(
@@ -172,8 +164,6 @@ object Numbers {
       case bd: JBigDecimal => bd.toBigInteger()
       case d: JDouble => new JBigDecimal(d).toBigInteger()
       case f: JFloat => new JBigDecimal(f.toDouble).toBigInteger()
-      case bi: BigInt => bi.underlying()
-      case bd: BigDecimal => bd.underlying().toBigInteger()
       // the rest of the JNumbers are integers long or smaller.
       case jn: JNumber => new JBigInt(jn.toString())
       case _ => Assert.invariantFailed("Unsupported conversion to BigInt. %s of type %s".format(
@@ -194,8 +184,6 @@ object Numbers {
       case bd: JBigDecimal => bd.toBigInteger()
       case d: JDouble => JBigDecimal.valueOf(d).toBigInteger()
       case f: JFloat => new JBigDecimal(f.toString()).toBigInteger()
-      case bi: BigInt => bi.bigInteger
-      case bd: BigDecimal => bd.toBigInt.bigInteger
       // the rest of the JNumbers are integers long or smaller.
       case jn: JNumber => JBigInt.valueOf(jn.longValue())
       case _ => Assert.invariantFailed("Unsupported conversion to BigInt. %s of type %s".format(
@@ -218,8 +206,6 @@ object Numbers {
       case s: JShort => s.toFloat
       case i: JInt => i.toFloat
       case l: JLong => l.toFloat
-      case bi: BigInt => bi.toFloat
-      case bd: BigDecimal => bd.toFloat
       case bi: JBigInt => bi.floatValue()
       case bd: JBigDecimal => bd.floatValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Float. %s of type %s".format(
@@ -242,8 +228,6 @@ object Numbers {
       case s: JShort => s.toDouble
       case i: JInt => i.toDouble
       case l: JLong => l.toDouble
-      case bi: BigInt => bi.toDouble
-      case bd: BigDecimal => bd.toDouble
       case bi: JBigInt => bi.doubleValue()
       case bd: JBigDecimal => bd.doubleValue()
       case _ => Assert.invariantFailed("Unsupported conversion to Double. %s of type %s".format(
@@ -266,8 +250,6 @@ object Numbers {
       // HALF_EVEN rounding mode would round this to 3.45 rather than the desired 3.46.
       case f: JFloat => new java.math.BigDecimal(f.toString)
       case d: JDouble => java.math.BigDecimal.valueOf(d)
-      case bi: BigInt => new java.math.BigDecimal(bi.toString())
-      case bd: BigDecimal => bd.underlying()
       case bi: JBigInt => new java.math.BigDecimal(bi.toString())
       case bd: JBigDecimal => bd
       // The rest of the cases are integers long or smaller
@@ -292,8 +274,6 @@ object Numbers {
       // HALF_EVEN rounding mode would round this to 3.45 rather than the desired 3.46.
       case f: JFloat => new JBigDecimal(f.toString)
       case d: JDouble => JBigDecimal.valueOf(d)
-      case bi: BigInt => new JBigDecimal(bi.underlying())
-      case bd: BigDecimal => bd.bigDecimal
       case bi: JBigInt => new JBigDecimal(bi)
       case bd: JBigDecimal => bd
       // The rest of the cases are integers long or smaller
@@ -321,8 +301,6 @@ object Numbers {
       case l: Long => JLong.valueOf(l)
       case f: Float => JFloat.valueOf(f)
       case d: Double => JDouble.valueOf(d)
-      // case bi: BigInt => bi.bigInteger
-      // case bd: BigDecimal => bd.bigDecimal
       case jn: JNumber => jn
       case _ => Assert.invariantFailed("Unsupported conversion to Number. %s of type %s".format(
         n, Misc.getNameFromClass(n)))

--- a/daffodil-lib/src/main/scala/passera/unsigned/SmallUInt.scala
+++ b/daffodil-lib/src/main/scala/passera/unsigned/SmallUInt.scala
@@ -26,6 +26,7 @@
 
 package passera.unsigned
 
+import java.math.{BigInteger => JBigInt}
 
 /**
  * Supertrait of UByte, UShort, UInt
@@ -39,7 +40,7 @@ trait SmallUInt[U <: Unsigned[U, UInt, Int]] extends Any with Unsigned[U, UInt, 
   override def toFloat = intValue.toFloat
   override def toDouble = intValue.toDouble
   override def toChar = intValue.toChar
-  def toBigInt = BigInt(intValue)
+  def toBigInt = JBigInt.valueOf(intValue)
 
   def toUByte = UByte(intValue.toByte)
   def toUShort = UShort(intValue.toShort)

--- a/daffodil-lib/src/main/scala/passera/unsigned/ULong.scala
+++ b/daffodil-lib/src/main/scala/passera/unsigned/ULong.scala
@@ -26,6 +26,7 @@
 
 package passera.unsigned
 
+import java.math.{BigInteger => JBigInt}
 
 case class ULong(override val longValue: Long) extends AnyVal with Unsigned[ULong, ULong, Long] with Serializable {
   private[unsigned] def rep = longValue
@@ -42,7 +43,7 @@ case class ULong(override val longValue: Long) extends AnyVal with Unsigned[ULon
   override def toLong: Long = rep
   override def toFloat: Float = (rep & 0x7fffffffffffffffL).toFloat
   override def toDouble: Double = (rep >>> 1).toDouble * 2.0 + (rep & 1L)
-  def toBigInt: BigInt = if (rep >= 0) BigInt(rep) else ULong.MaxValueAsBigInt - rep.abs + 1
+  def toBigInt: JBigInt = if (rep >= 0) JBigInt.valueOf(rep) else ULong.MaxValueAsBigInt.subtract(JBigInt.valueOf(rep.abs)).add(JBigInt.ONE)
 
   // override def intValue = rep
   override def byteValue = toByte
@@ -250,6 +251,6 @@ object ULong {
   val Zero = MinValue
   val MaxValue = ULong(~0L)
 
-  val MaxValueAsBigInt = BigInt(Long.MinValue).abs
+  val MaxValueAsBigInt = JBigInt.valueOf(Long.MinValue).abs
   private val maxULongString = MaxValueAsBigInt.toString()
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
@@ -17,15 +17,18 @@
 
 package org.apache.daffodil.util
 
+import java.lang.{ Long => JLong, Number => JNumber }
+import java.math.{ BigInteger => JBigInt }
+import java.text.ParsePosition
+
+import org.apache.daffodil.Implicits.intercept
+import org.junit.Test
+
 import com.ibm.icu.text.DecimalFormat
 import com.ibm.icu.text.DecimalFormatSymbols
-import java.text.ParsePosition
-import junit.framework.Assert._
-import org.junit.Test
-import org.junit.Test
-import scala.math.BigInt.int2bigInt
 
-import org.apache.daffodil.Implicits._
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertTrue
 
 /**
  * Tests that characterize ICU number parsing specifically with respect
@@ -177,19 +180,19 @@ case class LongConverter() extends ConvertTo[Long] {
   def getNum(j: Number) = j.longValue
 }
 
-case class UnsignedLongConverter() extends ConvertTo[BigInt] {
+case class UnsignedLongConverter() extends ConvertTo[JBigInt] {
 
-  val maxUnsignedLong = new BigInt(new java.math.BigInteger("18446744073709551615"))
+  val maxUnsignedLong = new JBigInt("18446744073709551615")
 
-  def getNum(j: Number) = j match {
-    case l: java.lang.Long => {
-      if (l >= 0L) new BigInt(java.math.BigInteger.valueOf(l))
+  def getNum(j: JNumber) = j match {
+    case l: JLong => {
+      if (l >= 0L) JBigInt.valueOf(l)
       else throw new Exception("parsed as negative value")
     }
     case icubd: com.ibm.icu.math.BigDecimal => {
-      val ul = new BigInt(icubd.toBigIntegerExact)
-      if (ul > maxUnsignedLong) throw new Exception("too big for unsignedLong")
-      if (ul < 0) throw new Exception("parsed as negative value")
+      val ul = icubd.toBigIntegerExact
+      if (ul.compareTo(maxUnsignedLong)>0) throw new Exception("too big for unsignedLong")
+      if (ul.signum() < 0) throw new Exception("parsed as negative value")
       ul
     }
     case other => throw new Exception("not a valid unsignedLong: " + other + " : " + other.getClass.getName)

--- a/daffodil-lib/src/test/scala/passera/test/TestULong.scala
+++ b/daffodil-lib/src/test/scala/passera/test/TestULong.scala
@@ -26,8 +26,11 @@
 
 package passera.test
 
+import java.math.{ BigInteger => JBigInt }
+
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.Assert._
+
 import passera.unsigned.ULong
 
 class TestULong {
@@ -36,7 +39,7 @@ class TestULong {
     val mm1 = ULong(-1L)
     assertEquals("FFFFFFFFFFFFFFFF", mm1.toHexString.toUpperCase)
     assertEquals(ULong.MaxValueAsBigInt, mm1.toBigInt)
-    assertEquals(BigInt(Long.MinValue).abs.toString, mm1.toString)
+    assertEquals(JBigInt.valueOf(Long.MinValue).abs.toString, mm1.toString)
   }
 
   // DAFFODIL-1714

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextNumberUnparser.scala
@@ -90,12 +90,6 @@ case class ConvertTextNumberUnparser[S](
         if (d > 0) df.getPositivePrefix + dfs.getInfinity + df.getPositiveSuffix
         else df.getNegativePrefix + dfs.getInfinity + df.getNegativeSuffix
       case d: JDouble if d.isNaN => dfs.getNaN
-      // Needed because the DecimalFormat class of ICU will call
-      // doubleValue on scala's BigInt and BigDecimal because it
-      // doesn't recognize it as Java's BigInteger and BigDecimal.
-      // This caused large numbers to be truncated silently.
-      case bd: scala.math.BigDecimal => Assert.usageError("Received scala.math.BigDecimal, expected java.math.BigDecimal.")
-      case bi: scala.math.BigInt => Assert.usageError("Received scala.math.BigInt, expected java.math.BigInteger.")
       case _ =>
         try {
           df.format(value.getAnyRef)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLConstructors.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLConstructors.scala
@@ -54,8 +54,6 @@ abstract class DFDLConstructorFunction(recipe: CompiledDPath, argType: NodeInfo.
         HexStringToLong.computeValue(hexStr, dstate)
       }
       case s: String => StringToLong.computeValue(s, dstate)
-      case bi: BigInt => BigIntToLong.computeValue(bi, dstate)
-      case bd: BigDecimal if (bd.isWhole()) => BigIntToLong.computeValue(bd.toBigInt, dstate)
       case bi: JBigInt => BigIntToLong.computeValue(bi, dstate)
       case bd: JBigDecimal if (bd.remainder(JBigDecimal.ONE) == JBigDecimal.ZERO) => BigIntToLong.computeValue(bd.toBigInteger(), dstate)
       case hb: Array[Byte] => {
@@ -117,19 +115,12 @@ case class DFDLHexBinary(recipe: CompiledDPath, argType: NodeInfo.Kind)
       }
       case b: JByte => HexBinaryConversions.toByteArray(b)
       case s: JShort => HexBinaryConversions.toByteArray(s)
-      case bi: BigInt => {
-        // Literal number
-        reduce(bi)
-      }
       case i: JInt => {
         // Possibly a Literal Number, try to fit it into the smallest
         // value anyway.
         reduce(i)
       }
       case l: JLong => HexBinaryConversions.toByteArray(l)
-      case ul: BigDecimal => {
-        reduce(ul)
-      }
       case bi: JBigInt => reduce(bi)
       case bd: JBigDecimal => reduce(bd)
 
@@ -216,8 +207,6 @@ case class DFDLUnsignedLong(recipe: CompiledDPath, argType: NodeInfo.Kind)
       case s: String => StringToUnsignedLong.computeValue(s, dstate)
       case bi: JBigInt => IntegerToUnsignedLong.computeValue(bi, dstate)
       case bd: JBigDecimal => IntegerToUnsignedLong.computeValue(bd, dstate)
-      case bi: BigInt => IntegerToUnsignedLong.computeValue(bi, dstate)
-      case bd: BigDecimal => IntegerToUnsignedLong.computeValue(bd, dstate)
       case x =>
         throw new NumberFormatException(nfeMsg.format(x))
     }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
@@ -267,10 +267,6 @@ case class NumericOperator(nop: NumericOp, left: CompiledDPath, right: CompiledD
 }
 
 trait NumericOp {
-  import scala.language.implicitConversions
-
-  implicit def BigDecimalToJBigDecimal(bd: BigDecimal): JBigDecimal = bd.bigDecimal
-  implicit def BigIntToJBigInt(bi: BigInt): JBigInt = bi.bigInteger
 
   /**
    * It is such a pain that there is no scala.math.Number base class above

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
@@ -106,8 +106,6 @@ case class NegateOp(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe
       case d: JDouble => d * -1.0
       case bi: JBigInt => bi.negate()
       case bd: JBigDecimal => bd.negate()
-      case bi: BigInt => bi.underlying().negate()
-      case bd: BigDecimal => bd.underlying().negate()
       case _ => Assert.invariantFailed("not a number: " + dstate.currentValue.toString)
     }
     dstate.setCurrentValue(value)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
@@ -340,15 +340,15 @@ case class FNRoundHalfToEven(recipeNum: CompiledDPath, recipePrecision: Compiled
     recipePrecision.run(dstate)
     val precision = dstate.intValue
     val bd = unrounded.getAnyRef match {
-      case s: String => BigDecimal(s) // TODO: Remove eventually. Holdover from JDOM where everything is a string.
-      case l: JLong => BigDecimal.valueOf(l)
-      case f: JFloat => BigDecimal.valueOf(f.toDouble)
-      case d: JDouble => BigDecimal.valueOf(d)
-      case bd: BigDecimal => bd
+      case s: String => new JBigDecimal(s) // TODO: Remove eventually. Holdover from JDOM where everything is a string.
+      case l: JLong => JBigDecimal.ONE
+      case f: JFloat => JBigDecimal.valueOf(f.toDouble)
+      case d: JDouble => JBigDecimal.valueOf(d)
+      case bd: JBigDecimal => bd
       case _ => Assert.invariantFailed("not a number")
     }
     val value = {
-      val rounded = bd.setScale(precision, BigDecimal.RoundingMode.HALF_EVEN)
+      val rounded = bd.setScale(precision, RoundingMode.HALF_EVEN)
       rounded
     }
     dstate.setCurrentValue(value)
@@ -396,9 +396,7 @@ trait FNRoundHalfToEvenKind {
       //
       case _: JFloat => roundIt
       case _: JDouble => roundIt
-      case _: BigDecimal => roundIt
       case _: JBigDecimal => roundIt
-      case _: BigInt => roundIt
       case _: JBigInt => roundIt
       case _: JLong => roundIt
       case _: JInt => roundIt
@@ -422,8 +420,8 @@ trait FNRoundHalfToEvenKind {
       // Any change in how asBigDecimal handles Float
       // will affect the correctness of this rounding operation.
       //
-      case _: JFloat | _: JDouble | _: BigDecimal | _: JBigDecimal => asBigDecimal(value.getAnyRef)
-      case _: BigInt | _: JBigInt | _: JLong | _: JInt | _: JByte | _: JShort => asBigDecimal(value.getAnyRef)
+      case _: JFloat | _: JDouble | _: JBigDecimal => asBigDecimal(value.getAnyRef)
+      case _: JBigInt | _: JLong | _: JInt | _: JByte | _: JShort => asBigDecimal(value.getAnyRef)
       case _ => Assert.usageError("Received a type other than xs:decimal, xs:double, xs:float, xs:integer or any of its sub-types.")
     }
     result
@@ -445,9 +443,7 @@ trait FNRoundHalfToEvenKind {
     val result:DataValuePrimitive = origValue.getAnyRef match {
       case _: JFloat => value.getBigDecimal.floatValue() // xs:float
       case _: JDouble => value.getBigDecimal.doubleValue() // xs:double
-      case _: BigDecimal => value // xs:decimal
       case _: JBigDecimal => value
-      case _: BigInt => value.getBigDecimal.toBigInteger()
       case _: JBigInt => value.getBigDecimal.toBigInteger()
       case _: JLong | _: JInt | _: JByte | _: JShort => value.getBigDecimal.toBigInteger() // xs:integer
       case _ => Assert.usageError("Received a type other than xs:decimal, xs:double, xs:float, xs:integer or any of its sub-types.")

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -218,9 +218,7 @@ object NodeInfo extends Enum {
       case x: Byte => NodeInfo.Byte
       case x: Short => NodeInfo.Short
       case x: Long => NodeInfo.Long
-      case x: BigInt => NodeInfo.Integer
       case x: JBigInt => NodeInfo.Integer
-      case x: BigDecimal => NodeInfo.Decimal
       case x: JBigDecimal => NodeInfo.Decimal
       case x: Double => NodeInfo.Double
       case x: Float => NodeInfo.Float

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSHexBinary.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSHexBinary.scala
@@ -67,9 +67,7 @@ trait HexBinaryKind {
       case bi: JBigInt if (bi.bitLength <= 63) => reduce(bi.longValue())
       case bi: JBigInt => bi.toByteArray()
       case bd: JBigDecimal if (try { bd.toBigIntegerExact(); true } catch { case e: ArithmeticException => false }) => reduce(bd.toBigIntegerExact())
-      case bi: BigInt => reduce(bi.underlying())
-      case bd: BigDecimal if (bd.isWhole()) => reduce(bd.toBigInt.underlying())
-      case str: String => reduce(BigInt(str).underlying())
+      case str: String => reduce(new JBigInt(str))
       case _ => throw new NumberFormatException("%s could not fit into a long".format(numeric.toString))
     }
     res

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BinaryNumberParsers.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.processors.parsers
 
 import java.lang.{ Long => JLong, Number => JNumber, Double => JDouble, Float => JFloat }
+import java.math.{BigInteger => JBigInt, BigDecimal => JBigDecimal}
 
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Evaluatable
@@ -103,11 +104,11 @@ abstract class BinaryDecimalParserBase(override val context: ElementRuntimeData,
       return
     }
 
-    val bigInt: BigInt =
+    val bigInt: JBigInt =
       if (signed == YesNo.Yes) { dis.getSignedBigInt(nBits, start) }
       else { dis.getUnsignedBigInt(nBits, start) }
 
-    val bigDec = BigDecimal(bigInt, binaryDecimalVirtualPoint)
+    val bigDec = new JBigDecimal(bigInt, binaryDecimalVirtualPoint)
     start.simpleElement.overwriteDataValue(bigDec)
   }
 }

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
@@ -17,9 +17,12 @@
 
 package org.apache.daffodil.dpath
 
-import junit.framework.Assert.assertEquals
+import org.apache.daffodil.Implicits.ImplicitsSuppressUnusedImportWarning
 import org.junit.Test
-import org.apache.daffodil.Implicits._; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
+
+import junit.framework.Assert.assertEquals; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
+import java.math.{ BigDecimal => JBigDecimal }
+import java.math.RoundingMode
 
 class TestRounding {
 
@@ -40,16 +43,16 @@ class TestRounding {
 
     //val bd0 = BigDecimal(f) // 3.4549999237060547 Deprecated
     //val bd1 = BigDecimal.valueOf(f) // 3.4549999237060547 Deprecated
-    val bd2 = BigDecimal(f.doubleValue()) // 3.4549999237060547
-    val bd3 = BigDecimal(f.toString) // 3.455
+    val bd2 = new JBigDecimal(f.doubleValue()) // 3.4549999237060547
+    val bd3 = new JBigDecimal(f.toString) // 3.455
 
-    def round(value: BigDecimal, precision: Int): BigDecimal = {
-      val rounded = value.setScale(precision, BigDecimal.RoundingMode.HALF_EVEN)
+    def round(value: JBigDecimal, precision: Int): JBigDecimal = {
+      val rounded = value.setScale(precision, RoundingMode.HALF_EVEN)
       rounded
     }
 
-    val expected0_to_2 = BigDecimal(3.45) // Incorrect/unexpected result
-    val expected3 = BigDecimal(3.46) // Correct result
+    val expected0_to_2 = new JBigDecimal("3.45") // Incorrect/unexpected result
+    val expected3 = new JBigDecimal("3.46") // Correct result
 
     //val res0 = round(bd0, 2) Deprecated
     //val res1 = round(bd1, 2) Deprecated
@@ -58,8 +61,8 @@ class TestRounding {
 
     //assertEquals(0, res0.compare(expected0_to_2)) Deprecated
     //assertEquals(0, res1.compare(expected0_to_2)) Deprecated
-    assertEquals(0, res2.compare(expected0_to_2))
-    assertEquals(0, res3.compare(expected3))
+    assertEquals(0, res2.compareTo(expected0_to_2))
+    assertEquals(0, res3.compareTo(expected3))
 
   }
 


### PR DESCRIPTION
Long ago, we switch over to use just Java's version of BigInt/BigDecimal,
instead of the Scala wrapper. This commit goes through and systemetically cleans up
all lingering uses of Scala's version.

DAFFODIL-2256