### PR TITLE
Embed a signature into release RPMs

### DIFF
--- a/containers/release-candidate/README.md
+++ b/containers/release-candidate/README.md
@@ -31,6 +31,7 @@ To use the container image to build a release run the following:
       -v ~/.gitconfig:/root/.gitconfig \
       -v ~/.gnupg/:/root/.gnupg/ \
       -v ~/.ssh/:/root/.ssh/ \
+      --hostname daffodil.build \
       daffodil-release-candidate
 
 When run, the container will periodically ask for user input (e.g. usernames,

--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -178,6 +178,9 @@ MSI_NAME=$(basename $DAFFODIL_RELEASE_DIR/bin/*.zip .zip).msi
 cp daffodil-cli/target/windows/Daffodil.msi $DAFFODIL_RELEASE_DIR/bin/$MSI_NAME
 chmod -x $DAFFODIL_RELEASE_DIR/bin/$MSI_NAME
 
+echo "Embedding RPM Signature..."
+rpmsign --define "_gpg_name $PGP_SIGNING_KEY_ID" --define "_binary_filedigest_algorithm 10" --addsign $DAFFODIL_RELEASE_DIR/bin/*.rpm
+
 echo "Calculating Checksums..."
 for i in src/ bin/
 do
@@ -232,7 +235,7 @@ echo "- Staged published files at https://repository.apache.org/"
 echo
 
 if [ "$DRY_RUN" = true ]; then
-  echo "!!! This was a dry run do not push/publish any changes !!!"
+  echo "!!! This was a dry run. Do not push/publish any changes !!!"
   echo
   echo "Type 'exit' when done with the container"
 else

--- a/containers/release-candidate/setup-container.sh
+++ b/containers/release-candidate/setup-container.sh
@@ -23,7 +23,7 @@ rm ~/*
 
 #install dependencies
 curl https://bintray.com/sbt/rpm/rpm -o /etc/yum.repos.d/bintray-sbt-rpm.repo
-microdnf install git svn sbt java-1.8.0-devel wine winetricks unzip rpm-build vim-minimal
+microdnf install git svn sbt java-1.8.0-devel wine winetricks unzip rpm-build rpm-sign vim-minimal
 winetricks --unattended dotnet45
 
 # install wix


### PR DESCRIPTION
Although we provide signatures and SHAs for all release sources and
binary helpers, it is possible to embed a signature in an RPM so that it
can be verified upon installation. This is a nice added layer of
verification that we should include.

The sbt-native-packager plugin we use to build RPMs does not support
embedding signatures, but it is easy enough to manually add a signature
after the RPM is built via the rpmsign tool. This patch modifies the
release candidate container to use that tool to embed a signature with
the same GPG key used to create all other signatures.

A side effect of this is that users installing the RPM will get a
warning if they do not import the Daffodil GPG keys, but that can be
done by running:

  rpm --import https://downloads.apache.org/incubator/daffodil/KEYS

Also fix a typo and modify README to set a hostname. The build hostname
is included in the RPM so we want this to be consistent and not a random
container ID as is the case by default.

DAFFODIL-2294