### PR TITLE
Only run the SonarCloud action when triggered in the Daffodil repo

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,7 @@ name: SonarCloud Workflow
 on: [push]
 jobs:
   sonarCloudTrigger:
+    if: github.repository == 'apache/incubator-daffodil'
     name: SonarCloud Trigger
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The SonarCloud action is currently configured to always run on any push,
regardless of the repo that the branch was pushed to, including the main
repo or any GitHub forks. And that action is configured to always use
the Apache Daffodil SonarCloud project, which requires a SONAR_TOKEN
secret that forks will not have. This means that any pushes to a fork
will result in a failure of the SonarCloud action, which might be
confusing to new users.

This adds a condition to the SonarCloud job so that it is only run when
the repository it was triggered from is the main Daffodil repository.
This repo will always have the correct SONAR_TOKEN so that the action
can succeed.

DAFFODIL-2300