### PR TITLE
Added try/catch for potential unparse exceptions

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -29,6 +29,7 @@ import scala.xml.NamespaceBinding
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.api.WarnID
 import java.lang.{Integer => JInt}
@@ -342,7 +343,12 @@ trait ElementBase
           // will work.
           //
           val str = defaultValueAsString
-          val value = primType.fromXMLString(str)
+          val value = try {
+            primType.fromXMLString(str)
+          } catch {
+            case ipd: InvalidPrimitiveDataException =>
+              SDE("Invalid default value: %s", ipd.getMessage)
+          }
           value
         }
       dv

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -24,6 +24,7 @@ import org.apache.daffodil.cookers.IntRangeCooker
 import org.apache.daffodil.cookers.RepValueCooker
 import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.IdentifyTypeCalculator
 import org.apache.daffodil.processors.RepValueSet
@@ -568,7 +569,11 @@ final class EnumerationDef(
   override lazy val optRepType = parentType.optRepType
 
   lazy val enumValueRaw: String = (xml \ "@value").head.text
-  lazy val enumValueCooked: DataValuePrimitive = parentType.primType.fromXMLString(enumValueRaw)
+  lazy val enumValueCooked: DataValuePrimitive = try {
+    parentType.primType.fromXMLString(enumValueRaw)
+  } catch {
+    case e: InvalidPrimitiveDataException => SDE("Invalid data for enumeration: %s", e.getMessage)
+  }
 
   override lazy val optRepValueSet: Option[RepValueSet] = optRepValueSetFromAttribute
   lazy val logicalValueSet: RepValueSet = RepValueSetCompiler.compile(Seq(enumValueCooked), Seq())

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
@@ -164,8 +164,7 @@ class TestDFDLParser {
     val e = intercept[Exception] {
       TestUtils.testString(sch, "70,000")
     }
-    // println("ERROR!!!!!" + e.getMessage())
-    assertTrue(e.getMessage().contains("xs:short"))
+    assertTrue(e.getMessage().contains("short"))
   }
 
   @Test def testByte1() {
@@ -228,7 +227,7 @@ class TestDFDLParser {
     val e = intercept[Exception] {
       TestUtils.testString(sch, "-3")
     }
-    assertTrue(e.getMessage().contains("xs:unsignedLong"))
+    assertTrue(e.getMessage().contains("unsignedLong"))
   }
 
   @Test def testUnsignedInt1() {
@@ -240,7 +239,7 @@ class TestDFDLParser {
       // As of 18:31 UTC (EST+5) Jun 8, 2012
       TestUtils.testString(sch, "7,018,631,476")
     }
-    assertTrue(e.getMessage().contains("xs:unsignedInt"))
+    assertTrue(e.getMessage().contains("unsignedInt"))
   }
 
   @Test def testUnsignedShort1() {
@@ -251,7 +250,7 @@ class TestDFDLParser {
     val e = intercept[Exception] {
       TestUtils.testString(sch, "-1")
     }
-    assertTrue(e.getMessage().contains("xs:unsignedShort"))
+    assertTrue(e.getMessage().contains("unsignedShort"))
   }
 
   @Test def testUnsignedByte1() {
@@ -262,7 +261,7 @@ class TestDFDLParser {
     val e = intercept[Exception] {
       TestUtils.testString(sch, "256")
     }
-    assertTrue(e.getMessage().contains("xs:unsignedByte"))
+    assertTrue(e.getMessage().contains("unsignedByte"))
   }
 
   @Test def testIntTooLong() {
@@ -279,7 +278,7 @@ class TestDFDLParser {
     val e = intercept[Exception] {
       TestUtils.testString(sch, "55555555555555555555")
     }
-    assertTrue(e.getMessage().contains("xs:int"))
+    assertTrue(e.getMessage().contains("int"))
   }
 
   @Test def testParseSequenceInt() {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps.scala
@@ -56,22 +56,14 @@ import org.apache.daffodil.util.Numbers.asLong
 import org.apache.daffodil.util.Numbers.asShort
 import org.apache.daffodil.xml.XMLUtils
 
-trait NumericRangeCheck {
-  protected val rangePrim: PrimNumeric
-  final protected def checkRange(num: Number) = {
-    if (!rangePrim.isValidRange(num)) {
-      val msg = "Value is out of range for %s type: %s".format(rangePrim.asInstanceOf[PrimType].globalQName, num)
-      throw new NumberFormatException(msg)
-    }
-  }
-}
-
 case object BooleanToLong extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = JLong.valueOf(if (asBoolean(a.getAnyRef) == true) 1L else 0L)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    JLong.valueOf(if (asBoolean(a.getAnyRef) == true) 1L else 0L)
 }
 
 case object BooleanToString extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueString = if (asBoolean(a.getAnyRef) == true) "true" else "false"
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueString =
+    if (asBoolean(a.getAnyRef) == true) "true" else "false"
 }
 
 case object DateTimeToDate extends Converter {
@@ -99,38 +91,24 @@ case object DateToDateTime extends Converter {
   }
 }
 case object DecimalToInteger extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = asBigInt(a.getBigDecimal)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.Integer.fromNumber(a.getBigDecimal).getBigInt
 }
-case object DecimalToLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getBigDecimal
-    checkRange(res)
-    asLong(res)
-  }
-  override protected val rangePrim = PrimType.Long
+case object DecimalToLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    PrimType.Long.fromNumber(a.getBigDecimal).getLong
 }
 case object DecimalToDouble extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble = {
-    val res = a.getBigDecimal
-    // TODO: why no range check here?
-    asDouble(res)
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble =
+    PrimType.Double.fromNumber(a.getBigDecimal).getDouble
 }
-case object DecimalToNonNegativeInteger extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getBigDecimal
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.NonNegativeInteger
+case object DecimalToNonNegativeInteger extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.NonNegativeInteger.fromNumber(a.getBigDecimal).getBigInt
 }
