### PR TITLE
Use reference equality for dsom shared keys

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -1480,4 +1480,25 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase name="similar_model_groups_01" root="root"
+    model="SimilarModelGroupRoot.dfdl.xsd" description="Section 14 - Groups - DFDL-14-042R">
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[0a0b]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root>
+          <similarElement1>
+            <field>0</field>
+            <differentElement1>a</differentElement1>
+          </similarElement1>
+          <similarElement2>
+            <field>0</field>
+            <differentElement2>b</differentElement2>
+          </similarElement2>
+        </root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupElement1.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupElement1.dfdl.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="similarElement1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="field" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="1" />
+        <xs:element name="differentElement1" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+        <xs:choice dfdl:choiceDispatchKey="{ xs:string(field) }">
+          <xs:sequence dfdl:choiceBranchKey="0" />
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupElement2.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupElement2.dfdl.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="similarElement2">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="field" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="1" />
+        <xs:element name="differentElement2" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+        <xs:choice dfdl:choiceDispatchKey="{ xs:string(field) }">
+          <xs:sequence dfdl:choiceBranchKey="0" />
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupRoot.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SimilarModelGroupRoot.dfdl.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  This schema contains references to two completely different elements
+  (simpleElement1 and simpleElement2), which are exactly the same (including
+  line numbers) except for the root elements and a sibling element. This schema
+  is used to test that even though these schemas are very similar (particularly
+  the choice with dispatch) and do have some object equality, because they are
+  in different XML files they should not have reference equality and dsom
+  elements will not be shared.
+-->
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+  <xs:include schemaLocation="SimilarModelGroupElement1.dfdl.xsd" />
+  <xs:include schemaLocation="SimilarModelGroupElement2.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ex:similarElement1" />
+        <xs:element ref="ex:similarElement2" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
@@ -46,4 +46,5 @@ class TestSequenceGroups3 {
   @Test def test_sequence_group_with_annotation_01() { runner_02.runOneTest("sequence_group_with_annotation_01") }
   @Test def test_choice_group_with_annotation_01() { runner_02.runOneTest("choice_group_with_annotation_01") }
 
+  @Test def test_similar_model_groups_01() { runner_02.runOneTest("similar_model_groups_01") }
 }


### PR DESCRIPTION
By using the default object equality, it is possible that two chunks of
XML could look exactly the same and will be shared, even though their
contexts are different and should not be shared. By using reference
equality, XML nodes that happen to have the exact same content but in
different contexts will be seen as different and will not be shared.

DAFFODIL-2308