### PR TITLE
Add support for textStandardBase

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -69,6 +69,7 @@ trait ElementBase
   with BooleanTextMixin
   with TextNumberFormatMixin
   with EmptyElementParsePolicyMixin
+  with TextStandardBaseMixin
   with OverlapCheckMixin {
 
   override final def eBase = this

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesNonBaseTenTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesNonBaseTenTextNumber.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.grammar.primitives
+
+import java.math.{ BigInteger => JBigInt }
+
+import org.apache.daffodil.dsom.ElementBase
+import org.apache.daffodil.grammar.Terminal
+import org.apache.daffodil.processors.parsers.Parser
+import org.apache.daffodil.processors.unparsers.Unparser
+import org.apache.daffodil.processors.parsers.ConvertNonBaseTenTextNumberParser
+import org.apache.daffodil.processors.unparsers.ConvertNonBaseTenTextNumberUnparser
+
+import org.apache.daffodil.processors.unparsers.NadaUnparser
+
+
+case class ConvertNonBaseTenTextNumberPrim(e: ElementBase)
+  extends Terminal(e, true) {
+
+  override lazy val parser: Parser =
+    new ConvertNonBaseTenTextNumberParser(
+      e.elementRuntimeData,
+      e.textStandardBaseDefaulted)
+
+  override lazy val unparser: Unparser =
+    new ConvertNonBaseTenTextNumberUnparser(
+    e.elementRuntimeData,
+    e.textStandardBaseDefaulted)
+}

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -374,6 +374,14 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="requireTextStandardBaseProperty" type="xs:boolean" default="false" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              If true, require that the dfdl:textStandardBase property is specified. If false
+              and the property is missing, behave as if the property is set to 10.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
         <xs:element name="suppressSchemaDefinitionWarnings" type="daf:TunableSuppressSchemaDefinitionWarnings" default="emptyElementParsePolicyError" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
@@ -464,6 +472,7 @@
           <xs:enumeration value="regexPatternZeroLength" />
           <xs:enumeration value="textBidiError" />
           <xs:enumeration value="textOutputMinLengthOutOfRange" />
+          <xs:enumeration value="textStandardBaseUndefined" />
           <xs:enumeration value="unsupportedAttributeBlockDefault" />
           <xs:enumeration value="unsupportedAttributeFinalDefault" />
           <xs:enumeration value="unsupportedAttributeFormDefault" />

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertNonBaseTenTextNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertNonBaseTenTextNumberUnparser.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processors.unparsers
+
+import java.lang.{ Long => JLong }
+import java.lang.{ Number => JNumber }
+import java.math.{ BigInteger => JBigInt }
+
+import org.apache.daffodil.processors.ElementRuntimeData
+
+case class ConvertNonBaseTenTextNumberUnparser(
+  override val context: ElementRuntimeData,
+  base: Int)
+  extends TextPrimUnparser {
+
+  override lazy val runtimeDependencies = Vector()
+
+  override def unparse(state: UState): Unit = {
+
+    val node = state.currentInfosetNode.asSimple
+    val value = node.dataValue
+
+    val baseStr = value.getNumber match {
+      case bi: JBigInt => {
+        if (bi.compareTo(JBigInt.ZERO) < 0) {
+          UE(state, "Unable to unparse negative values when dfdl:textStandardBase=\"%d\": %s", base, bi.toString)
+        }
+        bi.toString(base)
+      }
+      case n: JNumber => {
+        val l = n.longValue
+        if (l < 0) {
+          UE(state, "Unable to unparse negative values when dfdl:textStandardBase=\"%d\": %s", base, l.toString)
+        }
+        base match {
+          case 2 => JLong.toBinaryString(l)
+          case 8 => JLong.toOctalString(l)
+          case 16 => JLong.toHexString(l)
+        }
+      }
+    }
+
+    node.overwriteDataValue(baseStr)
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NonBaseTenTextNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NonBaseTenTextNumberParser.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processors.parsers
+
+import java.math.{ BigInteger => JBigInt }
+import java.lang.{ Number => JNumber }
+
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.processors.ElementRuntimeData
+
+class ConvertNonBaseTenTextNumberParser(
+  override val context: ElementRuntimeData,
+  base: Int)
+  extends TextPrimParser {
+
+  override lazy val runtimeDependencies = Vector()
+
+  private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
+
+  final def parse(state: PState): Unit = {
+
+    val node = state.simpleElement
+    val baseStr = node.dataValueAsString
+
+    if (baseStr == "") {
+      PE(state, "Unable to parse %s from empty string", context.optPrimType.get.globalQName)
+      return
+    }
+
+    // Must explicitly check for and error on text that start with + or -
+    // because DFDL does not allow a leading sign character, but parseInt and
+    // friends will accept them. Note that textNumberPattern is not used when
+    // textStandardBase is not 10--one might otherwise think that a +/- in the
+    // pattern would allow this.
+    val firstChar = baseStr(0)
+    if (firstChar == '-' || firstChar == '+') {
+      PE(state, "Unable to parse %s from base-%d text with leading sign: %s",
+        context.optPrimType.get.globalQName, base, baseStr)
+      return
+    }
+
+    // always parse the base string a BigInt since it allows us to differentiate
+    // between invalid characters or just too many characters for the prim type
+    val bi = try {
+      new JBigInt(baseStr, base)
+    } catch {
+      case e: NumberFormatException =>
+        PE(state, "Unable to parse %s from base-%d text due to invalid characters: %s",
+          context.optPrimType.get.globalQName, base, baseStr)
+        return
+    }
+
+    if (!primNumeric.isValidRange(bi)) {
+      PE(state, "Parsed %s is out of range for the type: %s",
+        context.optPrimType.get.globalQName, bi.toString)
+      return
+    }
+    
+    val num = primNumeric.fromNumber(bi)
+    node.overwriteDataValue(num)
+  }
+}

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaext2.tdml
@@ -145,7 +145,7 @@
 
     <tdml:parserTestCase name="simple_type_properties_text_number_13_03" root="base_group"
 		model="./fvt/ext/dpa/dpanum_properties.dfdl.xsd" 
-		 description="Section 13.5 Specification of number base - 2,8, and 16">
+		 description="Section 13.5 Specification of number base - 2,8, and 16" roundTrip="twoPass">
 		<tdml:document>0101*127*10F</tdml:document>
 		<tdml:infoset>
 			<tdml:dfdlInfoset>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BF.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BF.tdml
@@ -51,7 +51,7 @@ X:x3
   </parserTestCase>
 
   <parserTestCase name="BF001" root="root" model="BF.dfdl.xsd"
-    description="Unordered sequences">
+    description="Unordered sequences" validation="limited">
     <document><![CDATA[Y:y0
 Y:y1
 Y:y2
@@ -65,17 +65,26 @@ X:beyond
     <infoset>
       <dfdlInfoset>
         <ex:root>
-          <plain><![CDATA[Y:y0
-Y:y1
-Y:y2
-Y:y3
-Y:y4
-X:x1
-X:x2
-X:x3
-X:beyond]]></plain>
+          <seq>
+            <x>x1</x>
+            <x>x2</x>
+            <x>x3</x>
+            <x>beyond</x>
+            <y>y0</y>
+            <y>y1</y>
+            <y>y2</y>
+            <y>y3</y>
+            <y>y4</y>
+          </seq>
         </ex:root>
       </dfdlInfoset>
     </infoset>
+    <validationErrors>
+      <error>Validation Error</error>
+      <error>{}y</error>
+      <error>minOccurs='2'</error>
+      <error>maxOccurs='4'</error>
+      <error>5</error>
+    </validationErrors>
   </parserTestCase>
 </testSuite>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.dfdl.xsd
@@ -67,10 +67,9 @@
           dfdl:ignoreCase="yes" />
       </sequence>
       <sequence dfdl:separator="***" dfdl:terminator="%NL;">
-        <element name="y" type="xsd:double" maxOccurs="unbounded"
+        <element name="y" type="xsd:integer" maxOccurs="unbounded"
           dfdl:lengthKind="delimited" dfdl:textNumberRep="standard"
           dfdl:textNumberJustification="right"
-          dfdl:textNumberPattern="####"
           dfdl:textNumberPadCharacter="%SP;" dfdl:textStandardBase="16" />
       </sequence>
       <sequence dfdl:separator="***" dfdl:terminator="%NL;">

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.tdml
@@ -25,25 +25,25 @@
     description="Text number properties">
     <document><![CDATA[    9#876#543#210!01***   12#345!6*** 123456789123456789*** INFINITO***    NNN***   ZERO*** NA*** NIL
   aabbccddeeff*** 0f0f0f*** 123456789
-  10.1 *** 20.3***   -912E-13
+  10.1*** 20.3***   -912^-13
 ]]></document>
     <infoset>
       <dfdlInfoset>
         <ex:list>
-          <x>9876543210.012345678</x>
+          <x>9.87654321001E9</x>
           <x>12345.6</x>
-          <x>123456789123456789</x>
-          <x>Infinity</x>
+          <x>1.23456789123456784E17</x>
+          <x>INF</x>
           <x>NaN</x>
-          <x>0</x>
-          <x>0</x>
-          <x>0</x>
+          <x>0.0</x>
+          <x>0.0</x>
+          <x>0.0</x>
           <y>187723572702975</y>
           <y>986895</y>
           <y>4886718345</y>
           <z>10.1</z>
           <z>20.3</z>
-          <z>-0.0000000000912</z>
+          <z>-9.12E-11</z>
         </ex:list>
       </dfdlInfoset>
     </infoset>

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
@@ -94,7 +94,7 @@ class IBMTestsThatPass {
   //@Test def test_simple_type_properties_text_number_13_01() { runner2.runOneTest("simple_type_properties_text_number_13_01") }
 
   // DAFFODIL-840 textStandardBase (base 16)
-  //@Test def test_simple_type_properties_text_number_13_03() { runner2.runOneTest("simple_type_properties_text_number_13_03") }
+  @Test def test_simple_type_properties_text_number_13_03() { runner2.runOneTest("simple_type_properties_text_number_13_03") }
 
   // DAFFODIL-551 Needs dfdl:utf16Width='variable' implementation
   //@Test def test_syntax_entities_6_03() { runner1.runOneTest("syntax_entities_6_03") }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -161,14 +161,14 @@ class TresysTests {
   //@Test def test_BB000() { runnerBB.runOneTest("BB000") } // occursCountKind stopValue
 
   //DFDL-1010
-  //@Test def test_BE000() { runnerBE.runOneTest("BE000") } // unordered sequences
-  //@Test def test_BE001() { runnerBE.runOneTest("BE001") }
+  @Test def test_BE000() { runnerBE.runOneTest("BE000") } // unordered sequences
+  @Test def test_BE001() { runnerBE.runOneTest("BE001") }
 
   //DFDL-1010
-  //@Test def test_BF000() { runnerBF1.runOneTest("BF000") } // unordered sequences
-  //@Test def test_BF001() { runnerBF1.runOneTest("BF001") }
+  @Test def test_BF000() { runnerBF1.runOneTest("BF000") } // unordered sequences
+  @Test def test_BF001() { runnerBF1.runOneTest("BF001") }
 
-  // @Test def test_BG000() { runnerBG.runOneTest("BG000") } // Nested delimiters - DAFFODIL-2101
+  @Test def test_BG000() { runnerBG.runOneTest("BG000") }
 
   @Test def test_BC000() { runnerBC.runOneTest("BC000") } // text boolean type
   @Test def test_BD000() { runnerBD.runOneTest("BD000") } // binary boolean type

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -353,7 +353,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <tnp01>42</tnp01>
+        <tnp01>66</tnp01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextStandardBase.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextStandardBase.tdml
@@ -1,0 +1,1300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="text-standard-base"
+  description="Text Number Properties" 
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com" 
+  xmlns="http://example.com" 
+  xmlns:tns="http://example.com" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  defaultRoundTrip="onePass">
+
+  <tdml:defineSchema name="textStandardBase" elementFormDefault="qualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" occursCountKind="implicit"/>
+
+    <xs:element name="base2_integer" type="xs:integer" dfdl:textStandardBase="2" />
+    <xs:element name="base2_long" type="xs:long" dfdl:textStandardBase="2" />
+    <xs:element name="base2_int" type="xs:int" dfdl:textStandardBase="2" />
+    <xs:element name="base2_short" type="xs:short" dfdl:textStandardBase="2" />
+    <xs:element name="base2_byte" type="xs:byte" dfdl:textStandardBase="2" />
+
+    <xs:element name="base2_uinteger" type="xs:nonNegativeInteger" dfdl:textStandardBase="2" />
+    <xs:element name="base2_ulong" type="xs:unsignedLong" dfdl:textStandardBase="2" />
+    <xs:element name="base2_uint" type="xs:unsignedInt" dfdl:textStandardBase="2" />
+    <xs:element name="base2_ushort" type="xs:unsignedShort" dfdl:textStandardBase="2" />
+    <xs:element name="base2_ubyte" type="xs:unsignedByte" dfdl:textStandardBase="2" />
+ 
+    <xs:element name="base8_integer" type="xs:integer" dfdl:textStandardBase="8" />
+    <xs:element name="base8_long" type="xs:long" dfdl:textStandardBase="8" />
+    <xs:element name="base8_int" type="xs:int" dfdl:textStandardBase="8" />
+    <xs:element name="base8_short" type="xs:short" dfdl:textStandardBase="8" />
+    <xs:element name="base8_byte" type="xs:byte" dfdl:textStandardBase="8" />
+
+    <xs:element name="base8_uinteger" type="xs:nonNegativeInteger" dfdl:textStandardBase="8" />
+    <xs:element name="base8_ulong" type="xs:unsignedLong" dfdl:textStandardBase="8" />
+    <xs:element name="base8_uint" type="xs:unsignedInt" dfdl:textStandardBase="8" />
+    <xs:element name="base8_ushort" type="xs:unsignedShort" dfdl:textStandardBase="8" />
+    <xs:element name="base8_ubyte" type="xs:unsignedByte" dfdl:textStandardBase="8" />
+
+    <xs:element name="base16_integer" type="xs:integer" dfdl:textStandardBase="16" />
+    <xs:element name="base16_long" type="xs:long" dfdl:textStandardBase="16" />
+    <xs:element name="base16_int" type="xs:int" dfdl:textStandardBase="16" />
+    <xs:element name="base16_short" type="xs:short" dfdl:textStandardBase="16" />
+    <xs:element name="base16_byte" type="xs:byte" dfdl:textStandardBase="16" />
+
+    <xs:element name="base16_uinteger" type="xs:nonNegativeInteger" dfdl:textStandardBase="16" />
+    <xs:element name="base16_ulong" type="xs:unsignedLong" dfdl:textStandardBase="16" />
+    <xs:element name="base16_uint" type="xs:unsignedInt" dfdl:textStandardBase="16" />
+    <xs:element name="base16_ushort" type="xs:unsignedShort" dfdl:textStandardBase="16" />
+    <xs:element name="base16_ubyte" type="xs:unsignedByte" dfdl:textStandardBase="16" />
+
+    <xs:element name="base2_float_err" type="xs:float" dfdl:textStandardBase="2" />
+    <xs:element name="base8_float_err" type="xs:float" dfdl:textStandardBase="8" />
+    <xs:element name="base16_float_err" type="xs:float" dfdl:textStandardBase="16" />
+
+    <xs:element name="base2_double_err" type="xs:double" dfdl:textStandardBase="2" />
+    <xs:element name="base8_double_err" type="xs:double" dfdl:textStandardBase="8" />
+    <xs:element name="base16_double_err" type="xs:double" dfdl:textStandardBase="16" />
+
+    <xs:element name="base2_decimal_err" type="xs:decimal" dfdl:textStandardBase="2" />
+    <xs:element name="base8_decimal_err" type="xs:decimal" dfdl:textStandardBase="8" />
+    <xs:element name="base16_decimal_err" type="xs:decimal" dfdl:textStandardBase="16" />
+
+    <xs:element name="unsupported_base_err" type="xs:int" dfdl:textStandardBase="3" />
+
+  </tdml:defineSchema>
+  
+  <tdml:parserTestCase name="base2_integer_min" root="base2_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_integer>0</base2_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_integer_min" root="base8_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_integer>0</base8_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_integer_min" root="base16_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_integer>0</base16_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_integer_large" root="base2_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000000000000000000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_integer>9223372036854775808</base2_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_integer_large" root="base8_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_integer>9223372036854775808</base8_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_integer_large" root="base16_integer" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">8000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_integer>9223372036854775808</base16_integer>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_long_min" root="base2_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_long>0</base2_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_long_min" root="base8_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_long>0</base8_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_long_min" root="base16_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_long>0</base16_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_long_max" root="base2_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">111111111111111111111111111111111111111111111111111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_long>9223372036854775807</base2_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_long_max" root="base8_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">777777777777777777777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_long>9223372036854775807</base8_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_long_max" root="base16_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">7fffffffffffffff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_long>9223372036854775807</base16_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_long_max_plus_one" root="base2_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000000000000000000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:long</tdml:error>
+      <tdml:error>9223372036854775808</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_long_max_plus_one" root="base8_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:long</tdml:error>
+      <tdml:error>9223372036854775808</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_long_max_plus_one" root="base16_long" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">8000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:long</tdml:error>
+      <tdml:error>9223372036854775808</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_int_min" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_int>0</base2_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_int_min" root="base8_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_int>0</base8_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_int_min" root="base16_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_int>0</base16_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_int_max" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1111111111111111111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_int>2147483647</base2_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_int_max" root="base8_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">17777777777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_int>2147483647</base8_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_int_max" root="base16_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">7fffffff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_int>2147483647</base16_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_int_max_plus_one" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+      <tdml:error>2147483648</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_int_max_plus_one" root="base8_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">20000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+      <tdml:error>2147483648</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_int_max_plus_one" root="base16_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">80000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+      <tdml:error>2147483648</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_short_min" root="base2_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_short>0</base2_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_short_min" root="base8_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_short>0</base8_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_short_min" root="base16_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_short>0</base16_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_short_max" root="base2_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_short>32767</base2_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_short_max" root="base8_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">77777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_short>32767</base8_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_short_max" root="base16_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">7fff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_short>32767</base16_short>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_short_max_plus_one" root="base2_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:short</tdml:error>
+      <tdml:error>32768</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_short_max_plus_one" root="base8_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">100000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:short</tdml:error>
+      <tdml:error>32768</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_short_max_plus_one" root="base16_short" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">8000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:short</tdml:error>
+      <tdml:error>32768</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_byte_min" root="base2_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_byte>0</base2_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_byte_min" root="base8_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_byte>0</base8_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_byte_min" root="base16_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_byte>0</base16_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_byte_max" root="base2_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_byte>127</base2_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_byte_max" root="base8_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">177</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_byte>127</base8_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_byte_max" root="base16_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">7f</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_byte>127</base16_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_byte_max_plus_one" root="base2_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:byte</tdml:error>
+      <tdml:error>128</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_byte_max_plus_one" root="base8_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">200</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:byte</tdml:error>
+      <tdml:error>128</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_byte_max_plus_one" root="base16_byte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">80</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:byte</tdml:error>
+      <tdml:error>128</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  
+  <tdml:parserTestCase name="base2_uinteger_min" root="base2_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_uinteger>0</base2_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_uinteger_min" root="base8_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_uinteger>0</base8_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_uinteger_min" root="base16_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_uinteger>0</base16_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_uinteger_large" root="base2_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000000000000000000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_uinteger>9223372036854775808</base2_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_uinteger_large" root="base8_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_uinteger>9223372036854775808</base8_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_uinteger_large" root="base16_uinteger" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">8000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_uinteger>9223372036854775808</base16_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+
+  <tdml:parserTestCase name="base2_ulong_min" root="base2_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ulong>0</base2_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ulong_min" root="base8_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ulong>0</base8_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ulong_min" root="base16_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ulong>0</base16_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ulong_max" root="base2_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1111111111111111111111111111111111111111111111111111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ulong>18446744073709551615</base2_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ulong_max" root="base8_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1777777777777777777777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ulong>18446744073709551615</base8_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ulong_max" root="base16_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">ffffffffffffffff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ulong>18446744073709551615</base16_ulong>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ulong_max_plus_one" root="base2_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000000000000000000000000000000000000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedLong</tdml:error>
+      <tdml:error>18446744073709551616</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ulong_max_plus_one" root="base8_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">2000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedLong</tdml:error>
+      <tdml:error>18446744073709551616</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ulong_max_plus_one" root="base16_ulong" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedLong</tdml:error>
+      <tdml:error>18446744073709551616</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_uint_min" root="base2_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_uint>0</base2_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_uint_min" root="base8_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_uint>0</base8_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_uint_min" root="base16_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_uint>0</base16_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_uint_max" root="base2_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">11111111111111111111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_uint>4294967295</base2_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_uint_max" root="base8_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">37777777777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_uint>4294967295</base8_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_uint_max" root="base16_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">ffffffff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_uint>4294967295</base16_uint>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_uint_max_plus_one" root="base2_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">100000000000000000000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedInt</tdml:error>
+      <tdml:error>4294967296</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_uint_max_plus_one" root="base8_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">40000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedInt</tdml:error>
+      <tdml:error>4294967296</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_uint_max_plus_one" root="base16_uint" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">100000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedInt</tdml:error>
+      <tdml:error>4294967296</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_ushort_min" root="base2_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ushort>0</base2_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ushort_min" root="base8_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ushort>0</base8_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ushort_min" root="base16_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ushort>0</base16_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ushort_max" root="base2_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">1111111111111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ushort>65535</base2_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ushort_max" root="base8_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">177777</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ushort>65535</base8_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ushort_max" root="base16_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">ffff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ushort>65535</base16_ushort>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ushort_max_plus_one" root="base2_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000000000000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedShort</tdml:error>
+      <tdml:error>65536</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ushort_max_plus_one" root="base8_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">200000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedShort</tdml:error>
+      <tdml:error>65536</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ushort_max_plus_one" root="base16_ushort" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">10000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedShort</tdml:error>
+      <tdml:error>65536</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_ubyte_min" root="base2_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ubyte>0</base2_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ubyte_min" root="base8_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ubyte>0</base8_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ubyte_min" root="base16_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ubyte>0</base16_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ubyte_max" root="base2_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">11111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base2_ubyte>255</base2_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ubyte_max" root="base8_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">377</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base8_ubyte>255</base8_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ubyte_max" root="base16_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_ubyte>255</base16_ubyte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_ubyte_max_plus_one" root="base2_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">100000000</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedByte</tdml:error>
+      <tdml:error>256</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_ubyte_max_plus_one" root="base8_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">400</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedByte</tdml:error>
+      <tdml:error>256</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_ubyte_max_plus_one" root="base16_ubyte" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">100</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>out of range</tdml:error>
+      <tdml:error>xs:unsignedByte</tdml:error>
+      <tdml:error>256</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_float_err" root="base2_float_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="2"</tdml:error>
+      <tdml:error>xs:float</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_float_err" root="base8_float_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="8"</tdml:error>
+      <tdml:error>xs:float</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_float_err" root="base16_float_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="16"</tdml:error>
+      <tdml:error>xs:float</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_double_err" root="base2_double_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="2"</tdml:error>
+      <tdml:error>xs:double</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_double_err" root="base8_double_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="8"</tdml:error>
+      <tdml:error>xs:double</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_double_err" root="base16_double_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="16"</tdml:error>
+      <tdml:error>xs:double</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+
+  <tdml:parserTestCase name="base2_decimal_err" root="base2_decimal_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="2"</tdml:error>
+      <tdml:error>xs:decimal</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_decimal_err" root="base8_decimal_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="8"</tdml:error>
+      <tdml:error>xs:decimal</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_decimal_err" root="base16_decimal_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:textStandardBase="16"</tdml:error>
+      <tdml:error>xs:decimal</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="non_base_10_empty_string_err" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>empty string</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="non_base_10_leading_sign_negative_err" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">-0</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>leading sign</tdml:error>
+      <tdml:error>-0</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="non_base_10_leading_sign_positive_err" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">+0</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>leading sign</tdml:error>
+      <tdml:error>+0</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base2_invalid_char_err" root="base2_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">012</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>base-2</tdml:error>
+      <tdml:error>012</tdml:error>
+      <tdml:error>invalid characters</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base8_invalid_char_err" root="base8_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">012345678</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>base-8</tdml:error>
+      <tdml:error>012345678</tdml:error>
+      <tdml:error>invalid characters</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="base16_invalid_char_err" root="base16_int" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text">0123456789ABCDEFG</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>base-16</tdml:error>
+      <tdml:error>0123456789ABCDEFG</tdml:error>
+      <tdml:error>invalid characters</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="unsupported_base_err" root="unsupported_base_err" model="textStandardBase">
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>textStandardBase</tdml:error>
+      <tdml:error>3</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="base16_uppercase" root="base16_int" model="textStandardBase" roundTrip="twoPass">
+    <tdml:document>
+      <tdml:documentPart type="text">7FFFFFFF</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_int>2147483647</base16_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="non_base_10_leading_zeros_ignored" root="base16_int" model="textStandardBase" roundTrip="twoPass">
+    <tdml:document>
+      <tdml:documentPart type="text">0000000000000000000000000000000000000000000000000000000007FFFFFFF</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_int>2147483647</base16_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="non_base_10_unparse_negative_int_err" root="base16_int" model="textStandardBase">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_int>-1</base16_int>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Unable to unparse</tdml:error>
+      <tdml:error>negative</tdml:error>
+      <tdml:error>textStandardBase="16"</tdml:error>
+      <tdml:error>-1</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="non_base_10_unparse_negative_uinteger_err" root="base16_uinteger" model="textStandardBase">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_uinteger>-9223372036854775808</base16_uinteger>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Unable to unparse</tdml:error>
+      <tdml:error>negative</tdml:error>
+      <tdml:error>textStandardBase="16"</tdml:error>
+      <tdml:error>-9223372036854775808</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="non_base_10_unparse_lower_case" root="base16_long" model="textStandardBase">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_long>9223372036854775807</base16_long>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="text">7fffffffffffffff</tdml:documentPart>
+    </tdml:document>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="non_base_10_unparse_out_of_range" root="base16_byte" model="textStandardBase">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <base16_byte>9223372036854775807</base16_byte>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="text">7fffffffffffffff</tdml:documentPart>
+    </tdml:document>
+  </tdml:unparserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -32,6 +32,8 @@ object TestTextNumberProps {
 class TestTextNumberProps {
   import TestTextNumberProps._
 
+  @Test def test_textNumberPattern_baseConflict() { runner.runOneTest("textNumberPattern_baseConflict") }
+
   @Test def test_textNumberPattern_positiveMandatory() { runner.runOneTest("textNumberPattern_positiveMandatory") }
   @Test def test_textNumberPattern_negativeOptional() { runner.runOneTest("textNumberPattern_negativeOptional") }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section13.text_standard_base
+
+import org.junit.Test
+import org.junit.AfterClass
+import org.apache.daffodil.tdml.Runner
+
+object TestTextStandardBase {
+  val testDir = "/org/apache/daffodil/section13/text_number_props/"
+  val runner = Runner(testDir, "TextStandardBase.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
+
+  @AfterClass def shutDown() {
+    runner.reset
+  }
+}
+
+class TestTextStandardBase {
+  import TestTextStandardBase._
+
+  // Tests of min, max, and 1 + max for each numeric data type in all non-base-10 bases
+
+  @Test def test_base2_integer_min() { runner.runOneTest("base2_integer_min") }
+  @Test def test_base8_integer_min() { runner.runOneTest("base8_integer_min") }
+  @Test def test_base16_integer_min() { runner.runOneTest("base16_integer_min") }
+
+  @Test def test_base2_integer_large() { runner.runOneTest("base2_integer_large") }
+  @Test def test_base8_integer_large() { runner.runOneTest("base8_integer_large") }
+  @Test def test_base16_integer_large() { runner.runOneTest("base16_integer_large") }
+
+  @Test def test_base2_long_min() { runner.runOneTest("base2_long_min") }
+  @Test def test_base8_long_min() { runner.runOneTest("base8_long_min") }
+  @Test def test_base16_long_min() { runner.runOneTest("base16_long_min") }
+
+  @Test def test_base2_long_max() { runner.runOneTest("base2_long_max") }
+  @Test def test_base8_long_max() { runner.runOneTest("base8_long_max") }
+  @Test def test_base16_long_max() { runner.runOneTest("base16_long_max") }
+
+  @Test def test_base2_long_max_plus_one() { runner.runOneTest("base2_long_max_plus_one") }
+  @Test def test_base8_long_max_plus_one() { runner.runOneTest("base8_long_max_plus_one") }
+  @Test def test_base16_long_max_plus_one() { runner.runOneTest("base16_long_max_plus_one") }
+
+  @Test def test_base2_int_min() { runner.runOneTest("base2_int_min") }
+  @Test def test_base8_int_min() { runner.runOneTest("base8_int_min") }
+  @Test def test_base16_int_min() { runner.runOneTest("base16_int_min") }
+
+  @Test def test_base2_int_max() { runner.runOneTest("base2_int_max") }
+  @Test def test_base8_int_max() { runner.runOneTest("base8_int_max") }
+  @Test def test_base16_int_max() { runner.runOneTest("base16_int_max") }
+
+  @Test def test_base2_int_max_plus_one() { runner.runOneTest("base2_int_max_plus_one") }
+  @Test def test_base8_int_max_plus_one() { runner.runOneTest("base8_int_max_plus_one") }
+  @Test def test_base16_int_max_plus_one() { runner.runOneTest("base16_int_max_plus_one") }
+
+  @Test def test_base2_short_min() { runner.runOneTest("base2_short_min") }
+  @Test def test_base8_short_min() { runner.runOneTest("base8_short_min") }
+  @Test def test_base16_short_min() { runner.runOneTest("base16_short_min") }
+
+  @Test def test_base2_short_max() { runner.runOneTest("base2_short_max") }
+  @Test def test_base8_short_max() { runner.runOneTest("base8_short_max") }
+  @Test def test_base16_short_max() { runner.runOneTest("base16_short_max") }
+
+  @Test def test_base2_short_max_plus_one() { runner.runOneTest("base2_short_max_plus_one") }
+  @Test def test_base8_short_max_plus_one() { runner.runOneTest("base8_short_max_plus_one") }
+  @Test def test_base16_short_max_plus_one() { runner.runOneTest("base16_short_max_plus_one") }
+
+  @Test def test_base2_byte_min() { runner.runOneTest("base2_byte_min") }
+  @Test def test_base8_byte_min() { runner.runOneTest("base8_byte_min") }
+  @Test def test_base16_byte_min() { runner.runOneTest("base16_byte_min") }
+
+  @Test def test_base2_byte_max() { runner.runOneTest("base2_byte_max") }
+  @Test def test_base8_byte_max() { runner.runOneTest("base8_byte_max") }
+  @Test def test_base16_byte_max() { runner.runOneTest("base16_byte_max") }
+
+  @Test def test_base2_byte_max_plus_one() { runner.runOneTest("base2_byte_max_plus_one") }
+  @Test def test_base8_byte_max_plus_one() { runner.runOneTest("base8_byte_max_plus_one") }
+  @Test def test_base16_byte_max_plus_one() { runner.runOneTest("base16_byte_max_plus_one") }
+
+  @Test def test_base2_uinteger_min() { runner.runOneTest("base2_uinteger_min") }
+  @Test def test_base8_uinteger_min() { runner.runOneTest("base8_uinteger_min") }
+  @Test def test_base16_uinteger_min() { runner.runOneTest("base16_uinteger_min") }
+
+  @Test def test_base2_uinteger_large() { runner.runOneTest("base2_uinteger_large") }
+  @Test def test_base8_uinteger_large() { runner.runOneTest("base8_uinteger_large") }
+  @Test def test_base16_uinteger_large() { runner.runOneTest("base16_uinteger_large") }
+
+  @Test def test_base2_ulong_min() { runner.runOneTest("base2_ulong_min") }
+  @Test def test_base8_ulong_min() { runner.runOneTest("base8_ulong_min") }
+  @Test def test_base16_ulong_min() { runner.runOneTest("base16_ulong_min") }
+
+  @Test def test_base2_ulong_max() { runner.runOneTest("base2_ulong_max") }
+  @Test def test_base8_ulong_max() { runner.runOneTest("base8_ulong_max") }
+  @Test def test_base16_ulong_max() { runner.runOneTest("base16_ulong_max") }
+
+  @Test def test_base2_ulong_max_plus_one() { runner.runOneTest("base2_ulong_max_plus_one") }
+  @Test def test_base8_ulong_max_plus_one() { runner.runOneTest("base8_ulong_max_plus_one") }
+  @Test def test_base16_ulong_max_plus_one() { runner.runOneTest("base16_ulong_max_plus_one") }
+
+  @Test def test_base2_uint_min() { runner.runOneTest("base2_uint_min") }
+  @Test def test_base8_uint_min() { runner.runOneTest("base8_uint_min") }
+  @Test def test_base16_uint_min() { runner.runOneTest("base16_uint_min") }
+
+  @Test def test_base2_uint_max() { runner.runOneTest("base2_uint_max") }
+  @Test def test_base8_uint_max() { runner.runOneTest("base8_uint_max") }
+  @Test def test_base16_uint_max() { runner.runOneTest("base16_uint_max") }
+
+  @Test def test_base2_uint_max_plus_one() { runner.runOneTest("base2_uint_max_plus_one") }
+  @Test def test_base8_uint_max_plus_one() { runner.runOneTest("base8_uint_max_plus_one") }
+  @Test def test_base16_uint_max_plus_one() { runner.runOneTest("base16_uint_max_plus_one") }
+
+  @Test def test_base2_ushort_min() { runner.runOneTest("base2_ushort_min") }
+  @Test def test_base8_ushort_min() { runner.runOneTest("base8_ushort_min") }
+  @Test def test_base16_ushort_min() { runner.runOneTest("base16_ushort_min") }
+
+  @Test def test_base2_ushort_max() { runner.runOneTest("base2_ushort_max") }
+  @Test def test_base8_ushort_max() { runner.runOneTest("base8_ushort_max") }
+  @Test def test_base16_ushort_max() { runner.runOneTest("base16_ushort_max") }
+
+  @Test def test_base2_ushort_max_plus_one() { runner.runOneTest("base2_ushort_max_plus_one") }
+  @Test def test_base8_ushort_max_plus_one() { runner.runOneTest("base8_ushort_max_plus_one") }
+  @Test def test_base16_ushort_max_plus_one() { runner.runOneTest("base16_ushort_max_plus_one") }
+
+  @Test def test_base2_ubyte_min() { runner.runOneTest("base2_ubyte_min") }
+  @Test def test_base8_ubyte_min() { runner.runOneTest("base8_ubyte_min") }
+  @Test def test_base16_ubyte_min() { runner.runOneTest("base16_ubyte_min") }
+
+  @Test def test_base2_ubyte_max() { runner.runOneTest("base2_ubyte_max") }
+  @Test def test_base8_ubyte_max() { runner.runOneTest("base8_ubyte_max") }
+  @Test def test_base16_ubyte_max() { runner.runOneTest("base16_ubyte_max") }
+
+  @Test def test_base2_ubyte_max_plus_one() { runner.runOneTest("base2_ubyte_max_plus_one") }
+  @Test def test_base8_ubyte_max_plus_one() { runner.runOneTest("base8_ubyte_max_plus_one") }
+  @Test def test_base16_ubyte_max_plus_one() { runner.runOneTest("base16_ubyte_max_plus_one") }
+
+  // SDE if type is float, double, or decimal in each non-base-10 base
+
+  @Test def test_base2_float_err() { runner.runOneTest("base2_float_err") }
+  @Test def test_base8_float_err() { runner.runOneTest("base8_float_err") }
+  @Test def test_base16_float_err() { runner.runOneTest("base16_float_err") }
+
+  @Test def test_base2_double_err() { runner.runOneTest("base2_double_err") }
+  @Test def test_base8_double_err() { runner.runOneTest("base8_double_err") }
+  @Test def test_base16_double_err() { runner.runOneTest("base16_double_err") }
+
+  @Test def test_base2_decimal_err() { runner.runOneTest("base2_decimal_err") }
+  @Test def test_base8_decimal_err() { runner.runOneTest("base8_decimal_err") }
+  @Test def test_base16_decimal_err() { runner.runOneTest("base16_decimal_err") }
+
+  // PE if text number is the empty string
+
+  @Test def test_non_base_10_empty_string_err() { runner.runOneTest("non_base_10_empty_string_err") }
+
+  // PE if leading sign
+
+  @Test def test_non_base_10_leading_sign_negative_err() { runner.runOneTest("non_base_10_leading_sign_negative_err") }
+  @Test def test_non_base_10_leading_sign_positive_err() { runner.runOneTest("non_base_10_leading_sign_positive_err") }
+
+  // PE if text number contains characters not valid in the base
+
+  @Test def test_base2_invalid_char_err() { runner.runOneTest("base2_invalid_char_err") }
+  @Test def test_base8_invalid_char_err() { runner.runOneTest("base8_invalid_char_err") }
+  @Test def test_base16_invalid_char_err() { runner.runOneTest("base16_invalid_char_err") }
+
+  // SDE if textStandardBase is not a supported base
+
+  @Test def test_unsupported_base_err() { runner.runOneTest("unsupported_base_err") }
+
+  // Accepts uppercase hex characters, but always unparses to lowercase. Requires two-pass
+
+  @Test def test_base16_uppercase() { runner.runOneTest("base16_uppercase") }
+
+  // Leading zeros are accepted during parsing. Requires two-pass
+
+  @Test def test_non_base_10_leading_zeros_ignored() { runner.runOneTest("non_base_10_leading_zeros_ignored") }
+
+  // SDE if unparsing a negative number
+
+  @Test def test_non_base_10_unparse_negative_int_err() { runner.runOneTest("non_base_10_unparse_negative_int_err") }
+  @Test def test_non_base_10_unparse_negative_uinteger_err() { runner.runOneTest("non_base_10_unparse_negative_uinteger_err") }
+
+  // Unparse always goes to lowercase
+
+  @Test def test_non_base_10_unparse_lower_case() { runner.runOneTest("non_base_10_unparse_lower_case") }
+
+}


### PR DESCRIPTION
Add new primitive, parser, and unparser to handle non base-10 text
numbers. Actual logic from converting to/from bases is handled by Java's
builtin functions.

To maintain backwards compatibility, if the textStandardBase property is
not defined it defaults to "10" unless the requireTextStandardBaseProperty
tunable is set to true, default to false.

Also noticed some unordered sequence tests were commented out and work
with minor tweaks due to incorrect tests.

DAFFODIL-840