-case object DecimalToUnsignedLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getBigDecimal
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedLong
+case object DecimalToUnsignedLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.UnsignedLong.fromNumber(a.getBigDecimal).getBigInt
 }
 case object DecimalToBoolean extends Converter {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool = {
@@ -143,30 +121,20 @@ case object DecimalToBoolean extends Converter {
   }
 }
 case object DoubleToDecimal extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal = JBigDecimal.valueOf(a.getDouble)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal =
+    PrimType.Decimal.fromNumber(a.getDouble).getBigDecimal
 }
 case object DoubleToFloat extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueFloat = {
-    val res = a.getDouble
-    // TODO: why no range check here?
-    asFloat(res)
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueFloat =
+    PrimType.Float.fromNumber(a.getDouble).getFloat
 }
-case object DoubleToLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getDouble
-    checkRange(res)
-    asLong(res)
-  }
-  override protected val rangePrim = PrimType.Long
+case object DoubleToLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    PrimType.Long.fromNumber(a.getDouble).getLong
 }
-case object DoubleToUnsignedLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getDouble
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedLong
+case object DoubleToUnsignedLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    asBigInt(PrimType.UnsignedLong.fromNumber(a.getDouble).getAnyRef)
 }
 case object DoubleToBoolean extends Converter {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool = {
@@ -179,159 +147,103 @@ case object DoubleToBoolean extends Converter {
   }
 }
 case object FloatToDouble extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble = asDouble(a.getFloat)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble =
+    PrimType.Double.fromNumber(a.getFloat).getDouble
 }
 case object IntegerToDecimal extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal = new JBigDecimal(a.getBigInt)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal =
+    PrimType.Decimal.fromNumber(a.getBigInt).getBigDecimal
 }
-case object IntegerToUnsignedLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getBigInt
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedLong
+case object IntegerToUnsignedLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.UnsignedLong.fromNumber(a.getBigInt).getBigInt
 }
 case object LongToBoolean extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool = asBoolean(if (a.getLong == 0) false else true)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool =
+    asBoolean(if (a.getLong == 0) false else true)
 }
-case object LongToByte extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueByte = {
-    val res = a.getLong
-    checkRange(res)
-    asByte(res)
-  }
-  override protected val rangePrim = PrimType.Byte
+case object LongToByte extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueByte =
+    PrimType.Byte.fromNumber(a.getLong).getByte
 }
 case object LongToDecimal extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal = asBigDecimal(a.getLong)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal =
+    PrimType.Decimal.fromNumber(a.getLong).getBigDecimal
 }
 case object LongToDouble extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble = asDouble(a.getLong)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble =
+    PrimType.Double.fromNumber(a.getLong).getDouble
 }
 case object LongToFloat extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueFloat = asFloat(a.getLong)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueFloat =
+    PrimType.Float.fromNumber(a.getLong).getFloat
 }
-case object LongToInt extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueInt = {
-    val res = a.getLong
-    checkRange(res)
-    asInt(res)
-  }
-  override protected val rangePrim = PrimType.Int
+case object LongToInt extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueInt =
+    PrimType.Int.fromNumber(a.getLong).getInt
 }
 
 case object LongToInteger extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = asBigInt(a.getLong)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.Integer.fromNumber(a.getLong).getBigInt
 }
 
-case object LongToShort extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueShort = {
-    val res = a.getLong
-    checkRange(res)
-    asShort(res)
-  }
-  override protected val rangePrim = PrimType.Short
+case object LongToShort extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueShort =
+    PrimType.Short.fromNumber(a.getLong).getShort
 }
 
 case object LongToArrayIndex extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getLong
-    res
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    PrimType.Long.fromNumber(a.getLong).getLong
 }
-case object LongToUnsignedByte extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueShort = {
-    val res = a.getLong
-    checkRange(res)
-    asShort(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedByte
+case object LongToUnsignedByte extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueShort =
+    PrimType.UnsignedByte.fromNumber(a.getLong).getShort
 }
-case object LongToUnsignedInt extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getLong
-    checkRange(res)
-    res
-  }
-  override protected val rangePrim = PrimType.UnsignedInt
+case object LongToUnsignedInt extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    PrimType.UnsignedInt.fromNumber(a.getLong).getLong
 }
-case object LongToUnsignedShort extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueInt = {
-    val res = a.getLong
-    checkRange(res)
-    asInt(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedShort
+case object LongToUnsignedShort extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueInt =
+    PrimType.UnsignedShort.fromNumber(a.getLong).getInt
 }
 
-case object LongToNonNegativeInteger extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getLong
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.NonNegativeInteger
+case object LongToNonNegativeInteger extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.NonNegativeInteger.fromNumber(a.getLong).getBigInt
 }
 
-case object LongToUnsignedLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = a.getLong
-    checkRange(res)
-    asBigInt(res)
-  }
-  override protected val rangePrim = PrimType.UnsignedLong
+case object LongToUnsignedLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.UnsignedLong.fromNumber(a.getLong).getBigInt
 }
 
 case object NumericToDouble extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble = asDouble(a.getAnyRef)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble =
