### PR TITLE
Daffodil 2312 update gpg timeout

### DIFF
--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -61,6 +61,12 @@ read -s -p "Apache Password: " APACHE_PASSWD
 echo
 echo
 
+gpg-agent --daemon --default-cache-ttl 30000 --max-cache-ttl 30000
+if [ $? -ne 0 ]; then
+   echo -e "\n!!! Unable to change timeout of the gpg-agent !!!\n"
+   echo -e "\n!!! Try updating it manually at ~/.gnupg/gpg-agent.conf for 30000 seconds each !!!\n"
+   exit
+fi
 
 export GPG_TTY=$(tty)
 export WIX=/root/wix311/

--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -155,7 +155,7 @@ sbt \
   "set updateOptions in ThisBuild := updateOptions.value.withGigahorse(false)" \
   "set credentials in ThisBuild += Credentials(\"Sonatype Nexus Repository Manager\", \"repository.apache.org\", \"$APACHE_USERNAME\", \"$APACHE_PASSWD\")" \
   "set publishTo in ThisBuild := Some(\"Apache Staging Distribution Repository\" at \"https://repository.apache.org/service/local/staging/deploy/maven2\")" \
-  "set pgpSigningKey := Some(new java.math.BigInteger(\"$PGP_SIGNING_KEY_ID\", 16).longValue)" \
+  "set pgpSigningKey := Some(\"$PGP_SIGNING_KEY_ID\")" \
   "+compile" \
   "+$SBT_PUBLISH" \
   "daffodil-cli/rpm:packageBin" \

--- a/containers/release-candidate/setup-container.sh
+++ b/containers/release-candidate/setup-container.sh
@@ -34,7 +34,7 @@ rm wix311-binaries.zip
 
 # enable sbt pgp
 mkdir -p /root/.sbt/1.0/plugins/
-sh -c "echo 'addSbtPlugin(\"com.jsuereth\" % \"sbt-pgp\" % \"1.1.1\")' >> /root/.sbt/1.0/plugins/pgp.sbt"
+sh -c "echo 'addSbtPlugin(\"com.jsuereth\" % \"sbt-pgp\" % \"2.0.1\")' >> /root/.sbt/1.0/plugins/pgp.sbt"
 
 # pre-download sbt version used by daffodil
 TMP_SBT_PROJECT=/tmp/sbt-project/


### PR DESCRIPTION
update daffodil-release-candidate script to set the gpg-agent timeout to 30000s

DAFFODIL-2312