### PR TITLE
Update github actions/checkout to use v2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       ############################################################
 
       - name: Checkout Repository
-        uses: actions/checkout@v1.0.0
+        uses: actions/checkout@v2.0.0
 
       - name: Install Dependencies (Windows)
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
       ############################################################
 
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2.0.0
 
       ############################################################
       # Build & Scan


### PR DESCRIPTION
There is a bug in actions/checkout v1.0.0 that prevents re-running a
github workflow, which is needed in some cases when there is a random
failure (e.g. network failure downloaded dependencies). This updates it
to v2.0.0, which fixes this issue. Also updates SonarCloud to use a
specific version instead of master. We've had issues in the past where
the master branch was undergoing development and broke our builds.
Sticking to a specific version prevents that.

DAFFODIL-2301