### PR TITLE
Fixes format string

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
@@ -319,11 +319,8 @@ class Compiler(var validateDFDLSchemas: Boolean = true)
         val cpString =
           if (Misc.classPath.length == 0) " empty."
           else ":\n" + Misc.classPath.mkString("\n\t")
-        val msg = "%s\nThe class may not exist in this Java JVM version (%s)," +
-          "or it is missing from the classpath which is%s".format(
-            cnf.getMessage(),
-            scala.util.Properties.javaVersion,
-            cpString)
+        val fmtMsg = "%s\nThe class may not exist in this Java JVM version (%s), or it is missing from the classpath which is%s"
+        val msg = fmtMsg.format(cnf.getMessage(), scala.util.Properties.javaVersion, cpString)
         throw new InvalidParserException(msg, cnf)
       }
     }


### PR DESCRIPTION
On a ClassNotFoundException, we used to get
[error] %s
 The class may not exist in this Java JVM version (%s),or it is missing from the classpath which iscom.missing.class

rather than the intended

[error] com.missing.class
 The class may not exist in this Java JVM version (1.8.0_232-ea), or it is missing from the classpath which is:
 ...[classpath details]...

due to improper separation of a string to be formatted. I attempted to trigger the exception via tests and was unable. Since the fix is quite simple, I just made the update.

DAFFODIL-2245