### PR TITLE
Fix deep stack sizes when serializing some schemas

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Serialize.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Serialize.scala
@@ -41,7 +41,6 @@ trait PreSerialization extends Serializable {
 
   protected final def serializeObject(out: java.io.ObjectOutputStream) {
     try {
-      // println("serializing " + Misc.getNameFromClass(this)) // good place for a breakpoint
       preSerialization
       out.defaultWriteObject()
     } catch {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
@@ -40,4 +40,14 @@ final class SchemaSetRuntimeData(
   override def schemaFileLocation = elementRuntimeData.schemaFileLocation
   override def SDE(str: String, args: Any*) = elementRuntimeData.SDE(str, args)
 
+  private def writeObject(oos: java.io.ObjectOutputStream): Unit = {
+    oos.defaultWriteObject()
+    elementRuntimeData.dpathElementCompileInfo.serializeParents(oos)
+  }
+
+  private def readObject(ois: java.io.ObjectInputStream): Unit = {
+    ois.defaultReadObject()
+    elementRuntimeData.dpathElementCompileInfo.deserializeParents(ois)
+  }
+
 }


### PR DESCRIPTION
The "parents" val in a DPathCompileInfo is a backpointer to all
DPathCompileInfo's that reference it. The problem with this is that when
elements are shared, these backpointers create a highly connected graph
that requires a large stack to serialize using the default java
serialization as it jumps around parents and children. To avoid this
large stack requirement, we make the parents backpointer transient. This
prevents jumping back up to parents during serialization and results in
only needing a stack depth relative to the schema depth. Once all that
serialization is completed and all the DPathCompileInfo's are
serialized, we then manually traverse all the DPathCompileInfo's again
and serialize the parent sequences (via the serailizeParents method).
Because all the DPathCompileInfo's are already serialized, this just
serializes the Sequence objects and the stack depth is again relative to
the schema depth.

On complex schemas, this saw an order of magnitude reduction in stack
size during serialization.

DAFFODIL-2283