### PR TITLE
Remove excessive log messaging from CLI tests.

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -410,8 +410,6 @@ class TestCLIparsing {
       shell.sendLine(String.format("echo 0,1| %s -vvv parse -s %s -r matrix -", Util.binPath, testSchemaFile))
       shell.expect(contains("[debug]"))
 
-      shell.sendLine(String.format("echo 0,1| %s -vvvv parse -s %s -r matrix -", Util.binPath, testSchemaFile))
-      shell.expect(contains("[oolagdebug]"))
       shell.send("exit\n")
       shell.expect(eof)
     } finally {

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
@@ -192,9 +192,6 @@ class TestCLISaveParser {
       shell.sendLine(String.format("%s -vvv save-parser -s %s -r matrix %s", Util.binPath, testSchemaFile, savedParserFile.getName()))
       shell.expect(contains("[debug]"))
 
-      shell.sendLine(String.format("%s -vvvv save-parser -s %s -r matrix %s", Util.binPath, testSchemaFile, savedParserFile.getName()))
-      shell.expect(contains("[oolagdebug]"))
-
       shell.send("exit\n")
       shell.expect(eof())
     } finally {

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
@@ -257,8 +257,6 @@ class TestCLIunparsing {
       shell.sendLine(String.format("""echo '<tns:e1 xmlns:tns="http://example.com">Hello</tns:e1>' | %s -vvv unparse -s %s --root e1""", Util.binPath, testSchemaFile))
       shell.expect(contains("[debug]"))
 
-      shell.sendLine(String.format("""echo '<tns:e1 xmlns:tns="http://example.com">Hello</tns:e1>' | %s -vvvv unparse -s %s --root e1""", Util.binPath, testSchemaFile))
-      shell.expect(contains("[oolagdebug]"))
       shell.send("exit\n")
       shell.expect(eof)
     } finally {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLFormatAnnotation.scala
@@ -155,7 +155,6 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
         lazy val seenStrings = seen.map {
           case (qn, v) => qn.local // + " is " + v.xml
         }.toSeq
-        log(LogLevel.Debug, "Property sources are: %s", seenStrings.mkString("\n"))
         seen
       })
     res
@@ -304,7 +303,6 @@ abstract class DFDLFormatAnnotation(nodeArg: Node, annotatedSCArg: AnnotatedSche
    */
   final lazy val justThisOneProperties: PropMap = LV('justThisOneProperties) {
     val res = combinedJustThisOneProperties
-    log(LogLevel.Debug, "%s::%s justThisOneProperties are: %s", annotatedSC.diagnosticDebugName, diagnosticDebugName, res)
     res
   }.toOption.getOrElse(emptyPropMap)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/PropProviders.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/PropProviders.scala
@@ -78,7 +78,6 @@ trait LeafPropProvider
   final lazy val justThisOnePropertyPairsSet = justThisOneProperties.map { case (s1, (s2, _)) => (s1, s2) }.toSet
 
   final def leafFindProperty(pname: String): PropertyLookupResult = {
-    log(LogLevel.Debug, "%s leafFindProperty %s on %s", diagnosticDebugName, pname, this)
     val mine = justThisOneProperties.get(pname)
     val res = mine match {
       case Some((value, loc)) => {
@@ -97,7 +96,6 @@ trait LeafPropProvider
       }
       case None => NotFound(List(this), Nil, pname)
     }
-    log(LogLevel.Debug, "%s leafFindProperty %s ", diagnosticDebugName, res)
     res
   }
 
@@ -135,7 +133,6 @@ final class ChainPropProvider(leafProvidersArg: Seq[LeafPropProvider], forAnnota
   final lazy val diagnosticDebugName: String = "ChainPropProvider(" + forAnnotation + ")"
 
   final def chainFindProperty(pname: String): PropertyLookupResult = {
-    log(LogLevel.Debug, "%s chainFindProperty %s.", diagnosticDebugName, pname)
     lookupPropertyInSources(leafProviders, pname)
   }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
@@ -600,7 +600,6 @@ object OOLAG extends Logging {
     private def initialize = {
       val now = oolagContext.currentOVList
       oolagContext.currentOVList = this +: oolagContext.currentOVList
-      // log(LogLevel.OOLAGDebug, " " * indent + "push: " + thisThing))
       setIndent(indent + 2)
       now
     }


### PR DESCRIPTION
LogLevel.OOLAGDebug and LogLevel.Debug were being used excessively.

DAFFODIL-2187