### PR TITLE
Assortment of changes to improve performance

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Maybe.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Maybe.scala
@@ -118,6 +118,9 @@ object Maybe {
   @inline
   final def apply[T <: AnyRef](value: T) = if (value == null) Nope else new Maybe[T](value)
 
+  @inline
+  final def fromMaybeAnyRef[T <: AnyRef](anyref: Maybe[AnyRef]) = Maybe(anyref.v.asInstanceOf[T])
+
   val Nope = new Maybe[Nothing](NopeValue)
 
   /**

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MaybeInt.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MaybeInt.scala
@@ -140,7 +140,7 @@ object MaybeChar {
   val Nope = new MaybeChar(undefValue)
 }
 
-final case class MaybeBoolean private (__v: Int) extends AnyVal {
+final class MaybeBoolean private (val __v: Int) extends AnyVal {
   @inline final def get: Boolean = if (isEmpty) noneGet else __v == 1
   //@inline final def getOrElse(alternate: Boolean): Boolean = if (isDefined) get else alternate
   private def noneGet = throw new NoSuchElementException("Nope.get")
@@ -158,10 +158,10 @@ final case class MaybeBoolean private (__v: Int) extends AnyVal {
 object MaybeBoolean {
   private val undefValue = -1
 
-  @inline final def apply(v: Boolean) = new MaybeBoolean(if (v) 1 else 0)
+  @inline final def apply(v: Boolean) = if (v) MaybeBoolean.True else MaybeBoolean.False
 
   val Nope = new MaybeBoolean(undefValue)
-  val True = MaybeBoolean(true)
-  val False = MaybeBoolean(false)
+  val True = new MaybeBoolean(1)
+  val False = new MaybeBoolean(0)
   
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ChoiceAndOtherVariousUnparsers.scala
@@ -17,15 +17,14 @@
 
 package org.apache.daffodil.processors.unparsers
 
-import org.apache.daffodil.processors._
 import org.apache.daffodil.infoset._
 import org.apache.daffodil.processors.RuntimeData
+import org.apache.daffodil.processors._
 import org.apache.daffodil.processors.dfa.DFADelimiter
 import org.apache.daffodil.schema.annotation.props.gen.ChoiceLengthKind
-import org.apache.daffodil.util.Maybe._
 import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.util.MaybeInt
 import org.apache.daffodil.util.Maybe._
+import org.apache.daffodil.util.MaybeInt
 
 class ChoiceCombinatorUnparser(
   mgrd: ModelGroupRuntimeData,
@@ -120,9 +119,9 @@ class DelimiterStackUnparser(
 
   def unparse(state: UState): Unit = {
     // Evaluate Delimiters
-    val init = if (initiatorOpt.isDefined) initiatorOpt.get.evaluate(state) else Array[DFADelimiter]()
-    val sep = if (separatorOpt.isDefined) separatorOpt.get.evaluate(state) else Array[DFADelimiter]()
-    val term = if (terminatorOpt.isDefined) terminatorOpt.get.evaluate(state) else Array[DFADelimiter]()
+    val init = if (initiatorOpt.isDefined) initiatorOpt.get.evaluate(state) else EmptyDelimiterStackUnparseNode.empty
+    val sep = if (separatorOpt.isDefined) separatorOpt.get.evaluate(state) else EmptyDelimiterStackUnparseNode.empty
+    val term = if (terminatorOpt.isDefined) terminatorOpt.get.evaluate(state) else EmptyDelimiterStackUnparseNode.empty
 
     val node = DelimiterStackUnparseNode(init, sep, term)
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/DelimiterUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/DelimiterUnparsers.scala
@@ -56,7 +56,7 @@ class DelimiterTextUnparser(override val context: TermRuntimeData, delimiterType
       else localDelimNode.terminator
     }
 
-    if (delimDFAs.isEmpty) Assert.invariantFailed("Expected a delimiter of type " + delimiterType + " on the stack, but was not found.")
+    if (delimDFAs.length == 0) Assert.invariantFailed("Expected a delimiter of type " + delimiterType + " on the stack, but was not found.")
 
     val delimDFA = delimDFAs(0)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -903,7 +903,7 @@ sealed trait DIElement
    */
   final def maybeIsNilled: MaybeBoolean = {
     if (!_isNilledSet) MaybeBoolean.Nope
-    MaybeBoolean(_isNilled)
+    else MaybeBoolean(_isNilled)
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -91,7 +91,9 @@ abstract class InfosetInputter
 
   def isInitialized = isInitialized_
 
-  var tunable = DaffodilTunables()
+  // Should not need to be initialized for performance reasons, this will be
+  // set to an already allocated tunable when initialize() is called
+  var tunable: DaffodilTunables = _
 
   /**
    * Return the current infoset inputter event type

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DelimiterStackUnparseNode.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DelimiterStackUnparseNode.scala
@@ -18,9 +18,12 @@
 package org.apache.daffodil.processors
 
 import org.apache.daffodil.processors.dfa.DFADelimiter
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe.Nope
 
 object EmptyDelimiterStackUnparseNode {
-  val node = new DelimiterStackUnparseNode(Array(), Array(), Array())
+  val empty = Array[DFADelimiter]()
+  val node = new DelimiterStackUnparseNode(empty, empty, empty)
   def apply() = node
 }
 
@@ -30,7 +33,7 @@ object DelimiterStackUnparseNode {
     initiator: Array[DFADelimiter],
     separator: Array[DFADelimiter],
     terminator: Array[DFADelimiter]): DelimiterStackUnparseNode = {
-    if (initiator.isEmpty && terminator.isEmpty && separator.isEmpty) EmptyDelimiterStackUnparseNode()
+    if (initiator.length == 0 && terminator.length == 0 && separator.length == 0) EmptyDelimiterStackUnparseNode()
     else new DelimiterStackUnparseNode(initiator, separator, terminator)
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
@@ -285,7 +285,7 @@ abstract class Evaluatable[+T <: AnyRef](protected val ci: DPathCompileInfo, qNa
   /**
    * Preferred for use in the runtime.
    */
-  @inline final def maybeConstant = constValue_.asInstanceOf[Maybe[T]]
+  @inline final def maybeConstant = Maybe.fromMaybeAnyRef[T](constValue_)
   @inline final def isConstant = constValue_.isDefined
   @inline final def constValue = maybeConstant.get
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -409,7 +409,7 @@ final class UStateForSuspension(
   override def localDelimiters = delimiterStackMaybe.get.top
   override def allTerminatingMarkup = {
     delimiterStackMaybe.get.iterator.flatMap { dnode =>
-      (dnode.separator.toList ++ dnode.terminator.toList)
+      dnode.separator ++ dnode.terminator
     }.toList
   }
 
@@ -581,7 +581,7 @@ final class UStateMain private (
   override def localDelimiters = delimiterStack.top
   override def allTerminatingMarkup = {
     delimiterStack.iterator.flatMap { dnode =>
-      (dnode.separator.toList ++ dnode.terminator.toList)
+      dnode.separator ++ dnode.terminator
     }.toList
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc2.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc2.tdml
@@ -371,8 +371,8 @@
           <xs:element name="yi" type="xs:string" dfdl:length="5" dfdl:lengthKind="explicit"/>
           <xs:element name="zi" type="xs:string" dfdl:length="5" dfdl:lengthKind="explicit"/>
 
-          <xs:element name="x" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../xi }" dfdl:outputValueCalc="{ xs:date(fn:concat('2017-8-',dfdl:valueLength(../y, 'bytes'))) }" dfdl:calendarPatternKind="explicit" />
-          <xs:element name="y" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../yi }" dfdl:outputValueCalc="{ xs:date(fn:concat('1986-6-',dfdl:valueLength(../z, 'bytes'))) }" dfdl:calendarPatternKind="explicit" />
+          <xs:element name="x" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../xi }" dfdl:outputValueCalc="{ xs:date(fn:concat('2017-08-',dfdl:valueLength(../y, 'bytes'))) }" dfdl:calendarPatternKind="explicit" />
+          <xs:element name="y" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../yi }" dfdl:outputValueCalc="{ xs:date(fn:concat('1986-06-',dfdl:valueLength(../z, 'bytes'))) }" dfdl:calendarPatternKind="explicit" />
           <xs:element name="z" type="xs:date" dfdl:lengthKind="delimited" dfdl:representation="text" dfdl:calendarPattern="EEEE MMMM yyyy" dfdl:calendarLanguage="{ ../zi }" dfdl:calendarPatternKind="explicit" dfdl:encoding="UTF-8" />
         </xs:sequence>
       </xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -8315,7 +8315,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>"02-03-1998T12:30:34"</tdml:error>
+      <tdml:error>02-03-1998T12:30:34</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -8532,7 +8532,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>"03:61:00"</tdml:error>
+      <tdml:error>03:61:00</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -8552,7 +8552,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>"03:59:61"</tdml:error>
+      <tdml:error>03:59:61</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -8572,7 +8572,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>"five o'clock"</tdml:error>
+      <tdml:error>five o'clock</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   


### PR DESCRIPTION
- Optimize how we parse date/times from an XML infoset. Previously we
  attempted to parse a handful of different potential patterns using
  ICU4J SimpleDateFormat.parse(). Profiling show this simple parse
  performed many allocations. Considering that this is a fairly strict
  format we can implement the parsing ourselves, which is much more
  efficient, minimizes allocations, and avoids thread-locals since
  SimpleDateFormat is not thread safe.
- Instead of creating new calendar every time we parse an XML Date/Time,
  clone an already existing one. The process to initialize a new
  Calendar is pretty expensive, cloning is much more efficient.
- Skip remapping XML strings if they do not contain any invalid
  characters. This avoids unnecessary string allocations in the common
  case, but does incur some overhead in the rare case when remapping is
  needed.
- Use the same empty Array of DFADelimiters in the delimiter stack.
  Otherwise we allocate a bunch of empty arrays, and scala even ends up
  allocating even ore stuff to support it (e.g. ClassTags).
- Fix MaybeBoolean to avoid allocating new MaybeBoolean's
- Use Array.length == 0 instead of Array.isEmpty in inner loops. Using
  .isEmpty will allocate a scala ArrayOps, which is unnecssary if all
  were doing is checking the length. Note that .size will also allocate
  an ArrayOps.
- Fix maybeConstant_ in Evaluatable to avoid Maybe allocations

These issues were discovered while profiling an unparse of a CSV schema.
Performance averaged around 20% faster on my testing.

DAFFODIL-2222, DAFFODIL-1883