### PR TITLE
Remove unused term methods

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -1044,23 +1044,6 @@ trait ElementBase
     }
   }.value
 
-  protected final lazy val possibleFirstChildTerms: Seq[Term] =
-    termChildren
-
-  protected final def couldBeLastElementInModelGroup: Boolean = LV('couldBeLastElementInModelGroup) {
-    val couldBeLast = this.immediatelyEnclosingGroupDef match {
-      case None => true
-      case Some(s: SequenceTermBase) if s.isOrdered => {
-        !possibleNextSiblingTerms.exists {
-          case e: ElementBase => e.isRequiredStreamingUnparserEvent
-          case mg: ModelGroup => mg.mustHaveRequiredElement
-        }
-      }
-      case _ => true
-    }
-    couldBeLast
-  }.value
-
   final lazy val defaultParseUnparsePolicy = optionParseUnparsePolicy.getOrElse(ParseUnparsePolicy.Both)
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ModelGroup.scala
@@ -331,36 +331,6 @@ abstract class ModelGroup(index: Int)
   }
 
   /*
-   * Returns list of Terms that could contain the first child element in the infoset
-   */
-  protected final lazy val possibleFirstChildTerms: Seq[Term] = LV('possibleFirstChildTerms) {
-    val firstTerms = this match {
-      case c: ChoiceTermBase => groupMembers
-      case s: SequenceTermBase if !s.isOrdered => groupMembers
-      case s: SequenceTermBase => {
-        groupMembers.headOption match {
-          case None => Nil
-          case Some(e: ElementBase) if e.canBeAbsentFromUnparseInfoset => {
-            // this case covers optional elements, arrrays with minOccurs = 0,
-            // and elements with outputValueCalc. In each of these cases, the
-            // first child could be first, but so could any siblings that
-            // follow it
-            Seq(e) ++ e.possibleNextSiblingTerms
-          }
-          case Some(gr: GroupRef) if gr.isHidden => gr.possibleNextSiblingTerms
-          case Some(mg: ModelGroup) if !mg.mustHaveRequiredElement => Seq(mg) ++ mg.possibleNextSiblingTerms
-          case Some(e: ElementBase) => Seq(e)
-          case Some(mg: ModelGroup) => Seq(mg)
-        }
-      }
-    }
-    firstTerms
-  }.value
-
-  /** Always false as model groups can't be elements.*/
-  protected final def couldBeLastElementInModelGroup: Boolean = false
-
-  /*
    * Determines if this model group must have at least one required element, or
    * if everything in the model group is optional and thus, might not cause
    * any unparse events. This is used to determine next children/sibling

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -29,7 +29,7 @@ class TestMiddleEndAttributes {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testHasPriorRequiredSiblings {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_1 {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -53,12 +53,9 @@ class TestMiddleEndAttributes {
     val Seq(s1, s2) = seq.groupMembers
     assertTrue(s1.hasStaticallyRequiredOccurrencesInDataRepresentation)
     assertTrue(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
-    assertTrue(s1.hasLaterRequiredSiblings)
-    assertTrue(s2.hasPriorRequiredSiblings)
-
   }
 
-  @Test def testDoesNotHavePriorRequiredSiblings {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_2 {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -82,9 +79,6 @@ class TestMiddleEndAttributes {
     val Seq(s1, s2) = seq.groupMembers
     assertFalse(s1.hasStaticallyRequiredOccurrencesInDataRepresentation)
     assertFalse(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
-    assertFalse(s1.hasLaterRequiredSiblings)
-    assertFalse(s2.hasPriorRequiredSiblings)
-
   }
 
   @Test def testRequiredSiblings {
@@ -117,16 +111,6 @@ class TestMiddleEndAttributes {
     assertFalse(s3.hasStaticallyRequiredOccurrencesInDataRepresentation)
     assertTrue(s4.hasStaticallyRequiredOccurrencesInDataRepresentation)
     assertFalse(s5.hasStaticallyRequiredOccurrencesInDataRepresentation)
-    assertTrue(s1.hasLaterRequiredSiblings)
-    assertTrue(s2.hasLaterRequiredSiblings)
-    assertTrue(s3.hasLaterRequiredSiblings)
-    assertFalse(s4.hasLaterRequiredSiblings)
-    assertFalse(s5.hasLaterRequiredSiblings)
-    assertFalse(s1.hasPriorRequiredSiblings)
-    assertFalse(s2.hasPriorRequiredSiblings)
-    assertTrue(s3.hasPriorRequiredSiblings)
-    assertTrue(s4.hasPriorRequiredSiblings)
-    assertTrue(s5.hasPriorRequiredSiblings)
   }
 
   @Test def testStaticallyFirstWithChoice {
@@ -159,12 +143,10 @@ class TestMiddleEndAttributes {
     assertTrue(es.hasInfixSep)
     assertEquals(1, s1.position)
     assertTrue(s1.isScalar)
-    assertTrue(!s1.hasPriorRequiredSiblings)
     val es2 = s2.optLexicalParent.get.optLexicalParent.get.asInstanceOf[Sequence]
     assertEquals(es, es2)
     assertEquals(2, s2.position)
     assertTrue(s2.isScalar)
-    assertTrue(!s2.hasPriorRequiredSiblings)
   }
 
   @Test def testNearestEnclosingSequenceElementRef() {


### PR DESCRIPTION
Removed
- possibleFirstChildTerms
- couldBeLastElementInModelGroup
- hasPriorRequiredSiblings
- hasLastRequiredSiblings
- isSquenceChild
- possibleFirstChildElementsInInfoset
- possibleNextSiblingTerms
Rename tests to show representation of testing of
hasStaticallyRequiredOccurrencesInDataRepresentation

DAFFODIL-2305