### PR TITLE
Upgrades sbt to 1.3.9, scala to 2.12.11, genjavadoc to 0.16.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [ '8.x', '9.x', '11.x' ]
-        scala_version: [ '2.12.6', '2.11.12' ]
+        scala_version: [ '2.12.11', '2.11.12' ]
         os: [ 'ubuntu-latest', 'windows-latest' ]
     env:
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }} coverage
+      SBTNOCOV: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }}
     steps:
 
       ############################################################
@@ -63,15 +64,15 @@ jobs:
         shell: bash
 
       - name: Build Documentation
-        run: $SBT daffodil-japi/genjavadoc:doc daffodil-sapi/doc
+        run: $SBTNOCOV daffodil-japi/genjavadoc:doc daffodil-sapi/doc
         shell: bash
 
       - name: Package Zip & Tar
-        run: $SBT daffodil-cli/universal:packageBin daffodil-cli/universal:packageZipTarball
+        run: $SBTNOCOV daffodil-cli/universal:packageBin daffodil-cli/universal:packageZipTarball
         shell: bash
 
       - name: Package RPM
-        run: $SBT daffodil-cli/rpm:packageBin
+        run: $SBTNOCOV daffodil-cli/rpm:packageBin
         if: runner.os == 'Linux'
         shell: bash
 
@@ -80,7 +81,7 @@ jobs:
       ############################################################
 
       - name: Run Rat Check
-        run: $SBT ratCheck || (cat target/rat.txt; exit 1)
+        run: $SBTNOCOV ratCheck || (cat target/rat.txt; exit 1)
         shell: bash
 
       - name: Run Unit Tests

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala_version: [ '2.12.6', '2.11.12' ]
+        scala_version: [ '2.12.11', '2.11.12' ]
     steps:
 
       ############################################################

