### PR TITLE
Deep copy VariableMap when DataProcessor is copied

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -195,7 +195,7 @@ class DataProcessor private (
     areDebugging : Boolean = areDebugging,
     optDebugger : Option[Debugger] = optDebugger,
     validationMode: ValidationMode.Type = validationMode,
-    variableMap : VariableMap = variableMap,
+    variableMap : VariableMap = variableMap.copy,
     externalVars: Queue[Binding] = externalVars) =
     new DataProcessor(ssrd, tunables, variableMap, areDebugging, optDebugger, validationMode,  externalVars)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SchemaSetRuntimeData.scala
@@ -37,7 +37,7 @@ final class SchemaSetRuntimeData(
   /*
    * The original variables determined by the schema compiler.
    */
-  val originalVariables: VariableMap,
+  variables: VariableMap,
   val typeCalculators: TypeCalcMap)
   extends Serializable with ThrowsSDE {
 
@@ -55,5 +55,11 @@ final class SchemaSetRuntimeData(
     ois.defaultReadObject()
     elementRuntimeData.dpathElementCompileInfo.deserializeParents(ois)
   }
+
+  /**
+   * Always return a copy when original variables is requested, thus preserving
+   * the state of the actual original variables
+   */
+  def originalVariables = variables.copy
 
 }


### PR DESCRIPTION
This copy needs to happen now that VariableMap is mutable, so sharing
the VariableMap with other processors that use/set the same variables
can cause issues. Deep copying the VariableMap resolves this issue.

DAFFODIL-2342