### PR TITLE
Add new TimeTracker for more advanced performance analysis

### DIFF
--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/util/TimerMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/util/TimerMacros.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.util
+
+import scala.reflect.macros.blackbox.Context
+
+object TimeTrackerMacros {
+
+  def trackMacro(c: Context)(name: c.Tree)(body: c.Tree) = {
+    import c.universe._
+
+    val startTime = TermName(c.freshName)
+    val endTime = TermName(c.freshName)
+    val childrenTime = TermName(c.freshName)
+    val timeTaken = TermName(c.freshName)
+    val selfTime = TermName(c.freshName)
+    val sectionTime = TermName(c.freshName)
+    val result = TermName(c.freshName)
+    val key = TermName(c.freshName)
+
+    q"""
+    {
+      val $startTime = System.nanoTime
+      TimeTracker.childrenTimeStack.push(0)
+      
+      val $result = try {
+        $body
+      } finally {
+        val $endTime = System.nanoTime
+        val $timeTaken = $endTime - $startTime
+        val $childrenTime = TimeTracker.childrenTimeStack.pop()
+        val $selfTime = $timeTaken - $childrenTime
+
+        val $key = $name
+        val $sectionTime = TimeTracker.sectionTimes.get($key)
+        if ($sectionTime == null) {
+          TimeTracker.sectionTimes.put($key, new TimeTracker.SectionTime($selfTime, 1))
+        } else {
+          $sectionTime.time += $selfTime
+          $sectionTime.count += 1
+        }
+
+        if (!TimeTracker.childrenTimeStack.isEmpty) {
+          TimeTracker.childrenTimeStack.push(TimeTracker.childrenTimeStack.pop + $timeTaken) 
+        }
+      }
+
+      $result
+    }
+    """
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
@@ -54,7 +54,7 @@ sealed trait Parser
 
   def isEmpty = false // override in NadaParser
 
-  protected def parserName = Misc.getNameFromClass(this)
+  protected lazy val parserName = Misc.getNameFromClass(this)
 
   def PE(pstate: PState, s: String, args: Any*) = {
     pstate.setFailed(new ParseError(One(context.schemaFileLocation), One(pstate.currentLocation), s, args: _*))


### PR DESCRIPTION
Because of our nested parsers, it can sometimes be difficult to
determine how much time each processor takes on average to complete it's
parse/unparse, even when using a profiler. This adds a new timer that
makes it much easier to determine how much total time particular parsers
take and on average how long they take. This can help to prioritize
performance optimizations.

The intended use is to modify the Parser.scala parse1() function to look
like this:

  try {
    TimeTracker.track(parserName) {
      parse(pstate)
    }
  }

The resulting output gives a break down of all the parsers and how
performant they are. Once slow processors are found, it can then be
useful to wrap subsections of the parse() method in a call to
TimeTracker.track() to determine which sections are slow. This incurs
less overhead than traditional profilers and give more control over
which sections are actually profiled.

DAFFODIL-1883