### PR TITLE
Fixed issue with type casting on Variables

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -404,21 +404,27 @@ object NodeInfo extends Enum {
   val Date = PrimType.Date
   val Time = PrimType.Time
 
+  /**
+   * This list of types must be in order of most specific to least, i.e. Byte
+   * inherits from Short, which inherits from Int etc. This is becasue
+   * fromNodeInfo does a find on this list based on isSubtypeOf, which will
+   * return the first successful result.
+   */
   val allPrims = List(
     String,
-    Int,
     Byte,
     Short,
+    Int,
     Long,
-    Integer,
-    Decimal,
-    UnsignedInt,
     UnsignedByte,
     UnsignedShort,
+    UnsignedInt,
     UnsignedLong,
     NonNegativeInteger,
-    Double,
+    Integer,
     Float,
+    Double,
+    Decimal,
     HexBinary,
     AnyURI,
     Boolean,

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -312,6 +312,16 @@
 
     <dfdl:defineVariable name="badscope" type="xs:int" defaultValue="70"/>
 
+    <dfdl:defineVariable name="unsignedLen" type="xs:unsignedInt" defaultValue="2"/>
+    <xs:element name="u1">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="a" type="xs:string"
+            dfdl:lengthKind="explicit" dfdl:length="{ $ex:unsignedLen }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="setVar1" root="c"
@@ -511,7 +521,21 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
-  
+
+  <tdml:parserTestCase name="unsignedIntVarCast" root="u1"
+    model="v"
+    description="Variable of type unsignedInt used to indicate element length">
+    <tdml:document><![CDATA[ab]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <u1>
+          <a xsi:type="xs:string">ab</a>
+        </u1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   <tdml:defineSchema name="setVarSchema">
     <dfdl:defineVariable name="v_no_default" type="xs:int" />
     <dfdl:defineVariable name="v_with_default" type="xs:int"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -77,6 +77,8 @@ class TestVariables {
   @Test def test_logical_default_values() { runner.runOneTest("logical_default_values") }
   @Test def test_logical_default_values_err() { runner.runOneTest("logical_default_values_err") }
 
+  @Test def test_unsignedIntVarCast() { runner.runOneTest("unsignedIntVarCast") }
+
   @Test def test_doubleSetErr_d() { runner_01.runOneTest("doubleSetErr_d") }
   @Test def test_setVar1_d() { runner_01.runOneTest("setVar1_d") }
   // DFDL-1443 & DFDL-1448


### PR DESCRIPTION
There was an issue with how integer and decimal numbers were being
interpreted from Variables. The list of primitive types we were checking
against needed to be in order of most specific to least specific as we are
searching this list to see if the current primitive is a subtype of any of the
types in allPrimTypes. The prim type "Integer" came before UnsignedInt
so when we would try to find a subtype for an unsignedInt, it would see
that unsignedInt is a subtype of Integer first and would treat end up
treating the value as a BigInteger. Similar issues were present for decimal
numbers.

DAFFODIL-2327