### PR TITLE
Do not convert data values in postProcess after evaluating expressions

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Conversions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Conversions.scala
@@ -87,7 +87,7 @@ object Conversion {
       case (Boolean, Integer) => BooleanToLong +: conversionOps(Long, tt, context)
       case (Boolean, NonNegativeInteger) => BooleanToLong +: conversionOps(Long, tt, context)
       case (Boolean, Long) => List(BooleanToLong)
-      case (Boolean, UnsignedLong) => List(BooleanToLong) // no need to range check.
+      case (Boolean, UnsignedLong) => BooleanToLong +: conversionOps(Long, tt, context)
       case (Boolean, Int) => BooleanToLong +: conversionOps(Long, tt, context)
       case (Boolean, UnsignedInt) => BooleanToLong +: conversionOps(Long, tt, context)
       case (Boolean, Short) => BooleanToLong +: conversionOps(Long, tt, context)
@@ -101,7 +101,7 @@ object Conversion {
       case (Double, Integer) => DoubleToDecimal +: conversionOps(Decimal, tt, context)
       case (Double, NonNegativeInteger) => DoubleToDecimal +: conversionOps(Decimal, tt, context)
       case (Double, Long) => List(DoubleToLong)
-      case (Double, UnsignedLong) => List(DoubleToUnsignedLong)
+      case (Double, UnsignedLong) => DoubleToUnsignedLong +: conversionOps(Long, tt, context)
       case (Double, i: Int.Kind) => DoubleToLong +: conversionOps(Long, tt, context)
       case (Double, ui: UnsignedInt.Kind) => DoubleToUnsignedLong +: UnsignedLongToLong +: conversionOps(Long, tt, context)
 
@@ -177,7 +177,7 @@ object Conversion {
       case (UnsignedInt, Integer) => UnsignedIntToLong +: conversionOps(Long, tt, context)
       case (UnsignedInt, NonNegativeInteger) => UnsignedIntToLong +: conversionOps(Long, tt, context)
       case (UnsignedInt, Long) => List(UnsignedIntToLong)
-      case (UnsignedInt, UnsignedLong) => List(UnsignedIntToLong) // no need to range check.
+      case (UnsignedInt, UnsignedLong) => UnsignedIntToLong +: conversionOps(Long, tt, context)
       case (UnsignedInt, Int) => UnsignedIntToLong +: conversionOps(Long, tt, context)
       case (UnsignedInt, Short) => UnsignedIntToLong +: conversionOps(Long, tt, context)
       case (UnsignedInt, UnsignedShort) => UnsignedIntToLong +: conversionOps(Long, tt, context)
@@ -200,7 +200,7 @@ object Conversion {
       case (ArrayIndex, Integer) => ArrayIndexToLong +: conversionOps(Long, tt, context)
       case (ArrayIndex, NonNegativeInteger) => ArrayIndexToLong +: conversionOps(Long, tt, context)
       case (ArrayIndex, Long) => List(ArrayIndexToLong)
-      case (ArrayIndex, UnsignedLong) => List(ArrayIndexToLong) // no need to range check.
+      case (ArrayIndex, UnsignedLong) => ArrayIndexToLong +: conversionOps(Long, tt, context)
       case (ArrayIndex, Int) => ArrayIndexToLong +: conversionOps(Long, tt, context)
       case (ArrayIndex, UnsignedInt) => ArrayIndexToLong +: conversionOps(Long, tt, context)
       case (ArrayIndex, Short) => ArrayIndexToLong +: conversionOps(Long, tt, context)
@@ -213,7 +213,7 @@ object Conversion {
       case (Short, Integer) => ShortToLong +: conversionOps(Long, tt, context)
       case (Short, NonNegativeInteger) => ShortToLong +: conversionOps(Long, tt, context)
       case (Short, Long) => List(ShortToLong)
-      case (Short, UnsignedLong) => List(ShortToLong) // no need to range check.
+      case (Short, UnsignedLong) => ShortToLong +: conversionOps(Long, tt, context)
       case (Short, Int) => ShortToLong +: conversionOps(Long, tt, context)
       case (Short, UnsignedInt) => ShortToLong +: conversionOps(Long, tt, context)
       case (Short, UnsignedShort) => ShortToLong +: conversionOps(Long, tt, context)
@@ -225,7 +225,7 @@ object Conversion {
       case (UnsignedShort, Integer) => UnsignedShortToLong +: conversionOps(Long, tt, context)
       case (UnsignedShort, NonNegativeInteger) => UnsignedShortToLong +: conversionOps(Long, tt, context)
       case (UnsignedShort, Long) => List(UnsignedShortToLong)
-      case (UnsignedShort, UnsignedLong) => List(UnsignedShortToLong) // no need to range check.
+      case (UnsignedShort, UnsignedLong) => UnsignedShortToLong +: conversionOps(Long, tt, context)
       case (UnsignedShort, Int) => UnsignedShortToLong +: conversionOps(Long, tt, context)
       case (UnsignedShort, UnsignedInt) => UnsignedShortToLong +: conversionOps(Long, tt, context)
       case (UnsignedShort, Short) => UnsignedShortToLong +: conversionOps(Long, tt, context)
@@ -236,7 +236,7 @@ object Conversion {
       case (Byte, Float) => ByteToLong +: conversionOps(Long, tt, context)
       case (Byte, Integer) => ByteToLong +: conversionOps(Long, tt, context)
       case (Byte, NonNegativeInteger) => ByteToLong +: conversionOps(Long, tt, context)
-      case (Byte, UnsignedLong) => List(ByteToLong) // no need to range check.
+      case (Byte, UnsignedLong) => ByteToLong +: conversionOps(Long, tt, context)
       case (Byte, Int) => ByteToLong +: conversionOps(Long, tt, context)
       case (Byte, UnsignedInt) => ByteToLong +: conversionOps(Long, tt, context)
       case (Byte, Short) => ByteToLong +: conversionOps(Long, tt, context)
@@ -249,7 +249,7 @@ object Conversion {
       case (UnsignedByte, Integer) => UnsignedByteToLong +: conversionOps(Long, tt, context)
       case (UnsignedByte, NonNegativeInteger) => UnsignedByteToLong +: conversionOps(Long, tt, context)
       case (UnsignedByte, Long) => List(UnsignedByteToLong)
-      case (UnsignedByte, UnsignedLong) => List(UnsignedByteToLong) // no need to range check.
+      case (UnsignedByte, UnsignedLong) => UnsignedByteToLong +: conversionOps(Long, tt, context)
       case (UnsignedByte, Int) => UnsignedByteToLong +: conversionOps(Long, tt, context)
       case (UnsignedByte, UnsignedInt) => UnsignedByteToLong +: conversionOps(Long, tt, context)
       case (UnsignedByte, Short) => UnsignedByteToLong +: conversionOps(Long, tt, context)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -1639,17 +1639,17 @@ case class FunctionCallExpression(functionQNameString: String, expressions: List
       case (RefQName(_, "exactly-one", FUNC), args) =>
         FNExactlyOneExpr(functionQNameString, functionQName, args)
 
-      case (RefQName(_, "year-from-dateTime", FUNC), args) => FNOneArgExprConversionDisallowed(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.DateTime, FNYearFromDateTime(_, _))
-      case (RefQName(_, "month-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.DateTime, FNMonthFromDateTime(_, _))
-      case (RefQName(_, "day-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.DateTime, FNDayFromDateTime(_, _))
-      case (RefQName(_, "hours-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.DateTime, FNHoursFromDateTime(_, _))
-      case (RefQName(_, "minutes-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.DateTime, FNMinutesFromDateTime(_, _))
+      case (RefQName(_, "year-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.DateTime, FNYearFromDateTime(_, _))
+      case (RefQName(_, "month-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.DateTime, FNMonthFromDateTime(_, _))
+      case (RefQName(_, "day-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.DateTime, FNDayFromDateTime(_, _))
+      case (RefQName(_, "hours-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.DateTime, FNHoursFromDateTime(_, _))
+      case (RefQName(_, "minutes-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.DateTime, FNMinutesFromDateTime(_, _))
       case (RefQName(_, "seconds-from-dateTime", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Decimal, NodeInfo.DateTime, FNSecondsFromDateTime(_, _))
-      case (RefQName(_, "year-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.Date, FNYearFromDate(_, _))
-      case (RefQName(_, "month-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.Date, FNMonthFromDate(_, _))
-      case (RefQName(_, "day-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.Date, FNDayFromDate(_, _))
-      case (RefQName(_, "hours-from-time", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.Time, FNHoursFromTime(_, _))
-      case (RefQName(_, "minutes-from-time", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Long, NodeInfo.Time, FNMinutesFromTime(_, _))
+      case (RefQName(_, "year-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.Date, FNYearFromDate(_, _))
+      case (RefQName(_, "month-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.Date, FNMonthFromDate(_, _))
+      case (RefQName(_, "day-from-date", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.Date, FNDayFromDate(_, _))
+      case (RefQName(_, "hours-from-time", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.Time, FNHoursFromTime(_, _))
+      case (RefQName(_, "minutes-from-time", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Integer, NodeInfo.Time, FNMinutesFromTime(_, _))
       case (RefQName(_, "seconds-from-time", FUNC), args) => FNOneArgExpr(functionQNameString, functionQName, args, NodeInfo.Decimal, NodeInfo.Time, FNSecondsFromTime(_, _))
 
       case (RefQName(_, "occursIndex", DFDL), args) => {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -51,10 +51,6 @@ object XMLUtils {
    */
   val xmlNilAttribute = new PrefixedAttribute("xsi", "nil", "true", scala.xml.Null)
 
-  val PositiveInfinity = Double.PositiveInfinity
-  val NegativeInfinity = Double.NegativeInfinity
-  val NaN = Double.NaN
-
   val PositiveInfinityString = "INF"
   val NegativeInfinityString = "-INF"
   val NaNString = "NaN"

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
@@ -40,6 +40,7 @@ import org.apache.daffodil.exceptions.UnsuppressableException
 import org.apache.daffodil.infoset.DIElement
 import org.apache.daffodil.infoset.DIFinalizable
 import org.apache.daffodil.infoset.DataValue.DataValueBigDecimal
+import org.apache.daffodil.infoset.DataValue.DataValueBigInt
 import org.apache.daffodil.infoset.DataValue.DataValueBool
 import org.apache.daffodil.infoset.DataValue.DataValueCalendar
 import org.apache.daffodil.infoset.DataValue.DataValueInt
@@ -713,7 +714,7 @@ case class FNCeiling(recipe: CompiledDPath, argType: NodeInfo.Kind) extends FNOn
       bd.setScale(0, RoundingMode.CEILING)
     }
     case NodeInfo.Float => asFloat(value.getAnyRef).floatValue().ceil
-    case NodeInfo.Double => asDouble(value.getAnyRef).floatValue().ceil
+    case NodeInfo.Double => asDouble(value.getAnyRef).doubleValue().ceil
     case _: NodeInfo.Numeric.Kind => value
     case _ => Assert.invariantFailed(String.format("Type %s is not a valid type for function ceiling.", argType))
   }
@@ -773,7 +774,7 @@ abstract class FNFromDateTime(recipe: CompiledDPath, argType: NodeInfo.Kind)
   with FNFromDateTimeKind {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueNumber = {
     a.getAnyRef match {
-      case dt: DFDLDateTime => JLong.valueOf(dt.calendar.get(field))
+      case dt: DFDLDateTime => JBigInt.valueOf(dt.calendar.get(field))
       case _ => throw new NumberFormatException("fn:" + fieldName + "-from-dateTime only accepts xs:dateTime.")
     }
   }
@@ -784,7 +785,7 @@ abstract class FNFromDate(recipe: CompiledDPath, argType: NodeInfo.Kind)
   with FNFromDateTimeKind {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueNumber = {
     a.getAnyRef match {
-      case d: DFDLDate => JLong.valueOf(d.calendar.get(field))
+      case d: DFDLDate => JBigInt.valueOf(d.calendar.get(field))
       case _ => throw new NumberFormatException("fn:" + fieldName + "-from-date only accepts xs:date.")
     }
   }
@@ -795,7 +796,7 @@ abstract class FNFromTime(recipe: CompiledDPath, argType: NodeInfo.Kind)
   with FNFromDateTimeKind {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueNumber = {
     a.getAnyRef match {
-      case t: DFDLTime => JLong.valueOf(t.calendar.get(field))
+      case t: DFDLTime => JBigInt.valueOf(t.calendar.get(field))
       case _ => throw new NumberFormatException("fn:" + fieldName + "-from-time only accepts xs:time.")
     }
   }
@@ -810,7 +811,9 @@ case class FNMonthFromDateTime(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends FNFromDateTime(recipe, argType) {
   val fieldName = "month"
   val field = Calendar.MONTH
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = super.computeValue(a, dstate).getLong + 1 // JAN 0
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
+    super.computeValue(a, dstate).getBigInt.add(JBigInt.ONE) // JAN 0
+  }
 }
 case class FNDayFromDateTime(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends FNFromDateTime(recipe, argType) {
@@ -874,7 +877,9 @@ case class FNMonthFromDate(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends FNFromDate(recipe, argType) {
   val fieldName = "month"
   val field = Calendar.MONTH
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = super.computeValue(a, dstate).getLong + 1 // JAN 0
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
+    super.computeValue(a, dstate).getBigInt.add(JBigInt.ONE) // JAN 0
+  }
 }
 case class FNDayFromDate(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends FNFromDate(recipe, argType) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -502,9 +502,9 @@ object NodeInfo extends Enum {
       type Kind = FloatKind
       override def fromXMLString(s: String) = {
         val f: JFloat = s match {
-          case XMLUtils.PositiveInfinityString => scala.Float.PositiveInfinity
-          case XMLUtils.NegativeInfinityString => scala.Float.NegativeInfinity
-          case XMLUtils.NaNString => scala.Float.NaN
+          case XMLUtils.PositiveInfinityString => JFloat.POSITIVE_INFINITY
+          case XMLUtils.NegativeInfinityString => JFloat.NEGATIVE_INFINITY
+          case XMLUtils.NaNString => JFloat.NaN
           case _ => s.toFloat
         }
         f
@@ -519,9 +519,9 @@ object NodeInfo extends Enum {
       type Kind = DoubleKind
       override def fromXMLString(s: String): DataValueDouble = {
         val d: JDouble = s match {
-          case XMLUtils.PositiveInfinityString => scala.Double.PositiveInfinity
-          case XMLUtils.NegativeInfinityString => scala.Double.NegativeInfinity
-          case XMLUtils.NaNString => scala.Double.NaN
+          case XMLUtils.PositiveInfinityString => JDouble.POSITIVE_INFINITY
+          case XMLUtils.NegativeInfinityString => JDouble.NEGATIVE_INFINITY
+          case XMLUtils.NaNString => JDouble.NaN
           case _ => s.toDouble
         }
         d

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -6825,6 +6825,15 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
+    <xs:element name="ulong04">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="string" type="xs:string" dfdl:lengthKind="delimited"/>
+          <xs:element name="ulongified" type="xs:unsignedLong" dfdl:inputValueCalc="{ xs:unsignedLong(../ex:string) }"/>
+          <xs:element name="longified" type="xs:long" dfdl:inputValueCalc="{ xs:long(../ex:ulongified) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
     
     <xs:element name="ushort01" type="xs:unsignedShort" dfdl:inputValueCalc="{ xs:unsignedShort(-50) }"/>
     <xs:element name="ushort02" type="xs:unsignedShort" dfdl:inputValueCalc="{ xs:unsignedShort(12345678987654321) }"/>
@@ -7636,6 +7645,39 @@
         <tdml:error>out of range</tdml:error>
         <tdml:error>unsignedLong</tdml:error>
       </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="ulong_constructor_06" root="ulong03" model="constructorSchema"
+    description="Section 23 - Constructor Functions - xs:unsignedLong()  - DFDL-23-084R">
+
+    <tdml:document>
+      <tdml:documentPart type="text">9223372036854775808</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ulong03>
+          <string>9223372036854775808</string>
+          <ulongified>9223372036854775808</ulongified>
+        </ulong03>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="ulong_constructor_07" root="ulong04" model="constructorSchema"
+    description="Section 23 - Constructor Functions - xs:unsignedLong()  - DFDL-23-084R">
+
+    <tdml:document>
+      <tdml:documentPart type="text">12345</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ulong04>
+          <string>12345</string>
+          <ulongified>12345</ulongified>
+          <longified>12345</longified>
+        </ulong04>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
   
   <!--

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -853,6 +853,8 @@ class TestDFDLExpressions {
   @Test def test_ulong_constructor_03() { runner2.runOneTest("ulong_constructor_03") }
   @Test def test_ulong_constructor_04() { runner2.runOneTest("ulong_constructor_04") }
   @Test def test_ulong_constructor_05() { runner2.runOneTest("ulong_constructor_05") }
+  @Test def test_ulong_constructor_06() { runner2.runOneTest("ulong_constructor_06") }
+  @Test def test_ulong_constructor_07() { runner2.runOneTest("ulong_constructor_07") }
 
   @Test def test_long_constructor_01() { runner2.runOneTest("long_constructor_01") }
   @Test def test_long_constructor_02() { runner2.runOneTest("long_constructor_02") }


### PR DESCRIPTION
After an expression is evaluated, the postProcess function is called to
potentially modify the resulting value. One thing it does convert the
result to a Long if the target type of an expression is an
xs:unsignedLong. But this is simply a bug. If an xs:unsignedLong value
is too large to fit in a Long then it is silently truncated.
Additionally, now that we are more strict about elements containing
values of the correct type, this means that an element will have a Long
value when we expected a BigInt for xs:unsignedLong, which causes a
casting exception in some cases.

This removes these unnecessary conversions in postProcess, and instead
just changes the function to a validation function, adding new checks
that all underlying types are correct for their target type. This
ensures that expression conversions do the right thing. And this
actually discovered more cases where we weren't strict about types. The
following fixes were made so types are consistent:

- Infinity/NaN was always represented in the infoset as a Double type,
  even if the target type was xs:float. Switched to use the appropriate
  type for the primitive
- Expressions did not convert types to BigInt's when the target type was
  an xs:unsignedLong, but would just convert them to Longs
- fn:ceil always created a Float, even if the argument type was an
  xs:double
- fn:year-from-dateTime did not allow conversion to the target type
- fn:*-from-date* functions returned an xs:long instead of an xs:integer
  like the XPath spec requires.

DAFFODIL-2276