+    asDouble(a.getAnyRef)
 }
 
 case object StringToBoolean extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool = {
-    val str = a.getString
-    val res =
-      if (str == "true" || str == "1") true
-      else if (str == "false" || str == "0") false
-      else throw new NumberFormatException("Value '%s' is not a valid boolean value {true, false, 1, 0}.".format(str))
-    asBoolean(res)
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBool =
+    PrimType.Boolean.fromXMLString(a.getString).getBoolean
 }
 case object StringToDecimal extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal = new JBigDecimal(a.getString)
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigDecimal =
+    PrimType.Decimal.fromXMLString(a.getString).getBigDecimal
 }
 case object StringToDouble extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble = {
-    val str = a.getString
-    val d =
-      if (str == XMLUtils.PositiveInfinityString) JDouble.POSITIVE_INFINITY
-      else if (str == XMLUtils.NegativeInfinityString) JDouble.NEGATIVE_INFINITY
-      else if (str == XMLUtils.NaNString) JDouble.NaN
-      else str.toDouble
-    d
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueDouble =
+    PrimType.Double.fromXMLString(a.getString).getDouble
 }
 case object StringToLong extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res =
-      try {
-        a.getString.toLong
-      } catch {
-        case nfe: NumberFormatException => {
-          val e = new NumberFormatException("Cannot convert to type long: " + nfe.getMessage())
-          throw e
-        }
-      }
-    res
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong =
+    PrimType.Long.fromXMLString(a.getString).getLong
 }
-case object StringToUnsignedLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt = {
-    val res = new JBigInt(a.getString)
-    checkRange(res)
-    res
-  }
-  override protected val rangePrim = PrimType.UnsignedLong
+case object StringToUnsignedLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueBigInt =
+    PrimType.UnsignedLong.fromXMLString(a.getString).getBigInt
 }
 
 /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps3.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps3.scala
@@ -67,34 +67,20 @@ case object HexStringToUnsignedLong extends Converter {
     res
   }
 }
-case object IntegerToLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getBigInt
-    checkRange(res)
-    asLong(res)
-  }
-  override protected val rangePrim = PrimType.Long
+case object IntegerToLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = PrimType.Long.fromNumber(a.getBigInt).getLong
 }
 case object IntToLong extends Converter {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = asLong(a.getInt)
 }
