### PR TITLE
Define sbt options required by the project

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+-mem 4096

--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ For more information about Daffodil, see https://daffodil.apache.org/.
 [SBT] is the officially supported tool to build Daffodil, run all tests, create packages,
 and more. Below are some of the more common commands used for Daffodil development.
 
-> :exclamation: **SBT Memory Requirements**
->
-> *Compiling and running all Daffodil tests works best with at least 6GB of memory, more
-> than is usually provided by default. We recommended that you supply ``-mem 6144`` either
-> as an sbt option (e.g. ``sbt -mem 6144 test``) or edit ``/etc/sbt/sbtopts`` to increase
-> the available memory when running the below commands.*
-
 ### Compile
 
 ```text


### PR DESCRIPTION
Rather than providing instructions on how to increase sbt memory
options, which may be different depending on a users operating system,
just create an .sbtopts file in the project root with an appropriate
amount of memory. Now when sbt is run from this directory, it will
always be started with enough memory. 4GB of memory seems to be plenty
to compile and run all tests and is a reasonable amount to expect a user
to have.

DAFFODIL-2217