### PR TITLE
Disable Coursier for library management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ lazy val commonSettings = Seq(
   logBuffered := true,
   transitiveClassifiers := Seq("sources", "javadoc"),
   retrieveManaged := true,
+  useCoursier := false, // disabled because it breaks retrieveManaged (sbt issue #5078)
   exportJars := true,
   exportJars in Test := false,
   publishMavenStyle := true,


### PR DESCRIPTION
SBT 1.3.x switched to Coursier for library management. But a bug in
Coursier used by SBT causes retrieveManage to stop working:

  https://github.com/sbt/sbt/issues/5078

This feature is needed for SonarQube. So disable Coursier, and use the
old Ivy for library management.

DAFFODIL-2314