--- a/build.sbt
+++ b/build.sbt
@@ -105,8 +105,8 @@ lazy val testStdLayout    = Project("daffodil-test-stdLayout", file("test-stdLay
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
   version := "2.6.0",
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12"),
+  scalaVersion := "2.12.11",
+  crossScalaVersions := Seq("2.12.11", "2.11.12"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/containers/release-candidate/setup-container.sh
+++ b/containers/release-candidate/setup-container.sh
@@ -40,6 +40,6 @@ sh -c "echo 'addSbtPlugin(\"com.jsuereth\" % \"sbt-pgp\" % \"1.1.1\")' >> /root/
 TMP_SBT_PROJECT=/tmp/sbt-project/
 mkdir -p $TMP_SBT_PROJECT
 pushd $TMP_SBT_PROJECT &> /dev/null
-sbt --sbt-version 1.2.7 exit
+sbt --sbt-version 1.3.9 exit
 popd &> /dev/null
 rm -rf $TMP_SBT_PROJECT

--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -240,7 +240,7 @@ subcomponents is subject to the terms and conditions of the following licenses.
   This product bundles 'Scala', including the following files:
     - lib/org.scala-lang.modules.scala-parser-combinators_2.12-1.1.1.jar
     - lib/org.scala-lang.modules.scala-xml_2.12-1.1.0.jar
-    - lib/org.scala-lang.scala-library-2.12.6.jar
+    - lib/org.scala-lang.scala-library-2.12.11.jar
     - org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-2.6.0.jar
   These files are available under the BSD-3-Clause licnese:
 

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/blob/TestBlob.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/blob/TestBlob.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.blob
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import java.io.File
 import org.apache.daffodil.CLI.Util

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.executing
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import scala.language.postfixOps
 import scala.sys.process._

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.parsing
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import java.io.File
 import org.apache.daffodil.CLI.Util

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.performance
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.CLI.Util
 import net.sf.expectit.ExpectIOException

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.saving
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.Before
 import org.junit.After

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.udf
 
 import org.junit.AfterClass
 import org.junit.Test
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.CLI.Util
 import net.sf.expectit.matcher.Matchers.contains
 import net.sf.expectit.matcher.Matchers.anyOf

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.unparsing
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import java.io.File
 import org.apache.daffodil.CLI.Util

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementDeclMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementDeclMixin.scala
@@ -81,7 +81,7 @@ trait ElementDeclMixin
     if (ct.length == 1)
       Some(new LocalComplexTypeDef(ct(0), this))
     else {
-      Assert.invariant(nt != "")
+      nt.foreach{ s => Assert.invariant(s != "") }
       None
     }
   }.value

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.api
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import scala.xml._
 import org.apache.daffodil.util._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestDsomCompiler3.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestDsomCompiler3.scala
@@ -22,8 +22,8 @@ import org.apache.daffodil.util._
 import org.apache.daffodil.Implicits._
 import org.apache.daffodil.compiler._
 import org.apache.daffodil.schema.annotation.props.gen._
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import java.io.File
 import org.junit.Test
 import org.apache.daffodil.dsom.DFDLElement

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.dpath
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.util.SchemaUtils
 import org.apache.daffodil.compiler._

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.dpath
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.util.SchemaUtils
 import org.apache.daffodil.compiler._

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -39,7 +39,7 @@ import org.apache.daffodil.util.Misc
 import org.junit.After
 import org.junit.Test
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 
 // Do no harm number 16 of 626 fail in regression, 154 in total of 797
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.schema.annotation.props.gen.{ YesNo, TextNumberRep, S
 import org.apache.daffodil.schema.annotation.props.AlignmentType
 import org.apache.daffodil.util.{ Misc, Logging }
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.util._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
@@ -23,9 +23,9 @@ import org.apache.daffodil.compiler.Compiler
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.util.SchemaUtils
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
-import junit.framework.Assert._
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.xml.NS
 import scala.xml.Node

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestInteriorAlignmentElimination.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestInteriorAlignmentElimination.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.schema.annotation.props.gen.{ YesNo, TextNumberRep, S
 import org.apache.daffodil.schema.annotation.props.AlignmentType
 import org.apache.daffodil.util.{ Misc, Logging }
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.util._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestIsScannable.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestIsScannable.scala
@@ -22,7 +22,7 @@ import org.apache.daffodil.compiler._
 
 import org.apache.daffodil.util.Logging
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.util.SchemaUtils
 import org.junit.Test
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.dsom
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.util._
 import org.junit.Test
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPolymorphicUpwardRelativeExpressions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPolymorphicUpwardRelativeExpressions.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.schema.annotation.props.gen.{ YesNo, TextNumberRep, S
 import org.apache.daffodil.schema.annotation.props.AlignmentType
 import org.apache.daffodil.util.{ Misc, Logging }
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.util._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.schema.annotation.props.gen.{ YesNo, TextNumberRep, S
 import org.apache.daffodil.schema.annotation.props.AlignmentType
 import org.apache.daffodil.util.{ Misc, Logging }
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.util._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.dsom
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.util._
 import org.apache.daffodil.dpath.NodeInfo._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.externalvars
 import org.apache.daffodil.xml._
 import org.apache.daffodil.util._
 import scala.xml._
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.dsom.SchemaSet
 import org.apache.daffodil.xml.NS

--- a/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesNew.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesNew.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.externalvars
 
 import org.apache.daffodil.util._
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._; object INoWarn2 { ImplicitsSuppressUnusedImportWarning() }
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.util.Fakes
 import org.apache.daffodil.util.Logging
 import org.apache.daffodil.util.SchemaUtils
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.apache.daffodil.api.DaffodilTunables
 
 class TestTunables extends Logging {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/grammar/TestGrammar.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/grammar/TestGrammar.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.grammar
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.Implicits._; object INoWarnG1 { ImplicitsSuppressUnusedImportWarning() }
 import org.apache.daffodil.dsom._
 import org.apache.daffodil.exceptions.Assert

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
@@ -21,7 +21,7 @@ import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.util._
 import org.apache.daffodil.Implicits._
 import org.apache.daffodil.compiler._
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.exceptions.Assert

--- a/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.schema.annotation.props
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.junit.Test
 import org.apache.daffodil.dsom.SchemaComponentImpl

--- a/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import java.io.File

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import java.io.File
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.util.Maybe

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.io
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import java.nio.ByteBuffer
 import java.io.File

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import java.io.File
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
 import org.apache.daffodil.util.Maybe

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import java.io.File
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import passera.unsigned.ULong
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import org.junit.Test
-import junit.framework.Assert._
+import org.junit.Assert._
 
 import java.io.ByteArrayInputStream
 import java.io.InputStreamReader

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestFastAsciiConvert.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestFastAsciiConvert.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import java.nio.ByteBuffer
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 class TestFastAsciiConvert {

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import org.apache.commons.io.IOUtils

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.commons.io.IOUtils
 import collection.JavaConverters._

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.commons.io.IOUtils
 import collection.JavaConverters._

--- a/daffodil-japi/build.sbt
+++ b/daffodil-japi/build.sbt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-addCompilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.11" cross CrossVersion.full)
+addCompilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.16" cross CrossVersion.full)
 
 
 lazy val JavaDoc = config("genjavadoc") extend Compile

--- a/daffodil-lib/src/main/scala/passera/unsigned/SmallUInt.scala
+++ b/daffodil-lib/src/main/scala/passera/unsigned/SmallUInt.scala
@@ -181,19 +181,19 @@ trait SmallUInt[U <: Unsigned[U, UInt, Int]] extends Any with Unsigned[U, UInt, 
   def unary_~ = UInt(~intValue)
 
   def <<(x: Int)(implicit d: DummyImplicit) = UInt(intValue << x)
-  def <<(x: Long)(implicit d: DummyImplicit) = UInt(intValue << x)
+  def <<(x: Long)(implicit d: DummyImplicit) = UInt(intValue << x.toInt)
   def <<(x: UInt) = UInt(intValue << (x.toInt & 0x1f))
-  def <<(x: ULong) = UInt(intValue << (x.toLong & 0x1f))
+  def <<(x: ULong) = UInt(intValue << (x.toLong & 0x1f).toInt)
 
   def >>(x: Int)(implicit d: DummyImplicit) = UInt(intValue >>> x)
-  def >>(x: Long)(implicit d: DummyImplicit) = UInt(intValue >>> x)
+  def >>(x: Long)(implicit d: DummyImplicit) = UInt(intValue >>> x.toInt)
   def >>(x: UInt) = UInt(intValue >>> (x.toInt & 0x1f))
-  def >>(x: ULong) = UInt(intValue >>> (x.toLong & 0x1f))
+  def >>(x: ULong) = UInt(intValue >>> (x.toLong & 0x1f).toInt)
 
   def >>>(x: Int)(implicit d: DummyImplicit) = UInt(intValue >>> x)
-  def >>>(x: Long)(implicit d: DummyImplicit) = UInt(intValue >>> x)
+  def >>>(x: Long)(implicit d: DummyImplicit) = UInt(intValue >>> x.toInt)
   def >>>(x: UInt) = UInt(intValue >>> (x.toInt & 0x1f))
-  def >>>(x: ULong) = UInt(intValue >>> (x.toLong & 0x1f))
+  def >>>(x: ULong) = UInt(intValue >>> (x.toLong & 0x1f).toInt)
 
   override def toString = (intValue & 0xffffffffL).toString
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/HowToUseJUnit.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/HowToUseJUnit.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/TestBitOrderByteOrder.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/TestBitOrderByteOrder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.apache.daffodil.util._
 import org.junit.Test
 import org.apache.daffodil.util._

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/TestImplicits.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/TestImplicits.scala
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.apache.daffodil.Implicits._
 import org.apache.daffodil.exceptions._
 import java.io.FileNotFoundException
-import junit.framework.Assert._
+import org.junit.Assert._
 
 class TestImplicits {
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/functionality/icu/TestBigInteger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/functionality/icu/TestBigInteger.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.functionality.icu
 
 import org.junit.Test
-import junit.framework.Assert._
+import org.junit.Assert._
 import com.ibm.icu.text.DecimalFormat
 import com.ibm.icu.text.DecimalFormatSymbols
 import java.text.ParsePosition

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/oolag/TestOOLAG.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/oolag/TestOOLAG.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.oolag
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.oolag.OOLAG._
 import org.junit.Test
 import org.apache.daffodil.exceptions.Assert

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/schema/annotation/props/TestGeneratedProperties.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/schema/annotation/props/TestGeneratedProperties.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.schema.annotation.props
 
 import org.apache.daffodil.schema.annotation.props.gen._
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.oolag.OOLAG.OOLAGHostImpl
 import org.apache.daffodil.exceptions.SchemaFileLocation

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.util
 
 import org.junit.Test
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.nio.ByteBuffer
 
 class TestBits {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits2.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits2.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.util
 
 import org.junit.Test
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.nio.ByteBuffer
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListMap.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListMap.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import scala.collection.immutable.ListMap
 import scala.util.Random

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class TestListUtils {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.exceptions._
 import org.junit.Test
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
@@ -27,8 +27,8 @@ import org.junit.Test
 import com.ibm.icu.text.DecimalFormat
 import com.ibm.icu.text.DecimalFormatSymbols
 
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 
 /**
  * Tests that characterize ICU number parsing specifically with respect

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumbers.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumbers.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
 import java.math.{ BigDecimal => JBigDecimal }
@@ -59,7 +59,7 @@ class TestNumbers {
     val m = (new JBigDecimal("1048575.0")).doubleValue()
     val quotient = n / m
     val expected1 = 8.583077033116372E-5
-    assertEquals(expected1, quotient)
+    assertEquals(expected1, quotient, 1e-15)
     val decimalQuotient = new JBigDecimal(quotient)
     //
     // The giant number of digits below is in fact what you get as the
@@ -73,7 +73,7 @@ class TestNumbers {
     assertEquals(expected2, decimalQuotient)
 
     val double2 = expected2.doubleValue()
-    assertEquals(expected1, double2)
+    assertEquals(expected1, double2, 1e-15)
   }
 
   @Test def testDecimalAsDoubleDivision2() {
@@ -81,7 +81,7 @@ class TestNumbers {
     val m = (new JBigDecimal("1048575.0000000000")).doubleValue()
     val quotient = n / m
     val expected1 = 8.583077033116372E-5
-    assertEquals(expected1, quotient)
+    assertEquals(expected1, quotient, 1e-15)
     //
     // Must have a rounding mode here, or we get a ArithmeticException
     // rounding-necessary

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSchemaUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSchemaUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import scala.xml._
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSerializationAndLazy.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSerializationAndLazy.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
 import java.io.ByteArrayInputStream

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestUtil.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestUtil.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.util
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.apache.daffodil.exceptions._
 import org.junit.Test
 import org.apache.daffodil.Implicits._

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestXMLCatalogAndValidate.scala
@@ -26,7 +26,7 @@ import org.apache.xml.resolver.{ CatalogManager, Catalog }
 import org.junit.Test
 import Implicits.using
 import javax.xml.parsers.{ SAXParserFactory, SAXParser }
-import junit.framework.Assert.{ fail, assertTrue }
+import org.junit.Assert.{ fail, assertTrue }
 import scala.xml.NamespaceBinding
 import scala.xml.MetaData
 import org.apache.daffodil.exceptions.Assert

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestNamespaces.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestNamespaces.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml.test.unit
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestQName.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestQName.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml.test.unit
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.Assert._
 import org.apache.daffodil.xml.QNameRegex

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUTF8AndUTF16Conversions.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUTF8AndUTF16Conversions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml.test.unit
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 /**

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUnicodeXMLI18N.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUnicodeXMLI18N.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.xml.test.unit
 
 import scala.xml._
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import org.apache.daffodil.xml.NS

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLiterals.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLiterals.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml.test.unit
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 class TestXMLLiterals {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.xml.test.unit
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 class TestXMLLoader {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
@@ -24,7 +24,7 @@ import java.nio.file.StandardOpenOption
 
 import scala.xml._
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 import org.apache.daffodil.Implicits._

--- a/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
+++ b/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
@@ -245,7 +245,7 @@ class UnsignedCheck {
 
   @Test def testLshiftLong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f) == (a << (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f) == (a << (b & 0x1f).toInt).toUInt }
     )
   }
 
@@ -257,7 +257,7 @@ class UnsignedCheck {
 
   @Test def testLshiftULong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f).toULong == (a << (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f).toULong == (a << (b & 0x1f).toInt).toUInt }
     )
   }
 
@@ -270,7 +270,7 @@ class UnsignedCheck {
 
   @Test def testRshiftLong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f) == (a >>> (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f) == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
@@ -282,7 +282,7 @@ class UnsignedCheck {
 
   @Test def testRshiftULong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f).toULong == (a >>> (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f).toULong == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
@@ -295,7 +295,7 @@ class UnsignedCheck {
 
   @Test def testZrshiftLong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f) == (a >>> (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f).toInt == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
@@ -307,7 +307,7 @@ class UnsignedCheck {
 
   @Test def testZrshiftULong = {
     assertTrue(
-      forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f).toULong == (a >>> (b & 0x1f)).toUInt }
+      forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f).toULong == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 

--- a/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
+++ b/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.propGen
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 
 class TestPropertyGenerator {

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.dpath
 import org.apache.daffodil.Implicits.ImplicitsSuppressUnusedImportWarning
 import org.junit.Test
 
-import junit.framework.Assert.assertEquals; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
+import org.junit.Assert.assertEquals; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
 import java.math.{ BigDecimal => JBigDecimal }
 import java.math.RoundingMode
 

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/dsom/TestEntityReplacer.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/dsom/TestEntityReplacer.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.dsom
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import org.apache.daffodil.cookers.EntityReplacer

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestAISStreams.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestAISStreams.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io._
 import org.junit.Test
 import org.apache.daffodil.io.RegexLimitingStream

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestByteSwapStream.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestByteSwapStream.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io._
 import org.junit.Test
 import java.nio.charset.StandardCharsets

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestLengthLimitedLineFoldingStreams.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestLengthLimitedLineFoldingStreams.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io._
 import org.junit.Test
 import org.apache.daffodil.io.RegexLimitingStream

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestLineFoldingStreams.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/layers/TestLineFoldingStreams.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.layers
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io._
 import org.junit.Test
 

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetBehavior.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetBehavior.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.parser
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import java.io._
 import java.nio._
 import java.nio.charset._

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestDFDLRegularExpressions.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestDFDLRegularExpressions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.processors.input
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.processors.DFDLRegularExpressions
 import org.apache.daffodil.schema.annotation.props.gen.TextStringJustification

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestICU.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestICU.scala
@@ -17,9 +17,9 @@
 
 package org.apache.daffodil.processors.input
 
-import junit.framework.Assert._
-import org.junit.Test
+import org.junit.Assert._
 import java.text.ParsePosition
+
 import com.ibm.icu.text.SimpleDateFormat
 import com.ibm.icu.util.Calendar
 import com.ibm.icu.text.DecimalFormat
@@ -146,7 +146,7 @@ class TestICU {
     val df = new DecimalFormat("##.##E+0", dfs)
     val pp = new ParsePosition(0)
     val num = df.parse("12.34+2", pp)
-    assertEquals(12.34, num.doubleValue)
+    assertEquals(12.34, num.doubleValue, 1e-15)
     assertEquals(5, pp.getIndex)
     //assertEquals(1234L, num)
     //assertEquals(7, pp.getIndex)
@@ -177,6 +177,6 @@ class TestICU {
     val pp = new ParsePosition(0)
     val num = df.parse("123,456", pp)
     assertEquals(7, pp.getIndex)
-    assertEquals(123.456, num.doubleValue)
+    assertEquals(123.456, num.doubleValue, 1e-15)
   }
 }

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.processors.input
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import scala.util.parsing.combinator._
 import java.io.StringReader
 import org.junit.Test

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/processors/charset/TestLSBFirstAndUSASCII7BitPacked.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/processors/charset/TestLSBFirstAndUSASCII7BitPacked.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.processors.charset
 
 import java.nio.CharBuffer
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 
 import org.junit.Test
 import org.apache.daffodil.util.Misc

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/TestMoreEncodings.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/TestMoreEncodings.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.tdml
 
 import org.junit.Test
 
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 
 class TestMoreEncodings {
 

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
@@ -20,9 +20,9 @@ package org.apache.daffodil.tdml
 import java.io.File
 import org.apache.daffodil.Implicits.using
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
-import junit.framework.Assert.assertFalse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.apache.daffodil.util._
 import org.junit.Test
 import org.apache.daffodil.Implicits._

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestSchemaCache.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestSchemaCache.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.tdml
 
 import java.io.File
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import java.io.FileOutputStream

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.tdml
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 import org.junit.AssumptionViolatedException

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.tdml
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
@@ -20,9 +20,9 @@ package org.apache.daffodil.tdml
 import java.io.File
 import org.apache.daffodil.Implicits.using
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
-import junit.framework.Assert.assertFalse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.apache.daffodil.util._
 import org.junit.Test
 import org.apache.daffodil.Implicits._

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
@@ -19,9 +19,9 @@ package org.apache.daffodil.tdml
 
 import org.apache.daffodil.Implicits.using
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
-import junit.framework.Assert.fail
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.apache.daffodil.util._
 import org.junit.Test
 import org.apache.daffodil.Implicits._

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerConfig.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerConfig.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.tdml
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.tdml
 import org.junit.Test
 import org.junit.AfterClass
 import org.apache.daffodil.Implicits._
-import junit.framework.Assert.fail
+import org.junit.Assert.fail
 
 object TestTDMLRunnerWarnings {
   val runner = Runner("/test/tdml/", "testWarnings.tdml")

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.tdml
 
 import org.apache.daffodil.xml.XMLUtils
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.apache.daffodil.Implicits._
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -21,7 +21,7 @@ package org.apache.daffodil.section00.general
  * not related to any specific requirement
  */
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.Implicits.intercept
 import org.apache.daffodil.tdml.Runner

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.section12.length_properties
 
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass

--- a/daffodil-test/src/test/scala/org/apache/daffodil/xml/test/unit/TestDaffodilXMLLoader.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/xml/test/unit/TestDaffodilXMLLoader.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.xml.test.unit
 import scala.xml._
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.xml.DaffodilXMLLoader
-import junit.framework.Assert._
+import org.junit.Assert._
 import org.junit.Test
 import java.io.File
 import org.apache.daffodil.Implicits._

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-sbt.version=1.2.7
+sbt.version=1.3.9


### PR DESCRIPTION
sbt, depending on the terminal you are displaying it in, will issue ANSI
colorization escapes. You may need to add the color=false option to your
environment: e.g., in my .bash_aliases I have

export SBT_OPTS=" -Dsbt.color=false "

Had to fix a number of deprecations.
junit.framework.Assert is deprecated. Changed to org.junit.Assert.

Assert.assertEquals for float/double now requires a delta argument. Supplied
1e-15 where needed.

Since scala 2.12.7, shifting of values by quantities expressed as Long is deprectated. Had to insert ".toInt" calls a number of places to silence these.

DAFFODIL-2313