### PR TITLE
Implement fn:namespace-uri function

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -1504,11 +1504,19 @@ case class FunctionCallExpression(functionQNameString: String, expressions: List
 
       case (RefQName(_, "local-name", FUNC), args) if args.length == 0 =>
         FNZeroArgExpr(functionQNameString, functionQName,
-          NodeInfo.String, NodeInfo.AnyAtomic, FNLocalName0(_, _))
+          NodeInfo.String, NodeInfo.Exists, FNLocalName0(_, _))
 
       case (RefQName(_, "local-name", FUNC), args) if args.length == 1 =>
         FNOneArgExpr(functionQNameString, functionQName, args,
-          NodeInfo.String, NodeInfo.AnyAtomic, FNLocalName1(_, _))
+          NodeInfo.String, NodeInfo.Exists, FNLocalName1(_, _))
+
+      case (RefQName(_, "namespace-uri", FUNC), args) if args.length == 0 =>
+        FNZeroArgExpr(functionQNameString, functionQName,
+          NodeInfo.String, NodeInfo.Exists, FNNamespaceUri0(_, _))
+
+      case (RefQName(_, "namespace-uri", FUNC), args) if args.length == 1 =>
+        FNOneArgExpr(functionQNameString, functionQName, args,
+          NodeInfo.String, NodeInfo.Exists, FNNamespaceUri1(_, _))
 
       case (RefQName(_, "string", XSD), args) =>
         FNOneArgExpr(functionQNameString, functionQName, args,

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -11370,13 +11370,55 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
-  
-<!--
-    Test Name: nilled_01
-       Schema: booleanFunctions
-         Root: nilled01
-      Purpose: This test demonstrates that the fn:nilled function returns true if arg is a node with xsi:nil = true
--->
+
+  <!--
+      Test Name: namespace_uri_07
+         Schema: home_schema.dfdl.xsd
+           Root: e5
+        Purpose: This test demonstrates the namespace-uri() function causes a SDE if given a non-element arg
+  -->
+
+  <tdml:parserTestCase name="namespace_uri_07" root="e5"
+                       model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
+
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:namespace-uri</tdml:error>
+      <tdml:error>is not an element</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: namespace_uri_08
+         Schema: home_schema.dfdl.xsd
+           Root: e6
+        Purpose: This test demonstrates the namespace-uri() function on an element with no namespace
+  -->
+
+  <tdml:parserTestCase name="namespace_uri_08" root="e6"
+                       model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
+
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e6>
+          <uri xmlns=""></uri>
+        </e6>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: nilled_01
+         Schema: booleanFunctions
+           Root: nilled01
+        Purpose: This test demonstrates that the fn:nilled function returns true if arg is a node with xsi:nil = true
+  -->
 
   <tdml:parserTestCase name="nilled_01" root="nilled01"
     model="booleanFunctions" description="Section 23 - Functions - fn:nilled - DFDL-23-129R">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/home_schema.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/home_schema.dfdl.xsd
@@ -63,4 +63,14 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="e5" type="xs:string" dfdl:inputValueCalc="{ fn:namespace-uri(0) }"/>
+
+  <xs:element name="e6">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="uri" type="xs:string" dfdl:inputValueCalc="{ fn:namespace-uri(/home:e6/uri) }"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -516,10 +516,12 @@ class TestDFDLExpressions {
   //@Test def test_namespace_uri_01() { runner2.runOneTest("namespace_uri_01") }
   //@Test def test_namespace_uri_02() { runner2.runOneTest("namespace_uri_02") }
   //DFDL-1114
-  //@Test def test_namespace_uri_03() { runner2.runOneTest("namespace_uri_03") }
-  //@Test def test_namespace_uri_04() { runner2.runOneTest("namespace_uri_04") }
-  //@Test def test_namespace_uri_05() { runner2.runOneTest("namespace_uri_05") }
-  //@Test def test_namespace_uri_06() { runner2.runOneTest("namespace_uri_06") }
+  @Test def test_namespace_uri_03() { runner2.runOneTest("namespace_uri_03") }
+  @Test def test_namespace_uri_04() { runner2.runOneTest("namespace_uri_04") }
+  @Test def test_namespace_uri_05() { runner2.runOneTest("namespace_uri_05") }
+  @Test def test_namespace_uri_06() { runner2.runOneTest("namespace_uri_06") }
+  @Test def test_namespace_uri_07() { runner2.runOneTest("namespace_uri_07") }
+  @Test def test_namespace_uri_08() { runner2.runOneTest("namespace_uri_08") }
 
   //DFDL-1233
   @Test def test_nilled_02() { runner2.runOneTest("nilled_02") }


### PR DESCRIPTION
Add two new cases to FunctionCallExpression.functionObject (in file
Expression.scala) to allow expressions to call fn:namespace-uri with
zero and one arguments and get NodeInfo.AnyURI values.

Implement these calls with FNNamespaceUri0 and FNNamespaceUri1 case
classes in FNFunctions.scala.  These classes implement the calls using
the run() method instead of the computeValue() method since the
sibling case classes FNLocalName0 and FNLocalName1 (already
implemented by someone else) also do that.  Some parts tricky to
figure out were having to handle run() calls passing
DStateForConstantFolding (that's why we call dstate.fnExists() to
terminate such calls), how to get the namespace uri from the
currentNode, figuring out how to return NodeInfo.AnyURI instead of
NodeInfo.String, and figuring out what to do when fn:namespace-uri is
called with a currentValue instead of a currentNode.  (Please review
these new lines of code to make sure they seem correct.)

Add a new test case namespace_uri_07 to Functions.tdml to find out
what happens when we call fn:namespace-uri with a currentValue instead
of a currentNode.  Not sure how to test the similar situation where
fn:namespace-uri is called without a valid current node to use as "."
though.

Make sure to run the namespace_uri_03 to namespace_uri_06 test cases
in TestDFDLExpressions.scala now that fn:namespace-uri is implemented.