### PR TITLE
Converted many pass-by-name into pass-by-value for RuntimeData struct…

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -19,22 +19,20 @@ package org.apache.daffodil.dsom
 
 import org.apache.daffodil.equality._
 import org.apache.daffodil.processors._
-import org.apache.daffodil.infoset._
 import org.apache.daffodil.schema.annotation.props._
 import org.apache.daffodil.xml._
-import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.grammar.ElementBaseGrammarMixin
 import org.apache.daffodil.schema.annotation.props.gen._
-import org.apache.daffodil.dsom._
 import org.apache.daffodil.util.Misc
+
 import scala.xml.NamespaceBinding
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dpath.NodeInfo.PrimType
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.api.WarnID
-import java.lang.{ Integer => JInt }
-import org.apache.daffodil.infoset.DataValue.DataValuePrimitiveOrUseNilForDefaultOrNull
+import java.lang.{Integer => JInt}
+
 import org.apache.daffodil.infoset.DataValue
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitiveOrUseNilForDefaultOrNull
 
@@ -420,7 +418,7 @@ trait ElementBase
       case Representation.Binary =>
         if (isComplexType || (primType != PrimType.HexBinary && primType != PrimType.AnyURI)) byteOrderEv // ensure defined
       case _ =>
-        charsetEv // ensure defined
+        encodingRaw // ensure defined
     }
     rep
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaComponent.scala
@@ -19,21 +19,16 @@ package org.apache.daffodil.dsom
 
 import scala.xml.Node
 import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.xml.GetAttributesMixin
 import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.XMLUtils
-import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.xml.ResolvesQNames
 import org.apache.daffodil.schema.annotation.props.LookupLocation
-import org.apache.daffodil.schema.annotation.props.PropTypes
-import org.apache.daffodil.oolag.OOLAG._
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.xml.GetAttributesMixin
 import org.apache.daffodil.schema.annotation.props.PropTypes
-import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Misc
 import org.apache.daffodil.BasicComponent
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -17,10 +17,9 @@
 
 package org.apache.daffodil.dsom
 
-import java.math.{ BigInteger => JBigInt }
+import java.math.{BigInteger => JBigInt}
 
 import scala.xml.Node
-
 import org.apache.daffodil.cookers.IntRangeCooker
 import org.apache.daffodil.cookers.RepValueCooker
 import org.apache.daffodil.dpath.NodeInfo
@@ -37,15 +36,10 @@ import org.apache.daffodil.util.Misc
 import org.apache.daffodil.xml.GlobalQName
 import org.apache.daffodil.xml.QName
 import org.apache.daffodil.xml.XMLUtils
-import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.processors.RangeBound
-import org.apache.daffodil.util.Maybe.One
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitiveNullable
 import org.apache.daffodil.infoset.DataValue
-import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.infoset.DataValue.DataValueBigInt
-import org.apache.daffodil.infoset.DataValue.DataValueBigInt
-import org.apache.daffodil.infoset.DataValue.DataValueString
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.schema.annotation.props.gen.ParseUnparsePolicy
 
@@ -266,7 +260,6 @@ abstract class SimpleTypeDefBase(xml: Node, lexicalParent: SchemaComponent)
         optRepValueSet,
         optTypeCalculator,
         optRepType.map(_.primType))
