### PR TITLE
Require grouping and decimal separators for non-integer types

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesZoned.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesZoned.scala
@@ -132,6 +132,7 @@ case class ConvertZonedNumberPrim(e: ElementBase)
       roundingMode,
       roundingIncrement,
       Nil,
+      isInt = true,
       e.primType)
     ev.compile(tunable)
     ev

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
@@ -79,16 +79,12 @@ class TextNumberFormatEv(
   roundingMode: Maybe[TextNumberRoundingMode],
   roundingIncrement: MaybeDouble,
   zeroRepsRaw: List[String],
+  isInt: Boolean,
   primType: PrimType)
   extends Evaluatable[ThreadLocal[DecimalFormat]](tci)
   with InfosetCachedEvaluatable[ThreadLocal[DecimalFormat]] {
 
   override lazy val runtimeDependencies = (decimalSepEv.toList ++ groupingSepEv.toList ++ exponentRepEv.toList).toVector
-
-  private val isInt = primType match {
-    case PrimType.Double | PrimType.Float | PrimType.Decimal => false
-    case _ => true
-  }
 
   private def checkUnique(
     decimalSep: MaybeChar,

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -296,6 +296,10 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="tnp96" type="xs:float" dfdl:textNumberPattern="####"
+      dfdl:textStandardGroupingSeparator="." dfdl:textStandardDecimalSeparator=","
+      dfdl:textNumberRoundingIncrement="0.1" dfdl:textNumberRoundingMode="roundHalfEven" />
+
   </tdml:defineSchema>
   
   <tdml:defineSchema name="textNumberPattern2"  elementFormDefault="qualified">
@@ -4261,4 +4265,27 @@
     </tdml:errors>
 
   </tdml:parserTestCase>
+
+  <!--
+     Test Name: textStandardFloatPatternNoSeparators
+        Schema: textNumberPattern
+          Root: tnp96
+          Purpose: This test shows what even if the textNumberPattern contains
+            no grouping/decimal separators, we still require and use the
+            properties because ICU uses them for non-integer types
+  -->
+
+  <tdml:parserTestCase name="textStandardFloatPatternNoSeparators1" root="tnp96" model="textNumberPattern">
+
+    <tdml:document>
+      <tdml:documentPart type="text">10,1</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp96>10.1</tnp96>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -237,4 +237,6 @@ class TestTextNumberProps {
   @Test def test_textStandardDistinctValues() { runner.runOneTest("textStandardDistinctValues") }
   @Test def test_textStandardDistinctValues2() { runner.runOneTest("textStandardDistinctValues2") }
   @Test def test_textStandardDistinctValues3() { runner.runOneTest("textStandardDistinctValues3") }
+
+  @Test def test_textStandardFloatPatternNoSeparators1() { runner.runOneTest("textStandardFloatPatternNoSeparators1") }
 }


### PR DESCRIPTION
Even if the textNumberPattern does not include decimal or grouping
separators, ICU still looks for those separators when the primType is
not an integer. If we do not require and apply the grouping and decimal
separators for these prim types, ICU will get them from the users
LANG, which means our behavior is not system environment interdependent.

To fix this, this requires and applies the decimal and grouping
separator properties for float primTypes, even if textNumberPattern does
not specify the separators.

DAFFODIL-2320