### PR TITLE
Daffodil 2302 fixes external variables API difficulties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,13 @@ lazy val commonSettings = Seq(
     "-language:experimental.macros",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Xxml:-coalescing",
+    "-Xxml:-coalescing"
+  ),
+  // Workaround issue that some options are valid for javac, not javadoc.
+  // These javacOptions are for code compilation only. (Issue sbt/sbt#355)
+  javacOptions in Compile in compile ++= Seq(
+    "-Werror",
+    "-Xlint:deprecation"
   ),
   logBuffered := true,
   transitiveClassifiers := Seq("sources", "javadoc"),

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -110,13 +110,13 @@ class TestCLIparsing {
     val shell = Util.startIncludeErrors("")
 
     try {
-      var cmd = String.format("%s -v save-parser -s %s -r row -D\"{http://example.com}var1=99\" -c %s %s", Util.binPath, testSchemaFile, testConfigFile, savedParser)
+      var cmd = String.format("%s -v save-parser -s %s -r row -c %s %s", Util.binPath, testSchemaFile, testConfigFile, savedParser)
       shell.sendLine(cmd)
       shell.expectIn(1, (contains("[info] Time (saving)")))
       assertTrue("save-parser failed", parserFile.exists())
 
       shell.sendLine();
-      cmd = String.format("echo 0| %s parse --parser %s\n", Util.binPath, savedParser)
+      cmd = String.format("echo 0| %s parse --parser %s -D\"{http://example.com}var1=99\"\n", Util.binPath, savedParser)
       shell.sendLine(cmd)
       shell.expect(contains("<tns:row xmlns:tns=\"http://example.com\">"))
       shell.expect(contains("<cell>99</cell>"))

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
@@ -103,7 +103,7 @@ class TestCLISaveParser {
       val saveCmd = String.format("%s save-parser -s %s -r row2 -c %s %s", Util.binPath, testSchemaFile, testConfigFile, savedParserFile.getName())
       shell.sendLine(saveCmd)
 
-      val cmd = String.format("echo 0,1,2| %s parse --parser %s", Util.binPath, savedParserFile.getName())
+      val cmd = String.format("echo 0,1,2| %s parse --parser %s -c %s", Util.binPath, savedParserFile.getName(), testConfigFile)
       shell.sendLine(cmd)
       shell.expect(contains(output12))
 
@@ -262,6 +262,10 @@ class TestCLISaveParser {
     }
   }
 
+  /**
+   * Note that in Daffodil 2.6.0 behavior of external variables changed. They are not saved as part of binary
+   * compiling. They are a runtime-thing only.
+   */
   @Test def test_3508_CLI_Saving_SaveParser_extVars() {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
@@ -273,13 +277,13 @@ class TestCLISaveParser {
     val shell = Util.startIncludeErrors("")
 
     try {
-      var cmd = String.format("%s -v save-parser -s %s -r row2 -D\"{http://example.com}var1=25\" \"{http://example.com}var3=7\" %s", Util.binPath, testSchemaFile, savedParser)
+      var cmd = String.format("%s -v save-parser -s %s -r row2  %s", Util.binPath, testSchemaFile, savedParser)
       shell.sendLine(cmd)
       shell.expectIn(1, (contains("[info] Time (saving)")))
       assertTrue("save-parser failed", parserFile.exists())
 
       shell.sendLine();
-      cmd = String.format("echo 0| %s parse --parser %s\n", Util.binPath, savedParser)
+      cmd = String.format("""echo 0| %s parse --parser %s -D"{http://example.com}var1=25" "{http://example.com}var3=7" """, Util.binPath, savedParser)
       shell.sendLine(cmd)
       shell.expect(contains("<tns:row2 xmlns:tns=\"http://example.com\">"))
       shell.expect(contains("<cell>25</cell>"))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/compiler/RootSpec.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/compiler/RootSpec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.daffodil.compiler
 
+import org.apache.daffodil.api.UnqualifiedPathStepPolicy.NoNamespace
+import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.xml.NS
 
 /**
@@ -32,5 +34,15 @@ case class RootSpec(ns: Option[NS], name: String) {
   override def toString() = {
     val nsStr = ns.getOrElse("")
     "{" + nsStr + "}" + name
+  }
+}
+
+object RootSpec {
+  def makeRootSpec(optName: Option[String], optNamespace:Option[String]) = {
+    val ns = optNamespace.map{ NS(_) }
+    if (optNamespace.isDefined && optName.isEmpty)
+      Assert.usageError("Cannot specify only a namespace without a name. Namespace argument was: "
+        + (if (ns eq NoNamespace) "\"\" " + ns else ns))
+    optName.map{ RootSpec(ns, _) }
   }
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Nesting.scala
@@ -54,7 +54,6 @@ trait NestingLexicalMixin { self: SchemaComponent =>
       case sd: SchemaDocument => usageErr(sd)
       case ss: SchemaSet => usageErr(ss)
       case s: Schema => usageErr(s)
-      case pf: ProcessorFactory => usageErr(pf)
       case _ => // ok
     }
     val result =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSetIncludesAndImportsMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSetIncludesAndImportsMixins.scala
@@ -41,9 +41,8 @@ trait SchemaSetIncludesAndImportsMixin { self: SchemaSet =>
 
     // Any time we synthesize xml we have to grab the namespace definitions and
     // make sure we drag them along onto the new structures.
-    val fakeImportStatementsXML = schemaSources.map { ssrc =>
-      <xs:import schemaLocation={ ssrc.uriForLoading.toString } xmlns:xs={ xsd }/>
-    }
+    val fakeImportStatementsXML =
+      <xs:import schemaLocation={ schemaSource.uriForLoading.toString } xmlns:xs={ xsd }/>
 
     val fakeSchemaDocXML =
       <xs:schema xmlns:xs={ xsd }>{ fakeImportStatementsXML }</xs:schema>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SchemaSetGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SchemaSetGrammarMixin.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.grammar
+
+import org.apache.daffodil.api.ParseUnparsePolicyTunable
+import org.apache.daffodil.dsom.SchemaSet
+import org.apache.daffodil.runtime1.SchemaSetRuntime1Mixin
+import org.apache.daffodil.schema.annotation.props.gen.ParseUnparsePolicy
+
+trait SchemaSetGrammarMixin
+extends SchemaSetRuntime1Mixin { self: SchemaSet =>
+
+  lazy val (generateParser, generateUnparser) = {
+    val (context, policy) = tunable.parseUnparsePolicy match {
+      case ParseUnparsePolicyTunable.FromRoot => (Some(root), root.rootParseUnparsePolicy)
+      case ParseUnparsePolicyTunable.ParseOnly => (None, ParseUnparsePolicy.ParseOnly)
+      case ParseUnparsePolicyTunable.UnparseOnly => (None, ParseUnparsePolicy.UnparseOnly)
+      case ParseUnparsePolicyTunable.Both => (None, ParseUnparsePolicy.Both)
+    }
+    root.checkParseUnparsePolicyCompatibility(context, policy)
+    policy match {
+      case ParseUnparsePolicy.Both => (true, true)
+      case ParseUnparsePolicy.ParseOnly => (true, false)
+      case ParseUnparsePolicy.UnparseOnly => (false, true)
+    }
+  }
+
+}

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/VariableMap.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/VariableMap.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.daffodil.grammar.primitives
+package org.apache.daffodil.grammar
 
 import org.apache.daffodil.dsom._
 import org.apache.daffodil.externalvars.Binding
@@ -32,7 +32,7 @@ object VariableMapFactory {
 
   def setExternalVariables(currentVMap: VariableMap, bindings: Seq[Binding], referringContext: ThrowsSDE) = {
     var newVMap = currentVMap
-    bindings.foreach(b => newVMap = newVMap.setExtVariable(b.globalQName, b.varValue, referringContext))
+    bindings.foreach(b => newVMap = newVMap.setExtVariable(b.varQName, b.varValue, referringContext))
     newVMap
   }
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.runtime1
+
+import org.apache.daffodil.ExecutionMode
+import org.apache.daffodil.api.DFDL
+import org.apache.daffodil.api.ValidationMode
+import org.apache.daffodil.dsom.SchemaSet
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.externalvars.ExternalVariablesLoader
+import org.apache.daffodil.grammar.VariableMapFactory
+import org.apache.daffodil.processors.DataProcessor
+import org.apache.daffodil.processors.Processor
+import org.apache.daffodil.processors.SchemaSetRuntimeData
+import org.apache.daffodil.processors.VariableMap
+import org.apache.daffodil.processors.parsers.NotParsableParser
+import org.apache.daffodil.processors.unparsers.NotUnparsableUnparser
+import org.apache.daffodil.util.LogLevel
+
+trait SchemaSetRuntime1Mixin { self : SchemaSet =>
+
+  requiredEvaluationsAlways(variableMap)
+  requiredEvaluationsAlways(parser)
+  requiredEvaluationsAlways(unparser)
+  requiredEvaluationsAlways(root.runtimeData)
+
+  override def variableMap: VariableMap = LV('variableMap) {
+    val dvs = allSchemaDocuments.flatMap { _.defineVariables }
+    val alldvs = dvs.union(predefinedVars)
+    val vmap = VariableMapFactory.create(alldvs)
+    //
+    // Here we verify that any external variable bindings supplied at schema compilation time
+    // are properly structured - the variables they reference exist, are external, and the
+    // supplied value string is convertible into the declared variable's type.
+    //
+    // But... then we throw it away. We don't save the external variable bindings as
+    // part of the saved data structure representing the compiled schema.
+    // Because external variables really have to be bound at runtime, and the schema has
+    // to work with and without any such bindings.
+    //
+    // This same checking must be done at runtime, so we share that same code here at schema compile time.
+    // This is yet another example of where runtime1-specific code is being used in a general
+    // schema-compilation role. So even if building a runtime 2, you would still want to keep much of
+    // the runtime 1 code around.
+    //
+    ExternalVariablesLoader.loadVariables(compilerExternalVarSettings, this, vmap)
+    vmap
+  }.value
+
+  lazy val parser = LV('parser) {
+    val par = if (generateParser) root.document.parser else new NotParsableParser(root.erd)
+    Processor.initialize(par)
+    par
+  }.value
+
+  lazy val unparser = LV('unparser) {
+    val unp = if (generateUnparser) root.document.unparser else new NotUnparsableUnparser(root.erd)
+    Processor.initialize(unp)
+    unp
+  }.value
+
+  def onPath(xpath: String): DFDL.DataProcessor = {
+    ExecutionMode.usingCompilerMode {
+      Assert.usage(!isError)
+      if (xpath != "/") root.notYetImplemented("""Path must be "/". Other path support is not yet implemented.""")
+      val rootERD = root.elementRuntimeData
+      root.schemaDefinitionUnless(
+        rootERD.outputValueCalcExpr.isEmpty,
+        "The root element cannot have the dfdl:outputValueCalc property.")
+      val validationMode = ValidationMode.Off
+      val p = if (!root.isError) parser else null
+      val u = if (!root.isError) unparser else null
+      val ssrd = new SchemaSetRuntimeData(
+        p,
+        u,
+        this.diagnostics,
+        rootERD,
+        variableMap,
+        typeCalcMap)
+      if (root.numComponents > root.numUniqueComponents)
+        log(LogLevel.Info, "Compiler: component counts: unique %s, actual %s.",
+          root.numUniqueComponents, root.numComponents)
+      val dataProc = new DataProcessor(ssrd, tunable, self.compilerExternalVarSettings)
+      if (dataProc.isError) {
+        // NO longer printing anything here. Callers must do this.
+        //        val diags = dataProc.getDiagnostics
+        //        log(LogLevel.Error,"Compilation (DataProcessor) reports %s compile errors/warnings.", diags.length)
+        //        diags.foreach { diag => log(LogLevel.Error, diag.toString()) }
+      } else {
+        log(LogLevel.Compile, "Parser = %s.", ssrd.parser.toString)
+        //log(LogLevel.Error, "Unparser = %s.", ssrd.unparser.toString)
+        log(LogLevel.Compile, "Compilation (DataProcesor) completed with no errors.")
+      }
+      dataProc
+    }
+  }
+
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
@@ -37,8 +37,7 @@ import org.apache.daffodil.infoset.InfosetDocument
 class TestDFDLExpressionEvaluation extends Parsers {
 
   def testExpr(testSchema: scala.xml.Elem, infosetAsXML: scala.xml.Elem, expr: String)(body: Any => Unit) {
-    val schemaCompiler = Compiler()
-    schemaCompiler.setTunable("allowExternalPathExpressions", "true")
+    val schemaCompiler = Compiler().withTunable("allowExternalPathExpressions", "true")
     val pf = schemaCompiler.compileNode(testSchema).asInstanceOf[ProcessorFactory]
     val sset = pf.sset
     if (pf.isError) fail("pf compile errors")

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -80,8 +80,7 @@ class TestDsomCompiler extends Logging {
         </xs:complexType>
       </xs:element>)
 
-    val compiler = Compiler()
-    compiler.setCheckAllTopLevel(true)
+    val compiler = Compiler().withCheckAllTopLevel(true)
     val sset = compiler.compileNode(sch).sset
     assertTrue(sset.isError)
     val diagnostics = sset.getDiagnostics.asInstanceOf[Seq[Diagnostic]]
@@ -133,8 +132,7 @@ class TestDsomCompiler extends Logging {
           </xs:sequence>
         </xs:complexType>
       </xs:element>)
-    val compiler = Compiler()
-    compiler.setCheckAllTopLevel(true)
+    val compiler = Compiler().withCheckAllTopLevel(true)
     val sset = Compiler().compileNode(s).sset
     sset.isError // forces compilation
     val diags = sset.getDiagnostics

--- a/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
@@ -105,7 +105,8 @@ class TestExternalVariablesLoader extends Logging {
     assertTrue(var_v_with_default.value.isDefined)
     assertEquals("42", var_v_with_default.value.getAnyRef.toString())
 
-    val vmap = ExternalVariablesLoader.loadVariables(extVarFile1, sd, initialVMap, tunable)
+    val bindings = ExternalVariablesLoader.uriToBindings(extVarFile1)
+    val vmap = ExternalVariablesLoader.loadVariables(bindings, sd, initialVMap)
 
     // Verify that the external variables override the previous values
     // in the VariableMap
@@ -121,7 +122,8 @@ class TestExternalVariablesLoader extends Logging {
     val e = intercept[SchemaDefinitionError] {
       // fakeSD does not contain any defineVariables
       // Because we are trying to load external variables and none are defined we should SDE.
-      ExternalVariablesLoader.loadVariables(extVarFile1, Fakes.fakeSD, new VariableMap(), tunable)
+      val bindings = ExternalVariablesLoader.uriToBindings((extVarFile1))
+      ExternalVariablesLoader.loadVariables(bindings, Fakes.fakeSD, new VariableMap())
     }
     val err = e.getMessage()
     assertTrue(err.contains("unknown variable ex:v_no_default"))

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
@@ -56,21 +56,20 @@ class TestTunables extends Logging {
       </xs:complexType>)
 
     val c = Compiler()
+    val c1 = c.withTunable("maxSkipLengthInBytes", "1026")
+    val pf1 = c1.compileNode(testSchema)
 
-    c.setTunable("maxSkipLengthInBytes", "1026")
-    val pf1 = c.compileNode(testSchema)
-
-    c.setTunable("maxSkipLengthInBytes", "2048")
-    val pf2 = c.compileNode(testSchema)
+    val c2 = c.withTunable("maxSkipLengthInBytes", "2048")
+    val pf2 = c2.compileNode(testSchema)
 
     val dp1 = pf1.onPath("/")
-    val dp2 = pf2.onPath("/")
+    var dp2 = pf2.onPath("/")
 
     val t1 = dp1.getTunables()
     val t2 = dp2.getTunables()
 
     /* Set tunable at run-time via data processor */
-    dp2.setTunable("maxSkipLengthInBytes", "50")
+    dp2 = dp2.withTunable("maxSkipLengthInBytes", "50")
 
     val t3 = dp2.getTunables() // modified tunables at 'run-time'
     val t4 = dp1.getTunables() // obtain first data processor to see if anything changed

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
@@ -58,7 +58,7 @@ class TestInfosetInputterFromReader {
     val inputter = new ScalaXMLInfosetInputter(infosetXML)
     inputter.initialize(rootERD, u.getTunables())
     val is = Adapter(inputter)
-    (is, rootERD, inputter, u.tunable)
+    (is, rootERD, inputter, u.tunables)
   }
 
   @Test def testUnparseFixedLengthString1() {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/SchemaUtils.scala
@@ -52,11 +52,15 @@ object SchemaUtils {
     topLevelAnnotations: Seq[Node],
     contentElements: Seq[Node],
     theTargetNS: String,
-    elementFormDefault: String = "qualified"): Elem = {
+    elementFormDefault: String = "qualified",
+    hasDefaultNamespace: Boolean = true): Elem = {
     val tns = if (theTargetNS == "" || theTargetNS == null) NoNamespace else NS(theTargetNS)
     val sch =
       dfdlTestSchema(includeImports, topLevelAnnotations, contentElements,
-        targetNamespace = tns, defaultNamespace = tns, elementFormDefault = elementFormDefault)
+        targetNamespace = tns,
+        defaultNamespace = tns,
+        elementFormDefault = elementFormDefault,
+        hasDefaultNamespace = hasDefaultNamespace)
     sch
   }
 
@@ -78,7 +82,8 @@ object SchemaUtils {
     fileName: String = "",
     targetNamespace: NS = XMLUtils.targetNS,
     defaultNamespace: NS = XMLUtils.targetNS,
-    elementFormDefault: String = "qualified"): Elem = {
+    elementFormDefault: String = "qualified",
+    hasDefaultNamespace: Boolean = true): Elem = {
     val fileAttrib =
       if (fileName == "") Null
       else Attribute(XMLUtils.INT_PREFIX, "file", Text(fileName), Null)
@@ -92,7 +97,9 @@ object SchemaUtils {
         <ignore xmlns:xsd={ xsdURI } xmlns:dfdl={ dfdlURI } xmlns:xsi={ xsiURI } xmlns:fn={ fnURI } xmlns:math={ mathURI } xmlns:dafint={ dafintURI }/>.scope
       }
     scope = XMLUtils.combineScopes("xs", XMLUtils.xsdURI, scope) // always need this one
-    scope = XMLUtils.combineScopes(null, defaultNamespace, scope)
+    if (hasDefaultNamespace) {
+      scope = XMLUtils.combineScopes(null, defaultNamespace, scope)
+    }
     scope = XMLUtils.combineScopes("tns", targetNamespace, scope)
     scope = XMLUtils.combineScopes("ex", targetNamespace, scope)
     scope = XMLUtils.combineScopes("dfdlx", XMLUtils.DFDLX_NAMESPACE, scope)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceChildUnparsers.scala
@@ -113,7 +113,7 @@ abstract class RepeatingChildUnparser(
     Assert.invariant(state.processorStatus eq Success)
 
     val shouldValidate =
-      state.dataProc.isDefined && state.dataProc.value.getValidationMode != ValidationMode.Off
+      state.dataProc.isDefined && state.dataProc.value.validationMode != ValidationMode.Off
 
     if (shouldValidate) {
       val minO = erd.minOccurs

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -98,14 +98,20 @@ object DFDL {
      * it will search for a unique element with your root element name, and
      * if that is unambiguous, it will use it as the root.
      */
+    @deprecated("Use arguments to compileSource, or compileFile method.", "2.6.0")
     def setDistinguishedRootNode(name: String, namespace: String)
+
+    @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
     def setExternalDFDLVariable(name: String, namespace: String, value: String)
 
     /**
      * Compilation returns a parser factory, which must be interrogated for diagnostics
      * to see if compilation was successful or not.
      */
-    def compileSource(schemaSource: DaffodilSchemaSource): ProcessorFactory
+    def compileSource(
+      schemaSource: DaffodilSchemaSource,
+      optRootNodeName: Option[String] = None,
+      optRootNodeNamespace: Option[String] = None): ProcessorFactory
 
     def reload(savedParser: File): DataProcessor
   }
@@ -132,22 +138,48 @@ object DFDL {
      * To explicitly specify that there is no-namespace, pass "" as
      * the namespace argument.
      */
-    def setDistinguishedRootNode(name: String, namespace: String = null)
+    @deprecated("Use arguments to Compiler.compileSource or compileFile.", "2.6.0")
+    def setDistinguishedRootNode(name: String, namespace: String = null): Unit
+
     def onPath(xpath: String): DataProcessor
   }
 
   trait DataProcessor extends WithDiagnostics {
-    def setValidationMode(mode: ValidationMode.Type): Unit
-    def getValidationMode(): ValidationMode.Type
-    def save(output: DFDL.Output): Unit
-    def setExternalVariables(extVars: Map[String, String]): Unit
-    def setExternalVariables(extVars: File): Unit
-    def setExternalVariables(extVars: File, tunable: DaffodilTunables): Unit
-    def setExternalVariables(extVars: Seq[Binding]): Unit
-    def getVariables(): VariableMap
-    def setTunable(tunable: String, value: String): Unit
-    def setTunables(tunables: Map[String,String]): Unit
+
+    /**
+     * Returns a data processor with all the same state, but the validation mode changed to that of the argument.
+     *
+     * Note that the default validation mode is "off", that is, no validation is performed.
+     */
+    def withValidationMode(mode:ValidationMode.Type): DataProcessor
+    def withTunable(name: String, value: String): DataProcessor
+    def withTunables(tunables: Map[String, String]): DataProcessor
+    def withExternalVariables(extVars: Map[String, String]): DataProcessor
+    def withExternalVariables(extVars: File): DataProcessor
+    def withExternalVariables(extVars: Seq[Binding]): DataProcessor
+
+    def validationMode: ValidationMode.Type
+
     def getTunables(): DaffodilTunables
+    def save(output: DFDL.Output): Unit
+    def variableMap: VariableMap
+
+    @deprecated("Use withValidationMode.", "2.6.0")
+    def setValidationMode(mode: ValidationMode.Type): Unit
+    @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
+    def setExternalVariables(extVars: Map[String, String]): Unit
+    @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
+    def setExternalVariables(extVars: File): Unit
+    @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
+    def setExternalVariables(extVars: File, tunable: DaffodilTunables): Unit
+    @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
+    def setExternalVariables(extVars: Seq[Binding]): Unit
+    @deprecated("Use withTunables.", "2.6.0")
+    def setTunable(tunable: String, value: String): Unit
+    @deprecated("Use withTunables.", "2.6.0")
+    def setTunables(tunables: Map[String,String]): Unit
+
+
 
     /**
      * Unparses (that is, serializes) data to the output, returns an object which contains any diagnostics.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -1502,9 +1502,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
         // no children, or last child is not a DIArray for
         // this element, create the DIArray
         val ia = new DIArray(childERD, this, tunable.initialElementOccurrencesHint.toInt)
-        if (childERD.dpathElementCompileInfo.isReferencedByExpressions) {
-          addChildToFastLookup(ia)
-        }
+        addChildToFastLookup(ia)
         childNodes += ia
         _numChildren = childNodes.length
         ia
@@ -1512,9 +1510,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
       // Array is now always last, add the new child to it
       childNodes.last.asInstanceOf[DIArray].append(e)
     } else {
-      if (e.runtimeData.dpathElementCompileInfo.isReferencedByExpressions) {
-        addChildToFastLookup(e.asInstanceOf[DINode])
-      }
+      addChildToFastLookup(e.asInstanceOf[DINode])
       childNodes += e.asInstanceOf[DINode]
       _numChildren = childNodes.length
     }
@@ -1541,14 +1537,16 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
   }
 
   def addChildToFastLookup(node: DINode): Unit = {
-    val name = node.namedQName
-    val fastSeq = nameToChildNodeLookup.get(name)
-    if (fastSeq != null) {
-      fastSeq += node
-    } else {
-      val ab = new ArrayBuffer[DINode]()
-      ab += node
-      nameToChildNodeLookup.put(name, ab)
+    if (node.erd.dpathElementCompileInfo.isReferencedByExpressions) {
+      val name = node.namedQName
+      val fastSeq = nameToChildNodeLookup.get(name)
+      if (fastSeq != null) {
+        fastSeq += node
+      } else {
+        val ab = new ArrayBuffer[DINode]()
+        ab += node
+        nameToChildNodeLookup.put(name, ab)
+      }
     }
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
@@ -28,17 +28,23 @@ import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 final class SchemaSetRuntimeData(
   val parser: Parser,
   val unparser: Unparser,
+  /*
+   * Memory of the compiler's warnings. If we save a processor, it's useful to be able
+   * to have these warnings.
+   */
   val diagnostics: Seq[Diagnostic],
   val elementRuntimeData: ElementRuntimeData,
-  var variables: VariableMap,
-  var validationMode: ValidationMode.Type,
+  /*
+   * The original variables determined by the schema compiler.
+   */
+  val originalVariables: VariableMap,
   val typeCalculators: TypeCalcMap)
   extends Serializable with ThrowsSDE {
 
   def unqualifiedPathStepPolicy = elementRuntimeData.unqualifiedPathStepPolicy
   def encodingInfo = elementRuntimeData.encodingInfo
   override def schemaFileLocation = elementRuntimeData.schemaFileLocation
-  override def SDE(str: String, args: Any*) = elementRuntimeData.SDE(str, args)
+  override def SDE(str: String, args: Any*) = elementRuntimeData.SDE(str, args: _*)
 
   private def writeObject(oos: java.io.ObjectOutputStream): Unit = {
     oos.defaultWriteObject()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
@@ -275,7 +275,7 @@ class ElementParser(
 
     if (pstate.processorStatus eq Success) {
       val shouldValidate =
-        (pstate.dataProc.isDefined) && pstate.dataProc.value.getValidationMode != ValidationMode.Off
+        (pstate.dataProc.isDefined) && pstate.dataProc.value.validationMode != ValidationMode.Off
       if (shouldValidate && erd.isSimpleType) {
         // Execute checkConstraints
         validate(pstate)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -501,7 +501,7 @@ object PState {
     output: InfosetOutputter,
     dataProc: DFDL.DataProcessor): PState = {
 
-    val variables = dataProc.getVariables
+    val variables = dataProc.variableMap
     val diagnostics = Nil
     val mutablePState = MPState()
     val tunables = dataProc.getTunables()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
@@ -355,7 +355,7 @@ abstract class RepeatingChildParser(
     if (state.processorStatus eq Success) {
 
       val shouldValidate =
-        state.dataProc.isDefined && state.dataProc.value.getValidationMode != ValidationMode.Off
+        state.dataProc.isDefined && state.dataProc.value.validationMode != ValidationMode.Off
 
       if (shouldValidate) {
         val minO = erd.minOccurs

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -676,7 +676,7 @@ object UState {
     inputter: InfosetInputter): UStateMain = {
     Assert.invariant(inputter.isInitialized)
 
-    val variables = dataProc.getVariables
+    val variables = dataProc.variableMap
     val diagnostics = Nil
     val newState = new UStateMain(inputter, variables, diagnostics, dataProc.asInstanceOf[DataProcessor], out,
       new mutable.Queue[Suspension], dataProc.getTunables()) // null means no prior UState

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -108,13 +108,13 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
+      .withDebugger(debugger)
+      .withDebugging(true)
+      .withValidationMode(ValidationMode.Off)
 
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
@@ -158,7 +158,7 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp = pf.onPath("/")
@@ -172,8 +172,9 @@ class TestScalaAPI {
     val savedParser = Channels.newChannel(is)
     val compiler = Daffodil.compiler()
     val parser = compiler.reload(savedParser)
-    parser.setDebugger(debugger)
-    parser.setDebugging(true)
+    .withDebugger(debugger)
+    .withDebugging(true)
+    .withValidationMode(ValidationMode.Off)
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -215,7 +216,7 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Info)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
@@ -258,10 +259,10 @@ class TestScalaAPI {
   @Test
   def testScalaAPI3() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    pf.setDistinguishedRootNode("e3", null)
+      .withDistinguishedRootNode("e3", null)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -290,10 +291,10 @@ class TestScalaAPI {
   @Test
   def testScalaAPI3_A() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    pf.setDistinguishedRootNode("e3", null)
+      .withDistinguishedRootNode("e3", null)
     val dp = pf.onPath("/")
 
     // Serialize the parser to memory, then deserialize for parsing.
@@ -329,10 +330,9 @@ class TestScalaAPI {
   @Test
   def testScalaAPI4b() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFileName = getResource("/test/sapi/mySchema3.dfdl.xsd")
-    c.setDistinguishedRootNode("e4", null)
-    val pf = c.compileFile(schemaFileName)
+    val pf = c.compileFile(schemaFileName, Some("e4"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -359,11 +359,10 @@ class TestScalaAPI {
   @Test
   def testScalaAPI5() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFileName = getResource("/test/sapi/mySchema3.dfdl.xsd")
-    c.setDistinguishedRootNode("e4", null); // e4 is a 4-byte long string
     // element
-    val pf = c.compileFile(schemaFileName)
+    val pf = c.compileFile(schemaFileName, Some("e4"), None) // e4 is a 4-byte long string
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -403,17 +402,13 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = new java.io.File("/test/sapi/notHere1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     assertTrue(pf.isError())
     val diags = pf.getDiagnostics
-    var found1 = false
-    diags.foreach { d =>
-      if (d.getMessage().contains("notHere1")) {
-        found1 = true
-      }
-    }
+    val found1 = diags.exists{ _.getMessage().contains("notHere1") }
+
     assertTrue(found1)
 
     // reset the global logging state
@@ -439,10 +434,9 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
-    c.setDistinguishedRootNode("TopLevel", null)
-    val pf = c.compileFile(schemaFile)
+    val pf = c.compileFile(schemaFile, Some("TopLevel"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -484,10 +478,9 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
-    c.setDistinguishedRootNode("TopLevel2", null)
-    val pf = c.compileFile(schemaFile)
+    val pf = c.compileFile(schemaFile, Some("TopLevel2"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -525,10 +518,9 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/TopLevel.dfdl.xsd")
-    c.setDistinguishedRootNode("TopLevel2", null)
-    val pf = c.compileFile(schemaFile)
+    val pf = c.compileFile(schemaFile, Some("TopLevel2"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -572,7 +564,7 @@ class TestScalaAPI {
   def testScalaAPI10() {
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema4.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
@@ -598,7 +590,7 @@ class TestScalaAPI {
   def testScalaAPI11() {
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema5.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
@@ -634,15 +626,16 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
 
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
+      .withDebugger(debugger)
+      .withDebugging(true)
+      .withValidationMode(ValidationMode.Off)
 
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -678,17 +671,18 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val extVarsFile = getResource("/test/sapi/external_vars_1.xml")
     val schemaFile = getResource("/test/sapi/mySchemaWithVars.dfdl.xsd")
-    c.setExternalDFDLVariables(extVarsFile)
     val pf = c.compileFile(schemaFile)
 
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
+      .withExternalVariables(extVarsFile)
+      .withDebugger(debugger)
+      .withDebugging(true)
+      .withValidationMode(ValidationMode.Off)
 
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -719,16 +713,16 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val extVarFile = getResource("/test/sapi/external_vars_1.xml")
     val schemaFile = getResource("/test/sapi/mySchemaWithVars.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
-    dp1.setExternalVariables(extVarFile)
     val dp = reserializeDataProcessor(dp1)
-
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
+      .withExternalVariables(extVarFile)
+      .withDebugger(debugger)
+      .withDebugging(true)
+      .withValidationMode(ValidationMode.Off)
 
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
@@ -772,12 +766,12 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp = pf.onPath("/")
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
+      .withDebugger(debugger)
+      .withDebugging(true)
     // Serialize the parser to memory, then deserialize for parsing.
     val os = new ByteArrayOutputStream()
     val output = Channels.newChannel(os)
@@ -789,7 +783,7 @@ class TestScalaAPI {
     val parser = compiler.reload(input)
 
     try {
-      parser.setValidationMode(ValidationMode.Full)
+      parser.withValidationMode(ValidationMode.Full)
       fail()
     } catch { case e: InvalidUsageException => assertEquals("'Full' validation not allowed when using a restored parser.", e.getMessage()) }
 
@@ -808,13 +802,13 @@ class TestScalaAPI {
     Daffodil.setLoggingLevel(LogLevel.Debug)
 
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
-    dp.setDebugger(debugger)
-    dp.setDebugging(true)
+      .withDebugger(debugger)
+      .withDebugging(true)
 
     val file = getResource("/test/sapi/myInfosetBroken.xml")
     val xml = scala.xml.XML.loadFile(file)
@@ -840,13 +834,12 @@ class TestScalaAPI {
   @Test
   def testScalaAPI16() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
-    dp1.setValidationMode(ValidationMode.Limited)
     val dp = reserializeDataProcessor(dp1)
-
+      .withValidationMode(ValidationMode.Limited)
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -868,13 +861,11 @@ class TestScalaAPI {
   @Test
   def testScalaAPI17() {
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
-    val dp1 = pf.onPath("/")
-    dp1.setValidationMode(ValidationMode.Full)
-    val dp = reserializeDataProcessor(dp1)
-
+    val dp = pf.onPath("/")
+      .withValidationMode(ValidationMode.Full)
     val file = getResource("/test/sapi/myData.dat")
     val fis = new java.io.FileInputStream(file)
     val input = new InputSourceDataInputStream(fis)
@@ -907,10 +898,9 @@ class TestScalaAPI {
   def testScalaAPI18() {
     // Demonstrate that we can use the API to continue a parse where we left off
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
-    c.setDistinguishedRootNode("e4", null)
-    val pf = c.compileFile(schemaFile)
+    val pf = c.compileFile(schemaFile, Some("e4"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -951,10 +941,9 @@ class TestScalaAPI {
     // Demonstrate that we cannot use the API to continue a parse with an invalid InputSource
     // ie. after a runtime SDE. This test needs to be run with an input file larger than 256MB
     val c = Daffodil.compiler()
-    c.setValidateDFDLSchemas(false)
+
     val schemaFile = getResource("/test/sapi/ambig_elt.dfdl.xsd")
-    c.setDistinguishedRootNode("root", null)
-    val pf = c.compileFile(schemaFile)
+    val pf = c.compileFile(schemaFile, Some("root"), None)
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
@@ -38,35 +38,75 @@ object TDML {
  *
  * This interface/trait can depend on Daffodil utilities and libraries, but *cannot* depend on anything
  * about any particular DFDL implementation.
+ *
+ * This object is stateful. It cannot be shared across threads.
  */
 trait AbstractTDMLDFDLProcessorFactory {
+
+  protected type R <: AbstractTDMLDFDLProcessorFactory
 
   def implementationName: String
 
   def validateDFDLSchemas: Boolean
 
+  @deprecated("Use withValidateDFDLSchemas.", "2.6.0")
   def setValidateDFDLSchemas(bool: Boolean): Unit
 
+  def withValidateDFDLSchemas(bool: Boolean): R
+
+  @deprecated("Use withCheckAllTopLevel.", "2.6.0")
   def setCheckAllTopLevel(checkAllTopLevel: Boolean): Unit
 
+  def withCheckAllTopLevel(checkAllTopLevel: Boolean): R
+
+  @deprecated("Use withTunables.", "2.6.0")
   def setTunables(tunables: Map[String, String]): Unit
 
+  def withTunables(tunables: Map[String, String]): R
+
+  @deprecated("Use TDMLDFDLProcessor.withExternalDFDLVariables", "2.6.0")
   def setExternalDFDLVariables(externalVarBindings: Seq[Binding]): Unit
 
+  def withExternalDFDLVariables(externalVarBindings: Seq[Binding]): R
+
+  @deprecated("Use arguments to getProcessor()", "2.6.0")
   def setDistinguishedRootNode(name: String, namespace: String): Unit
 
-  def getProcessor(schemaSource: DaffodilSchemaSource, useSerializedProcessor: Boolean): TDML.CompileResult
+  def getProcessor(schemaSource: DaffodilSchemaSource, useSerializedProcessor: Boolean,
+    optRootName: Option[String] = None, optRootNamespace: Option[String] = None): TDML.CompileResult
 }
 
+/**
+ *  This object is stateful. It cannot be shared across threads.
+ */
 trait TDMLDFDLProcessor {
 
+  protected type R <: TDMLDFDLProcessor
+
+  @deprecated("Use withDebugging.", "2.6.0")
   def setDebugging(onOff: Boolean): Unit
 
+  def withDebugging(onOff: Boolean): R
+
+  @deprecated("Use withTracing.", "2.6.0")
   def setTracing(onOff: Boolean): Unit
 
+  def withTracing(onOff: Boolean): R
+
+  @deprecated("Use withDebugger.", "2.6.0")
   def setDebugger(db: AnyRef): Unit
 
+  def withDebugger(db: AnyRef): R
+
+  @deprecated("Use withValidationMode.", "2.6.0")
   def setValidationMode(validationMode: ValidationMode.Type): Unit
+
+  def withValidationMode(validationMode: ValidationMode.Type): R
+
+  @deprecated("Use withExternalDFDLVariables.", "2.6.0")
+  def setExternalDFDLVariables(externalVarBindings: Seq[Binding]): Unit
+
+  def withExternalDFDLVariables(externalVarBindings: Seq[Binding]): R
 
   def isError: Boolean
 

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/SchemaCache.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/SchemaCache.scala
@@ -45,9 +45,9 @@ object SchemaDataProcessorCache extends SchemaCache[(Seq[Diagnostic], DFDL.DataP
 class SchemaCache[CachedType, DiagnosticType] {
 
   private class Cache
-    extends mutable.HashMap[(URISchemaSource, Boolean, Boolean, String, String), (URISchemaSource, CachedType)] {
+    extends mutable.HashMap[(URISchemaSource, Boolean, Boolean, Option[String], Option[String]), (URISchemaSource, CachedType)] {
 
-    override def getOrElseUpdate(key: (URISchemaSource, Boolean, Boolean, String, String), body: => (URISchemaSource, CachedType)) = synchronized {
+    override def getOrElseUpdate(key: (URISchemaSource, Boolean, Boolean, Option[String], Option[String]), body: => (URISchemaSource, CachedType)) = synchronized {
       super.getOrElseUpdate(key, body)
     }
 
@@ -90,10 +90,10 @@ class SchemaCache[CachedType, DiagnosticType] {
    */
   def compileAndCache(uss: URISchemaSource, useSerializedProcessor: Boolean,
     compileAllTopLevels: Boolean,
-    rootElementName: String,
-    rootElementNamespace: String)(doCompileByName: => CompileResult): CompileResult = {
+    optRootName: Option[String],
+    optRootNamespace: Option[String])(doCompileByName: => CompileResult): CompileResult = {
     lazy val doCompile = doCompileByName // exactly once
-    val key = (uss, useSerializedProcessor, compileAllTopLevels, rootElementName, rootElementNamespace)
+    val key = (uss, useSerializedProcessor, compileAllTopLevels, optRootName, optRootNamespace)
     synchronized {
       // if the file is newer then when last compiled, drop from the cache.
       val optExistingEntry = compiledSchemaCache.get(key)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.tdml
@@ -22,7 +22,8 @@
 	xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-	xmlns:ex="http://example.com" xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+	xmlns:ex="http://example.com"
+	xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
 
 	<tdml:defineSchema name="predefinedVars">
 		<dfdl:defineVariable name="v_no_default" type="xsd:int"
@@ -125,8 +126,7 @@
 
 	<!-- Overrides define variables -->
 	<tdml:defineConfig name="cfg_01">
-		<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
-			xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+		<daf:externalVariableBindings>
 			<daf:bind name="ex:v_no_default">1</daf:bind>
 			<daf:bind name="ex:v_with_default">2</daf:bind>
 		</daf:externalVariableBindings>
@@ -169,8 +169,7 @@
 	</tdml:parserTestCase>
 
 	<tdml:defineConfig name="config_05">
-		<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
-			xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+		<daf:externalVariableBindings>
 			<daf:bind name="ex:v_with_default">48</daf:bind>
 		</daf:externalVariableBindings>
 	</tdml:defineConfig>
@@ -218,8 +217,7 @@
 	</tdml:defineSchema>
 
 	<tdml:defineConfig name="config_02">
-		<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
-			xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+		<daf:externalVariableBindings>
 			<daf:bind name="ex:v_no_default">1</daf:bind>
 			<daf:bind name="ex:v_with_default">2</daf:bind>
 		</daf:externalVariableBindings>
@@ -270,8 +268,7 @@
 	</tdml:defineSchema>
 
 	<tdml:defineConfig name="config_03">
-		<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
-			xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+		<daf:externalVariableBindings>
 			<daf:bind name="ex:v_no_default">1</daf:bind>
 			<daf:bind name="ex:v_with_default">2</daf:bind>
 		</daf:externalVariableBindings>
@@ -319,8 +316,7 @@
 	</tdml:defineSchema>
 
 	<tdml:defineConfig name="config_04">
-		<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
-			xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+		<daf:externalVariableBindings>
 			<daf:bind name="ex:v_no_default">1</daf:bind>
 			<daf:bind name="ex:v_with_global_default">48</daf:bind>
 		</daf:externalVariableBindings>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
@@ -36,9 +36,6 @@ class TestExternalVariables {
 
   import TestExternalVariables._
 
-  // It's important to note here that external variables
-  // via the TDMLRunner are currently passed in during
-  // compilation.
   @Test def test_override_define_vars_01() {
     runner.runOneTest("override_define_vars_01")
   }
@@ -66,5 +63,4 @@ class TestExternalVariables {
   @Test def test_set_predefined_var() {
     runner.runOneTest("set_predefined_var")
   }
-
 }


### PR DESCRIPTION
Turned into a large change set.

There is a functional change here. External variables are no longer saved when we save a binary compiled object. They are irrelevant to schema compilation. They are applied just before runtime. 

DAFFODIL-2302