### PR TITLE
Configure Sonarcloud.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@
 # the License. You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: SonarCloud Workflow
+on: [push]
+jobs:
+  sonarCloudTrigger:
+    name: SonarCloud Trigger
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scala_version: [ '2.12.6', '2.11.12' ]
+    steps:
+
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Checkout Repository
+        uses: actions/checkout@master
+
+      ############################################################
+      # Build & Scan
+      ############################################################
+
+      - name: Compile
+        run: $SBT compile test:compile it:compile
+        shell: bash
+        env:
+          SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }} coverage
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sonar.organization=apache
+sonar.projectKey=apache_inbubator-daffodil
+
+sonar.modules=daffodil-cli,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-unparser,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
+sonar.sources=src/main
+sonar.tests=src/it,src/test
+sonar.java.binaries=target/**/classes
+sonar.java.test.binaries=target/**/test-classes
+sonar.java.libraries=../lib_managed/**/*.jar


### PR DESCRIPTION
- sonarcloud workflow with compilation of code and tests, and sonarcloud
action to do the scanning and upload to site based on
sonar-scanner.properties specification
- properties file with organization, projectKey, module information etc
- we didn't configure for scoverage information as that is already provided by codecov
- test run can be found here: https://sonarcloud.io/dashboard?branch=daffodil-2275-sonarqube-config&id=olabusayoT_incubator-daffodil
- we're awaiting final configuration changes on sonarcloud.io that should reduce the amount of codesmells

DAFFODIL-2275