### PR TITLE
Fix missing argument for format specifier and ambiguous e1

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -286,7 +286,7 @@ final class SchemaSet(
   private def findRootElement(name: String) = {
     val candidates = schemas.flatMap { _.getGlobalElementDecl(name) }
     schemaDefinitionUnless(candidates.length != 0, "No root element found for %s in any available namespace", name)
-    schemaDefinitionUnless(candidates.length <= 1, "Root element %s is ambiguous. Candidates are %s.",
+    schemaDefinitionUnless(candidates.length <= 1, "Root element %s is ambiguous. Candidates are %s.", name,
       candidates.map { gef =>
         {
           val tns = gef.schemaDocument.targetNamespace

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -22,6 +22,8 @@
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:math="http://www.w3.org/2005/xpath-functions/math"
   xmlns:ex="http://example.com"
+  xmlns:home="http://home.com"
+  xmlns:first="http://first.com"
   defaultRoundTrip="onePass">
     
   <tdml:defineSchema name="Functions.dfdl.xsd">
@@ -11240,7 +11242,7 @@
       Purpose: This test demonstrates the namespace-uri() function
 -->
 
-  <tdml:parserTestCase name="namespace_uri_01" root="e1"
+  <tdml:parserTestCase name="namespace_uri_01"
     model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
 
     <tdml:document>
@@ -11248,11 +11250,11 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e1>
+        <home:e1>
           <two>123</two>
           <uri1>http://home.com</uri1>
           <uri2>http://first.com</uri2>
-        </e1>
+        </home:e1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -11264,7 +11266,7 @@
       Purpose: This test demonstrates the namespace-uri() function
 -->
 
-  <tdml:parserTestCase name="namespace_uri_02" root="e2"
+  <tdml:parserTestCase name="namespace_uri_02"
     model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
 
     <tdml:document>
@@ -11272,13 +11274,13 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e2>
-          <e1>
+        <home:e2>
+          <first:e1>
             <three>data</three>
-          </e1>
+          </first:e1>
           <uri>http://first.com</uri>
           <uri2>http://second.com</uri2>
-        </e2>
+        </home:e2>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -11371,12 +11373,12 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <!--
-      Test Name: namespace_uri_07
-         Schema: home_schema.dfdl.xsd
-           Root: e5
-        Purpose: This test demonstrates the namespace-uri() function causes a SDE if given a non-element arg
-  -->
+<!--
+    Test Name: namespace_uri_07
+       Schema: home_schema.dfdl.xsd
+         Root: e5
+      Purpose: This test demonstrates the namespace-uri() function causes a SDE if given a non-element arg
+-->
 
   <tdml:parserTestCase name="namespace_uri_07" root="e5"
                        model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
@@ -11391,12 +11393,12 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <!--
-      Test Name: namespace_uri_08
-         Schema: home_schema.dfdl.xsd
-           Root: e6
-        Purpose: This test demonstrates the namespace-uri() function on an element with no namespace
-  -->
+<!--
+    Test Name: namespace_uri_08
+       Schema: home_schema.dfdl.xsd
+         Root: e6
+      Purpose: This test demonstrates the namespace-uri() function on an element with no namespace
+-->
 
   <tdml:parserTestCase name="namespace_uri_08" root="e6"
                        model="home_schema.dfdl.xsd" description="Section 23 - Functions - fn:namespace-uri() - DFDL-23-126R">
@@ -11413,12 +11415,12 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <!--
-      Test Name: nilled_01
-         Schema: booleanFunctions
-           Root: nilled01
-        Purpose: This test demonstrates that the fn:nilled function returns true if arg is a node with xsi:nil = true
-  -->
+<!--
+    Test Name: nilled_01
+       Schema: booleanFunctions
+         Root: nilled01
+      Purpose: This test demonstrates that the fn:nilled function returns true if arg is a node with xsi:nil = true
+-->
 
   <tdml:parserTestCase name="nilled_01" root="nilled01"
     model="booleanFunctions" description="Section 23 - Functions - fn:nilled - DFDL-23-129R">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -513,8 +513,8 @@ class TestDFDLExpressions {
   //@Test def test_local_name_07() { runner2.runOneTest("local_name_07") }
 
   //DFDL-1101
-  //@Test def test_namespace_uri_01() { runner2.runOneTest("namespace_uri_01") }
-  //@Test def test_namespace_uri_02() { runner2.runOneTest("namespace_uri_02") }
+  @Test def test_namespace_uri_01() { runner2.runOneTest("namespace_uri_01") }
+  @Test def test_namespace_uri_02() { runner2.runOneTest("namespace_uri_02") }
   //DFDL-1114
   @Test def test_namespace_uri_03() { runner2.runOneTest("namespace_uri_03") }
   @Test def test_namespace_uri_04() { runner2.runOneTest("namespace_uri_04") }


### PR DESCRIPTION
Two parser test cases (namespace_uri_01 and namespace_uri_02, set
aside until fn:namespace-uri() gets implemented) were failing for
other reasons that need to be fixed too.  These test cases were using
root elements e1 & e2 that could be found in two namespaces (home and
first), making the lookup ambiguous.  The lookup error handling code
tried to format an exception message with two format specifiers but
only one argument, causing an exception to be thrown that was not the
original problem.

Add the missing argument for the second format specifier %s to
SchemaSet.findRootElement.

Remove the ambiguous root element lookups and add namespace prefixes
to the elements e1 & e2 in the namespace_uri_01 and namespace_uri_02
test cases within Functions.tdml.

Allow TestDFDLExpressions to run test_namespace_uri_01 and
test_namespace_uri_02 since the reasons for them failing are fixed
now.

DAFFODIL-1101