### PR TITLE
Fix non-thread safe code in checking for local delimiters

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Runtime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Runtime.scala
@@ -129,8 +129,7 @@ trait DFADelimiter extends DFA {
   def delimType: DelimiterTextType.Type
   def lookingFor: String
   def location: SchemaFileLocation
-  var indexInDelimiterStack: Int = -1
-  override def toString(): String = "<DFA type='%s' lookingFor='%s' index='%d' />".format(delimType, lookingFor, indexInDelimiterStack)
+  override def toString(): String = "<DFA type='%s' lookingFor='%s' />".format(delimType, lookingFor)
 
   final override def run(r: Registers): Unit = runLoop(r, DFA.FinalState, StateKind.Succeeded)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
@@ -76,14 +76,6 @@ class DelimiterStackParser(
         i += 1
       }
 
-      // set the index of the newly added delimiters
-      val newDelimLen = start.mpstate.delimiters.length
-      i = newLocalIndex
-      while (i < newDelimLen) {
-        start.mpstate.delimiters(i).indexInDelimiterStack = i
-        i += 1
-      }
-
       // parse
         bodyParser.parse1(start)
     } finally {


### PR DESCRIPTION
As an optimization, when we add a DFADelimiter to the stack of in-scope
delimiters, we mutate the DFADelimiter to store its index in that stack.
This stored index allows us to quickly determine if a found delimiter is
local or remote by just comparing the index to first local DFA index.
Although these DFADelimiters are mutated, which is the sort of thing
that is usually not thread safe for us, it actually is thread safe
because each instance of a DFADelmiter always ends up in the same index.
So different threads might mutate the same DFADelimiter, but they always
mutated it to the same value.

However, with the recent change to avoid copying, the same DFADelimiter
can now be shared at different stack positions in a parse. This causes
mutable state in the DFADelimiter to differ, and now different threads
can mutate that state with different values and cause random failures.

This commit removes this mutable state and instead just searches the
in-scope delimiters for a matched delimiter to determine if it is local
or remote. Although this removes the optimization, initial performance
testing shows no real difference.

DAFFODIL-2284