-    strd.preSerialization // we can get away with this for simple types.
     strd
   }
   override lazy val runtimeData = simpleTypeRuntimeData

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/TermEncodingMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/TermEncodingMixin.scala
@@ -31,7 +31,6 @@ import org.apache.daffodil.schema.annotation.props.gen.YesNo
  */
 trait TermEncodingMixin extends KnownEncodingMixin { self: Term =>
 
-  requiredEvaluationsAlways(encodingInfo.preSerialization)
   requiredEvaluationsAlways(checkTextBidi)
 
   private lazy val optionTextBidi = findPropertyOption("textBidi")
@@ -93,8 +92,10 @@ trait TermEncodingMixin extends KnownEncodingMixin { self: Term =>
   }
 
   lazy val encodingInfo =
-    new EncodingRuntimeData(termRuntimeData, charsetEv, schemaFileLocation, optionUTF16Width, defaultEncodingErrorPolicy,
-      summaryEncoding, isKnownEncoding, isScannable, knownEncodingAlignmentInBits)
+    new EncodingRuntimeData(charsetEv, schemaFileLocation, optionUTF16Width, defaultEncodingErrorPolicy,
+      summaryEncoding, isKnownEncoding, isScannable, knownEncodingAlignmentInBits, hasTextAlignment)
+
+
 
   /**
    * True if this element itself consists only of text. No binary stuff like alignment

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -34,10 +34,8 @@ import org.apache.daffodil.util.LogLevel
 
 trait SchemaSetRuntime1Mixin { self : SchemaSet =>
 
-  requiredEvaluationsAlways(variableMap)
   requiredEvaluationsAlways(parser)
   requiredEvaluationsAlways(unparser)
-  requiredEvaluationsAlways(root.runtimeData)
 
   override def variableMap: VariableMap = LV('variableMap) {
     val dvs = allSchemaDocuments.flatMap { _.defineVariables }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -21,7 +21,6 @@ import org.apache.daffodil.xml.XMLUtils
 import org.junit.Assert._
 import org.apache.daffodil.util._
 import org.junit.Test
-import org.junit.Test
 
 class TestMiddleEndAttributes {
   val xsd = XMLUtils.XSD_NAMESPACE
@@ -116,7 +115,8 @@ class TestMiddleEndAttributes {
   @Test def testStaticallyFirstWithChoice {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
-      <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
+      <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"
+        alignment="1" alignmentUnits="bytes" leadingSkip="0" trailingSkip="0"/>,
       <xs:element name="e1" dfdl:lengthKind="implicit">
         <xs:complexType>
           <xs:sequence dfdl:sequenceKind="ordered" dfdl:separator="," dfdl:separatorPosition="infix">

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -207,7 +207,19 @@ class DPathCompileInfo(
   val path: String,
   override val schemaFileLocation: SchemaFileLocation,
   val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy,
-  @TransientParam typeCalcMapArg: => TypeCalcMap,
+  typeCalcMapArg: TypeCalcMap,
+  //
+  // lexicalContextRuntimeData is used to get the partialNextElementResolver which is used
+  // to get the next sibling info to support the outputTypeCalcNextSibling function.
+  //
+  // TODO: DAFFODIL-2326 do not pass runtime data as argment to DPathCompileInfo. The point
+  // is for DPathCompileInfo to NOT have all of the runtime data for the term, but just what
+  // is needed to compile DPath. If functions need info about next sibling, then we should
+  // compute what it needs and pass that here (e.g, sequence of possible next sibling DPathCompileInfos,
+  // or if this applies only to elements, then it should be on that object.
+  //
+  // We should not hook in the whole runtime data object here. This should be runtime independent code.
+  //
   val lexicalContextRuntimeData: RuntimeData)
   extends ImplementsThrowsSDE with PreSerialization
   with HasSchemaFileLocation {
@@ -322,7 +334,7 @@ class DPathCompileInfo(
  */
 class DPathElementCompileInfo(
   @TransientParam parentsArg: Seq[DPathElementCompileInfo],
-  @TransientParam variableMap: => VariableMap,
+  variableMap: VariableMap,
   @TransientParam elementChildrenCompileInfoArg: => Seq[DPathElementCompileInfo],
   namespaces: scala.xml.NamespaceBinding,
   path: String,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EncodingRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EncodingRuntimeData.scala
@@ -121,7 +121,6 @@ trait KnownEncodingMixin { self: ThrowsSDE =>
  */
 
 final class EncodingRuntimeData(
-  @TransientParam termRuntimeDataArg: => TermRuntimeData,
   @TransientParam charsetEvArg: => CharsetEv,
   override val schemaFileLocation: SchemaFileLocation,
   optionUTF16WidthArg: Option[UTF16Width],
@@ -129,14 +128,14 @@ final class EncodingRuntimeData(
   val summaryEncoding: EncodingLattice,
   val isKnownEncoding: Boolean,
   val isScannable: Boolean,
-  override val knownEncodingAlignmentInBits: Int)
+  override val knownEncodingAlignmentInBits: Int,
+  val hasTextAlignment: Boolean)
   extends KnownEncodingMixin with ImplementsThrowsSDE with PreSerialization {
 
   private val maybeUTF16Width_ = Maybe.toMaybe[UTF16Width](optionUTF16WidthArg)
 
   def maybeUTF16Width = maybeUTF16Width_
 
-  lazy val termRuntimeData = termRuntimeDataArg
   lazy val charsetEv = charsetEvArg
 
   lazy val runtimeDependencies = Vector(charsetEv)
@@ -165,19 +164,10 @@ final class EncodingRuntimeData(
 
   override def preSerialization: Any = {
     super.preSerialization
-    termRuntimeData
     charsetEv
   }
 
   @throws(classOf[java.io.IOException])
   private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
-  /**
-   * no alignment properties that would explicitly create
-   * a need to align in a way that is not on a suitable boundary
-   * for a character.
-   */
-  lazy val hasTextAlignment = {
-    this.knownEncodingAlignmentInBits == termRuntimeData.alignmentValueInBits
-  }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -75,10 +75,10 @@ sealed trait RuntimeData
   extends ImplementsThrowsSDE
   with HasSchemaFileLocation
   with PreSerialization {
-  val schemaFileLocation: SchemaFileLocation
-  val diagnosticDebugName: String
-  val path: String
-  val namespaces: NamespaceBinding
+  def schemaFileLocation: SchemaFileLocation
+  def diagnosticDebugName: String
+  def path: String
+  def namespaces: NamespaceBinding
 
   def variableMap: VariableMap
   override def toString = diagnosticDebugName
@@ -102,19 +102,23 @@ object TermRuntimeData {
 sealed abstract class TermRuntimeData(
   /**
    * These transient by-name args are part of how we
-   * hook these objects into a parent-child tree without
-   * having to use an assignment to a var.
+   * create a structure here which contains some objects that
+   * somewhere within themselves, refer back to this structure.
+   *
+   * These are passed by-name, and ultimately what is serialized is not
+   * these, but lazy vals that refer to them which are forced to have
+   * values at the time of object serialization.
    */
-  @TransientParam positionArg: => Int,
+  val position: Int,
   @TransientParam partialNextElementResolverArg: => PartialNextElementResolver,
-  @TransientParam encodingInfoArg: => EncodingRuntimeData,
+  @TransientParam encodingInfoArg: => EncodingRuntimeData, // depends on CharsetEv
   @TransientParam dpathCompileInfoArg: => DPathCompileInfo,
-  @TransientParam isRepresentedArg: => Boolean,
+  val isRepresented:  Boolean,
   @TransientParam couldHaveTextArg: => Boolean,
-  @TransientParam alignmentValueInBitsArg: => Int,
-  @TransientParam hasNoSkipRegionsArg: => Boolean,
-  @TransientParam defaultBitOrderArg: => BitOrder,
-  @TransientParam optIgnoreCaseArg: => Option[YesNo],
+  @TransientParam alignmentValueInBitsArg: => Int, // depends ultimately on EncodingEv.isConstant
+  val hasNoSkipRegions: Boolean,
+  val defaultBitOrder:  BitOrder,
+  val optIgnoreCase: Option[YesNo],
   @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
@@ -147,32 +151,22 @@ sealed abstract class TermRuntimeData(
    */
   def unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy = dpathCompileInfo.unqualifiedPathStepPolicy
 
-  lazy val position = positionArg
   lazy val partialNextElementResolver = partialNextElementResolverArg
   lazy val encodingInfo = encodingInfoArg
   lazy val dpathCompileInfo = dpathCompileInfoArg
-  lazy val isRepresented = isRepresentedArg
   lazy val couldHaveText = couldHaveTextArg
   lazy val alignmentValueInBits = alignmentValueInBitsArg
-  lazy val hasNoSkipRegions = hasNoSkipRegionsArg
-  lazy val defaultBitOrder = defaultBitOrderArg
-  lazy val optIgnoreCase = optIgnoreCaseArg
   lazy val maybeFillByteEv = maybeFillByteEvArg
   lazy val maybeCheckByteAndBitOrderEv = maybeCheckByteAndBitOrderEvArg
   lazy val maybeCheckBitOrderAndCharsetEv = maybeCheckBitOrderAndCharsetEvArg
 
   override def preSerialization: Unit = {
     super.preSerialization
-    position
     partialNextElementResolver
     encodingInfo
     dpathCompileInfo
-    isRepresented
     couldHaveText
     alignmentValueInBits
-    hasNoSkipRegions
-    defaultBitOrder
-    optIgnoreCase
     maybeFillByteEv
     maybeCheckByteAndBitOrderEv
     maybeCheckBitOrderAndCharsetEv
@@ -183,35 +177,14 @@ sealed abstract class TermRuntimeData(
 }
 
 sealed class NonTermRuntimeData(
-  /**
-   * These transient by-name args are part of how we
-   * hook these objects into a parent-child tree without
-   * having to use an assignment to a var.
-   */
-  @TransientParam variableMapArg: => VariableMap,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam unqualifiedPathStepPolicyArg: => UnqualifiedPathStepPolicy)
+  override val variableMap:  VariableMap,
+  val schemaFileLocation:  SchemaFileLocation,
+  val diagnosticDebugName:  String,
+  val path: String,
+  val namespaces: NamespaceBinding,
+  val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy)
   extends RuntimeData {
 
-  override lazy val variableMap = variableMapArg
-  lazy val schemaFileLocation = schemaFileLocationArg
-  lazy val diagnosticDebugName = diagnosticDebugNameArg
-  lazy val path = pathArg
-  lazy val namespaces = namespacesArg
-  lazy val unqualifiedPathStepPolicy = unqualifiedPathStepPolicyArg
-
-  override def preSerialization: Unit = {
-    super.preSerialization
-    variableMap
-    schemaFileLocation
-    diagnosticDebugName
-    path
-    namespaces
-    unqualifiedPathStepPolicy
-  }
   @throws(classOf[java.io.IOException])
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
@@ -224,72 +197,33 @@ sealed class NonTermRuntimeData(
 object UseNilForDefault
 
 final class SimpleTypeRuntimeData(
-  @TransientParam variableMapArg: => VariableMap,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam primTypeArg: => NodeInfo.PrimType,
-  @TransientParam noFacetChecksArg: => Boolean,
-  @TransientParam patternValuesArg: => Seq[FacetTypes.FacetValueR],
-  @TransientParam enumerationValuesArg: => Option[String],
-  @TransientParam minLengthArg: => Option[java.math.BigDecimal],
-  @TransientParam maxLengthArg: => Option[java.math.BigDecimal],
-  @TransientParam minInclusiveArg: => Option[java.math.BigDecimal],
-  @TransientParam maxInclusiveArg: => Option[java.math.BigDecimal],
-  @TransientParam minExclusiveArg: => Option[java.math.BigDecimal],
-  @TransientParam maxExclusiveArg: => Option[java.math.BigDecimal],
-  @TransientParam totalDigitsArg: => Option[java.math.BigDecimal],
-  @TransientParam fractionDigitsArg: => Option[java.math.BigDecimal],
-  @TransientParam unionMemberTypesArg: => Seq[SimpleTypeRuntimeData],
-  @TransientParam unqualifiedPathStepPolicyArg: => UnqualifiedPathStepPolicy,
-  @TransientParam repTypeRuntimeDataArg: => Option[SimpleTypeRuntimeData],
-  @TransientParam repValueSetArg: => Option[RepValueSet],
-  @TransientParam typeCalculatorArg: => Option[TypeCalculator],
-  @TransientParam optRepPrimTypeArg: => Option[PrimType])
+  variableMapArg: VariableMap,
+  schemaFileLocationArg:  SchemaFileLocation,
+  diagnosticDebugNameArg:  String,
+  pathArg:  String,
+  namespacesArg:  NamespaceBinding,
+  val primType: NodeInfo.PrimType,
+  val noFacetChecks:  Boolean,
+  val patternValues:  Seq[FacetTypes.FacetValueR],
+  val enumerationValues:  Option[String],
+  val minLength:  Option[java.math.BigDecimal],
+  val maxLength:  Option[java.math.BigDecimal],
+  val minInclusive:  Option[java.math.BigDecimal],
+  val maxInclusive:  Option[java.math.BigDecimal],
+  val minExclusive:  Option[java.math.BigDecimal],
+  val maxExclusive:  Option[java.math.BigDecimal],
+  val totalDigits:  Option[java.math.BigDecimal],
+  val fractionDigits:  Option[java.math.BigDecimal],
+  val unionMemberTypes:  Seq[SimpleTypeRuntimeData],
+  unqualifiedPathStepPolicyArg: UnqualifiedPathStepPolicy,
+  val repTypeRuntimeData:  Option[SimpleTypeRuntimeData],
+  val repValueSet: Option[RepValueSet],
+  val typeCalculator: Option[TypeCalculator],
+  val optRepPrimType:  Option[PrimType])
   extends NonTermRuntimeData(variableMapArg, schemaFileLocationArg, diagnosticDebugNameArg,
     pathArg, namespacesArg, unqualifiedPathStepPolicyArg) {
 
   import org.apache.daffodil.util.OKOrError._
-
-  lazy val primType = primTypeArg
-  lazy val noFacetChecks = noFacetChecksArg
-  lazy val patternValues = patternValuesArg
-  lazy val enumerationValues = enumerationValuesArg
-  lazy val minLength = minLengthArg
-  lazy val maxLength = maxLengthArg
-  lazy val minInclusive = minInclusiveArg
-  lazy val maxInclusive = maxInclusiveArg
-  lazy val minExclusive = minExclusiveArg
-  lazy val maxExclusive = maxExclusiveArg
-  lazy val totalDigits = totalDigitsArg
-  lazy val fractionDigits = fractionDigitsArg
-  lazy val unionMemberTypes = unionMemberTypesArg
-  lazy val repTypeRuntimeData = repTypeRuntimeDataArg
-  lazy val repValueSet = repValueSetArg
-  lazy val typeCalculator = typeCalculatorArg
-  lazy val optRepPrimType = optRepPrimTypeArg
-
-  override def preSerialization: Unit = {
-    super.preSerialization
-    primType
-    noFacetChecks
-    patternValues
-    enumerationValues
-    minLength
-    maxLength
-    minInclusive
-    maxInclusive
-    minExclusive
-    maxExclusive
-    totalDigits
-    fractionDigits
-    unionMemberTypes
-    repTypeRuntimeData
-    repValueSet
-    typeCalculator
-    optRepPrimType
-  }
 
   @throws(classOf[java.io.IOException])
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
@@ -603,23 +537,29 @@ final class SimpleTypeRuntimeData(
 
 sealed class ElementRuntimeData(
   /**
-   * These transient by-name args are part of how we hook these objects into a
-   * parent-child tree without having to use an assignment to a var. Note that
-   * all transient elements must be added to the preSerialization method below
+   * These transient by-name args are part of how we
+   * create a structure here which contains some objects that
+   * somewhere within themselves, refer back to this structure.
+   *
+   * These are passed by-name, and ultimately what is serialized is not
+   * these, but lazy vals that refer to them which are forced to have
+   * values at the time of object serialization.
+   *
+   * Note that all transient elements must be added to the preSerialization method below
    * to allow parser serialization/deserialization to work.
    */
-  @TransientParam positionArg: => Int,
+  positionArg: Int,
   @TransientParam childrenArg: => Seq[ElementRuntimeData],
   @TransientParam variableMapArg: => VariableMap,
   @TransientParam partialNextElementResolverArg: => PartialNextElementResolver,
   @TransientParam encInfoArg: => EncodingRuntimeData,
   @TransientParam dpathElementCompileInfoArg: => DPathElementCompileInfo,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
+  val schemaFileLocation: SchemaFileLocation,
+  val diagnosticDebugName: String,
+  val path: String,
+  val namespaces: NamespaceBinding,
   @TransientParam minimizedScopeArg: => NamespaceBinding,
-  @TransientParam defaultBitOrderArg: => BitOrder,
+  defaultBitOrderArg: BitOrder,
   @TransientParam optPrimTypeArg: => Option[PrimType],
   @TransientParam targetNamespaceArg: => NS,
   @TransientParam thisElementsNamespaceArg: => NS,
@@ -644,12 +584,12 @@ sealed class ElementRuntimeData(
    * If 'unqualified' the the namespace component will be No_Namespace.
    */
   @TransientParam namedQNameArg: => NamedQName,
-  @TransientParam isRepresentedArg: => Boolean,
+  isRepresentedArg: Boolean,
   @TransientParam couldHaveTextArg: => Boolean,
   @TransientParam alignmentValueInBitsArg: => Int,
-  @TransientParam hasNoSkipRegionsArg: => Boolean,
+  hasNoSkipRegionsArg: Boolean,
   @TransientParam impliedRepresentationArg: => Representation,
-  @TransientParam optIgnoreCaseArg: => Option[YesNo],
+  optIgnoreCaseArg: Option[YesNo],
   @TransientParam optDefaultValueArg: => DataValuePrimitiveOrUseNilForDefaultOrNull,
   //
   // Unparser-specific arguments
@@ -674,10 +614,6 @@ sealed class ElementRuntimeData(
   lazy val variableMap = variableMapArg
   lazy val encInfo = encInfoArg
   lazy val dpathElementCompileInfo = dpathElementCompileInfoArg
-  lazy val schemaFileLocation = schemaFileLocationArg
-  lazy val diagnosticDebugName = diagnosticDebugNameArg
-  lazy val path = pathArg
-  lazy val namespaces = namespacesArg
   lazy val minimizedScope = minimizedScopeArg
   lazy val optPrimType = optPrimTypeArg
   lazy val targetNamespace = targetNamespaceArg
@@ -709,10 +645,6 @@ sealed class ElementRuntimeData(
     variableMap
     encInfo
     dpathElementCompileInfo
-    schemaFileLocation
-    diagnosticDebugName
-    path
-    namespaces
     minimizedScope
     optPrimType
     targetNamespace
@@ -899,25 +831,29 @@ final class NamespaceAmbiguousElementErrorERD(
 sealed abstract class ModelGroupRuntimeData(
   /**
    * These transient by-name args are part of how we
-   * hook these objects into a parent-child tree without
-   * having to use an assignment to a var.
+   * create a structure here which contains some objects that
+   * somewhere within themselves, refer back to this structure.
+   *
+   * These are passed by-name, and ultimately what is serialized is not
+   * these, but lazy vals that refer to them which are forced to have
+   * values at the time of object serialization.
    */
-  @TransientParam positionArg: => Int,
+  positionArg: Int,
   @TransientParam partialNextElementResolverArg: => PartialNextElementResolver,
   @TransientParam variableMapArg: => VariableMap,
   @TransientParam encInfoArg: => EncodingRuntimeData,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
+  val schemaFileLocation:  SchemaFileLocation,
   @TransientParam ciArg: => DPathCompileInfo,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam defaultBitOrderArg: => BitOrder,
+  val diagnosticDebugName:  String,
+  val path:  String,
+  val namespaces:  NamespaceBinding,
+  defaultBitOrderArg: BitOrder,
   @TransientParam groupMembersArg: => Seq[TermRuntimeData],
-  @TransientParam isRepresentedArg: => Boolean,
+  isRepresentedArg: Boolean,
   @TransientParam couldHaveTextArg: => Boolean,
-  @TransientParam alignmentValueInBitsArg: => Int,
-  @TransientParam hasNoSkipRegionsArg: => Boolean,
-  @TransientParam optIgnoreCaseArg: => Option[YesNo],
+  alignmentValueInBitsArg:  Int,
+  hasNoSkipRegionsArg:  Boolean,
+  optIgnoreCaseArg: Option[YesNo],
   @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
@@ -933,22 +869,14 @@ sealed abstract class ModelGroupRuntimeData(
 
   lazy val variableMap = variableMapArg
   lazy val encInfo = encInfoArg
-  lazy val schemaFileLocation = schemaFileLocationArg
   lazy val ci = ciArg
-  lazy val diagnosticDebugName = diagnosticDebugNameArg
-  lazy val path = pathArg
-  lazy val namespaces = namespacesArg
   lazy val groupMembers = groupMembersArg
 
   override def preSerialization: Unit = {
     super.preSerialization
     variableMap
     encInfo
-    schemaFileLocation
     ci
-    diagnosticDebugName
-    path
-    namespaces
     groupMembers
   }
   @throws(classOf[java.io.IOException])
@@ -958,25 +886,29 @@ sealed abstract class ModelGroupRuntimeData(
 final class SequenceRuntimeData(
   /**
    * These transient by-name args are part of how we
-   * hook these objects into a parent-child tree without
-   * having to use an assignment to a var.
+   * create a structure here which contains some objects that
+   * somewhere within themselves, refer back to this structure.
+   *
+   * These are passed by-name, and ultimately what is serialized is not
+   * these, but lazy vals that refer to them which are forced to have
+   * values at the time of object serialization.
    */
-  @TransientParam positionArg: => Int,
+  positionArg: Int,
   @TransientParam partialNextElementResolverArg: => PartialNextElementResolver,
   @TransientParam variableMapArg: => VariableMap,
   @TransientParam encInfoArg: => EncodingRuntimeData,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
+  schemaFileLocationArg: SchemaFileLocation,
   @TransientParam ciArg: => DPathCompileInfo,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam defaultBitOrderArg: => BitOrder,
+  diagnosticDebugNameArg: String,
+  pathArg:  String,
+  namespacesArg: NamespaceBinding,
+  defaultBitOrderArg: BitOrder,
   @TransientParam groupMembersArg: => Seq[TermRuntimeData],
-  @TransientParam isRepresentedArg: => Boolean,
+  isRepresentedArg: Boolean,
   @TransientParam couldHaveTextArg: => Boolean,
-  @TransientParam alignmentValueInBitsArg: => Int,
-  @TransientParam hasNoSkipRegionsArg: => Boolean,
-  @TransientParam optIgnoreCaseArg: => Option[YesNo],
+  alignmentValueInBitsArg: Int,
+  hasNoSkipRegionsArg: Boolean,
+  optIgnoreCaseArg: Option[YesNo],
   @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
@@ -990,25 +922,29 @@ final class SequenceRuntimeData(
 final class ChoiceRuntimeData(
   /**
    * These transient by-name args are part of how we
-   * hook these objects into a parent-child tree without
-   * having to use an assignment to a var.
+   * create a structure here which contains some objects that
+   * somewhere within themselves, refer back to this structure.
+   *
+   * These are passed by-name, and ultimately what is serialized is not
+   * these, but lazy vals that refer to them which are forced to have
+   * values at the time of object serialization.
    */
-  @TransientParam positionArg: => Int,
+  positionArg: Int,
   @TransientParam partialNextElementResolverArg: => PartialNextElementResolver,
   @TransientParam variableMapArg: => VariableMap,
   @TransientParam encInfoArg: => EncodingRuntimeData,
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
+  schemaFileLocationArg: SchemaFileLocation,
   @TransientParam ciArg: => DPathCompileInfo,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam defaultBitOrderArg: => BitOrder,
+  diagnosticDebugNameArg: String,
+  pathArg: String,
+  namespacesArg: NamespaceBinding,
+  defaultBitOrderArg: BitOrder,
   @TransientParam groupMembersArg: => Seq[TermRuntimeData],
-  @TransientParam isRepresentedArg: => Boolean,
+  isRepresentedArg: Boolean,
   @TransientParam couldHaveTextArg: => Boolean,
-  @TransientParam alignmentValueInBitsArg: => Int,
-  @TransientParam hasNoSkipRegionsArg: => Boolean,
-  @TransientParam optIgnoreCaseArg: => Option[YesNo],
+  alignmentValueInBitsArg: Int,
+  hasNoSkipRegionsArg: Boolean,
+  optIgnoreCaseArg: Option[YesNo],
   @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
@@ -1019,16 +955,16 @@ final class ChoiceRuntimeData(
     maybeCheckBitOrderAndCharsetEvArg)
 
 final class VariableRuntimeData(
-  @TransientParam schemaFileLocationArg: => SchemaFileLocation,
-  @TransientParam diagnosticDebugNameArg: => String,
-  @TransientParam pathArg: => String,
-  @TransientParam namespacesArg: => NamespaceBinding,
-  @TransientParam externalArg: => Boolean,
+  schemaFileLocationArg:  SchemaFileLocation,
+  diagnosticDebugNameArg:  String,
+  pathArg: String,
+  namespacesArg: NamespaceBinding,
+  val external: Boolean,
   @TransientParam maybeDefaultValueExprArg: => Maybe[CompiledExpression[AnyRef]],
-  @TransientParam typeRefArg: => RefQName,
-  @TransientParam globalQNameArg: => GlobalQName,
-  @TransientParam primTypeArg: => NodeInfo.PrimType,
-  @TransientParam unqualifiedPathStepPolicyArg: => UnqualifiedPathStepPolicy)
+  val typeRef:  RefQName,
+  val globalQName: GlobalQName,
+  val primType:  NodeInfo.PrimType,
+  unqualifiedPathStepPolicyArg:  UnqualifiedPathStepPolicy)
   extends NonTermRuntimeData(
     null, // no variable map
     schemaFileLocationArg,
@@ -1038,19 +974,11 @@ final class VariableRuntimeData(
     unqualifiedPathStepPolicyArg)
   with Serializable {
 
-  lazy val external = externalArg
   lazy val maybeDefaultValueExpr = maybeDefaultValueExprArg
-  lazy val typeRef = typeRefArg
-  lazy val globalQName = globalQNameArg
-  lazy val primType = primTypeArg
 
   override def preSerialization: Unit = {
     super.preSerialization
-    external
     maybeDefaultValueExpr
-    typeRef
-    globalQName
-    primType
   }
 
   @throws(classOf[java.io.IOException])


### PR DESCRIPTION
Converted many pass-by-name into pass-by-value for RuntimeData structures.

Other minor mods that eliminate some circularities that allow for more
by-value passing.

One of the major problems preventing more by-value passing is described in DAFFODIL-2326, which is about the passing of RuntimeData to the constructor of DPathCompileInfo.

This branch changes things that can be changed without fixing DAFFODIL-2326.

This set of changes should make incremental progress on DAFFODIL-1879.

DAFFODIL-2325