-case object UnsignedLongToLong extends Converter with NumericRangeCheck {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    val res = a.getBigInt
-    checkRange(res)
-    asLong(res)
-  }
-  override protected val rangePrim = PrimType.Long
+case object UnsignedLongToLong extends Converter {
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = PrimType.Long.fromNumber(a.getBigInt).getLong
 }
 case object UnsignedIntToLong extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    a.getLong
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = a.getLong
 }
 case object ArrayIndexToLong extends Converter {
-  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = {
-    asLong(a.getAnyRef)
-  }
+  override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = asLong(a.getAnyRef)
 }
 case object ShortToLong extends Converter {
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueLong = asLong(a.getShort)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
@@ -113,6 +113,7 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
         // are typically typographical errors so it is good to pick them up here.
         case e: java.lang.ArithmeticException => throw new SchemaDefinitionError(Some(sfl), None, e.getMessage())
         case e: java.lang.NumberFormatException => throw new SchemaDefinitionError(Some(sfl), None, e.getMessage())
+        case e: InvalidPrimitiveDataException => throw new SchemaDefinitionError(Some(sfl), None, e.getMessage())
         case e: java.lang.IndexOutOfBoundsException => false
         case e: java.lang.IllegalArgumentException => false
         case e: FNErrorException => false
@@ -291,7 +292,7 @@ abstract class Converter extends RecipeOp {
       try {
         computeValue(arg, dstate)
       } catch {
-        case e: NumberFormatException => {
+        case e: InvalidPrimitiveDataException => {
           val (fromTypeName, toTypeName) = typeNames
           val msg =
             if (e.getMessage() != null && e.getMessage() != "") e.getMessage()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -29,10 +29,13 @@ import org.apache.daffodil.util.CursorImplMixin
 import org.apache.daffodil.util.MStack
 import org.apache.daffodil.processors.unparsers.UnparseError
 import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.ErrorERD
 import org.apache.daffodil.util.MStackOfAnyRef
+
+import java.net.URISyntaxException
 
 class InfosetError(kind: String, args: String*)
   extends ProcessingError("Infoset", Nope, Nope, kind, args: _*)
@@ -420,7 +423,12 @@ abstract class InfosetInputter
         }
       } else if (erd.outputValueCalcExpr.isEmpty) {
         val primType = elem.erd.optPrimType.get
-        val obj = primType.fromXMLString(txt)
+        val obj = try {
+          primType.fromXMLString(txt)
+        } catch {
+          case ipd: InvalidPrimitiveDataException =>
+            UnparseError(One(elem.erd.schemaFileLocation), Nope, ipd.getMessage)
+        }
         elem.asInstanceOf[DISimple].setDataValue(obj)
       }
     }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BinaryNumberParsers.scala
@@ -21,6 +21,7 @@ import java.lang.{ Long => JLong, Number => JNumber, Double => JDouble, Float =>
 import java.math.{BigInteger => JBigInt, BigDecimal => JBigDecimal}
 
 import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Evaluatable
 import org.apache.daffodil.processors.ParseOrUnparseState
@@ -168,13 +169,14 @@ abstract class BinaryIntegerBaseParser(override val context: ElementRuntimeData,
         else { dis.getUnsignedLong(nBits, start).toLong }
       }
 
-    if (!primNumeric.isValidRange(num)) {
-      PE(start, "Parsed %s is out of range for type: %s",
-        context.optPrimType.get.globalQName, num)
-      return
+    val res = try {
+      primNumeric.fromNumber(num)
+    } catch {
+      case e: InvalidPrimitiveDataException => {
+        PE(start, "%s", e.getMessage)
+        return
+      }
     }
-
-    val res = primNumeric.fromNumber(num)
 
     start.simpleElement.overwriteDataValue(res)
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NonBaseTenTextNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NonBaseTenTextNumberParser.scala
@@ -21,6 +21,7 @@ import java.math.{ BigInteger => JBigInt }
 import java.lang.{ Number => JNumber }
 
 import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.processors.ElementRuntimeData
 
 class ConvertNonBaseTenTextNumberParser(
@@ -65,13 +66,14 @@ class ConvertNonBaseTenTextNumberParser(
         return
     }
 
-    if (!primNumeric.isValidRange(bi)) {
-      PE(state, "Parsed %s is out of range for the type: %s",
-        context.optPrimType.get.globalQName, bi.toString)
-      return
+    val num = try {
+      primNumeric.fromNumber(bi)
+    } catch {
+      case e: InvalidPrimitiveDataException => {
+        PE(state, "%s", e.getMessage)
+        return
+      }
     }
-    
-    val num = primNumeric.fromNumber(bi)
     node.overwriteDataValue(num)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ZonedTextParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ZonedTextParsers.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.processors.parsers
 
 import java.text.ParsePosition
 import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.exceptions.UnsuppressableException
 import org.apache.daffodil.infoset.DISimple
@@ -95,17 +96,13 @@ case class ConvertZonedNumberParser(
         return
       }
 
-      val numValue = {
-        if (!primNumeric.isValidRange(num)) {
-          PE(start, "Parsed %s is out of range for type: %s",
-            context.optPrimType.get.globalQName, str, num)
+      val numValue = try {
+        primNumeric.fromNumber(num)
+      } catch {
+        case e: InvalidPrimitiveDataException => {
+          PE(start, "%s", e.getMessage)
           return
         }
-
-        // convert to proper type
-        val asNumber = primNumeric.fromNumber(num)
-
-        asNumber
       }
       numValue
     }

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.tdml
 
 import java.net.URI
+import java.net.URISyntaxException
 
 import org.apache.daffodil.infoset.InfosetInputter
 import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
@@ -89,18 +90,22 @@ class TDMLInfosetInputter(val scalaInputter: ScalaXMLInfosetInputter, others: Se
       throw TDMLException("getSimpleText does not match", Some(implString))
 
     if (primType.isInstanceOf[NodeInfo.AnyURI.Kind]) {
-      val uri = new URI(res)
-      if (!uri.getPath.startsWith("/")) {
-        // TDML files must allow blob URI's to be relative, but Daffodil
-        // requires them to be absolute with a scheme. So search for the file
-        // using TDML semantics and convert to an absolute URI
-        val abs = Misc.searchResourceOption(uri.getPath, None)
-        if (abs.isEmpty) {
-          throw TDMLException("Unable to find URI: " + res, Some(implString))
+      try {
+        val uri = new URI(res)
+        if (!uri.getPath.startsWith("/")) {
+          // TDML files must allow blob URI's to be relative, but Daffodil
+          // requires them to be absolute with a scheme. So search for the file
+          // using TDML semantics and convert to an absolute URI
+          val abs = Misc.searchResourceOption(uri.getPath, None)
+          if (abs.isEmpty) {
+            throw TDMLException("Unable to find URI: " + res, Some(implString))
+          }
+          abs.get.toString
+        } else {
+          res
         }
-        abs.get.toString
-      } else {
-        res
+      } catch {
+        case uri: URISyntaxException => res
       }
     } else {
       res

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
@@ -256,6 +256,18 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+  <tdml:unparserTestCase name="blob_unparseError" root="blob_01" model="Blob.dfdl.xsd">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:blob_01 xsi:type="xs:anyURI">this isn't a URI</ex:blob_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Illegal character</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <!-- parse, not enough bits -->
   <tdml:parserTestCase name="blob_10" root="blob_01" model="Blob.dfdl.xsd">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Boolean.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Boolean.tdml
@@ -537,6 +537,21 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+  <tdml:unparserTestCase name="textBoolean_unparseError" root="textList_pe" model="boolean"
+    description="Text boolean" roundTrip="false">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:textList_pe>
+          <ex:x>garbage</ex:x>
+        </ex:textList_pe>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:boolean</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="textBoolean_sde_3" root="textList_sde4" model="boolean"
     description="Text boolean" roundTrip="false">
     <tdml:document><![CDATA[yes,non;]]></tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -150,12 +150,18 @@
     <xs:element name="nonNegIntBin5" type="xs:nonNegativeInteger" 
       dfdl:representation="binary" dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ -30 }"/>
 
-  <xs:element name="dateText" type="xs:date" dfdl:calendarPattern="EEEE, MMM d, ''yy" dfdl:calendarPatternKind="explicit"
+    <xs:element name="dateText" type="xs:date" dfdl:calendarPattern="EEEE, MMM d, ''yy" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 23 }" />
     <xs:element name="timeText" type="xs:time" dfdl:calendarPattern="h:mm a" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 8 }" />
     <xs:element name="dateTimeText" type="xs:dateTime" dfdl:calendarPattern="yyyy.MM.dd G 'at' HH:mm:ss ZZZZ" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 35 }" />
+    <xs:element name="dateTextInvalid" type="xs:date" dfdl:calendarPattern="EEEE, MMM d, ''yy" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ xs:string('Wday, July 10, 1996') }" />
+    <xs:element name="timeTextInvalid" type="xs:time" dfdl:calendarPattern="h:mm a" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ xs:string('not a time') }" />
+    <xs:element name="dateTimeTextInvalid" type="xs:dateTime" dfdl:calendarPattern="yyyy.MM.dd G 'at' HH:mm:ss ZZZZ" dfdl:calendarPatternKind="explicit"
+      dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ xs:string('not a date time') }" />
 
     <xs:element name="limits" dfdl:lengthKind="implicit">
       <xs:complexType>
@@ -209,6 +215,7 @@
 
     <xs:element name="posint01" type="xs:nonNegativeInteger" />
     <xs:element name="int01" type="xs:int" />
+    <xs:element name="int02" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="65" />
     <xs:element name="l_1" type="xs:long" />
     <xs:element name="s_1" type="xs:short" />
     <xs:element name="b_01" type="xs:byte" />
@@ -512,7 +519,7 @@
     <tdml:document><![CDATA[-2147483649]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:int</tdml:error>
+      <tdml:error>int</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-2147483649</tdml:error>
     </tdml:errors>
@@ -524,7 +531,7 @@
     <tdml:document><![CDATA[2147483648]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:int</tdml:error>
+      <tdml:error>int</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>2147483648</tdml:error>
     </tdml:errors>
@@ -581,7 +588,7 @@
     <tdml:document><![CDATA[-1]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedLong</tdml:error>
+      <tdml:error>unsignedLong</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-1</tdml:error>
     </tdml:errors>
@@ -645,7 +652,7 @@
     <tdml:document><![CDATA[70000]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:short</tdml:error>
+      <tdml:error>short</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>70000</tdml:error>
     </tdml:errors>
@@ -666,7 +673,7 @@
     <tdml:document><![CDATA[7018631476]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedInt</tdml:error>
+      <tdml:error>unsignedInt</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>7018631476</tdml:error>
     </tdml:errors>
@@ -693,7 +700,7 @@
     <tdml:document><![CDATA[-999]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedInt</tdml:error>
+      <tdml:error>unsignedInt</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-999</tdml:error>
     </tdml:errors>
@@ -710,6 +717,20 @@
       <tdml:error>9a99</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unsignedInt_unparseError"
+    root="uI_03" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid unsigned int - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:uI_03>9a99</ex:uI_03>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:unsignedInt</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededUnsignedInt"
     root="uI_03" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -805,6 +826,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="int_unparseError"
+    root="int05" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid int - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:int05>9a99</ex:int05>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:int</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededInt"
     root="int05" model="SimpleTypes-Embedded.dfdl.xsd"
     description="Test parsing when encountering a whitespace character after an invalid int - DFDL-5-013R">
@@ -898,6 +933,20 @@
       <tdml:error>9a99</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="integer_unparseError"
+    root="integer02" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid integer - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:integer02>9a99</ex:integer02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:integer</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededInteger"
     root="integer02" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -994,6 +1043,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="long_unparseError"
+    root="l_4" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid long - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:l_4>9a99</ex:l_4>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:long</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededLong"
     root="l_4" model="SimpleTypes-Embedded.dfdl.xsd"
     description="Test parsing when encountering a whitespace character after an invalid long - DFDL-5-012R">
@@ -1087,6 +1150,20 @@
       <tdml:error>9a991</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="short_unparseError"
+    root="s_1" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid short - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:s_1>9a99</ex:s_1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:short</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededShort"
     root="s_1" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -1183,6 +1260,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="byte_unparseError"
+    root="b_01" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid byte - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:b_01>9a99</ex:b_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:byte</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededByte"
     root="b_01" model="SimpleTypes-Embedded.dfdl.xsd"
     description="Test parsing when encountering a whitespace character after an invalid byte - DFDL-5-015R">
@@ -1277,7 +1368,7 @@
     <tdml:document><![CDATA[-123]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedLong</tdml:error>
+      <tdml:error>unsignedLong</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-123</tdml:error>
     </tdml:errors>
@@ -1294,6 +1385,20 @@
       <tdml:error>9a99</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unsignedLong_unparseError"
+    root="uL_04" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid unsigned long - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:uL_04>9a99</ex:uL_04>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:unsignedLong</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededUnsignedLong"
     root="uL_04" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -1389,7 +1494,7 @@
     <tdml:document><![CDATA[-999]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedShort</tdml:error>
+      <tdml:error>unsignedShort</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-999</tdml:error>
     </tdml:errors>
@@ -1406,6 +1511,20 @@
       <tdml:error>9a99</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unsignedShort_unparseError"
+    root="uS_02" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid unsigned short - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:uS_02>9a99</ex:uS_02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:unsignedShort</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededUnsignedShort"
     root="uS_02" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -1501,7 +1620,7 @@
     <tdml:document><![CDATA[-99]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedByte</tdml:error>
+      <tdml:error>unsignedByte</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-99</tdml:error>
     </tdml:errors>
@@ -1518,6 +1637,20 @@
       <tdml:error>9a9</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unsignedByte_unparseError"
+    root="uB_01" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid unsigned byte - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:uB_01>9a99</ex:uB_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:unsignedByte</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="whiteSpaceAfterLengthExceededUnsignedByte"
     root="uB_01" model="SimpleTypes-Embedded.dfdl.xsd"
@@ -1606,7 +1739,7 @@
     <tdml:document><![CDATA[-1]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:unsignedShort</tdml:error>
+      <tdml:error>unsignedShort</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-1</tdml:error>
     </tdml:errors>
@@ -1912,6 +2045,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="nonNegativeInteger_unparseError"
+    root="nonNegIntText" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid nonNegativeInteger - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:nonNegIntText>9a99</ex:nonNegIntText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:nonNegativeInteger</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
 <!--
     Test name: nonNegativeInteger_bin
     Schema: SimpleTypes-Embedded.dfdl.xsd
@@ -2154,6 +2301,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="decimal_unparseError"
+    root="decimalText2" model="SimpleTypes-Embedded.dfdl.xsd"
+    description="Test unparsing when encountering a non numeric character during a valid decimal - DFDL-5-018R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:decimalText2>9a99</ex:decimalText2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:decimal</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="dateText" root="dateText"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R"
     roundTrip="twoPass">
@@ -2164,6 +2325,18 @@
         <dateText xsi:type="xs:date">1996-07-10+00:00</dateText>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTextInvalid" root="dateTextInvalid"
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document></tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Failed to parse xs:date</tdml:error>
+      <tdml:error>Wday</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="timeText" root="timeText"
@@ -2177,6 +2350,18 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase name="timeTextInvalid" root="timeTextInvalid"
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document></tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Failed to parse xs:time</tdml:error>
+      <tdml:error>not a time</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
   <tdml:parserTestCase name="dateTimeText" root="dateTimeText"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-dateTime - DFDL-5-016R"
     roundTrip="true">
@@ -2187,6 +2372,18 @@
         <dateTimeText>1996-07-10T15:08:56-05:00</dateTimeText>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeTextInvalid" root="dateTimeTextInvalid"
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-date - DFDL-5-016R"
+    roundTrip="twoPass">
+
+    <tdml:document></tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Failed to parse xs:dateTime</tdml:error>
+      <tdml:error>not a date time</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <!-- xs:dateTime with binaryCalendarRep='binarySeconds' -->
@@ -3471,6 +3668,20 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:unparserTestCase name="double_unparseError" root="doubleText"
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Test unparsing when encountering a non numeric character during a valid double - DFDL-5-009R">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:doubleText>9a99</ex:doubleText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:double</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <tdml:parserTestCase name="float_text" root="floatText"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Simple type-float - DFDL-5-008R"
     roundTrip="false">
@@ -3528,6 +3739,19 @@
       <tdml:error>9a99</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="float_unparseError" root="floatText" roundTrip="false"
+      model="SimpleTypes-Embedded.dfdl.xsd" description="Test unparsing when encountering a non numeric character during a valid float">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:floatText>9a99</ex:floatText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:float</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <!--
     Test name: float_binary_01
@@ -3981,7 +4205,26 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+   <!--
+    Test name: binaryInt_unparseError
+    Schema: SimpleTypes-binary
+    Purpose: Unparse a binary int with a value that is too large to be an xs:int
+  -->
   
+  <tdml:unparserTestCase name="binaryInt_unparseError" root="int02" roundTrip="false"
+      model="SimpleTypes-binary" description="Section 5 Schema types - int - DFDL-5-013R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:int02>7089904312036126320</ex:int02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a valid xs:int</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
   <!--
     Test name: int_implicit
     Schema: SimpleTypes-Embedded.dfdl.xsd
@@ -4091,6 +4334,25 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+   <!--
+    Test name: hexBinary_unparseError
+    Schema: SimpleTypes-binary
+    Purpose: Attempt to unparse an invalid hexBinary value
+  -->
+
+  <tdml:unparserTestCase name="hexBinary_unparseError" root="hB_fromString" roundTrip="false"
+      model="HexBinary" description="Section 5 Schema types - int - DFDL-5-013R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:hB_fromString>DEADBEE</ex:hB_fromString>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>even number of characters</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:defineSchema name="SimpleTypes-padding">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
@@ -7072,6 +7334,25 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+   <!--
+    Test name: calendar_unparseError
+    Schema: dateTimeSchema
+    Purpose: Attempt to unparse an invalid calendar
+  -->
+
+  <tdml:unparserTestCase name="calendar_unparseError" root="date" roundTrip="false"
+      model="dateTimeSchemaTNR" description="Section 5 Schema types - int - DFDL-5-013R">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:date>Not a calendar</ex:date>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>not a calendar</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
 <!--
      Test Name: dateTextNumberRep
         Schema: dateTimeSchemaTNR
@@ -7782,7 +8063,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>xs:nonNegativeInteger</tdml:error>
+      <tdml:error>nonNegativeInteger</tdml:error>
       <tdml:error>out of range</tdml:error>
       <tdml:error>-2</tdml:error>
     </tdml:errors>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextStandardBase.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextStandardBase.tdml
@@ -1268,10 +1268,9 @@
     </tdml:infoset>
     <tdml:errors>
       <tdml:error>Unparse Error</tdml:error>
-      <tdml:error>Unable to unparse</tdml:error>
-      <tdml:error>negative</tdml:error>
-      <tdml:error>textStandardBase="16"</tdml:error>
       <tdml:error>-9223372036854775808</tdml:error>
+      <tdml:error>out of range for type</tdml:error>
+      <tdml:error>xs:nonNegativeInteger</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -6778,7 +6778,7 @@
 
     <tdml:document><![CDATA[cray,false]]></tdml:document>
     <tdml:errors>
-        <tdml:error>Value 'cray' is not a valid boolean value {true, false, 1, 0}.</tdml:error>
+        <tdml:error>Value 'cray' is not a valid xs:boolean</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -5317,7 +5317,7 @@
       <tdml:error>Parse Error</tdml:error>
       <tdml:error>convert</tdml:error>
       <tdml:error>string</tdml:error>
-      <tdml:error>"string"</tdml:error>
+      <tdml:error>'string'</tdml:error>
       <tdml:error>double</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -5513,7 +5513,7 @@
       <tdml:error>Parse Error</tdml:error>
       <tdml:error>convert</tdml:error>
       <tdml:error>string</tdml:error>
-      <tdml:error>"string"</tdml:error>
+      <tdml:error>'string'</tdml:error>
       <tdml:error>double</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -5712,7 +5712,6 @@
       <tdml:error>Parse Error</tdml:error>
       <tdml:error>convert</tdml:error>
       <tdml:error>string</tdml:error>
-      <tdml:error>"string"</tdml:error>
       <tdml:error>double</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -8289,9 +8288,9 @@
       <tdml:errors>
         <tdml:error>Parse Error</tdml:error>
         <tdml:error>convert</tdml:error>
-        <tdml:error>string</tdml:error>
+        <tdml:error>String</tdml:error>
         <tdml:error>double</tdml:error>
-        <tdml:error>"1.23E"</tdml:error>
+        <tdml:error>'1.23E'</tdml:error>
       </tdml:errors>
   </tdml:parserTestCase>
   
@@ -13172,7 +13171,8 @@
     </tdml:document>
     <tdml:errors>
     	<tdml:error>Schema Definition Error</tdml:error>
-    	<tdml:error>Cannot convert to type long: For input string: "9223372036854775808"</tdml:error>
+      <tdml:error>'9223372036854775808'</tdml:error>
+      <tdml:error>not a valid xs:long</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
@@ -51,6 +51,8 @@ class TestBlobs {
   @Test def test_blob_14() { runner.runOneTest("blob_14") }
   @Test def test_blob_15() { runner.runOneTest("blob_15") }
 
+  @Test def test_blob_unparseError() { runner.runOneTest("blob_unparseError") }
+
   @Test def test_clob_01() { runner.runOneTest("clob_01") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
@@ -57,6 +57,7 @@ class TestBoolean2 {
   @Test def test_textBoolean_sde_4() { runner.runOneTest("textBoolean_sde_4") }
   @Test def test_textBoolean_sde_5() { runner.runOneTest("textBoolean_sde_5") }
   @Test def test_textBoolean_pe_0() { runner.runOneTest("textBoolean_pe_0") }
+  @Test def test_textBoolean_unparseError() { runner.runOneTest("textBoolean_unparseError") }
 
   @Test def test_textBoolean_IgnoreCase() { runner.runOneTest("textBoolean_IgnoreCase") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -171,8 +171,11 @@ class TestSimpleTypes {
   //DAFFODIL-1945 @Test def test_dateCalendarFirstDayOfWeek04() { runner.runOneTest("dateCalendarFirstDayOfWeek04") }
   @Test def test_timeFractionalSeconds01() { runner.runOneTest("timeFractionalSeconds01") }
   @Test def test_dateText() { runner.runOneTest("dateText") }
+  @Test def test_dateTextInvalid() { runner.runOneTest("dateTextInvalid") }
   @Test def test_timeText() { runner.runOneTest("timeText") }
+  @Test def test_timeTextInvalid() { runner.runOneTest("timeTextInvalid") }
   @Test def test_dateTimeText() { runner.runOneTest("dateTimeText") }
+  @Test def test_dateTimeTextInvalid() { runner.runOneTest("dateTimeTextInvalid") }
   @Test def test_dateImplicitPattern() { runner.runOneTest("dateImplicitPattern") }
   @Test def test_dateImplicitPatternFail() { runner.runOneTest("dateImplicitPatternFail") }
   @Test def test_timeImplicitPattern() { runner.runOneTest("timeImplicitPattern") }
@@ -324,23 +327,28 @@ class TestSimpleTypes {
   @Test def test_whiteSpaceAfterValidInteger() { runner.runOneTest("whiteSpaceAfterValidInteger") }
 
   @Test def test_characterDuringValidInt() { runner.runOneTest("characterDuringValidInt") }
+  @Test def test_int_unparseError() { runner.runOneTest("int_unparseError") }
   @Test def test_whiteSpaceAfterLengthExceededInt() { runner.runOneTest("whiteSpaceAfterLengthExceededInt") }
   @Test def test_whiteSpaceBeforeLengthExceededInt() { runner.runOneTest("whiteSpaceBeforeLengthExceededInt") }
   @Test def test_whiteSpaceDuringLengthExceededInt() { runner.runOneTest("whiteSpaceDuringLengthExceededInt") }
   @Test def test_characterDuringValidInteger() { runner.runOneTest("characterDuringValidInteger") }
+  @Test def test_integer_unparseError() { runner.runOneTest("integer_unparseError") }
   @Test def test_whiteSpaceAfterLengthExceededInteger() { runner.runOneTest("whiteSpaceAfterLengthExceededInteger") }
   @Test def test_whiteSpaceBeforeLengthExceededInteger() { runner.runOneTest("whiteSpaceBeforeLengthExceededInteger") }
   @Test def test_whiteSpaceDuringLengthExceededInteger() { runner.runOneTest("whiteSpaceDuringLengthExceededInteger") }
   @Test def test_characterDuringValidLong() { runner.runOneTest("characterDuringValidLong") }
+  @Test def test_long_unparseError() { runner.runOneTest("long_unparseError") }
   @Test def test_whiteSpaceAfterLengthExceededLong() { runner.runOneTest("whiteSpaceAfterLengthExceededLong") }
   @Test def test_whiteSpaceBeforeLengthExceededLong() { runner.runOneTest("whiteSpaceBeforeLengthExceededLong") }
   @Test def test_whiteSpaceDuringLengthExceededLong() { runner.runOneTest("whiteSpaceDuringLengthExceededLong") }
 
   @Test def test_characterDuringValidShort() { runner.runOneTest("characterDuringValidShort") }
+  @Test def test_short_unparseError() { runner.runOneTest("short_unparseError") }
   @Test def test_whiteSpaceAfterLengthExceededShort() { runner.runOneTest("whiteSpaceAfterLengthExceededShort") }
   @Test def test_whiteSpaceBeforeLengthExceededShort() { runner.runOneTest("whiteSpaceBeforeLengthExceededShort") }
   @Test def test_whiteSpaceDuringLengthExceededShort() { runner.runOneTest("whiteSpaceDuringLengthExceededShort") }
   @Test def test_characterDuringValidByte() { runner.runOneTest("characterDuringValidByte") }
+  @Test def test_byte_unparseError() { runner.runOneTest("byte_unparseError") }
   @Test def test_whiteSpaceAfterLengthExceededByte() { runner.runOneTest("whiteSpaceAfterLengthExceededByte") }
   @Test def test_whiteSpaceBeforeLengthExceededByte() { runner.runOneTest("whiteSpaceBeforeLengthExceededByte") }
   @Test def test_whiteSpaceDuringLengthExceededByte() { runner.runOneTest("whiteSpaceDuringLengthExceededByte") }
@@ -350,17 +358,20 @@ class TestSimpleTypes {
   @Test def test_whiteSpaceBeforeLengthExceededUnsignedInt() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedInt") }
   @Test def test_whiteSpaceDuringLengthExceededUnsignedInt() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedInt") }
   @Test def test_characterDuringValidUnsignedByte() { runner.runOneTest("characterDuringValidUnsignedByte") }
+  @Test def test_unsignedByte_unparseError() { runner.runOneTest("unsignedByte_unparseError") }
   @Test def test_negativeUnsignedByte() { runner.runOneTest("negativeUnsignedByte") }
   @Test def test_whiteSpaceAfterLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedByte") }
   @Test def test_whiteSpaceBeforeLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedByte") }
   @Test def test_whiteSpaceDuringLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedByte") }
   @Test def test_characterDuringValidUnsignedLong() { runner.runOneTest("characterDuringValidUnsignedLong") }
+  @Test def test_unsignedLong_unparseError() { runner.runOneTest("unsignedLong_unparseError") }
   @Test def test_negativeUnsignedLong() { runner.runOneTest("negativeUnsignedLong") }
   @Test def test_whiteSpaceAfterLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedLong") }
   @Test def test_whiteSpaceBeforeLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedLong") }
   @Test def test_whiteSpaceDuringLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedLong") }
 
   @Test def test_characterDuringValidUnsignedShort() { runner.runOneTest("characterDuringValidUnsignedShort") }
+  @Test def test_unsignedShort_unparseError() { runner.runOneTest("unsignedShort_unparseError") }
   @Test def test_negativeUnsignedShort() { runner.runOneTest("negativeUnsignedShort") }
   @Test def test_whiteSpaceAfterLengthExceededUnsignedShort() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedShort") }
   @Test def test_whiteSpaceBeforeLengthExceededUnsignedShort() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedShort") }
@@ -421,6 +432,10 @@ class TestSimpleTypes {
   @Test def test_int_binary_04() { runner.runOneTest("int_binary_04") }
   @Test def test_int_binary_05() { runner.runOneTest("int_binary_05") }
 
+  @Test def test_binaryInt_unparseError() { runner.runOneTest("binaryInt_unparseError") }
+  @Test def test_hexBinary_unparseError() { runner.runOneTest("hexBinary_unparseError") }
+  @Test def test_calendar_unparseError() { runner.runOneTest("calendar_unparseError") }
+
   @Test def test_int_implicit() { runner.runOneTest("int_implicit") }
 
   @Test def test_posinteger_binary_01() { runner.runOneTest("nonNegInt_binary_01") }
@@ -454,6 +469,7 @@ class TestSimpleTypes {
   @Test def test_nonNegativeInteger_text_fail() { runner.runOneTest("nonNegativeInteger_text_fail") }
   @Test def test_nonNegativeInteger_text_fail2() { runner.runOneTest("nonNegativeInteger_text_fail2") }
   @Test def test_nonNegativeInteger_text_fail3() { runner.runOneTest("nonNegativeInteger_text_fail3") }
+  @Test def test_nonNegativeInteger_unparseError() { runner.runOneTest("nonNegativeInteger_unparseError") }
 
   @Test def test_nonNegativeInteger_bin() { runner.runOneTest("nonNegativeInteger_bin") }
   @Test def test_nonNegativeInteger_bin2() { runner.runOneTest("nonNegativeInteger_bin2") }
@@ -473,6 +489,7 @@ class TestSimpleTypes {
   @Test def test_decimal_text3() { runner.runOneTest("decimal_text3") }
   @Test def test_decimal_text_fail() { runner.runOneTest("decimal_text_fail") }
   @Test def test_characterDuringValidDecimal() { runner.runOneTest("characterDuringValidDecimal") }
+  @Test def test_decimal_unparseError() { runner.runOneTest("decimal_unparseError") }
 
   @Test def test_decimal_binary() { runner.runOneTest("decimal_binary") }
   @Test def test_decimal_binary_01() { runner.runOneTest("decimal_binary_01") }
@@ -502,12 +519,14 @@ class TestSimpleTypes {
   @Test def test_double_text3() { runner.runOneTest("double_text3") }
   @Test def test_double_text4() { runner.runOneTest("double_text4") }
   @Test def test_characterDuringValidDouble() { runner.runOneTest("characterDuringValidDouble") }
+  @Test def test_double_unparseError() { runner.runOneTest("double_unparseError") }
 
   @Test def test_float_text() { runner.runOneTest("float_text") }
   @Test def test_float_text2() { runner.runOneTest("float_text2") }
   @Test def test_float_text3() { runner.runOneTest("float_text3") }
   @Test def test_float_text_fail() { runner.runOneTest("float_text_fail") }
   @Test def test_characterDuringValidFloat() { runner.runOneTest("characterDuringValidFloat") }
+  @Test def test_float_unparseError() { runner.runOneTest("float_unparseError") }
   @Test def test_float_binary_01() { runner.runOneTest("float_binary_01") }
   @Test def test_float_binary_02() { runner.runOneTest("float_binary_02") }
   @Test def test_float_binary_03() { runner.runOneTest("float_binary_03") }


### PR DESCRIPTION
There are a couple unhandled exceptions resulting from attempting to
unparse a string into various primitive types that was resulting in
NumberFormatExceptions and potentially IllegalArgumentExceptions. This
simply adds a try/catch to turn these exceptions into a reasonable
UnparseError.

DAFFODIL-2124