### PR TITLE
Scalafix ProcedureSyntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,8 @@ lazy val commonSettings = Seq(
     "-language:experimental.macros",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Xxml:-coalescing"
+    "-Xxml:-coalescing",
+    "-Xfuture"
   ),
   // Workaround issue that some options are valid for javac, not javadoc.
   // These javacOptions are for code compilation only. (Issue sbt/sbt#355)

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/blob/TestBlob.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/blob/TestBlob.scala
@@ -57,7 +57,7 @@ class TestBlob {
    * python gen_blob.py -s 1 -o 1MB.bin
    *
    ***/
-  /*@Test*/ def test_1MB_blob() {
+  /*@Test*/ def test_1MB_blob(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/large_blob.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/1MB.bin")
@@ -111,7 +111,7 @@ class TestBlob {
    * python gen_blob.py -s 2049 -o 2049MB.bin
    *
    ***/
-  /*@Test*/ def test_2GB_blob() {
+  /*@Test*/ def test_2GB_blob(): Unit = {
 
     val DAFFODIL_JAVA_OPTS = Map("DAFFODIL_JAVA_OPTS" -> "-Xms256m -Xmx512m")
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/large_blob.dfdl.xsd")
@@ -168,7 +168,7 @@ class TestBlob {
    * python gen_blob.py -s 2049 -o 2049MB.bin
    *
    ***/
-  /*@Test*/ def test_blob_backtracking() {
+  /*@Test*/ def test_blob_backtracking(): Unit = {
 
     val DAFFODIL_JAVA_OPTS = Map("DAFFODIL_JAVA_OPTS" -> "-Xms256m -Xmx512m")
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/blob_backtracking.dfdl.xsd")
@@ -202,7 +202,7 @@ class TestBlob {
    * python gen_blob.py -s 2049 -o 2049MB.bin
    *
    ***/
-  /*@Test*/ def test_blob_backtracking_streaming_fail() {
+  /*@Test*/ def test_blob_backtracking_streaming_fail(): Unit = {
 
     val DAFFODIL_JAVA_OPTS = Map("DAFFODIL_JAVA_OPTS" -> "-Xms256m -Xmx512m")
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/blob_backtracking.dfdl.xsd")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -32,7 +32,7 @@ class TestCLIdebugger {
   //  the use of an unsupported terminal: -Djline.terminal=jline.UnsupportedTerminal
   //  Also added a Java option to specify the character encoding: -Dfile.encoding=UTF-8
 
-  @Test def test_3385_CLI_Debugger_invalidExpressions() {
+  @Test def test_3385_CLI_Debugger_invalidExpressions(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -71,7 +71,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1591_CLI_Debugger_invalidCommandError() {
+  @Test def test_1591_CLI_Debugger_invalidCommandError(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -90,7 +90,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1335_CLI_Debugger_dataAndWrapLength() {
+  @Test def test_1335_CLI_Debugger_dataAndWrapLength(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -124,7 +124,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_982_CLI_Debugger_simpleDebugger() {
+  @Test def test_982_CLI_Debugger_simpleDebugger(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -142,7 +142,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1326_CLI_Debugger_displaysTesting() {
+  @Test def test_1326_CLI_Debugger_displaysTesting(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -185,7 +185,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1339_CLI_Debugger_removeHidden() {
+  @Test def test_1339_CLI_Debugger_removeHidden(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input6.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -208,7 +208,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_3268_CLI_Debugger_removeHidden2() {
+  @Test def test_3268_CLI_Debugger_removeHidden2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input6.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -234,7 +234,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1331_CLI_Debugger_breakpointTesting4() {
+  @Test def test_1331_CLI_Debugger_breakpointTesting4(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input3.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -290,7 +290,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1463_CLI_Debugger_breakOnValueOfElement() {
+  @Test def test_1463_CLI_Debugger_breakOnValueOfElement(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input3.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -346,7 +346,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1338_CLI_Debugger_discriminatorInfo() {
+  @Test def test_1338_CLI_Debugger_discriminatorInfo(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input5.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -376,7 +376,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1328_CLI_Debugger_breakpointTesting() {
+  @Test def test_1328_CLI_Debugger_breakpointTesting(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -417,7 +417,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1329_CLI_Debugger_breakpointTesting2() {
+  @Test def test_1329_CLI_Debugger_breakpointTesting2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -453,7 +453,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_SDE_message() {
+  @Test def test_CLI_Debugger_SDE_message(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -478,7 +478,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1330_CLI_Debugger_breakpointTesting3() {
+  @Test def test_1330_CLI_Debugger_breakpointTesting3(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -520,7 +520,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1333_CLI_Debugger_settingInfosetLines() {
+  @Test def test_1333_CLI_Debugger_settingInfosetLines(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input3.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -563,7 +563,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1334_CLI_Debugger_infoBitPosition() {
+  @Test def test_1334_CLI_Debugger_infoBitPosition(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -595,7 +595,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1337_CLI_Debugger_childIndex() {
+  @Test def test_1337_CLI_Debugger_childIndex(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input4.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -628,7 +628,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1340_CLI_Debugger_infoPath() {
+  @Test def test_1340_CLI_Debugger_infoPath(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -657,7 +657,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1382_CLI_Debugger_dataAndWrapLength2() {
+  @Test def test_1382_CLI_Debugger_dataAndWrapLength2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -700,7 +700,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1863_CLI_Debugger_groupIndex01() {
+  @Test def test_1863_CLI_Debugger_groupIndex01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_03.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input9.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -733,7 +733,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1029_CLI_Debugger_validation1() {
+  @Test def test_1029_CLI_Debugger_validation1(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_03.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input9.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -757,7 +757,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_3258_CLI_Debugger_infodata() {
+  @Test def test_3258_CLI_Debugger_infodata(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -789,7 +789,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_3264_CLI_Debugger_undefined_command() {
+  @Test def test_3264_CLI_Debugger_undefined_command(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -814,7 +814,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_delimiterStack() {
+  @Test def test_CLI_Debugger_delimiterStack(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input2.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -853,7 +853,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_utf16_encoding() {
+  @Test def test_CLI_Debugger_utf16_encoding(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/utf16schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/hextest.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -874,7 +874,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1337_CLI_Debugger_info_infoset() {
+  @Test def test_1337_CLI_Debugger_info_infoset(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -899,7 +899,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_InfoHidden_1() {
+  @Test def test_CLI_Debugger_InfoHidden_1(): Unit = {
     val schemaFile = Util.daffodilPath(
       "daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequencesWithHiddenRefs.dfdl.xsd")
     val inputFile = Util.newTempFile("testInput_", ".tmp", optFileContents = Some("2~3"))
@@ -939,7 +939,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_InfoHidden_2() {
+  @Test def test_CLI_Debugger_InfoHidden_2(): Unit = {
     val schemaFile = Util.daffodilPath(
       "daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequencesWithHiddenRefs.dfdl.xsd")
     val inputFile = Util.newTempFile("testInput_", ".tmp", optFileContents = Some("2~3"))
@@ -979,7 +979,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_InfoHidden_3() {
+  @Test def test_CLI_Debugger_InfoHidden_3(): Unit = {
     val schemaFile = Util.daffodilPath(
       "daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoicesInHiddenContexts.dfdl.xsd")
     val inputFile = Util.newTempFile("testInput_", ".tmp", optFileContents = Some("2,3"))
@@ -1026,7 +1026,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_InfoHidden_4() {
+  @Test def test_CLI_Debugger_InfoHidden_4(): Unit = {
     val schemaFile = Util.daffodilPath(
       "daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoicesInHiddenContexts.dfdl.xsd")
     val inputFile = Util.newTempFile("testInput_", ".tmp", optFileContents = Some("[6~]9"))

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
@@ -34,7 +34,7 @@ class TestCLIexecuting {
   val output15 = Util.getExpectedString("output15.txt", true)
   val output16 = Util.getExpectedString("output16.txt", true)
 
-  @Test def test_995_CLI_Executing_Listing_negativeTest01() {
+  @Test def test_995_CLI_Executing_Listing_negativeTest01(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -50,7 +50,7 @@ class TestCLIexecuting {
     }
   }
 
-  @Test def test_1001_CLI_Executing_Listing_execRegex01() {
+  @Test def test_1001_CLI_Executing_Listing_execRegex01(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -66,7 +66,7 @@ class TestCLIexecuting {
     }
   }
 
-  @Test def test_1000_CLI_Executing_Listing_listRegex02() {
+  @Test def test_1000_CLI_Executing_Listing_listRegex02(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -85,7 +85,7 @@ class TestCLIexecuting {
     }
   }
 
-  @Test def test_999_CLI_Executing_Listing_listRegex01() {
+  @Test def test_999_CLI_Executing_Listing_listRegex01(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -123,7 +123,7 @@ class TestCLIexecuting {
   //    }
   //  }
 
-  @Test def test_993_CLI_Executing_Listing_listAll() {
+  @Test def test_993_CLI_Executing_Listing_listAll(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -138,7 +138,7 @@ class TestCLIexecuting {
     }
   }
 
-  @Test def test_992_CLI_Executing_Listing_singleTestList() {
+  @Test def test_992_CLI_Executing_Listing_singleTestList(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 
@@ -154,7 +154,7 @@ class TestCLIexecuting {
     }
   }
 
-  @Test def test_990_CLI_Executing_Listing_singleTest() {
+  @Test def test_990_CLI_Executing_Listing_singleTest(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
 

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/listing/TestCLIListing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/listing/TestCLIListing.scala
@@ -24,7 +24,7 @@ import net.sf.expectit.matcher.Matchers.eof
 
 class TestCLIlisting {
 
-  @Test def test_992_CLI_Executing_Listing_singleTestList() {
+  @Test def test_992_CLI_Executing_Listing_singleTestList(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
     val shell = Util.start("")
@@ -71,7 +71,7 @@ class TestCLIlisting {
   }
 */
 
-  @Test def test_1016_CLI_Executing_Listing_listVerbose() {
+  @Test def test_1016_CLI_Executing_Listing_listVerbose(): Unit = {
     val tdmlFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/assertions/assert.tdml")
     val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
     val shell = Util.start("")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -36,7 +36,7 @@ class TestCLIparsing {
   val output10 = Util.getExpectedString("output10.txt")
   val output12 = Util.getExpectedString("output12.txt")
 
-  @Test def test_3677_CLI_Parsing_elementFormDefault_qualified() {
+  @Test def test_3677_CLI_Parsing_elementFormDefault_qualified(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/elementFormDefaultQualified.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -56,7 +56,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3678_CLI_Parsing_elementFormDefault_unqualified() {
+  @Test def test_3678_CLI_Parsing_elementFormDefault_unqualified(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/elementFormDefaultUnqualified.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -76,7 +76,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_2358_CLI_Parsing_SimpleParse_stdOut_extVars() {
+  @Test def test_2358_CLI_Parsing_SimpleParse_stdOut_extVars(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -98,7 +98,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3507_CLI_Parsing_SimpleParse_SaveParser_extVars() {
+  @Test def test_3507_CLI_Parsing_SimpleParse_SaveParser_extVars(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -134,7 +134,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_2360_CLI_Parsing_SimpleParse_stdOut_extVars2() {
+  @Test def test_2360_CLI_Parsing_SimpleParse_stdOut_extVars2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -154,7 +154,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3506_CLI_Parsing_SimpleParse_extVars2() {
+  @Test def test_3506_CLI_Parsing_SimpleParse_extVars2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
@@ -188,7 +188,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3227_CLI_Parsing_SimpleParse_DFDL1197_fix() {
+  @Test def test_3227_CLI_Parsing_SimpleParse_DFDL1197_fix(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/testOptionalInfix.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -205,7 +205,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1593_CLI_Parsing_MultifileSchema_noGlobalElem() {
+  @Test def test_1593_CLI_Parsing_MultifileSchema_noGlobalElem(): Unit = {
     val tmp_filename: String = (System.currentTimeMillis / 1000).toString()
     val file = new File(tmp_filename)
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/TopLevel.dfdl.xsd")
@@ -231,7 +231,7 @@ class TestCLIparsing {
   }
 
   //  See comment in DFDL-952
-  @Test def test_1585_CLI_Parsing_MultifileSchema_methodImportSameDir() {
+  @Test def test_1585_CLI_Parsing_MultifileSchema_methodImportSameDir(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_14.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -247,7 +247,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1586_CLI_Parsing_MultifileSchema_methodIncludeSameDir() {
+  @Test def test_1586_CLI_Parsing_MultifileSchema_methodIncludeSameDir(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_15.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -264,7 +264,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1587_CLI_Parsing_MultifileSchema_methodImportSameDir2() {
+  @Test def test_1587_CLI_Parsing_MultifileSchema_methodImportSameDir2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_16.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -281,7 +281,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1317_IBMCompatibility_ABC_test_ibm_abc_cli() {
+  @Test def test_1317_IBMCompatibility_ABC_test_ibm_abc_cli(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/ABC_IBM.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -298,7 +298,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_977_CLI_Parsing_SimpleParse_stdOut() {
+  @Test def test_977_CLI_Parsing_SimpleParse_stdOut(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -315,7 +315,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_978_CLI_Parsing_SimpleParse_outFile() {
+  @Test def test_978_CLI_Parsing_SimpleParse_outFile(): Unit = {
     val tmp_filename: String = (System.currentTimeMillis / 1000).toString()
     val file = new File(tmp_filename)
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
@@ -340,7 +340,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_979_CLI_Parsing_SimpleParse_inFile() {
+  @Test def test_979_CLI_Parsing_SimpleParse_inFile(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -358,7 +358,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_980_CLI_Parsing_SimpleParse_stOutDash() {
+  @Test def test_980_CLI_Parsing_SimpleParse_stOutDash(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -376,7 +376,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_981_CLI_Parsing_SimpleParse_stdInDash() {
+  @Test def test_981_CLI_Parsing_SimpleParse_stdInDash(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -393,7 +393,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_983_CLI_Parsing_SimpleParse_verboseMode() {
+  @Test def test_983_CLI_Parsing_SimpleParse_verboseMode(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -417,7 +417,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_984_CLI_Parsing_negativeTest() {
+  @Test def test_984_CLI_Parsing_negativeTest(): Unit = {
     val shell = Util.start("", true)
 
     try {
@@ -431,7 +431,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_985_CLI_Parsing_SimpleParse_defaultRoot() {
+  @Test def test_985_CLI_Parsing_SimpleParse_defaultRoot(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -448,7 +448,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_988_CLI_Parsing_SimpleParse_specifiedRoot() {
+  @Test def test_988_CLI_Parsing_SimpleParse_specifiedRoot(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -468,7 +468,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_996_CLI_Parsing_negativeTest04() {
+  @Test def test_996_CLI_Parsing_negativeTest04(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -485,7 +485,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_997_CLI_Parsing_multSchemas() {
+  @Test def test_997_CLI_Parsing_multSchemas(): Unit = {
     val schemaFile1 = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val schemaFile2 = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd")
     val (testSchemaFile1, testSchemaFile2) = if (Util.isWindows) (Util.cmdConvert(schemaFile1), Util.cmdConvert(schemaFile2)) else (schemaFile1, schemaFile2)
@@ -503,7 +503,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3661_CLI_Parsing_badSchemaPath() {
+  @Test def test_3661_CLI_Parsing_badSchemaPath(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/doesnotexist.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -521,7 +521,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1002_CLI_Parsing_negativeTest03() {
+  @Test def test_1002_CLI_Parsing_negativeTest03(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -542,7 +542,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1003_CLI_Parsing_SimpleParse_emptyNamespace() {
+  @Test def test_1003_CLI_Parsing_SimpleParse_emptyNamespace(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input7.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -560,7 +560,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1004_CLI_Parsing_SimpleParse_namespaceUsed() {
+  @Test def test_1004_CLI_Parsing_SimpleParse_namespaceUsed(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input8.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -578,7 +578,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_2615_CLI_Parsing_SimpleParse_namespaceUsedLongOpt() {
+  @Test def test_2615_CLI_Parsing_SimpleParse_namespaceUsedLongOpt(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input8.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -596,7 +596,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1005_CLI_Parsing_SimpleParse_rootPath() {
+  @Test def test_1005_CLI_Parsing_SimpleParse_rootPath(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -617,7 +617,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1015_CLI_Parsing_SimpleParse_defaultRootMultSchema() {
+  @Test def test_1015_CLI_Parsing_SimpleParse_defaultRootMultSchema(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input7.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -635,7 +635,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOn() {
+  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOn(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -652,7 +652,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validation_missing_mode() {
+  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validation_missing_mode(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -671,7 +671,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationLimited() {
+  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationLimited(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -688,7 +688,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOff() {
+  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOff(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -705,7 +705,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationFooBar() {
+  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationFooBar(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -735,7 +735,7 @@ class TestCLIparsing {
   }
 */
 
-  @Test def test_1319_CLI_Parsing_invalidElementSDE() {
+  @Test def test_1319_CLI_Parsing_invalidElementSDE(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/ABC_IBM_invalid.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -751,7 +751,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1346_CLI_Parsing_SimpleParse_defaultRootMultSchemaMultiple() {
+  @Test def test_1346_CLI_Parsing_SimpleParse_defaultRootMultSchemaMultiple(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input7.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -773,7 +773,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1386_CLI_Parsing_negativeTest05() {
+  @Test def test_1386_CLI_Parsing_negativeTest05(): Unit = {
     val cmd = String.format("echo 12| %s", Util.binPath)
     val shell = Util.start("", true)
 
@@ -787,7 +787,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1971_CLI_Parsing_traceMode01() {
+  @Test def test_1971_CLI_Parsing_traceMode01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_15.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -803,7 +803,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1973_CLI_Parsing_traceMode03() {
+  @Test def test_1973_CLI_Parsing_traceMode03(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.startIncludeErrors("")
@@ -822,7 +822,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_1941_CLI_Parsing_SimpleParse_leftOverData() {
+  @Test def test_1941_CLI_Parsing_SimpleParse_leftOverData(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -840,7 +840,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_CLI_Parsing_BitParse_LSBPartialByte_leftOverData() {
+  @Test def test_CLI_Parsing_BitParse_LSBPartialByte_leftOverData(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -859,7 +859,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_CLI_Parsing_BitParse_MSBPartialByte_leftOverData() {
+  @Test def test_CLI_Parsing_BitParse_MSBPartialByte_leftOverData(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -878,7 +878,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_CLI_Parsing_BitParse_MSBFullByte_leftOverData() {
+  @Test def test_CLI_Parsing_BitParse_MSBFullByte_leftOverData(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/bits_parsing.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -896,7 +896,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_DFDL_714() {
+  @Test def test_DFDL_714(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/global_element.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/test_DFDL-714.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -917,7 +917,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_DFDL_1203_schema_from_jar() {
+  @Test def test_DFDL_1203_schema_from_jar(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/global_element.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/test_DFDL-714.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -938,7 +938,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_3606_CLI_Parsing_SimpleParse_largeInfoset() {
+  @Test def test_3606_CLI_Parsing_SimpleParse_largeInfoset(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -960,7 +960,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_CLI_Parsing_built_in_formats() {
+  @Test def test_CLI_Parsing_built_in_formats(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_04.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input6.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -986,7 +986,7 @@ class TestCLIparsing {
   // of those provided by dependencies (e.g. Xerces) included with Daffodil.
   // Some places require dependency version of these classes. This test ensures
   // that we override defaults when necesssary
-  @Test def test_CLI_Parsing_JavaDefaults() {
+  @Test def test_CLI_Parsing_JavaDefaults(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val java_opts = Map("DAFFODIL_JAVA_OPTS" ->
@@ -1007,7 +1007,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_Stream_01() {
+  @Test def test_XXX_CLI_Parsing_Stream_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -1025,7 +1025,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_Stream_02() {
+  @Test def test_XXX_CLI_Parsing_Stream_02(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.startIncludeErrors("")
@@ -1045,7 +1045,7 @@ class TestCLIparsing {
     }
   }
 
-  @Test def test_CLI_Parsing_XCatalog_Resolution_Failure() {
+  @Test def test_CLI_Parsing_XCatalog_Resolution_Failure(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/xcatalog_import_failure.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
@@ -27,7 +27,7 @@ import net.sf.expectit.matcher.Matchers.anyString
 
 class TestCLIPerformance {
 
-  @Test def test_3393_CLI_Performance_2_Threads_2_Times() {
+  @Test def test_3393_CLI_Performance_2_Threads_2_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -58,7 +58,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3394_CLI_Performance_3_Threads_20_Times() {
+  @Test def test_3394_CLI_Performance_3_Threads_20_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -89,7 +89,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3395_CLI_Performance_5_Threads_50_Times() {
+  @Test def test_3395_CLI_Performance_5_Threads_50_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input5.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -121,7 +121,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3396_CLI_Performance_2_Threads_2_Times_Negative() {
+  @Test def test_3396_CLI_Performance_2_Threads_2_Times_Negative(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input5.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -153,7 +153,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3641_CLI_Performance_Unparse_2_Threads_2_Times() {
+  @Test def test_3641_CLI_Performance_Unparse_2_Threads_2_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -184,7 +184,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3643_CLI_Performance_Unparse_3_Threads_20_Times() {
+  @Test def test_3643_CLI_Performance_Unparse_3_Threads_20_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -215,7 +215,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3644_CLI_Performance_Unparse_5_Threads_50_Times() {
+  @Test def test_3644_CLI_Performance_Unparse_5_Threads_50_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -246,7 +246,7 @@ class TestCLIPerformance {
     }
   }
 
-  @Test def test_3642_CLI_Performance_Unparse_2_Threads_2_Times_Negative() {
+  @Test def test_3642_CLI_Performance_Unparse_2_Threads_2_Times_Negative(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input16.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/saving/TestCLISaveParser.scala
@@ -34,15 +34,15 @@ class TestCLISaveParser {
   val output12 = Util.getExpectedString("output12.txt")
   val savedParserFile = new File("savedParser.xsd.bin")
 
-  @Before def before() {
+  @Before def before(): Unit = {
     savedParserFile.delete
   }
 
-  @After def after() {
+  @After def after(): Unit = {
     savedParserFile.delete
   }
 
-  @Test def test_3017_CLI_Saving_SaveParser_simple() {
+  @Test def test_3017_CLI_Saving_SaveParser_simple(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -61,7 +61,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3018_CLI_Saving_SaveParser_stdout() {
+  @Test def test_3018_CLI_Saving_SaveParser_stdout(): Unit = {
 
     val shell = Util.startIncludeErrors("")
     val savedParser = "external_variables.dfdl.xsd.bin"
@@ -91,7 +91,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3019_CLI_Saving_SaveParser_withConfig() {
+  @Test def test_3019_CLI_Saving_SaveParser_withConfig(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -114,7 +114,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3020_CLI_Saving_SaveParser_namespaceUsed() {
+  @Test def test_3020_CLI_Saving_SaveParser_namespaceUsed(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input8.txt")
@@ -137,7 +137,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3021_CLI_Saving_SaveParser_path() {
+  @Test def test_3021_CLI_Saving_SaveParser_path(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -156,7 +156,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3022_CLI_Saving_SaveParser_MultSchema() {
+  @Test def test_3022_CLI_Saving_SaveParser_MultSchema(): Unit = {
 
     val schemaFile1 = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd")
     val schemaFile2 = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/charClassEntities.dfdl.xsd")
@@ -176,7 +176,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3023_CLI_Saving_SaveParser_verboseMode() {
+  @Test def test_3023_CLI_Saving_SaveParser_verboseMode(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
@@ -213,7 +213,7 @@ class TestCLISaveParser {
     shell.close()
   }*/
 
-  @Test def test_3039_CLI_Saving_SaveParser_emptyNamespace() {
+  @Test def test_3039_CLI_Saving_SaveParser_emptyNamespace(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
@@ -235,7 +235,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_DFDL_1205_CLI_FullValidation_SavedParser_Incompatible() {
+  @Test def test_DFDL_1205_CLI_FullValidation_SavedParser_Incompatible(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input8.txt")
@@ -263,7 +263,7 @@ class TestCLISaveParser {
    * Note that in Daffodil 2.6.0 behavior of external variables changed. They are not saved as part of binary
    * compiling. They are a runtime-thing only.
    */
-  @Test def test_3508_CLI_Saving_SaveParser_extVars() {
+  @Test def test_3508_CLI_Saving_SaveParser_extVars(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -384,7 +384,7 @@ class TestCLISaveParser {
   }
 */
 
-  @Test def test_3573_CLI_Saving_SaveParser_unparse2() {
+  @Test def test_3573_CLI_Saving_SaveParser_unparse2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input12.txt")
@@ -408,7 +408,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3941_CLI_Saving_SaveParser_tunables() {
+  @Test def test_3941_CLI_Saving_SaveParser_tunables(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input12.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/tunables/TestCLITunables.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/tunables/TestCLITunables.scala
@@ -29,7 +29,7 @@ class TestCLITunables {
   val unqualifiedPathStep03 = Util.getExpectedString("unqualified_path_step_03.txt")
   val unqualifiedPathStep04 = Util.getExpectedString("unqualified_path_step_04.txt")
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_01() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -45,7 +45,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_02() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_02(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -62,7 +62,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_03() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_03(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -79,7 +79,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_04() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_noNamespace_test_04(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -97,7 +97,7 @@ class TestCLITunables {
 
 
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_01() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -113,7 +113,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_02() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_02(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -129,7 +129,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_03() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_03(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -146,7 +146,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_04() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_defaultNamespace_test_04(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -165,7 +165,7 @@ class TestCLITunables {
 
 
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_01() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -181,7 +181,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_02() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_02(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -197,7 +197,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_03() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_03(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("", true)
@@ -214,7 +214,7 @@ class TestCLITunables {
     }
   }
 
-  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_04() {
+  @Test def test_CLI_Parsing_unqualifiedPathStepPolicy_preferDefaultNamespace_test_04(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/unqualified_path_step.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/tunables/TestCLITunables2.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/tunables/TestCLITunables2.scala
@@ -27,7 +27,7 @@ class TestCLITunables2 {
   /**
    * Suppresses SDW messages.
    */
-  @Test def test_CLI_Parsing_SuppressSDEWarnings1() {
+  @Test def test_CLI_Parsing_SuppressSDEWarnings1(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/suppressWarnTest.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")
@@ -51,7 +51,7 @@ class TestCLITunables2 {
   /**
    * Will display SDW warnings. Does not set the tunable that suppresses them.
    */
-  @Test def test_CLI_Parsing_SuppressSDEWarnings2() {
+  @Test def test_CLI_Parsing_SuppressSDEWarnings2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/suppressWarnTest.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
     val shell = Util.start("")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/udf/TestCLIUdfs.scala
@@ -54,7 +54,7 @@ class TestCLIUdfs {
    * Tests the case when no User Defined Functions on classpath, and a schema makes
    * no User Defined Function calls, so they don't get loaded
    */
-  @Test def test_noUdfsLoaded_regular_schema() {
+  @Test def test_noUdfsLoaded_regular_schema(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -82,7 +82,7 @@ class TestCLIUdfs {
    * Tests the case when no User Defined Function are loaded, but a schema makes a
    * User Defined Function call
    */
-  @Test def test_noUdfsLoaded_udf_schema() {
+  @Test def test_noUdfsLoaded_udf_schema(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -112,7 +112,7 @@ class TestCLIUdfs {
    *
    * The schema makes a User Defined Function call
    */
-  @Test def test_noUdfsLoaded_MissingClassInMetaInfFile() {
+  @Test def test_noUdfsLoaded_MissingClassInMetaInfFile(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -148,7 +148,7 @@ class TestCLIUdfs {
    * Tests the case when no User Defined Function are loaded, due to absent META-INF
    * file, but a schema makes a User Defined Function call
    */
-  @Test def test_noUdfsLoaded_MissingMetaInfFile() {
+  @Test def test_noUdfsLoaded_MissingMetaInfFile(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -177,7 +177,7 @@ class TestCLIUdfs {
   /**
    * Tests the case when a User Defined Function Provider returns null for its list of UDFs
    */
-  @Test def test_UDFPClass_NoUdfClasses() {
+  @Test def test_UDFPClass_NoUdfClasses(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -212,7 +212,7 @@ class TestCLIUdfs {
   /**
    * Tests the case when a User Defined Function Provider returns an empty list of UDFs
    */
-  @Test def test_UDFPClass_emptyUdfClasses() {
+  @Test def test_UDFPClass_emptyUdfClasses(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -248,7 +248,7 @@ class TestCLIUdfs {
    * Tests the case when a function class from the UDFP doesn't implement the UDF
    * interface
    */
-  @Test def test_UDFClass_nonUDF() {
+  @Test def test_UDFClass_nonUDF(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -287,7 +287,7 @@ class TestCLIUdfs {
    * Tests the case when a function class doesn't have annotations or have empty/invalid
    * annotstion fields
    */
-  @Test def test_UDFClass_nonAnn() {
+  @Test def test_UDFClass_nonAnn(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -336,7 +336,7 @@ class TestCLIUdfs {
    *   has unsupported param types
    *   has unsupported return type
    */
-  @Test def test_UDFClass_noEvaluate() {
+  @Test def test_UDFClass_noEvaluate(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -387,7 +387,7 @@ class TestCLIUdfs {
    * Tests the case when a function class:
    *   throws custom error on evaluate
    */
-  @Test def test_UDFClass_CustomExceptionOnEvaluate() {
+  @Test def test_UDFClass_CustomExceptionOnEvaluate(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -421,7 +421,7 @@ class TestCLIUdfs {
    * Tests the case when a function class:
    *   throws processing error on evaluate
    */
-  @Test def test_UDFClass_ProcessingErrorOnEvaluate() {
+  @Test def test_UDFClass_ProcessingErrorOnEvaluate(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -450,7 +450,7 @@ class TestCLIUdfs {
    * Tests the case when a function class:
    *   throws an error while being loaded
    */
-  @Test def test_UDFClass_exceptionOnLoad() {
+  @Test def test_UDFClass_exceptionOnLoad(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -487,7 +487,7 @@ class TestCLIUdfs {
    * Tests the case when a provider class:
    *   throws an error while loading its UDFs
    */
-  @Test def test_UDFPClass_exceptionOnLoadingUDFs() {
+  @Test def test_UDFPClass_exceptionOnLoadingUDFs(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -523,7 +523,7 @@ class TestCLIUdfs {
    * Tests the case when a provider class:
    *   throws an error while being loaded
    */
-  @Test def test_UDFPClass_exceptionOnLoad() {
+  @Test def test_UDFPClass_exceptionOnLoad(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -560,7 +560,7 @@ class TestCLIUdfs {
    *   incorrectly implements createUserDefinedFunction and returns the incorrect function
    *   class object
    */
-  @Test def test_UDFPClass_incorrectUDFObject() {
+  @Test def test_UDFPClass_incorrectUDFObject(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -595,7 +595,7 @@ class TestCLIUdfs {
    * Tests the case when a provider class:
    *   incorrectly implements createUserDefinedFunction that results in an exception
    */
-  @Test def test_UDFPClass_incorrectUDFCreateImplementation() {
+  @Test def test_UDFPClass_incorrectUDFCreateImplementation(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -631,7 +631,7 @@ class TestCLIUdfs {
    * Tests the case when a UDF class:
    *    contains a non serializable member
    */
-  @Test def test_UDFClass_serializability() {
+  @Test def test_UDFClass_serializability(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -664,7 +664,7 @@ class TestCLIUdfs {
    * Tests the case when a UDF class:
    *    contains serializable member
    */
-  @Test def test_UDFClass_serializability2() {
+  @Test def test_UDFClass_serializability2(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
@@ -26,7 +26,7 @@ import net.sf.expectit.matcher.Matchers.eof
 
 class TestCLIunparsing {
 
-  @Test def test_3525_CLI_Unparsing_SimpleUnparse_inFile() {
+  @Test def test_3525_CLI_Unparsing_SimpleUnparse_inFile(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input12.txt")
@@ -47,7 +47,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3526_CLI_Unparsing_SimpleUnparse_inFile2() {
+  @Test def test_3526_CLI_Unparsing_SimpleUnparse_inFile2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input13.txt")
@@ -68,7 +68,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3527_CLI_Unparsing_SimpleUnparse_stdin() {
+  @Test def test_3527_CLI_Unparsing_SimpleUnparse_stdin(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
@@ -89,7 +89,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3528_CLI_Unparsing_SimpleUnparse_stdin2() {
+  @Test def test_3528_CLI_Unparsing_SimpleUnparse_stdin2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -109,7 +109,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3529_CLI_Unparsing_SimpleUnparse_stdin3() {
+  @Test def test_3529_CLI_Unparsing_SimpleUnparse_stdin3(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -129,7 +129,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3584_CLI_Unparsing_SimpleUnparse_stdin4() {
+  @Test def test_3584_CLI_Unparsing_SimpleUnparse_stdin4(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -151,7 +151,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3574_CLI_Unparsing_SimpleUnparse_extVars() {
+  @Test def test_3574_CLI_Unparsing_SimpleUnparse_extVars(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -173,7 +173,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3575_CLI_Unparsing_SimpleUnparse_extVars2() {
+  @Test def test_3575_CLI_Unparsing_SimpleUnparse_extVars2(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
     val configFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml")
@@ -195,7 +195,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3582_CLI_Unparsing_SimpleUnparse_outFile() {
+  @Test def test_3582_CLI_Unparsing_SimpleUnparse_outFile(): Unit = {
     val tmp_filename: String = (System.currentTimeMillis / 1000).toString()
     val file = new File(tmp_filename)
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
@@ -221,7 +221,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3581_CLI_Unparsing_SimpleUnparse_stOutDash() {
+  @Test def test_3581_CLI_Unparsing_SimpleUnparse_stOutDash(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input13.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -240,7 +240,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3580_CLI_Unparsing_SimpleUnparse_verboseMode() {
+  @Test def test_3580_CLI_Unparsing_SimpleUnparse_verboseMode(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
 
@@ -264,7 +264,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3579_CLI_Unparsing_negativeTest() {
+  @Test def test_3579_CLI_Unparsing_negativeTest(): Unit = {
     val shell = Util.start("", true)
 
     try {
@@ -278,7 +278,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3578_CLI_Unparsing_SimpleUnparse_defaultRoot() {
+  @Test def test_3578_CLI_Unparsing_SimpleUnparse_defaultRoot(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
@@ -298,7 +298,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_3583_CLI_Unparsing_SimpleUnparse_rootPath() {
+  @Test def test_3583_CLI_Unparsing_SimpleUnparse_rootPath(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -371,7 +371,7 @@ class TestCLIunparsing {
   }
 */
 
-  @Test def test_3662_CLI_Unparsing_badSchemaPath() {
+  @Test def test_3662_CLI_Unparsing_badSchemaPath(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/doesnotexist.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
 
@@ -389,7 +389,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_w3cdom() {
+  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_w3cdom(): Unit = {
 
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input18.txt")
@@ -410,7 +410,7 @@ class TestCLIunparsing {
     }
   }
 
-  @Test def test_XXX_CLI_Unparsing_Stream_01() {
+  @Test def test_XXX_CLI_Unparsing_Stream_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input19.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -150,7 +150,7 @@ trait CLILogPrefix extends LogWriter {
 
 object CLILogWriter extends CLILogPrefix {
 
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     Console.err.println(msg)
     Console.flush
   }
@@ -159,11 +159,11 @@ object CLILogWriter extends CLILogPrefix {
 object TDMLLogWriter extends CLILogPrefix {
   var logs: scala.collection.mutable.Queue[String] = scala.collection.mutable.Queue.empty
 
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     logs += msg
   }
 
-  def reset() {
+  def reset(): Unit = {
     logs = scala.collection.mutable.Queue.empty
   }
 }
@@ -224,7 +224,7 @@ class CLIConf(arguments: Array[String]) extends scallop.ScallopConf(arguments)
       override def argFormat(name: String): String = "[" + name + "]"
     }
 
-  def validateConf(c1: => Option[scallop.ScallopConfBase])(fn: (Option[scallop.ScallopConfBase]) => Either[String, Unit]) {
+  def validateConf(c1: => Option[scallop.ScallopConfBase])(fn: (Option[scallop.ScallopConfBase]) => Either[String, Unit]): Unit = {
     validations :+= new Function0[Either[String, Unit]] {
       def apply = {
         fn(c1)
@@ -609,7 +609,7 @@ object Main extends Logging {
     bindingsWithUpdates
   }
 
-  def displayDiagnostics(pr: WithDiagnostics) {
+  def displayDiagnostics(pr: WithDiagnostics): Unit = {
     pr.getDiagnostics.foreach { d =>
       val lvl = if (d.isError) LogLevel.Error else LogLevel.Warning
       log(lvl, d.getMessage())
@@ -1019,7 +1019,7 @@ object Main extends Logging {
             implicit val executionContext = new ExecutionContext {
               val threadPool = Executors.newFixedThreadPool(performanceOpts.threads())
 
-              def execute(runnable: Runnable) {
+              def execute(runnable: Runnable): Unit = {
                 threadPool.submit(runnable)
               }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -178,7 +178,7 @@ abstract class Expression extends OOLAGHostImpl()
 
   def children: Seq[Expression]
 
-  def setContextsForChildren(context: OOLAGHost = this) {
+  def setContextsForChildren(context: OOLAGHost = this): Unit = {
     children.foreach {
       c =>
         c.setOOLAGContext(context);
@@ -581,7 +581,7 @@ case class WholeExpression(
   final override lazy val tunable: DaffodilTunables = host.tunable
   final override lazy val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy = host.unqualifiedPathStepPolicy
 
-  def init() {
+  def init(): Unit = {
     this.setOOLAGContext(host) // we are the root of expression, but we propagate diagnostics further.
     this.setContextsForChildren()
   }
@@ -1949,7 +1949,7 @@ abstract class FunctionCallBase(
     res
   }
 
-  final def checkArgCount(n: Int) {
+  final def checkArgCount(n: Int): Unit = {
     if (expressions.length != n) argCountErr(n)
   }
   final def argCountErr(n: Int) = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/PropProviders.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/PropProviders.scala
@@ -237,7 +237,7 @@ trait OverlapCheckMixin {
    * iterate through all properties of the a-arg, checking each for
    * whether it appears in the b-arg. If so, SDE.
    */
-  private def checkNonOverlap3(a: ChainPropProvider, b: ChainPropProvider) {
+  private def checkNonOverlap3(a: ChainPropProvider, b: ChainPropProvider): Unit = {
     val aLeaves = a.leafProviders
     aLeaves.foreach { aLeaf =>
       val propMap = aLeaf.justThisOneProperties

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.util.TestUtils
 
 class TestDFDLParser_New {
 
-  @Test def testParseOccursCountKindOfParsedDelimitedBySeparatorImplicitWithMaxOccurs() {
+  @Test def testParseOccursCountKindOfParsedDelimitedBySeparatorImplicitWithMaxOccurs(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -40,7 +40,7 @@ class TestDFDLParser_New {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedDelimitedBySeparatorImplicitWithMaxOccurs2() {
+  @Test def testParseOccursCountKindOfParsedDelimitedBySeparatorImplicitWithMaxOccurs2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestAPI1.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.Implicits._
 
 class TestDFDLParser {
 
-  @Test def testParseSimple1() {
+  @Test def testParseSimple1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -35,7 +35,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseSequenceOfJustOneScalar() {
+  @Test def testParseSequenceOfJustOneScalar(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -51,7 +51,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseSequence1() {
+  @Test def testParseSequence1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -68,7 +68,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseSequence2() {
+  @Test def testParseSequence2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -84,7 +84,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseSequence3() {
+  @Test def testParseSequence3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format separatorSuppressionPolicy="never" separatorPosition="infix" ref="tns:GeneralFormat"/>,
@@ -100,7 +100,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testInt1() {
+  @Test def testInt1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -116,7 +116,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
   }
 
-  @Test def testInt2() {
+  @Test def testInt2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -134,7 +134,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("xs:int"))
   }
 
-  @Test def testShort1() {
+  @Test def testShort1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -150,7 +150,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
   }
 
-  @Test def testShort2() {
+  @Test def testShort2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -167,7 +167,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("short"))
   }
 
-  @Test def testByte1() {
+  @Test def testByte1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -183,7 +183,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<e1><s1>55</s1><s2>123</s2></e1>, actual)
   }
 
-  @Test def testNumber1() {
+  @Test def testNumber1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -201,7 +201,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<e1><country>1</country><area>-800</area><region>-555</region><number>-1212</number></e1>, actual)
   }
 
-  @Test def testNumber2() {
+  @Test def testNumber2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -210,7 +210,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<mersenne>-127</mersenne>, actual)
   }
 
-  @Test def testNumber3() {
+  @Test def testNumber3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -219,7 +219,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(<perfect>3</perfect>, actual)
   }
 
-  @Test def testUnsignedLong1() {
+  @Test def testUnsignedLong1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -230,7 +230,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("unsignedLong"))
   }
 
-  @Test def testUnsignedInt1() {
+  @Test def testUnsignedInt1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -242,7 +242,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("unsignedInt"))
   }
 
-  @Test def testUnsignedShort1() {
+  @Test def testUnsignedShort1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -253,7 +253,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("unsignedShort"))
   }
 
-  @Test def testUnsignedByte1() {
+  @Test def testUnsignedByte1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -264,7 +264,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("unsignedByte"))
   }
 
-  @Test def testIntTooLong() {
+  @Test def testIntTooLong(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -281,7 +281,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("int"))
   }
 
-  @Test def testParseSequenceInt() {
+  @Test def testParseSequenceInt(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format separatorSuppressionPolicy="never" separatorPosition="infix" ref="tns:GeneralFormat"/>,
@@ -297,7 +297,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseSequenceInt3Operands() {
+  @Test def testParseSequenceInt3Operands(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format separatorSuppressionPolicy="never" separatorPosition="infix" ref="tns:GeneralFormat"/>,
@@ -313,7 +313,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBadInt() {
+  @Test def testBadInt(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -324,7 +324,7 @@ class TestDFDLParser {
     assertTrue(e.getMessage().contains("xs:int"))
   }
 
-  @Test def testParseOccursCountKindOfParsed() {
+  @Test def testParseOccursCountKindOfParsed(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -341,7 +341,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedWithTerminator() {
+  @Test def testParseOccursCountKindOfParsedWithTerminator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -358,7 +358,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedDelimitedByTerminator() {
+  @Test def testParseOccursCountKindOfParsedDelimitedByTerminator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -376,7 +376,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedDelimitedByTerminator2() {
+  @Test def testParseOccursCountKindOfParsedDelimitedByTerminator2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -393,7 +393,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedDelimitedBySeparator() {
+  @Test def testParseOccursCountKindOfParsedDelimitedBySeparator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -411,7 +411,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testParseOccursCountKindOfParsedDelimitedBySeparator3() {
+  @Test def testParseOccursCountKindOfParsedDelimitedBySeparator3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -429,7 +429,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryIntMinusOne() {
+  @Test def testBinaryIntMinusOne(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" ref="tns:GeneralFormat"/>,
@@ -445,7 +445,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryInts() {
+  @Test def testBinaryInts(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" ref="tns:GeneralFormat"/>,
@@ -463,7 +463,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryDoubleOne() {
+  @Test def testBinaryDoubleOne(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" binaryFloatRep="ieee" ref="tns:GeneralFormat"/>,
@@ -473,7 +473,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryDoubleMinusOne() {
+  @Test def testBinaryDoubleMinusOne(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" binaryFloatRep="ieee" ref="tns:GeneralFormat"/>,
@@ -483,7 +483,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryDoubleLSB() {
+  @Test def testBinaryDoubleLSB(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" binaryFloatRep="ieee" ref="tns:GeneralFormat"/>,
@@ -493,7 +493,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryDoubles() {
+  @Test def testBinaryDoubles(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" binaryFloatRep="ieee" ref="tns:GeneralFormat"/>,
@@ -510,7 +510,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testTextDoubles() {
+  @Test def testTextDoubles(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -528,7 +528,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testBinaryFloats() {
+  @Test def testBinaryFloats(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" binaryFloatRep="ieee" ref="tns:GeneralFormat"/>,
@@ -545,7 +545,7 @@ class TestDFDLParser {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testTextFloats() {
+  @Test def testTextFloats(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestDsomCompiler3.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestDsomCompiler3.scala
@@ -35,7 +35,7 @@ class TestDsomCompiler3 {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testTmpDirProvided() {
+  @Test def testTmpDirProvided(): Unit = {
     val sc = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
@@ -36,7 +36,7 @@ import org.apache.daffodil.infoset.InfosetDocument
 
 class TestDFDLExpressionEvaluation extends Parsers {
 
-  def testExpr(testSchema: scala.xml.Elem, infosetAsXML: scala.xml.Elem, expr: String)(body: Any => Unit) {
+  def testExpr(testSchema: scala.xml.Elem, infosetAsXML: scala.xml.Elem, expr: String)(body: Any => Unit): Unit = {
     val schemaCompiler = Compiler().withTunable("allowExternalPathExpressions", "true")
     val pf = schemaCompiler.compileNode(testSchema).asInstanceOf[ProcessorFactory]
     val sset = pf.sset
@@ -68,7 +68,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     }
   }
 
-  @Test def test_ba() {
+  @Test def test_ba(): Unit = {
     val schema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -86,7 +86,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     }
   }
 
-  @Test def test_arrayCount1() {
+  @Test def test_arrayCount1(): Unit = {
     val schema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -103,7 +103,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     }
   }
 
-  @Test def test_arrayIndex1() {
+  @Test def test_arrayIndex1(): Unit = {
     val schema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -120,7 +120,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     }
   }
 
-  @Test def test_absPathWithArrayIndex1() {
+  @Test def test_absPathWithArrayIndex1(): Unit = {
     val schema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -137,7 +137,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
     }
   }
 
-  @Test def test_ivc1() {
+  @Test def test_ivc1(): Unit = {
     val schema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionTree.scala
@@ -37,7 +37,7 @@ class TestDFDLExpressionTree extends Parsers {
     <dfdl:format ref="tns:GeneralFormat"/>,
     <xs:element name="title" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(5) }"/>)
 
-  def testExpr(testSchema: scala.xml.Elem, expr: String)(body: Expression => Unit) {
+  def testExpr(testSchema: scala.xml.Elem, expr: String)(body: Expression => Unit): Unit = {
     val schemaCompiler = Compiler()
     val sset = schemaCompiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -51,7 +51,7 @@ class TestDFDLExpressionTree extends Parsers {
     body(result)
   }
 
-  def testExpr2(testSchema: scala.xml.Elem, expr: String)(body: (Expression, ElementRuntimeData) => Unit) {
+  def testExpr2(testSchema: scala.xml.Elem, expr: String)(body: (Expression, ElementRuntimeData) => Unit): Unit = {
     val schemaCompiler = Compiler()
     val sset = schemaCompiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
@@ -113,7 +113,7 @@ class TestDFDLExpressionTree extends Parsers {
       </xs:complexType>
     </xs:element>)
 
-  @Test def test_a_pred() {
+  @Test def test_a_pred(): Unit = {
     testExpr2(bSchema, "{ /tns:b/a[/tns:b/i] }") { (ce, erd) =>
       val w @ WholeExpression(_, RootPathExpression(Some(RelativePathExpression(steps, _))), _, _, _) = ce
       val List(b, a) = steps
@@ -129,7 +129,7 @@ class TestDFDLExpressionTree extends Parsers {
     }
   }
 
-  @Test def test_a_predPred() {
+  @Test def test_a_predPred(): Unit = {
     testExpr(dummySchema, "{ a[i[j]] }") { actual =>
       val WholeExpression(_, RelativePathExpression(steps, _), _, _, _) = actual
       val List(n1) = steps
@@ -214,7 +214,7 @@ class TestDFDLExpressionTree extends Parsers {
     }
   }
 
-  @Test def test_pathNoSuchElement1() {
+  @Test def test_pathNoSuchElement1(): Unit = {
     testExpr2(testSchema, "{ /thereIsNoElementWithThisName }") { (actual, erd) =>
       val WholeExpression(_, RootPathExpression(Some(RelativePathExpression(List(step: NamedStep), _))), _, _, _) = actual
       val exc = intercept[Exception] {
@@ -241,7 +241,7 @@ class TestDFDLExpressionTree extends Parsers {
     }
   }
 
-  @Test def testAddConstants() {
+  @Test def testAddConstants(): Unit = {
     testExpr(dummySchema, "{ 1 + 2 }") { actual =>
       val a @ WholeExpression(_, AdditiveExpression("+", List(LiteralExpression(one: JBigInt), LiteralExpression(two: JBigInt))), _, _, _) = actual; assertNotNull(a)
       assertEquals(JBigInt.valueOf(1), one)
@@ -249,7 +249,7 @@ class TestDFDLExpressionTree extends Parsers {
     }
   }
 
-  @Test def testFnTrue() {
+  @Test def testFnTrue(): Unit = {
     testExpr(dummySchema, "{ fn:true() }") { actual =>
       val a @ WholeExpression(_, FunctionCallExpression("fn:true", Nil), _, _, _) = actual; assertNotNull(a)
     }
@@ -300,7 +300,7 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_stringLit() = {
 
-    def testStringLit(expr: String) {
+    def testStringLit(expr: String): Unit = {
       testExpr(dummySchema, expr) {
         case WholeExpression(_, LiteralExpression(expr), _, _, _) => /* ok */
       }
@@ -321,7 +321,7 @@ class TestDFDLExpressionTree extends Parsers {
     val decl = declf.asRoot
     decl.elementRuntimeData
 
-    def testFn(expr: String)(body: FunctionCallExpression => Unit) {
+    def testFn(expr: String)(body: FunctionCallExpression => Unit): Unit = {
       testExpr(dummySchema, expr) { actual =>
         val WholeExpression(_, fnExpr: FunctionCallExpression, _, _, _) = actual
         body(fnExpr)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDPath.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDPath.scala
@@ -42,7 +42,7 @@ class TestDPath {
       </xs:complexType>
     </xs:element>)
 
-  @Test def test_twoUpwardSteps() {
+  @Test def test_twoUpwardSteps(): Unit = {
     TestUtils.testString(testSchemaNoRef, "")
   }
 
@@ -65,7 +65,7 @@ class TestDPath {
       </xs:complexType>
     </xs:element>)
 
-  @Test def test_twoUpwardStepsAcrossElementReference() {
+  @Test def test_twoUpwardStepsAcrossElementReference(): Unit = {
     TestUtils.testString(testSchema, "")
   }
 
@@ -82,7 +82,7 @@ class TestDPath {
     </xs:element>
     <xs:element name="c" type="xs:int" dfdl:inputValueCalc="{ ../b }"/>)
 
-  @Test def test_oneUpwardStepsAcrossElementReference() {
+  @Test def test_oneUpwardStepsAcrossElementReference(): Unit = {
     TestUtils.testString(testSchema2, "")
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestAppinfoSyntax.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestAppinfoSyntax.scala
@@ -38,7 +38,7 @@ class TestAppinfoSyntax {
   /**
    * Test that non-native attributes can be placed on DFDL appinfo annotations.
    */
-  @Test def testAppinfoWithNonNativeAttributes() {
+  @Test def testAppinfoWithNonNativeAttributes(): Unit = {
     val expected = "this is a non-native attribute"
     val nnURI = "urn:nonNativeAttributeNamespaceURN"
     val sc = <xs:schema xmlns:xs={ xsd } xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:foo={ nnURI }>
@@ -72,7 +72,7 @@ class TestAppinfoSyntax {
    * Test that more than one DFDL appinfo at the same point causes
    * an exception.
    */
-  @Test def testMultipleAppinfos() {
+  @Test def testMultipleAppinfos(): Unit = {
     val expected = "this is a non-native attribute"
     val nnURI = "urn:nonNativeAttributeNamespaceURN"
     val sc = <xs:schema xmlns:xs={ xsd } xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:foo={ nnURI }>
@@ -117,7 +117,7 @@ class TestAppinfoSyntax {
    * This is not allowed as it would impact our ability to provide good
    * diagnostics around the DFDL annotation elements.
    */
-  @Test def testMixedAnnotationElementsInsideDFDLAppinfo() {
+  @Test def testMixedAnnotationElementsInsideDFDLAppinfo(): Unit = {
     val expected = "this is a non-native attribute"
     val nnURI = "urn:nonNativeAttributeNamespaceURN"
     val sc = <xs:schema xmlns:xs={ xsd } xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:foo={ nnURI }>
@@ -152,7 +152,7 @@ class TestAppinfoSyntax {
   /**
    * Test that non-DFDL appinfos do not interact with DFDL.
    */
-  @Test def testNonDFDLAppinfos() {
+  @Test def testNonDFDLAppinfos(): Unit = {
     val expected = "this is a non-native attribute"
     val nnURI = "urn:nonNativeAttributeNamespaceURN"
     val nnURI2 = "urn:anotherNonNativeURI"
@@ -196,7 +196,7 @@ class TestAppinfoSyntax {
    * Test that XML comments are allowed at all places in and around appinfo
    * elements.
    */
-  @Test def testAppinfoWithComments() {
+  @Test def testAppinfoWithComments(): Unit = {
     val expected = "this is a non-native attribute"
     val nnURI = "urn:nonNativeAttributeNamespaceURN"
     val sc = <xs:schema xmlns:xs={ xsd } xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:foo={ nnURI }>

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -79,7 +79,7 @@ class TestBinaryInput_01 {
     (dis, finfo)
   }
 
-  @After def shutDown {
+  @After def shutDown: Unit = {
     dis.discard(startOver)
   }
 
@@ -104,7 +104,7 @@ class TestBinaryInput_01 {
   val BE = ByteOrder.BigEndian
   val LE = ByteOrder.LittleEndian
 
-  @Test def testOneBit1() {
+  @Test def testOneBit1(): Unit = {
     val (dis, finfo) = fromBytes(Misc.bits2Bytes(Seq("00000011")), BE, msbFirst)
 
     val bit1 = getLong(finfo, dis, 6, 2)
@@ -113,7 +113,7 @@ class TestBinaryInput_01 {
     assertEquals(0, bit2)
   }
 
-  @Test def testOneBit2() {
+  @Test def testOneBit2(): Unit = {
     val (dis, finfo) = fromBytes(Misc.bits2Bytes(Seq("11000000")), BE, msbFirst)
 
     val bit1 = getLong(finfo, dis, 0, 2)
@@ -122,7 +122,7 @@ class TestBinaryInput_01 {
     assertEquals(0, bit2)
   }
 
-  @Test def testOneBit3() {
+  @Test def testOneBit3(): Unit = {
     val (dis, finfo) = fromBytes(Misc.bits2Bytes(Seq("00000011")), BE, msbFirst)
 
     val n = getLong(finfo, dis, 6, 2)
@@ -130,21 +130,21 @@ class TestBinaryInput_01 {
   }
 
   @Test
-  def testBufferBitExtraction() {
+  def testBufferBitExtraction(): Unit = {
     val (dis, finfo) = fromString("3", BE, msbFirst)
 
     assertEquals(3, getLong(finfo, dis, 1, 3))
   }
 
   @Test
-  def testBufferBitExtractionShift() {
+  def testBufferBitExtractionShift(): Unit = {
     val (dis, finfo) = fromString("3", BE, msbFirst)
 
     assertEquals(12, getLong(finfo, dis, 2, 4))
   }
 
   @Test
-  def testBufferLeastSignificantBitExtractionShift() {
+  def testBufferLeastSignificantBitExtractionShift(): Unit = {
     val (dis, finfo) = fromString("4", BE, msbFirst)
 
     assertEquals(4, getLong(finfo, dis, 5, 3))
@@ -152,57 +152,57 @@ class TestBinaryInput_01 {
 
   // Verify aligned byte/short/int/long/bigint extraction
   @Test
-  def testBufferByteBigEndianExtraction() {
+  def testBufferByteBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3", BE, msbFirst)
 
     assertEquals(51, getLong(finfo, dis, 0, 8))
   }
 
   @Test
-  def testBufferByteLittleEndianExtraction() {
+  def testBufferByteLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3", LE, msbFirst)
 
     assertEquals(51, getLong(finfo, dis, 0, 8))
   }
 
   @Test
-  def testBufferShortBigEndianExtraction() {
+  def testBufferShortBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Om", BE, msbFirst)
     assertEquals(20333, getLong(finfo, dis, 0, 16))
   }
 
   @Test
-  def testBufferShortLittleEndianExtraction() {
+  def testBufferShortLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Om", LE, msbFirst)
     assertEquals(27983, getLong(finfo, dis, 0, 16))
   }
 
   @Test
-  def testBufferIntBigEndianExtraction() {
+  def testBufferIntBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Help", BE, msbFirst)
     assertEquals(1214606448, getLong(finfo, dis, 0, 32))
   }
 
   @Test
-  def testBufferIntLittleEndianExtraction() {
+  def testBufferIntLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Help", LE, msbFirst)
     assertEquals(1886152008, getLong(finfo, dis, 0, 32))
   }
 
   @Test
-  def testBufferLongBigEndianExtraction() {
+  def testBufferLongBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Harrison", BE, msbFirst)
     assertEquals(JBigInt.valueOf(5215575679192756078L), getBigInt(finfo, dis, 0, 64))
   }
 
   @Test
-  def testBufferLongLittleEndianExtraction() {
+  def testBufferLongLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Harrison", LE, msbFirst)
     assertEquals(JBigInt.valueOf(7957705963315814728L), getBigInt(finfo, dis, 0, 64))
   }
 
   @Test
-  def testBufferBigIntBigEndianExtraction() {
+  def testBufferBigIntBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Something in the way she moves, ", BE, msbFirst)
     val bigInt = getBigInt(finfo, dis, 0, 256)
     assertEquals(new JBigInt("37738841482167102822784581157237036764884875846207476558974346160344516471840"),
@@ -210,7 +210,7 @@ class TestBinaryInput_01 {
   }
 
   @Test
-  def testBufferBigIntLittleEndianExtraction() {
+  def testBufferBigIntLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("Something in the way she moves, ", LE, msbFirst)
     assertEquals(new JBigInt("14552548861771956163454220823873430243364312915206513831353612029437431082835"),
       getBigInt(finfo, dis, 0, 256))
@@ -218,53 +218,53 @@ class TestBinaryInput_01 {
 
   // Aligned but not full string
   @Test
-  def testBufferPartialIntBigEndianExtraction() {
+  def testBufferPartialIntBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", BE, msbFirst)
     assertEquals(5456468, getLong(finfo, dis, 0, 24))
   }
 
   @Test
-  def testBufferPartialIntLittleEndianExtraction() {
+  def testBufferPartialIntLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", LE, msbFirst)
     assertEquals(5522003, getLong(finfo, dis, 0, 24))
   }
 
   // Non-Aligned 1 Byte or less
   @Test
-  def testBufferBitNumberBigEndianExtraction() {
+  def testBufferBitNumberBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3", BE, msbFirst)
 
     assertEquals(3, getLong(finfo, dis, 1, 3))
   }
 
   @Test
-  def testBufferBitNumberLittleEndianExtraction() {
+  def testBufferBitNumberLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3", LE, msbFirst)
 
     assertEquals(3, getLong(finfo, dis, 1, 3))
   }
 
   @Test
-  def testBufferBitByteBigEndianExtraction() {
+  def testBufferBitByteBigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3>", BE, msbFirst)
     assertEquals(204, getLong(finfo, dis, 2, 8))
   }
 
   @Test
-  def testBufferBitByteLittleEndianExtraction() {
+  def testBufferBitByteLittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("3>", LE, msbFirst)
     assertEquals(0xCC, getLong(finfo, dis, 2, 8))
   }
 
   // Non-Aligned multi-byte
   @Test
-  def testBufferPartialInt22At0BigEndianExtraction() {
+  def testBufferPartialInt22At0BigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", BE, msbFirst)
     assertEquals(1364117, getLong(finfo, dis, 0, 22))
   }
 
   @Test
-  def testBufferPartialInt22At0LittleEndianExtraction() {
+  def testBufferPartialInt22At0LittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", LE, msbFirst)
     assertEquals(0x154253, getLong(finfo, dis, 0, 22))
     // Corrected. Was 544253, but that omits shifting the most significant byte left 2
@@ -272,20 +272,20 @@ class TestBinaryInput_01 {
   }
 
   @Test
-  def testBufferPartialInt22At2BigEndianExtraction() {
+  def testBufferPartialInt22At2BigEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", BE, msbFirst)
     assertEquals(0x134254, getLong(finfo, dis, 2, 22))
   }
 
   @Test
-  def testBufferPartialInt22At2LittleEndianExtraction() {
+  def testBufferPartialInt22At2LittleEndianExtraction(): Unit = {
     val (dis, finfo) = fromString("SBT", LE, msbFirst)
     assertEquals(0x14094d, getLong(finfo, dis, 2, 22)) // Corrected.
     // Was 0x50094d, but that omits shifting the most significant byte >> 2 to
     // add the bits on the most significant side, not the least significant side.
   }
 
-  @Test def testOneBit1LSBFirst() {
+  @Test def testOneBit1LSBFirst(): Unit = {
     val (dis, finfo) = fromBytes(Misc.bits2Bytes(Seq("01100000")), LE, lsbFirst)
 
     val bit1 = getLong(finfo, dis, 5, 2)
@@ -294,7 +294,7 @@ class TestBinaryInput_01 {
     assertEquals(2, bit2)
   }
 
-  @Test def testOneBit2LSBFirst() {
+  @Test def testOneBit2LSBFirst(): Unit = {
     val (dis, finfo) = fromBytes(Misc.bits2Bytes(Seq("01010000")), LE, lsbFirst)
 
     val bit1 = getLong(finfo, dis, 5, 2)
@@ -303,7 +303,7 @@ class TestBinaryInput_01 {
     assertEquals(1, bit2)
   }
 
-  @Test def testOneBit3LSBFirst() {
+  @Test def testOneBit3LSBFirst(): Unit = {
     val (dis, finfo) = fromBytes(JBigInt.valueOf(0xE4567A).toByteArray, LE, lsbFirst)
 
     val bit1 = getLong(finfo, dis, 13, 12)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -46,7 +46,7 @@ class TestDsomCompiler extends Logging {
   // is any problem in the Fakes, the whole class can't be constructed, and None
   // of the tests will run. Lazy lets this class be constructed no matter what.
 
-  @Test def testHasProps() {
+  @Test def testHasProps(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -67,7 +67,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(TextNumberRep.Standard, tnr)
   }
 
-  @Test def testSchemaValidationSubset() {
+  @Test def testSchemaValidationSubset(): Unit = {
     val sch: Node = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -93,7 +93,7 @@ class TestDsomCompiler extends Logging {
   // FIXME: convert this test to TDML or discard. It is testing internal APIs
   // and not defending itself from thrown exceptions the way the real APIs do (or
   // are supposed to anyway.
-  @Test def testTypeReferentialError() {
+  @Test def testTypeReferentialError(): Unit = {
     // LoggingDefaults.setLoggingLevel(LogLevel.OOLAGDebug)
     val sch: Node = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
@@ -107,7 +107,7 @@ class TestDsomCompiler extends Logging {
   }
 
   // FIXME - convert this test to TDML or drop if there is coverage other places.
-  @Test def testTypeReferentialError2() {
+  @Test def testTypeReferentialError2(): Unit = {
     val sch: Node = <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
                       <element name="foo" type="bar"/><!-- Illegal: no prefix on name of the type. -->
                       <complexType name="bar">
@@ -121,7 +121,7 @@ class TestDsomCompiler extends Logging {
     if (!hasErrorText) fail("Didn't get expected error. Got: " + msg)
   }
 
-  @Test def testSchemaValidationPropertyChecking() {
+  @Test def testSchemaValidationPropertyChecking(): Unit = {
     val s: Node = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -142,7 +142,7 @@ class TestDsomCompiler extends Logging {
     if (!hasErrorText) fail("Didn't get expected error. Got: " + msg)
   }
 
-  @Test def test2() {
+  @Test def test2(): Unit = {
     val sc = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -172,7 +172,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(AlignmentUnits.Bytes, decl.alignmentUnits)
   }
 
-  @Test def testSequence1() {
+  @Test def testSequence1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -206,7 +206,7 @@ class TestDsomCompiler extends Logging {
     assertTrue(elem.isInstanceOf[LocalElementDecl])
   }
 
-  @Test def test3 {
+  @Test def test3: Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = new SchemaSet(testSchema)
@@ -288,7 +288,7 @@ class TestDsomCompiler extends Logging {
     assertEquals("ex:a", e1r.ref)
   }
 
-  @Test def test4 {
+  @Test def test4: Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = new SchemaSet(testSchema)
@@ -315,7 +315,7 @@ class TestDsomCompiler extends Logging {
     assertEquals("{ $myVar1 eq xs:int(xs:string(fn:round-half-to-even(8.5))) }", asrt1.testTxt)
   }
 
-  @Test def test_named_format_chaining {
+  @Test def test_named_format_chaining: Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -333,7 +333,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(true, a1.verifyPropValue("binaryNumberRep", "packed"))
   }
 
-  @Test def test_simple_types_access_works {
+  @Test def test_simple_types_access_works: Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -348,7 +348,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(AlignmentUnits.Bytes, x.alignmentUnits)
   }
 
-  @Test def test_simple_types_property_combining {
+  @Test def test_simple_types_property_combining: Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -380,7 +380,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(BinaryNumberRep.Packed, ge6.binaryNumberRep)
   }
 
-  @Test def test_simpleType_base_combining {
+  @Test def test_simpleType_base_combining: Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = new SchemaSet(testSchema)
@@ -427,7 +427,7 @@ class TestDsomCompiler extends Logging {
     assertTrue(msgs.contains("initiator".toLowerCase))
   }
 
-  @Test def test_group_references {
+  @Test def test_group_references: Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = new SchemaSet(testSchema)
@@ -480,7 +480,7 @@ class TestDsomCompiler extends Logging {
 
   }
 
-  @Test def test_ibm_7132 {
+  @Test def test_ibm_7132: Unit = {
     val ibm7132Schema = XML.load(Misc.getRequiredResource("/test/TestRefChainingIBM7132.dfdl.xml").toURL)
     // val ibm7132Schema = "test/TestRefChainingIBM7132.dfdl.xml"
     val sset = new SchemaSet(ibm7132Schema)
@@ -508,7 +508,7 @@ class TestDsomCompiler extends Logging {
     e1.lengthKind
   }
 
-  @Test def testDfdlRef() {
+  @Test def testDfdlRef(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:defineFormat name="ref1"> <dfdl:format initiator=":"/> </dfdl:defineFormat>,
@@ -547,7 +547,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(XMLUtils.EXAMPLE_NAMESPACE, nsURI)
   }
 
-  @Test def testGetAllNamespaces() {
+  @Test def testGetAllNamespaces(): Unit = {
     val xml = <bar xmlns:foo="fooNS" xmlns:bar="barNS">
                 <quux xmlns:baz="bazNS" attr1="x"/>
               </bar>
@@ -599,7 +599,7 @@ class TestDsomCompiler extends Logging {
     assertEquals("cStyleComment", e2f_esref)
   }
 
-  @Test def test_element_references {
+  @Test def test_element_references: Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = new SchemaSet(testSchema)
@@ -623,7 +623,7 @@ class TestDsomCompiler extends Logging {
     assertEquals(NilKind.LiteralValue, e1r.nilKind)
   }
 
-  @Test def testPathWithIndexes() {
+  @Test def testPathWithIndexes(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -663,7 +663,7 @@ class TestDsomCompiler extends Logging {
     found
   }
 
-  @Test def testInitiator() {
+  @Test def testInitiator(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -677,7 +677,7 @@ class TestDsomCompiler extends Logging {
     TestUtils.testUnparsing(testSchema, infoset, "*word")
   }
 
-  @Test def testTerminator() {
+  @Test def testTerminator(): Unit = {
     // LoggingDefaults.setLoggingLevel(LogLevel.Debug)
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
@@ -692,7 +692,7 @@ class TestDsomCompiler extends Logging {
     TestUtils.testUnparsing(testSchema, infoset, "37!")
   }
 
-  @Test def testDelims() {
+  @Test def testDelims(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -735,7 +735,7 @@ class TestDsomCompiler extends Logging {
   //    TestUtils.testUnparsing(testSchema, infoset, "943.281")
   //  }
 
-  @Test def testUnparseMultiElem2() {
+  @Test def testUnparseMultiElem2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -963,7 +963,7 @@ class TestDsomCompiler extends Logging {
   //    TestUtils.testUnparsing(testSchema, infoset, "567,word,choice2:2038.67")
   //  }
 
-  @Test def testUnparseBinaryIntBE() {
+  @Test def testUnparseBinaryIntBE(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -978,7 +978,7 @@ class TestDsomCompiler extends Logging {
     TestUtils.testUnparsingBinary(testSchema, infoset, bytes)
   }
 
-  @Test def testUnparseBinaryIntLE() {
+  @Test def testUnparseBinaryIntLE(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -1018,7 +1018,7 @@ class TestDsomCompiler extends Logging {
   //    TestUtils.testUnparsingBinary(testSchema, infoset, bytes)
   //  }
 
-  @Test def testHasPatternFacets() {
+  @Test def testHasPatternFacets(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -1043,7 +1043,7 @@ class TestDsomCompiler extends Logging {
     assertEquals("1|2|3", pattern.toString())
   }
 
-  @Test def testPatternFacetsInheritance() {
+  @Test def testPatternFacetsInheritance(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompilerUnparse1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompilerUnparse1.scala
@@ -29,7 +29,7 @@ class TestDsomCompilerUnparse1 {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testUnparse1() {
+  @Test def testUnparse1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
@@ -49,7 +49,7 @@ class TestDsomCompilerUnparse1 {
   /**
    * Test emphasis on delimiter unparsers
    */
-  @Test def testUnparse2() {
+  @Test def testUnparse2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" outputNewLine="%CR;%LF;"/>,
@@ -68,7 +68,7 @@ class TestDsomCompilerUnparse1 {
   /**
    * Test emphasis on StringDelimitedUnparser
    */
-  @Test def testUnparse3() {
+  @Test def testUnparse3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" outputNewLine="%CR;%LF;"/>,
@@ -87,7 +87,7 @@ class TestDsomCompilerUnparse1 {
   /**
    * Test emphasis on StringDelimitedUnparser w/ padding
    */
-  @Test def testUnparse4() {
+  @Test def testUnparse4(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" outputNewLine="%CR;%LF;" truncateSpecifiedLengthString="no"/>,
@@ -113,7 +113,7 @@ class TestDsomCompilerUnparse1 {
   /**
    * Test emphasis on StringDelimitedUnparser w/ escape scheme
    */
-  @Test def testUnparse5() {
+  @Test def testUnparse5(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" outputNewLine="%CR;%LF;"/>

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
@@ -160,7 +160,7 @@ class TestExternalVariablesNew {
     }
   }
 
-  @Test def test_figures_out_namespace_success() {
+  @Test def test_figures_out_namespace_success(): Unit = {
     // Here we want to test that if we do not give
     // a namespace that Daffodil is able to figure
     // out what it should be if there is no ambiguity.
@@ -212,7 +212,7 @@ class TestExternalVariablesNew {
 
   }
 
-  @Test def test_no_namespace_success() {
+  @Test def test_no_namespace_success(): Unit = {
     // Here we want to test that even when multiple var2's
     // are defined with different namespaces that we can
     // set the correct one.
@@ -257,7 +257,7 @@ class TestExternalVariablesNew {
 
   }
 
-  @Test def test_figures_out_namespace_failure() {
+  @Test def test_figures_out_namespace_failure(): Unit = {
     // We are purposefully defining multiple var3's but
     // in separate namespaces.  This test should fail
     // stating that var3 is ambiguous.
@@ -301,7 +301,7 @@ class TestExternalVariablesNew {
     }
   }
 
-  @Test def test_data_processor_vmap_copy() {
+  @Test def test_data_processor_vmap_copy(): Unit = {
     // Here we want to test that even when multiple var2's
     // are defined with different namespaces that we can
     // set the correct one.

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestInputValueCalc.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestInputValueCalc.scala
@@ -25,7 +25,7 @@ import org.junit.Test
 class TestInputValueCalc extends Logging {
 
   // @Test
-  @Test def testInputValueCalc1() {
+  @Test def testInputValueCalc1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -36,7 +36,7 @@ class TestInputValueCalc extends Logging {
   }
 
   // @Test
-  @Test def testInputValueCalcString2() {
+  @Test def testInputValueCalcString2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii"/>,
@@ -55,7 +55,7 @@ class TestInputValueCalc extends Logging {
   }
 
   // @Test
-  @Test def testInputValueCalcInt3() {
+  @Test def testInputValueCalcInt3(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestIsScannable.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestIsScannable.scala
@@ -33,7 +33,7 @@ class TestIsScannable extends Logging {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testIsScannableAllText1() {
+  @Test def testIsScannableAllText1(): Unit = {
     val sc = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="utf-8"/>,
@@ -64,7 +64,7 @@ class TestIsScannable extends Logging {
     assertEquals(NamedEncoding("UTF-8"), child.summaryEncoding)
   }
 
-  @Test def testIsScannableHasBinary1() {
+  @Test def testIsScannableHasBinary1(): Unit = {
     val sc = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -99,7 +99,7 @@ class TestIsScannable extends Logging {
     assertEquals(NamedEncoding("US-ASCII"), e2.summaryEncoding)
   }
 
-  @Test def testIsScannableDifferentEncodings1() {
+  @Test def testIsScannableDifferentEncodings1(): Unit = {
     val sc = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="utf-8"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -28,7 +28,7 @@ class TestMiddleEndAttributes {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_1 {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_1: Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -54,7 +54,7 @@ class TestMiddleEndAttributes {
     assertTrue(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_2 {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_2: Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -80,7 +80,7 @@ class TestMiddleEndAttributes {
     assertFalse(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def testRequiredSiblings {
+  @Test def testRequiredSiblings: Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -112,7 +112,7 @@ class TestMiddleEndAttributes {
     assertFalse(s5.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def testStaticallyFirstWithChoice {
+  @Test def testStaticallyFirstWithChoice: Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"
@@ -149,7 +149,7 @@ class TestMiddleEndAttributes {
     assertTrue(s2.isScalar)
   }
 
-  @Test def testNearestEnclosingSequenceElementRef() {
+  @Test def testNearestEnclosingSequenceElementRef(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -179,7 +179,7 @@ class TestMiddleEndAttributes {
     assertEquals(seq, nes)
   }
 
-  @Test def testImmediatelyEnclosingModelGroup1() {
+  @Test def testImmediatelyEnclosingModelGroup1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPropertyScoping.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPropertyScoping.scala
@@ -28,7 +28,7 @@ class HasProps(xml: Node) extends DFDLFormatAnnotation(xml, Fakes.fakeElem)
 class TestPropertyScoping {
   val x1 = new HasProps(<fake alignmentUnits="bytes"/>)
 
-  @Test def test1() {
+  @Test def test1(): Unit = {
     LogLevel
     //    println(x1.formatRefs)
     //    println(x1.shortFormProperties)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestRefMap.scala
@@ -38,7 +38,7 @@ class TestRefMap extends Logging {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testRefMapEmpty() {
+  @Test def testRefMapEmpty(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -55,7 +55,7 @@ class TestRefMap extends Logging {
     assertEquals(1, numRefPairs) // good proxy for schema size
   }
 
-  @Test def testRefMapComplex1() {
+  @Test def testRefMapComplex1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -80,7 +80,7 @@ class TestRefMap extends Logging {
     assertEquals(root.referencedElement.shortSchemaComponentDesignator, edecl)
   }
 
-  @Test def testRefMapGroupRefSeq1() {
+  @Test def testRefMapGroupRefSeq1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -114,7 +114,7 @@ class TestRefMap extends Logging {
     assertEquals(6, root.numUniqueComponents)
   }
 
-  @Test def testRefMapGroupRefChoice1() {
+  @Test def testRefMapGroupRefChoice1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -149,7 +149,7 @@ class TestRefMap extends Logging {
     assertEquals(7, root.numUniqueComponents)
   }
 
-  @Test def testRefMapGroupRefNest1() {
+  @Test def testRefMapGroupRefNest1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -195,7 +195,7 @@ class TestRefMap extends Logging {
     assertEquals(14, root.numUniqueComponents)
   }
 
-  @Test def testRefMapNonExplosion1() {
+  @Test def testRefMapNonExplosion1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -241,7 +241,7 @@ class TestRefMap extends Logging {
     assertEquals(14, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion2() {
+  @Test def testRefMapExplosion2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -289,7 +289,7 @@ class TestRefMap extends Logging {
     assertEquals(19, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion3() {
+  @Test def testRefMapExplosion3(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -340,7 +340,7 @@ class TestRefMap extends Logging {
     assertEquals(21, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion4() {
+  @Test def testRefMapExplosion4(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -399,7 +399,7 @@ class TestRefMap extends Logging {
     assertEquals(26, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion5() {
+  @Test def testRefMapExplosion5(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -466,7 +466,7 @@ class TestRefMap extends Logging {
     assertEquals(31, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion6() {
+  @Test def testRefMapExplosion6(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -541,7 +541,7 @@ class TestRefMap extends Logging {
     assertEquals(36, root.numUniqueComponents)
   }
 
-  @Test def testRefMapExplosion7() {
+  @Test def testRefMapExplosion7(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
@@ -53,7 +53,7 @@ class TestSimpleTypeUnions {
     </xs:simpleType>
     <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:oneOrTwo"/>)
 
-  @Test def testUnion01 {
+  @Test def testUnion01: Unit = {
 
     val sset = new SchemaSet(testSchema1)
     val Seq(sch) = sset.schemas
@@ -84,7 +84,7 @@ class TestSimpleTypeUnions {
     assertEquals("ex:int2Type", st2rd.diagnosticDebugName)
   }
 
-  @Test def testUnionFirstUnionMemberOk {
+  @Test def testUnionFirstUnionMemberOk: Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -94,7 +94,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionSecondUnionMemberOk {
+  @Test def testUnionSecondUnionMemberOk: Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "2")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -104,7 +104,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNoUnionMemberOK {
+  @Test def testUnionNoUnionMemberOK: Unit = {
     val (result, _) = TestUtils.testString(testSchema1, "3")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
@@ -181,7 +181,7 @@ class TestSimpleTypeUnions {
     </xs:simpleType>
     <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:eType"/>)
 
-  @Test def testUnionNot3 {
+  @Test def testUnionNot3: Unit = {
     val (result, _) = TestUtils.testString(testSchema2, "3")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
@@ -206,7 +206,7 @@ class TestSimpleTypeUnions {
       die
   }
 
-  @Test def testUnionNot3_01 {
+  @Test def testUnionNot3_01: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -216,7 +216,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNot3_02 {
+  @Test def testUnionNot3_02: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "2")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -226,7 +226,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNot3_03 {
+  @Test def testUnionNot3_03: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "-1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -272,7 +272,7 @@ class TestSimpleTypeUnions {
     </xs:simpleType>
     <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:foo3bar"/>)
 
-  @Test def testRestrictionOnUnion_01 {
+  @Test def testRestrictionOnUnion_01: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo3bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -282,7 +282,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnion_02 {
+  @Test def testRestrictionOnUnion_02: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo1bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -292,7 +292,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnion_03 {
+  @Test def testRestrictionOnUnion_03: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo2bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -302,7 +302,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnionFail_01 {
+  @Test def testRestrictionOnUnionFail_01: Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "foo4bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
@@ -331,7 +331,7 @@ class TestSimpleTypeUnions {
    * This test shows that the union isn't even attempted if the
    * restriction on the union fails.
    */
-  @Test def testRestrictionOnUnionFail_02 {
+  @Test def testRestrictionOnUnionFail_02: Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "notfoo1bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.util.SchemaUtils
 
 class TestPrimitives {
 
-  @Test def testInitiator {
+  @Test def testInitiator: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" representation="text" lengthUnits="bytes" encoding="US-ASCII" terminator="" separator="" ignoreCase="no"/>,
@@ -39,7 +39,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testTerminator {
+  @Test def testTerminator: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" separator="" ignoreCase="no"/>,
@@ -52,7 +52,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testSeparator() {
+  @Test def testSeparator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" separator="" terminator="" ignoreCase="no"/>,
@@ -71,7 +71,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited {
+  @Test def testLengthKindDelimited: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -91,7 +91,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited2 {
+  @Test def testLengthKindDelimited2: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -110,7 +110,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited3 {
+  @Test def testLengthKindDelimited3: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -137,7 +137,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testDelimiterInheritance {
+  @Test def testDelimiterInheritance: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:defineFormat name="config">
@@ -177,7 +177,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementSeparator {
+  @Test def testEntityReplacementSeparator: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -197,7 +197,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementInitiator {
+  @Test def testEntityReplacementInitiator: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -210,7 +210,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementTerminator {
+  @Test def testEntityReplacementTerminator: Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives2.scala
@@ -29,7 +29,7 @@ class TestPrimitives2 {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testUnparseNilValueEntities() {
+  @Test def testUnparseNilValueEntities(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
@@ -39,7 +39,7 @@ class TestPrimitives2 {
     TestUtils.testUnparsing(sch, infoset, " nil\u000a")
   }
 
-  @Test def testUnparseNilValueEntities2() {
+  @Test def testUnparseNilValueEntities2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
@@ -44,7 +44,7 @@ class TestTunables extends Logging {
   // of the tests will run. Lazy lets this class be constructed no matter what.
   lazy val dummyGroupRef = Fakes.fakeGroupRef
 
-  @Test def testTunableCopy() {
+  @Test def testTunableCopy(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -83,7 +83,7 @@ class TestTunables extends Logging {
     assertEquals(1026, t4.maxSkipLengthInBytes)
   }
 
-  @Test def testTunableSuppressionListCopying() {
+  @Test def testTunableSuppressionListCopying(): Unit = {
     val t1 = DaffodilTunables("suppressSchemaDefinitionWarnings", "escapeSchemeRefUndefined")
     val t2 = DaffodilTunables("suppressSchemaDefinitionWarnings", "all")
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/grammar/TestGrammar.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/grammar/TestGrammar.scala
@@ -38,7 +38,7 @@ class TestGrammar extends GrammarMixin {
     def unparser: Unparser = Assert.notYetImplemented()
   }
 
-  @Test def testBasicTripleSequential() {
+  @Test def testBasicTripleSequential(): Unit = {
 
     object first extends Primitive1(fakeTerm)
     object mid extends Primitive1(fakeTerm)
@@ -60,7 +60,7 @@ class TestGrammar extends GrammarMixin {
     assertTrue(s.contains(" ~ "))
   }
 
-  @Test def testMiddleSplicedOut() {
+  @Test def testMiddleSplicedOut(): Unit = {
 
     object first extends Primitive1(fakeTerm)
     object mid extends Primitive1(fakeTerm, false)
@@ -79,7 +79,7 @@ class TestGrammar extends GrammarMixin {
 
   }
 
-  @Test def testTopProdSplicedOut() {
+  @Test def testTopProdSplicedOut(): Unit = {
 
     object first extends Primitive1(fakeTerm)
     object mid extends Primitive1(fakeTerm, false)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
@@ -106,7 +106,7 @@ class TestInfoset1 {
   val ex = XMLUtils.EXAMPLE_NAMESPACE
   import TestInfoset._
 
-  @Test def testXMLToInfoset1() {
+  @Test def testXMLToInfoset1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -129,7 +129,7 @@ class TestInfoset1 {
 
   }
 
-  @Test def testXMLToInfoset2() {
+  @Test def testXMLToInfoset2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -158,7 +158,7 @@ class TestInfoset1 {
     assertEquals(infoset, cItem.parent)
   }
 
-  @Test def testXMLToInfoset2a() {
+  @Test def testXMLToInfoset2a(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -187,7 +187,7 @@ class TestInfoset1 {
     }
   }
 
-  @Test def testXMLToInfoset3() {
+  @Test def testXMLToInfoset3(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -225,7 +225,7 @@ class TestInfoset1 {
     }
   }
 
-  @Test def testXMLToInfosetNil1() {
+  @Test def testXMLToInfosetNil1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -256,7 +256,7 @@ class TestInfoset1 {
     }
   }
 
-  @Test def testXMLToInfoset4() {
+  @Test def testXMLToInfoset4(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -289,7 +289,7 @@ class TestInfoset1 {
     }
   }
 
-  @Test def testXMLToInfoset5() {
+  @Test def testXMLToInfoset5(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -333,7 +333,7 @@ class TestInfoset1 {
     }
   }
 
-  @Test def testXMLToInfoset6() {
+  @Test def testXMLToInfoset6(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset2.scala
@@ -31,7 +31,7 @@ class TestInfoset2 {
   val xsi = XMLUtils.XSI_NAMESPACE
   val ex = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testXMLToInfoset1() {
+  @Test def testXMLToInfoset1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchemaUnqualified(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor.scala
@@ -95,7 +95,7 @@ class TestInfosetInputter {
     (infosetInputter, rootERD)
   }
 
-  @Test def testInfosetInputterFromSimpleValue1() {
+  @Test def testInfosetInputterFromSimpleValue1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -122,7 +122,7 @@ class TestInfosetInputter {
     assertFalse(ic.advance)
   }
 
-  @Test def testInfosetInputterFromTreeNil() {
+  @Test def testInfosetInputterFromTreeNil(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -149,7 +149,7 @@ class TestInfosetInputter {
     assertFalse(ic.advance)
   }
 
-  @Test def testInfosetInputterFromTreeComplex1() {
+  @Test def testInfosetInputterFromTreeComplex1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -201,7 +201,7 @@ class TestInfosetInputter {
     assertFalse(ic.advance)
   }
 
-  @Test def testInfosetComplex2() {
+  @Test def testInfosetComplex2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -243,7 +243,7 @@ class TestInfosetInputter {
     assertTrue(baz_s.dataValueAsString =:= "World")
   }
 
-  @Test def testInfosetComplex3() {
+  @Test def testInfosetComplex3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -328,7 +328,7 @@ class TestInfosetInputter {
     assertTrue(quux_s eq quux_e)
   }
 
-  @Test def testInfosetArray1() {
+  @Test def testInfosetArray1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -370,7 +370,7 @@ class TestInfosetInputter {
     assertTrue(foo_2_s.dataValueAsString =:= "World")
   }
 
-  @Test def testInfosetArray2() {
+  @Test def testInfosetArray2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -418,7 +418,7 @@ class TestInfosetInputter {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetArray3() {
+  @Test def testInfosetArray3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -468,7 +468,7 @@ class TestInfosetInputter {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetArray4() {
+  @Test def testInfosetArray4(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -521,7 +521,7 @@ class TestInfosetInputter {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetComplexPeek1() {
+  @Test def testInfosetComplexPeek1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -565,7 +565,7 @@ class TestInfosetInputter {
     assertTrue(foo_s1.dataValueAsString =:= "Hello")
   }
 
-  @Test def testInfosetArrayComplex1() {
+  @Test def testInfosetArrayComplex1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor1.scala
@@ -46,7 +46,7 @@ class TestInfosetInputter1 {
     ic
   }
 
-  @Test def testInfosetInputterOnBadData() {
+  @Test def testInfosetInputterOnBadData(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -62,7 +62,7 @@ class TestInfosetInputter1 {
     assertTrue(msg.contains("prolog")) // content not allowed in prolog of an XML document.
   }
 
-  @Test def testInfosetInputterOnBadData2() {
+  @Test def testInfosetInputterOnBadData2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -79,7 +79,7 @@ class TestInfosetInputter1 {
     assertTrue(msg.contains("Unexpected character")) // expects an equal sign for an attribute
   }
 
-  @Test def testInfosetInputterOnBadData3() {
+  @Test def testInfosetInputterOnBadData3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
@@ -61,7 +61,7 @@ class TestInfosetInputterFromReader {
     (is, rootERD, inputter, u.tunables)
   }
 
-  @Test def testUnparseFixedLengthString1() {
+  @Test def testUnparseFixedLengthString1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -70,7 +70,7 @@ class TestInfosetInputterFromReader {
     TestUtils.testUnparsing(sch, infosetXML, "Hello")
   }
 
-  @Test def testInfosetInputter1() {
+  @Test def testInfosetInputter1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -84,7 +84,7 @@ class TestInfosetInputterFromReader {
     assertTrue(s.dataValueAsString =:= "Hello")
   }
 
-  @Test def testInfosetInputterNil1() {
+  @Test def testInfosetInputterNil1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -97,7 +97,7 @@ class TestInfosetInputterFromReader {
     assertTrue(s.isNilled)
   }
 
-  @Test def testInfosetComplex1() {
+  @Test def testInfosetComplex1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -127,7 +127,7 @@ class TestInfosetInputterFromReader {
     assertTrue(foo_s.dataValueAsString =:= "Hello")
   }
 
-  @Test def testInfosetComplex2() {
+  @Test def testInfosetComplex2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -161,7 +161,7 @@ class TestInfosetInputterFromReader {
     assertTrue(baz_s.dataValueAsString =:= "World")
   }
 
-  @Test def testInfosetComplex3() {
+  @Test def testInfosetComplex3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -262,7 +262,7 @@ class TestInfosetInputterFromReader {
     assertTrue(quux_s eq quux_e)
   }
 
-  @Test def testInfosetArray1() {
+  @Test def testInfosetArray1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -304,7 +304,7 @@ class TestInfosetInputterFromReader {
     assertTrue(foo_2_s.dataValueAsString =:= "World")
   }
 
-  @Test def testInfosetArray2() {
+  @Test def testInfosetArray2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -354,7 +354,7 @@ class TestInfosetInputterFromReader {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetArray3() {
+  @Test def testInfosetArray3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -404,7 +404,7 @@ class TestInfosetInputterFromReader {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetArray4() {
+  @Test def testInfosetArray4(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -451,7 +451,7 @@ class TestInfosetInputterFromReader {
     assertTrue(baz_s.dataValueAsString =:= "Yadda")
   }
 
-  @Test def testInfosetComplexPeek1() {
+  @Test def testInfosetComplexPeek1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -490,7 +490,7 @@ class TestInfosetInputterFromReader {
     assertTrue(foo_s1.dataValueAsString =:= "Hello")
   }
 
-  @Test def testInfosetArrayComplex1() {
+  @Test def testInfosetArrayComplex1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
@@ -87,15 +87,15 @@ class TestInfosetInputterFromReader2 {
       }
     }
 
-    override def close() { bytes = Nil.toStream }
+    override def close(): Unit = { bytes = Nil.toStream }
   }
 
-  @Test def testStreamingBehavior1() {
+  @Test def testStreamingBehavior1(): Unit = {
     val count = 100
     doTest(count)
   }
 
-  def doTest(count: Int) {
+  def doTest(count: Int): Unit = {
     val (is, rootERD, inp) = infosetUnlimitedSource(count)
     val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
     val Seq(fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
@@ -122,7 +122,7 @@ class TestInfosetInputterFromReader2 {
   }
 
   // @Test // uncomment to watch storage on jvisualvm to convince self of non-leaking.
-  def testStreamingBehavior2() {
+  def testStreamingBehavior2(): Unit = {
     val count = 100000000
     doTest(count)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -45,7 +45,7 @@ class TestLayers {
         </xs:complexType>
       </xs:element>, elementFormDefault = "unqualified")
 
-  @Test def testParseB64Layer1() {
+  @Test def testParseB64Layer1(): Unit = {
     val sch = B64Layer1Schema
     val data = "cGxl!" // encoding of "ple" + "!"
     val infoset = <ex:e1 xmlns:ex={ example }><s1>ple</s1></ex:e1>
@@ -68,7 +68,7 @@ class TestLayers {
         </xs:complexType>
       </xs:element>, elementFormDefault = "unqualified")
 
-  @Test def testParseB64Layer2() {
+  @Test def testParseB64Layer2(): Unit = {
     val sch = B64Layer2Schema
     val data = "cGxl!" // encoding of "ple" + "!"
     val infoset = <ex:e1 xmlns:ex={ example }><s1>ple</s1></ex:e1>
@@ -94,7 +94,7 @@ class TestLayers {
         </xs:complexType>
       </xs:element>, elementFormDefault = "unqualified")
 
-  @Test def testParseB64Layer3() {
+  @Test def testParseB64Layer3(): Unit = {
     val sch = B64Layer3Schema
     val data = "cGxl" + "!" + "moreDataAfter"
     val infoset = <ex:e1 xmlns:ex={ example }><s1>ple</s1><s2>moreDataAfter</s2></ex:e1>
@@ -120,7 +120,7 @@ so boring to read. Use of famous quotes or song lyrics or anything like that
 introduces copyright notice issues, so it is easier to simply make up
 a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", " ")
 
-  @Test def testGZIPRoundTrips() {
+  @Test def testGZIPRoundTrips(): Unit = {
     val bais = new ByteArrayInputStream(makeGZIPData(text))
     val gzis = new java.util.zip.GZIPInputStream(bais)
     val rdr = new InputStreamReader(gzis, StandardCharsets.UTF_8)
@@ -163,7 +163,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     (data, dataLength)
   }
 
-  @Test def testGZIPLayer1() {
+  @Test def testGZIPLayer1(): Unit = {
     val sch = GZIPLayer1Schema
     val (data, dataLength) = makeGZIPLayer1Data()
     val infoset = <ex:e1 xmlns:ex={ example }><len>{ dataLength }</len><x1><s1>{ text }</s1></x1><s2>afterGzip</s2></ex:e1>
@@ -223,7 +223,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     (baos2.toByteArray(), dataLength)
   }
 
-  @Test def testParseB64GZIPLayer1() {
+  @Test def testParseB64GZIPLayer1(): Unit = {
     val term = ";"
     val layerTerm = "=_END_="
     val sch = makeB64GZIPSchema(term, layerTerm)
@@ -259,7 +259,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
 
   val ipsumLorem1Unfolded = s"""Lorem ipsum dolor sit amet"""
 
-  @Test def testParseLineFoldIMF1() {
+  @Test def testParseLineFoldIMF1(): Unit = {
     val sch = lineFoldLayer1Schema
     val data = ipsumLorem1
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem1Unfolded }</s1></e1>
@@ -272,7 +272,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
   /////////////////////          1         2         3         4         5         6         7           8
   val ipsumLorem2Unfolded = s"""Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad"""
 
-  @Test def testUnparseLineFoldIMF1() {
+  @Test def testUnparseLineFoldIMF1(): Unit = {
     val sch = lineFoldLayer1Schema
     val data = ipsumLorem2
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem2Unfolded }</s1></e1>
@@ -302,7 +302,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
 
   val ipsumLorem3Unfolded = s"""Lorem ipsum dolor sit amet,"""
 
-  @Test def testParseLineFoldIMF2() {
+  @Test def testParseLineFoldIMF2(): Unit = {
     val sch = lineFoldLayer2Schema
     val data = ipsumLorem3
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem3Unfolded }</s1></e1>
@@ -315,7 +315,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
   /////////////////////          1         2         3         4         5         6         7           8
   val ipsumLorem4Unfolded = s"""Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"""
 
-  @Test def testUnparseLineFoldIMF2() {
+  @Test def testUnparseLineFoldIMF2(): Unit = {
     val sch = lineFoldLayer2Schema
     val data = ipsumLorem4
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem4Unfolded }</s1></e1>
@@ -345,7 +345,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
 
   val ipsumLorem5Unfolded = s"""Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor"""
 
-  @Test def testParseLineFoldIMF3() {
+  @Test def testParseLineFoldIMF3(): Unit = {
     val sch = lineFoldLayer3Schema
     val data = ipsumLorem5
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem5Unfolded }</s1></e1>
@@ -359,7 +359,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
 
   val ipsumLorem6Unfolded = s"""Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor"""
 
-  @Test def testUnparseLineFoldIMF3() {
+  @Test def testUnparseLineFoldIMF3(): Unit = {
     val sch = lineFoldLayer3Schema
     val data = ipsumLorem6
     val infoset = <e1 xmlns={ example }><s1>{ ipsumLorem6Unfolded }</s1></e1>
@@ -397,7 +397,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
         </xs:complexType>
       </xs:element>, elementFormDefault = "qualified")
 
-  @Test def testFourByteSwapLayer() {
+  @Test def testFourByteSwapLayer(): Unit = {
     val sch = le32BitSchema
     val data = le32BitData
     val infoset =

--- a/daffodil-core/src/test/scala/org/apache/daffodil/outputValueCalc/TestOutputValueCalcAndAlignment.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/outputValueCalc/TestOutputValueCalcAndAlignment.scala
@@ -42,7 +42,7 @@ class TestOutputValueCalcAndAlignment {
    * Test verifies that if the OVC's length is known, the alignment afterwards
    * works.
    */
-  @Test def testOutputValueCalcAlignmentFixed() {
+  @Test def testOutputValueCalcAlignmentFixed(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" alignmentUnits="bytes" fillByte="X"/>,
@@ -65,7 +65,7 @@ class TestOutputValueCalcAndAlignment {
    * point then the absolute position is known, the alignment can proceed,
    * and the unparsing will complete.
    */
-  @Test def testOutputValueCalcVariableLengthThenAlignment() {
+  @Test def testOutputValueCalcVariableLengthThenAlignment(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" alignmentUnits="bytes" fillByte="X"/>,
@@ -104,7 +104,7 @@ class TestOutputValueCalcAndAlignment {
    *
    * This is supposed to deadlock.
    */
-  @Test def testOutputValueCalcVariableLengthThenAlignmentDeadlock() {
+  @Test def testOutputValueCalcVariableLengthThenAlignmentDeadlock(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" alignmentUnits="bytes" fillByte="X"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/outputValueCalc/TestOutputValueCalcForwardReference.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/outputValueCalc/TestOutputValueCalcForwardReference.scala
@@ -36,7 +36,7 @@ class TestOutputValueCalcForwardReference {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def testOutputValueCalcForwardReference1() {
+  @Test def testOutputValueCalcForwardReference1(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
@@ -53,7 +53,7 @@ class TestOutputValueCalcForwardReference {
     TestUtils.testUnparsing(sch, infoset, "22", areTracing)
   }
 
-  @Test def testOutputValueCalcForwardReference2() {
+  @Test def testOutputValueCalcForwardReference2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes" textTrimKind="padChar" textStringPadCharacter="%SP;"/>,
@@ -71,7 +71,7 @@ class TestOutputValueCalcForwardReference {
     TestUtils.testUnparsing(sch, infoset, "333", areTracing)
   }
 
-  @Test def testOutputValueCalcForwardReference3() {
+  @Test def testOutputValueCalcForwardReference3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
@@ -89,7 +89,7 @@ class TestOutputValueCalcForwardReference {
     TestUtils.testUnparsing(sch, infoset, "222", areTracing)
   }
 
-  @Test def testOutputValueCalcDeadlock() {
+  @Test def testOutputValueCalcDeadlock(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" encoding="ascii" lengthUnits="bytes"/>,
@@ -118,7 +118,7 @@ class TestOutputValueCalcForwardReference {
 
   }
 
-  @Test def testOutputValueCalcConstant() {
+  @Test def testOutputValueCalcConstant(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -135,7 +135,7 @@ class TestOutputValueCalcForwardReference {
     TestUtils.testUnparsing(sch, infoset, "abcdefghij", areTracing)
   }
 
-  @Test def testOutputValueCalcAfterOptional() {
+  @Test def testOutputValueCalcAfterOptional(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,
@@ -153,7 +153,7 @@ class TestOutputValueCalcForwardReference {
     TestUtils.testUnparsing(sch, infoset, "beforeFoo=12345, foo=abcde, afterFoo=67890", areTracing)
   }
 
-  @Test def testMultipleOutputValueCalcAndDefaultablePresent() {
+  @Test def testMultipleOutputValueCalcAndDefaultablePresent(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/runtime1/TestStreamingUnparserCompilerAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/runtime1/TestStreamingUnparserCompilerAttributes.scala
@@ -552,7 +552,7 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:sequence>
     </xs:group>
 
-  @Test def testUnparseHiddenGroupsPresenceFlags6() {
+  @Test def testUnparseHiddenGroupsPresenceFlags6(): Unit = {
     val r = getRoot(
       schemaX,
       topLevels =

--- a/daffodil-core/src/test/scala/org/apache/daffodil/runtime1/TestUnparseHidden.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/runtime1/TestUnparseHidden.scala
@@ -56,7 +56,7 @@ class TestUnparseHidden {
       </xs:sequence>
     </xs:group>
 
-  @Test def testUnparseHiddenGroupsPresenceFlags1() {
+  @Test def testUnparseHiddenGroupsPresenceFlags1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -73,7 +73,7 @@ class TestUnparseHidden {
     TestUtils.testUnparsing(testSchema, infoset, data)
   }
 
-  @Test def testUnparseHiddenGroupsPresenceFlags2() {
+  @Test def testUnparseHiddenGroupsPresenceFlags2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -123,7 +123,7 @@ class TestUnparseHidden {
       </xs:sequence>
     </xs:group>
 
-  @Test def testUnparseHiddenGroupsPresenceFlags3() {
+  @Test def testUnparseHiddenGroupsPresenceFlags3(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -141,7 +141,7 @@ class TestUnparseHidden {
     TestUtils.testUnparsing(testSchema, infoset, data)
   }
 
-  @Test def testUnparseHiddenGroupsPresenceFlags4() {
+  @Test def testUnparseHiddenGroupsPresenceFlags4(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -196,7 +196,7 @@ class TestUnparseHidden {
    * so that element, if present, will be used to select the choice branch, but if absent, the other branch will be
    * used.
    */
-  @Test def testUnparseHiddenGroupsPresenceFlags5a() {
+  @Test def testUnparseHiddenGroupsPresenceFlags5a(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -217,7 +217,7 @@ class TestUnparseHidden {
    * In this test the 'b' element which has dfdl:outputValueCalc is found in the infoset, and so guides the
    * selection of the choice branch. However its value is ignored and recomputed.
    */
-  @Test def testUnparseHiddenGroupsPresenceFlags5b() {
+  @Test def testUnparseHiddenGroupsPresenceFlags5b(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,
@@ -267,7 +267,7 @@ class TestUnparseHidden {
       </xs:sequence>
     </xs:group>
 
-  @Test def testUnparseHiddenGroupsPresenceFlags6() {
+  @Test def testUnparseHiddenGroupsPresenceFlags6(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/schema/annotation/props/TestPropertyRuntime.scala
@@ -46,7 +46,7 @@ class RealObject extends MyPropMixin
 class TestPropertyRuntime {
 
   @Test
-  def testConstructed() {
+  def testConstructed(): Unit = {
     // val myPropUser = new RealObject
     val av = MyProp.allValues
     val pv1 = MyProp.PropVal1
@@ -56,13 +56,13 @@ class TestPropertyRuntime {
   }
 
   @Test
-  def testCanCreateProp() {
+  def testCanCreateProp(): Unit = {
     val propVal1 = MyProp("propVal1")
     assertEquals(MyProp.PropVal1, propVal1)
   }
 
   @Test
-  def testMixin() {
+  def testMixin(): Unit = {
     val m = new HasMixin
     assertTrue(m.initWasCalled)
     m.theExampleProp

--- a/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
@@ -55,7 +55,7 @@ object TestUtils {
   /**
    * Compares two XML Elements, after having (optionally) stripped off all attributes.
    */
-  def assertEqualsXMLElements(expected: Node, actual: Node) {
+  def assertEqualsXMLElements(expected: Node, actual: Node): Unit = {
     XMLUtils.compareAndReport(expected, actual)
   }
 
@@ -129,7 +129,7 @@ object TestUtils {
     actual.getDiagnostics
   }
 
-  def throwDiagnostics(ds: Seq[Diagnostic]) {
+  def throwDiagnostics(ds: Seq[Diagnostic]): Unit = {
     if (ds.length == 1) throw (ds(0))
     else {
       val msgs = ds.map(_.getMessage()).mkString("\n")
@@ -137,7 +137,7 @@ object TestUtils {
     }
   }
 
-  def testUnparsingBinary(testSchema: scala.xml.Elem, infoset: Node, unparseTo: Array[Byte], areTracing: Boolean = false) {
+  def testUnparsingBinary(testSchema: scala.xml.Elem, infoset: Node, unparseTo: Array[Byte], areTracing: Boolean = false): Unit = {
     val compiler = Compiler()
     val pf = compiler.compileNode(testSchema)
     if (pf.isError) throwDiagnostics(pf.diagnostics)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/xml/TestXMLLoaderWithLocation.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.api.URISchemaSource
 
 class TestXMLLoaderWithLocation {
 
-  @Test def testFile1() {
+  @Test def testFile1(): Unit = {
     val tmpXMLFileName = getClass.getName() + ".xml"
     // Our loader looks for xs:schema node, and appends a file attribute
     // if it can.
@@ -47,7 +47,7 @@ class TestXMLLoaderWithLocation {
     }
   }
 
-  @Test def testCatalogResolver() {
+  @Test def testCatalogResolver(): Unit = {
     val baseURI: String = new File(".").toURI().toString
     // val ldr = new DaffodilXMLLoader(BasicErrorHandler)
     val pId: String = null
@@ -58,7 +58,7 @@ class TestXMLLoaderWithLocation {
     // println(resolved)
   }
 
-  @Test def testFileValidation() {
+  @Test def testFileValidation(): Unit = {
     val tmpXMLFileName = getClass.getName() + ".xml"
     // Our loader looks for xs:schema node, and appends a file attribute
     // if it can.

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
@@ -24,7 +24,7 @@ trait DataInputStreamImplMixin extends DataInputStream
   with DataStreamCommonImplMixin
   with LocalBufferMixin {
 
-  override def setDebugging(setting: Boolean) {
+  override def setDebugging(setting: Boolean): Unit = {
     if (bitPos0b > 0) throw new IllegalStateException("Must call before any access to data")
     cst.debugging = setting
   }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
@@ -121,7 +121,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
 
   private var maybeAbsStartingBitPos0b_ : MaybeULong = MaybeULong.Nope
 
-  private def checkInvariants() {
+  private def checkInvariants(): Unit = {
     // nothing right now
   }
 
@@ -163,14 +163,14 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
     Assert.usage(maybeAbsStartingBitPos0b.isDefined)
     maybeAbsStartingBitPos0b.getULong + relBitPos0b
   }
-  def resetAllBitPos() {
+  def resetAllBitPos(): Unit = {
     this.maybeAbsolutizedRelativeStartingBitPosInBits_ = MaybeULong.Nope
     maybeAbsStartingBitPos0b_ = MaybeULong.Nope
     relBitPos0b_ = ULong(0)
     zlStatus_ = ZeroLengthStatus.Unknown
   }
 
-  def setAbsStartingBitPos0b(newStartingBitPos0b: ULong) {
+  def setAbsStartingBitPos0b(newStartingBitPos0b: ULong): Unit = {
     checkInvariants()
     val mv = MaybeULong(newStartingBitPos0b.longValue)
     //
@@ -190,7 +190,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
     checkInvariants()
   }
 
-  protected final def setRelBitPos0b(newRelBitPos0b: ULong) {
+  protected final def setRelBitPos0b(newRelBitPos0b: ULong): Unit = {
     Assert.usage(isWritable)
     checkInvariants()
     relBitPos0b_ = newRelBitPos0b
@@ -292,7 +292,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
   private var fragmentLastByteLimit_ : Int = 0
   def fragmentLastByteLimit = fragmentLastByteLimit_
 
-  def setFragmentLastByte(newFragmentByte: Int, nBitsInUse: Int) {
+  def setFragmentLastByte(newFragmentByte: Int, nBitsInUse: Int): Unit = {
     Assert.usage(nBitsInUse >= 0 && nBitsInUse <= 7)
     Assert.usage(newFragmentByte >= 0 && newFragmentByte <= 255) // no bits above first byte are in use.
     if (nBitsInUse == 0) {
@@ -308,7 +308,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
 
   @inline final def dosState = _dosState
 
-  @inline protected final def setDOSState(newState: DOSState) { _dosState = newState }
+  @inline protected final def setDOSState(newState: DOSState): Unit = { _dosState = newState }
 
   private[io] def isBuffering: Boolean
 
@@ -335,7 +335,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
 
   final protected def cst = this
 
-  protected def assignFrom(other: DataOutputStreamImplMixin) {
+  protected def assignFrom(other: DataOutputStreamImplMixin): Unit = {
     Assert.usage(isWritable)
     super.assignFrom(other)
     this.maybeAbsStartingBitPos0b_ = other.maybeAbsStartingBitPos0b_
@@ -352,7 +352,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
    */
   protected final def realStream = getJavaOutputStream()
 
-  final override def setDebugging(setting: Boolean) {
+  final override def setDebugging(setting: Boolean): Unit = {
     Assert.usage(isWritable)
     if (setting) {
       Assert.usage(!areDebugging)
@@ -1078,7 +1078,7 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
     setMaybeRelBitLimit0b(savedBitLimit0b, true)
   }
 
-  final override def validateFinalStreamState {
+  final override def validateFinalStreamState: Unit = {
     // nothing to validate
   }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommonImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommonImplMixin.scala
@@ -31,7 +31,7 @@ trait DataStreamCommonState {
    */
   private var maybePriorBitOrder_ : Maybe[BitOrder] = Maybe.Nope
 
-  def setPriorBitOrder(pbo: BitOrder) {
+  def setPriorBitOrder(pbo: BitOrder): Unit = {
     maybePriorBitOrder_ = One(pbo)
   }
 
@@ -55,7 +55,7 @@ trait DataStreamCommonState {
   var maybeTrailingSurrogateForUTF8: MaybeChar = MaybeChar.Nope
   var priorBitPos: Long = 0L
 
-  def resetUTF8SurrogatePairCapture {
+  def resetUTF8SurrogatePairCapture: Unit = {
     this.priorBitPos = -1
   }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
@@ -278,7 +278,7 @@ class DirectOrBufferedDataOutputStream private[io] (
     res
   }
 
-  override def setJavaOutputStream(newOutputStream: java.io.OutputStream) {
+  override def setJavaOutputStream(newOutputStream: java.io.OutputStream): Unit = {
     Assert.usage(newOutputStream ne null)
     _javaOutputStream = newOutputStream
     Assert.usage(newOutputStream ne bufferingJOS) // these are born buffering, and evolve into direct.
@@ -381,7 +381,7 @@ class DirectOrBufferedDataOutputStream private[io] (
    * A buffering stream, when preceded by a direct stream, can become a
    * direct stream when the preceding direct stream is finished.
    */
-  private def convertToDirect(oldDirectDOS: ThisType) {
+  private def convertToDirect(oldDirectDOS: ThisType): Unit = {
     Assert.usage(isBuffering)
     Assert.usage(oldDirectDOS.isDirect)
 
@@ -413,7 +413,7 @@ class DirectOrBufferedDataOutputStream private[io] (
     Assert.invariant(isDirect)
   }
 
-  override def setFinished(finfo: FormatInfo) {
+  override def setFinished(finfo: FormatInfo): Unit = {
     Assert.usage(!isFinished)
     // if we are direct, and there's a buffer following this one
     //
@@ -977,7 +977,7 @@ object DirectOrBufferedDataOutputStream {
   private def deliverBufferContent(
     directDOS: DirectOrBufferedDataOutputStream,
     bufDOS: DirectOrBufferedDataOutputStream,
-    finfo: FormatInfo) {
+    finfo: FormatInfo): Unit = {
     Assert.invariant(bufDOS.isBuffering)
     Assert.invariant(!directDOS.isBuffering)
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/Dump.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/Dump.scala
@@ -139,7 +139,7 @@ class DataDumper {
 
   private def textDump(addr: Long, rowStart0b: Int, txtsb: StringBuilder,
     limit0b: Int, endByteAddress0b: Long, byteSource: ByteSource, decoder: Option[JavaCharsetDecoder],
-    textByteWidth: Int) {
+    textByteWidth: Int): Unit = {
     var i = rowStart0b + nPadBytesFromPriorLine
     txtsb ++= paddingFromPriorLine
     while (i <= limit0b) {

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -117,7 +117,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
   @inline
   override final def bitLimit0b: MaybeULong = cst.bitLimit0b
 
-  def setBitPos0b(newBitPos0b: Long) {
+  def setBitPos0b(newBitPos0b: Long): Unit = {
     // threadCheck()
     Assert.invariant(newBitPos0b >= 0)
     Assert.invariant(bitLimit0b.isEmpty || newBitPos0b <= bitLimit0b.get)
@@ -566,11 +566,11 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
   }
 
   override def markPos: MarkPos = bitPos0b
-  override def resetPos(m: MarkPos) {
+  override def resetPos(m: MarkPos): Unit = {
     setBitPos0b(m)
   }
 
-  def validateFinalStreamState {
+  def validateFinalStreamState: Unit = {
     // threadCheck()
     markPool.finalCheck
   }
@@ -742,7 +742,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     ci
   }
 
-  override def setDebugging(setting: Boolean) {
+  override def setDebugging(setting: Boolean): Unit = {
     super.setDebugging(setting)
     inputSource.setDebugging(setting)
   }
@@ -807,7 +807,7 @@ class InputSourceDataInputStreamCharIteratorState {
     bitPositionAtLastFetch0b = 0L
   }
 
-  def assignFrom(other: InputSourceDataInputStreamCharIteratorState) {
+  def assignFrom(other: InputSourceDataInputStreamCharIteratorState): Unit = {
     // We are intentionally not saving/restoring any state here. This is
     // because saving state requires duplicating the long and charbuffers,
     // which is fairly expensive and can use up alot of memory, especially when

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
@@ -38,7 +38,7 @@ final class StringDataInputStreamForUnparse
   var str: String = null
   var dis: DataInputStream = null
 
-  def reset(str: String, finfo: FormatInfo) {
+  def reset(str: String, finfo: FormatInfo): Unit = {
     this.str = str
     // TODO: This only works for Java charsets, we should really use our own
     // encoders to convert the string to bytes and support non-byte-size
@@ -81,5 +81,5 @@ final class StringDataInputStreamForUnparse
   override def isDefinedForLength(length: Long): Boolean = doNotUse
   override def skip(nBits: Long, finfo: FormatInfo): Boolean = doNotUse
   override def resetBitLimit0b(savedBitLimit0b: MaybeULong): Unit = doNotUse
-  override def validateFinalStreamState {} // does nothing
+  override def validateFinalStreamState: Unit = {} // does nothing
 }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/ThreadCheckMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/ThreadCheckMixin.scala
@@ -27,7 +27,7 @@ trait ThreadCheckMixin {
 
   private lazy val myFirstThread = Thread.currentThread()
 
-  protected final def threadCheck() {
+  protected final def threadCheck(): Unit = {
     Assert.invariant(Thread.currentThread eq myFirstThread)
   }
 }

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
@@ -79,7 +79,7 @@ class TestInputStream extends java.io.InputStream {
 // expected
 class TestTestInputStream {
 
-  @Test def testTestInputStream1 {
+  @Test def testTestInputStream1: Unit = {
     val is = new TestInputStream
     var i = 0
     while (i < 100) {
@@ -88,7 +88,7 @@ class TestTestInputStream {
     }
   }
   
-  @Test def testTestInputStream2 {
+  @Test def testTestInputStream2: Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.read(b)
@@ -99,7 +99,7 @@ class TestTestInputStream {
     }
   }
   
-  @Test def testTestInputStream3 {
+  @Test def testTestInputStream3: Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.read(b, 3, 3)
@@ -110,7 +110,7 @@ class TestTestInputStream {
     }
   }
 
-  @Test def testTestInputStream4 {
+  @Test def testTestInputStream4: Unit = {
     val is = new TestInputStream
     is.setEOF(4)
     assertEquals(0, is.read)
@@ -120,7 +120,7 @@ class TestTestInputStream {
     assertEquals(-1, is.read)
   }
   
-  @Test def testTestInputStream5 {
+  @Test def testTestInputStream5: Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.setEOF(4)
@@ -131,7 +131,7 @@ class TestTestInputStream {
 
 class TestBucketingInputSource {
 
-  @Test def testBucketingInputSource1 {
+  @Test def testBucketingInputSource1: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 17)
     var i = 0
@@ -143,7 +143,7 @@ class TestBucketingInputSource {
     }
   }
 
-  @Test def testBucketingInputSource2 {
+  @Test def testBucketingInputSource2: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -162,7 +162,7 @@ class TestBucketingInputSource {
     assertEquals(20, bis.position())
   }
  
-  @Test def testBucketingInputSource3 {
+  @Test def testBucketingInputSource3: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -179,7 +179,7 @@ class TestBucketingInputSource {
     }
   }
 
-  @Test def testBucketingInputSource4 {
+  @Test def testBucketingInputSource4: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(4)
@@ -190,7 +190,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get)
   }
  
-  @Test def testBucketingInputSource5 {
+  @Test def testBucketingInputSource5: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -205,7 +205,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testBucketingInputSource6 {
+  @Test def testBucketingInputSource6: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(17)
@@ -224,7 +224,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get) 
   }
 
-  @Test def testBucketingInputSource7 {
+  @Test def testBucketingInputSource7: Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(17)
@@ -265,7 +265,7 @@ class TestByteBufferInputSource {
                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
-  @Test def testByteBufferInputSource1 {
+  @Test def testByteBufferInputSource1: Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     var i = 0
@@ -278,7 +278,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testByteBufferInputSource2 {
+  @Test def testByteBufferInputSource2: Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -297,7 +297,7 @@ class TestByteBufferInputSource {
     assertEquals(20, bis.position())
   }
 
-  @Test def testByteBufferInputSource3 {
+  @Test def testByteBufferInputSource3: Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -314,7 +314,7 @@ class TestByteBufferInputSource {
     }
   }
 
-  @Test def testByteBufferInputSource4 {
+  @Test def testByteBufferInputSource4: Unit = {
     val bb = ByteBuffer.wrap(data, 0, 4)
     val bis = new ByteBufferInputSource(bb)
     assertEquals(0, bis.get)
@@ -324,7 +324,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
  
-  @Test def testByteBufferInputSource5 {
+  @Test def testByteBufferInputSource5: Unit = {
     val bb = ByteBuffer.wrap(data, 0, 4)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -338,7 +338,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testByteBufferInputSource6 {
+  @Test def testByteBufferInputSource6: Unit = {
     val bb = ByteBuffer.wrap(data, 0, 17)
     val bis = new ByteBufferInputSource(bb)
     var i = 0
@@ -356,7 +356,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get) 
   }
 
-  @Test def testByteBufferInputSource7 {
+  @Test def testByteBufferInputSource7: Unit = {
     val bb = ByteBuffer.wrap(data, 0, 17)
     val bis = new ByteBufferInputSource(bb)
     var i = 0

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
@@ -34,7 +34,7 @@ class TestDataOutputStream {
     os
   }
 
-  @Test def testPutLongDirect1_BE_MSBF {
+  @Test def testPutLongDirect1_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -52,7 +52,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect1Bit_BE_MSBF {
+  @Test def testPutLongDirect1Bit_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -69,7 +69,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect2Bit_BE_MSBF {
+  @Test def testPutLongDirect2Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -85,7 +85,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect7Bit_BE_MSBF {
+  @Test def testPutLongDirect7Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -101,7 +101,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect8Bit_BE_MSBF {
+  @Test def testPutLongDirect8Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -117,7 +117,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect9Bit_BE_MSBF {
+  @Test def testPutLongDirect9Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -134,7 +134,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect63Bit_BE_MSBF {
+  @Test def testPutLongDirect63Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -157,7 +157,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect64Bit_BE_MSBF {
+  @Test def testPutLongDirect64Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -184,7 +184,7 @@ class TestDataOutputStream {
   // Tests of Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongBuffered1_BE_MSBF {
+  @Test def testPutLongBuffered1_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -207,7 +207,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered1Bit_BE_MSBF {
+  @Test def testPutLongBuffered1Bit_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -227,7 +227,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered2Bit_BE_MSBF {
+  @Test def testPutLongBuffered2Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -246,7 +246,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered7Bit_BE_MSBF {
+  @Test def testPutLongBuffered7Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -265,7 +265,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered8Bit_BE_MSBF {
+  @Test def testPutLongBuffered8Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     direct.setPriorBitOrder(BitOrder.MostSignificantBitFirst)
@@ -285,7 +285,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered9Bit_BE_MSBF {
+  @Test def testPutLongBuffered9Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -305,7 +305,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered63Bit_BE_MSBF {
+  @Test def testPutLongBuffered63Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -331,7 +331,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered64Bit_BE_MSBF {
+  @Test def testPutLongBuffered64Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -361,7 +361,7 @@ class TestDataOutputStream {
   // Tests of Direct + Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongDirectAndBuffered1_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered1_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -389,7 +389,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered1Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered1Bit_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -410,7 +410,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered2Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered2Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -430,7 +430,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered7Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered7Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -451,7 +451,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered8Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered8Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -472,7 +472,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered9Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered9Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -494,7 +494,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -521,7 +521,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -557,7 +557,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_BE_MSBF {
+  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_BE_MSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -593,7 +593,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLong5_4Bits_BE_MSBF {
+  @Test def testPutLong5_4Bits_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
@@ -31,7 +31,7 @@ class TestDataOutputStream2 {
    * BitBuffer tests
    */
 
-  @Test def testPutBitBufferDirect0_BE_MSBF {
+  @Test def testPutBitBufferDirect0_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)
@@ -51,7 +51,7 @@ class TestDataOutputStream2 {
 
   }
 
-  @Test def testPutBitBufferDirect1_BE_MSBF {
+  @Test def testPutBitBufferDirect1_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)
@@ -71,7 +71,7 @@ class TestDataOutputStream2 {
 
   }
 
-  @Test def testPutBitBufferDirect7_BE_MSBF {
+  @Test def testPutBitBufferDirect7_BE_MSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
@@ -37,7 +37,7 @@ class TestDataOutputStream3 {
     os
   }
 
-  @Test def testPutLongDirect1_LE_LSBF {
+  @Test def testPutLongDirect1_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -55,7 +55,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect1Bit_LE_LSBF {
+  @Test def testPutLongDirect1Bit_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -72,7 +72,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect2Bit_LE_LSBF {
+  @Test def testPutLongDirect2Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -88,7 +88,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect7Bit_LE_LSBF {
+  @Test def testPutLongDirect7Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -104,7 +104,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect8Bit_LE_LSBF {
+  @Test def testPutLongDirect8Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -120,7 +120,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect9Bit_LE_LSBF {
+  @Test def testPutLongDirect9Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -137,7 +137,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect63Bit_LE_LSBF {
+  @Test def testPutLongDirect63Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -160,7 +160,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect64Bit_LE_LSBF {
+  @Test def testPutLongDirect64Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -187,7 +187,7 @@ class TestDataOutputStream3 {
   // Tests of Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongBuffered1_LE_LSBF {
+  @Test def testPutLongBuffered1_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -209,7 +209,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered1Bit_LE_LSBF {
+  @Test def testPutLongBuffered1Bit_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -228,7 +228,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered2Bit_LE_LSBF {
+  @Test def testPutLongBuffered2Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -246,7 +246,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered7Bit_LE_LSBF {
+  @Test def testPutLongBuffered7Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -264,7 +264,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered8Bit_LE_LSBF {
+  @Test def testPutLongBuffered8Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -282,7 +282,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered9Bit_LE_LSBF {
+  @Test def testPutLongBuffered9Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -301,7 +301,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered63Bit_LE_LSBF {
+  @Test def testPutLongBuffered63Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -326,7 +326,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered64Bit_LE_LSBF {
+  @Test def testPutLongBuffered64Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -355,7 +355,7 @@ class TestDataOutputStream3 {
   // Tests of Direct + Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongDirectAndBuffered1_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered1_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -382,7 +382,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered1Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered1Bit_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
@@ -402,7 +402,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered2Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered2Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -421,7 +421,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered7Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered7Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     direct.setPriorBitOrder(BitOrder.LeastSignificantBitFirst)
@@ -442,7 +442,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered8Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered8Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -462,7 +462,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered9Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered9Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -483,7 +483,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -509,7 +509,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -544,7 +544,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_LE_LSBF {
+  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_LE_LSBF: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -579,7 +579,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLong5_4Bits_LE_LSBF {
+  @Test def testPutLong5_4Bits_LE_LSBF: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
@@ -76,7 +76,7 @@ class TestDataOutputStream4 {
     assertEquals(0x80.toByte, buf(7))
   }
 
-  @Test def testPutLong19FinishInOrderAbs {
+  @Test def testPutLong19FinishInOrderAbs: Unit = {
     val (baos, direct, out, out2) = setup()
 
     direct.setFinished(finfo)
@@ -87,7 +87,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder1Abs {
+  @Test def testPutLong19FinishOutOfOrder1Abs: Unit = {
     val (baos, direct, out, out2) = setup()
 
     out.setFinished(finfo)
@@ -98,7 +98,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder2Abs {
+  @Test def testPutLong19FinishOutOfOrder2Abs: Unit = {
     val (baos, direct, out, out2) = setup()
 
     out2.setFinished(finfo)
@@ -109,7 +109,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder3Abs {
+  @Test def testPutLong19FinishOutOfOrder3Abs: Unit = {
     val (baos, direct, out, out2) = setup()
 
     out2.setFinished(finfo)
@@ -120,7 +120,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishInOrder {
+  @Test def testPutLong19FinishInOrder: Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     direct.setFinished(finfo)
@@ -131,7 +131,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder1 {
+  @Test def testPutLong19FinishOutOfOrder1: Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out.setFinished(finfo)
@@ -142,7 +142,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder2 {
+  @Test def testPutLong19FinishOutOfOrder2: Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out2.setFinished(finfo)
@@ -153,7 +153,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder3 {
+  @Test def testPutLong19FinishOutOfOrder3: Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out2.setFinished(finfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDecoder.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDecoder.scala
@@ -65,7 +65,7 @@ class TestDecoder {
    * It seems they don't check for the decode error until after they've
    * checked for enough room for a surrogate pair.
    */
-  @Test def testDecoder1 {
+  @Test def testDecoder1: Unit = {
     val originalDecoder = JavaCharset.forName("utf-8").newDecoder()
     originalDecoder.onMalformedInput(CodingErrorAction.REPORT)
     originalDecoder.onUnmappableCharacter(CodingErrorAction.REPORT)
@@ -132,7 +132,7 @@ class TestDecoder {
     assertEquals(0, bb.position())
   }
 
-  @Test def testDecoderWorkaround1 {
+  @Test def testDecoderWorkaround1: Unit = {
     val originalDecoder = JavaCharset.forName("utf-8").newDecoder()
     originalDecoder.onMalformedInput(CodingErrorAction.REPORT)
     originalDecoder.onUnmappableCharacter(CodingErrorAction.REPORT)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
@@ -47,7 +47,7 @@ class TestDirectOrBufferedDataOutputStream {
    * Tests that the toString method doesn't throw. Can't even use a debugger
    * if that happens.
    */
-  @Test def testToStringDoesNotThrow {
+  @Test def testToStringDoesNotThrow: Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
     assertFalse(layered.toString().isEmpty())
@@ -55,7 +55,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   val finfo = FormatInfoForUnitTest()
 
-  @Test def testCollapsingBufferIntoDirect1 {
+  @Test def testCollapsingBufferIntoDirect1: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
@@ -82,7 +82,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   }
 
-  @Test def testCollapsingFinishedBufferIntoLayered {
+  @Test def testCollapsingFinishedBufferIntoLayered: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
@@ -111,7 +111,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   }
 
-  @Test def testCollapsingTwoBuffersIntoDirect {
+  @Test def testCollapsingTwoBuffersIntoDirect: Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDump.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDump.scala
@@ -39,7 +39,7 @@ class TestDump {
     }
   }
 
-  @Test def testDumpHexAndText1() {
+  @Test def testDumpHexAndText1(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
@@ -56,7 +56,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText1a() {
+  @Test def testDumpHexAndText1a(): Unit = {
 
     val dateString = "Date 年月日=2003年08月27日"
     val dateStringLengthInBytes = dateString.getBytes("utf-8").length
@@ -81,7 +81,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText1WithIndicator1() {
+  @Test def testDumpHexAndText1WithIndicator1(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
@@ -100,7 +100,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText1WithIndicator2() {
+  @Test def testDumpHexAndText1WithIndicator2(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
@@ -119,7 +119,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText2() {
+  @Test def testDumpHexAndText2(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-32BE")
     val lengthInBits = bytes.length * 8
@@ -138,7 +138,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText2WithIndicator1() {
+  @Test def testDumpHexAndText2WithIndicator1(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-32BE")
     val lengthInBits = bytes.length * 8
@@ -159,7 +159,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText2WithIndicator2() {
+  @Test def testDumpHexAndText2WithIndicator2(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-32BE")
     val lengthInBits = bytes.length * 8
@@ -180,7 +180,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText3() {
+  @Test def testDumpHexAndText3(): Unit = {
 
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-16LE")
     val lengthInBits = bytes.length * 8
@@ -197,7 +197,7 @@ class TestDump {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpHexAndText4() {
+  @Test def testDumpHexAndText4(): Unit = {
 
     val bytes =
       """da8b f090 a487 f48b be8b be7a 1234 4567 f48b 8018 0156
@@ -223,7 +223,7 @@ dada 0000 0101 0817 ece2 8017 ece2 dead beef cc7a 1234
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDump1() {
+  @Test def testDump1(): Unit = {
 
     val bs = new BS((0 to 255).map { _.toByte }.toArray)
 
@@ -250,7 +250,7 @@ dada 0000 0101 0817 ece2 8017 ece2 dead beef cc7a 1234
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDump2() {
+  @Test def testDump2(): Unit = {
 
     val bs = new BS((0 to 255).map { _.toByte }.toArray)
 
@@ -279,7 +279,7 @@ dada 0000 0101 0817 ece2 8017 ece2 dead beef cc7a 1234
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDump3() {
+  @Test def testDump3(): Unit = {
 
     val bs = new BS((0 to 255).map { _.toByte }.toArray)
 
@@ -304,7 +304,7 @@ dada 0000 0101 0817 ece2 8017 ece2 dead beef cc7a 1234
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDump4() {
+  @Test def testDump4(): Unit = {
 
     val bs = new BS((0 to 255).map { _.toByte }.toArray)
 
@@ -316,7 +316,7 @@ dada 0000 0101 0817 ece2 8017 ece2 dead beef cc7a 1234
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpLSBFirst1() {
+  @Test def testDumpLSBFirst1(): Unit = {
 
     val bs = new BS((0 to 255).map { _.toByte }.toArray)
 
@@ -328,7 +328,7 @@ fedcba9876543210  ffee ddcc bbaa 9988 7766 5544 3322 1100  87654321
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpLSBFirst2() {
+  @Test def testDumpLSBFirst2(): Unit = {
 
     val bytes: Array[Byte] =
       """E4 67 00 80 55
@@ -348,7 +348,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def testDumpTextLine1() {
+  @Test def testDumpTextLine1(): Unit = {
     val data = (0 to 255).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -359,7 +359,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine2() {
+  @Test def testDumpTextLine2(): Unit = {
     val data = (0 to 255).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -375,7 +375,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine3() {
+  @Test def testDumpTextLine3(): Unit = {
     val data = (32 to 255).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -402,7 +402,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine4() {
+  @Test def testDumpTextLine4(): Unit = {
     val data = (32 to 63).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -426,7 +426,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine5() {
+  @Test def testDumpTextLine5(): Unit = {
     val data = (32 to 63).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -446,7 +446,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine6() {
+  @Test def testDumpTextLine6(): Unit = {
     val data = (32 to 63).map { _.toByte }.toArray
     val bs = new BS(data)
     val lengthInbits = data.length * 8
@@ -461,7 +461,7 @@ cø€␀␀␀wü␚’gU€␀gä  63f8 8000 0000 77fc 1a92 6755 8000 67e4 :00
     assertEquals(expected, dumpString)
   }
 
-  @Test def testDumpTextLine7() {
+  @Test def testDumpTextLine7(): Unit = {
     val data = """da8b f090 a487 f48b be8b be7a 1234
       4567 f48b 8018 0156 dada
       0000 0101 0817 dead beef cc7a"""

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestFastAsciiConvert.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestFastAsciiConvert.scala
@@ -25,21 +25,21 @@ class TestFastAsciiConvert {
 
   val cvt = FastAsciiToUnicodeConverter
 
-  @Test def testConvertByte1() {
+  @Test def testConvertByte1(): Unit = {
     assertEquals(cvt.UnicodeReplacementCharacter, cvt.convertByte(-1.toByte))
     assertEquals(0.toChar, cvt.convertByte(0.toByte))
     assertEquals(127.toChar, cvt.convertByte(127.toByte))
     assertEquals(cvt.UnicodeReplacementCharacter, cvt.convertByte(128.toByte))
   }
 
-  @Test def testConvertInt1() {
+  @Test def testConvertInt1(): Unit = {
     assertEquals(cvt.UnicodeReplacementCharacter, cvt.convertInt(-1.toByte))
     assertEquals(0.toChar, cvt.convertInt(0.toByte))
     assertEquals(127.toChar, cvt.convertInt(127.toByte))
     assertEquals(cvt.UnicodeReplacementCharacter, cvt.convertInt(128.toByte))
   }
 
-  @Test def testConvertLong1() {
+  @Test def testConvertLong1(): Unit = {
     assertEquals(0xFFFDFFFDFFFDFFFDL, cvt.convertLong(-1))
     assertEquals(0x0L, cvt.convertLong(0))
     assertEquals(0xFFFDL, cvt.convertLong(128))
@@ -49,7 +49,7 @@ class TestFastAsciiConvert {
     assertEquals(0x002c002c002c002cL, cvt.convertLong(0x2c2c2c2c))
   }
 
-  @Test def testConvert1() {
+  @Test def testConvert1(): Unit = {
     val data = "abcdefg".toList.map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(data)
     val cb = cvt.convert(bb)
@@ -57,7 +57,7 @@ class TestFastAsciiConvert {
     assertEquals("abcdefg", str)
   }
 
-  @Test def testConvert2() {
+  @Test def testConvert2(): Unit = {
     val data = "12345678abcdefg".toList.map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(data)
     val cb = cvt.convert(bb)
@@ -65,7 +65,7 @@ class TestFastAsciiConvert {
     assertEquals("12345678abcdefg", str)
   }
 
-  @Test def testConvert2a() {
+  @Test def testConvert2a(): Unit = {
     val data = "12345678a".toList.map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(data)
     val cb = cvt.convert(bb)
@@ -73,7 +73,7 @@ class TestFastAsciiConvert {
     assertEquals("12345678a", str)
   }
 
-  @Test def testConvert3() {
+  @Test def testConvert3(): Unit = {
     val data = "\u00802345\u007F78abcdefg".toList.map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(data)
     val cb = cvt.convert(bb)
@@ -81,7 +81,7 @@ class TestFastAsciiConvert {
     assertEquals("\uFFFD2345\u007F78abcdefg", str)
   }
 
-  @Test def testConvert4() {
+  @Test def testConvert4(): Unit = {
     val data = "\u00802345\u007F78\u00802345\u007F78abcdefg".toList.map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(data)
     val cb = cvt.convert(bb)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestISO8859_1.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestISO8859_1.scala
@@ -46,7 +46,7 @@ class TestISO8859_1 {
    * non-whitespace glyph. That transformation does NOT preserve the 256 codepoint values. E.g., all the
    * CO Control characters are mapped to the Unicode CO Control "picture" characters.
    */
-  @Test def test_ISO_8859_1_has256CodepointsIsomorphicToUnicodeCodepointsU0000toU00FF() {
+  @Test def test_ISO_8859_1_has256CodepointsIsomorphicToUnicodeCodepointsU0000toU00FF(): Unit = {
     val byteArray = (0 to 255).map { _.toByte }.toArray
     val bb = ByteBuffer.wrap(byteArray)
     val cs = Charset.forName("iso-8859-1")

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -62,7 +62,7 @@ class TestInputSourceDataInputStream {
   def assertEqualsTyped(expected: Float, actual: Float, threshold: Float) = assertEquals(expected, actual, threshold)
   def assertEqualsTyped(expected: Double, actual: Double, threshold: Double) = assertEquals(expected, actual, threshold)
 
-  @Test def testBitAndBytePos0 {
+  @Test def testBitAndBytePos0: Unit = {
     val dis = InputSourceDataInputStream(ten)
     0L assertEqualsTyped (dis.bitPos0b)
     false assertEqualsTyped (dis.bitLimit0b.isDefined)
@@ -71,7 +71,7 @@ class TestInputSourceDataInputStream {
     0L assertEqualsTyped (dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePos1 {
+  @Test def testBitAndBytePos1: Unit = {
     val dis = InputSourceDataInputStream(ten)
     val arr = dis.getByteArray(8, finfo)
     assertEqualsTyped[Long](1, arr.size)
@@ -83,7 +83,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](1, dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePos10 {
+  @Test def testBitAndBytePos10: Unit = {
     val dis = InputSourceDataInputStream(ten)
     val arr = dis.getByteArray(80, finfo)
     assertEqualsTyped[Long](10, arr.size)
@@ -95,7 +95,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePosNotEnoughData1 {
+  @Test def testBitAndBytePosNotEnoughData1: Unit = {
     val dis = InputSourceDataInputStream(ten)
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getByteArray(81, finfo)
@@ -104,7 +104,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Boolean](false, dis.bitLimit0b.isDefined)
   }
 
-  @Test def testBitAndBytePosMoreThanEnoughData1 {
+  @Test def testBitAndBytePosMoreThanEnoughData1: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val arr = dis.getByteArray(80, finfo)
     assertEqualsTyped[Long](10, arr.size)
@@ -114,7 +114,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBitLengthLimit1 {
+  @Test def testBitLengthLimit1: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     assertEqualsTyped[Boolean](false, dis.bitLimit0b.isDefined)
     val isLimitOk = dis.withBitLengthLimit(80) {
@@ -130,7 +130,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBinaryDouble1 {
+  @Test def testBinaryDouble1: Unit = {
     val dis = InputSourceDataInputStream("123".getBytes("utf-8"))
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getBinaryDouble(finfo)
@@ -138,14 +138,14 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0, dis.bitPos0b)
   }
 
-  @Test def testBinaryDouble2 {
+  @Test def testBinaryDouble2: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val expected = ByteBuffer.wrap(twenty).asDoubleBuffer().get()
     val d = dis.getBinaryDouble(finfo)
     assertEqualsTyped(expected, d, 0.0)
   }
 
-  @Test def testBinaryDouble3 {
+  @Test def testBinaryDouble3: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(63)) // not enough bits
     intercept[DataInputStream.NotEnoughDataException] {
@@ -153,7 +153,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryDouble4 {
+  @Test def testBinaryDouble4: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.getByteArray(8, finfo)
     dis.setBitLimit1b(MaybeULong(71)) // not enough bits
@@ -162,7 +162,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryFloat1 {
+  @Test def testBinaryFloat1: Unit = {
     val dis = InputSourceDataInputStream("123".getBytes("utf-8"))
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getBinaryFloat(finfo)
@@ -170,14 +170,14 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0, dis.bitPos0b)
   }
 
-  @Test def testBinaryFloat2 {
+  @Test def testBinaryFloat2: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val expected = ByteBuffer.wrap(twenty).asFloatBuffer().get()
     val d = dis.getBinaryFloat(finfo)
     assertEqualsTyped(expected, d, 0.0)
   }
 
-  @Test def testBinaryFloat3 {
+  @Test def testBinaryFloat3: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(31)) // not enough bits
     assertFalse(dis.isDefinedForLength(32))
@@ -186,7 +186,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryFloat4 {
+  @Test def testBinaryFloat4: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.getByteArray(8, finfo)
     dis.setBitLimit1b(MaybeULong(39)) // not enough bits
@@ -196,7 +196,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong1 {
+  @Test def testSignedLong1: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(1)) // 1b so 1 means no data
     intercept[DataInputStream.NotEnoughDataException] {
@@ -204,7 +204,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong2 {
+  @Test def testSignedLong2: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(63))
     intercept[DataInputStream.NotEnoughDataException] {
@@ -212,7 +212,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong3 {
+  @Test def testSignedLong3: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     // buffer has 0x3132 in first 16 bits
     // binary that is 00110001 00110010
@@ -225,7 +225,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bitPos0b)
   }
 
-  @Test def testSignedLong4 {
+  @Test def testSignedLong4: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -234,7 +234,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0x3132333435363738L << 1, ml)
   }
 
-  @Test def testSignedLong5 {
+  @Test def testSignedLong5: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xC0).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -244,7 +244,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long]((0xC1C2C3C4C5C6C7C8L << 1) + (0xC9 >>> 7), ml)
   }
 
-  @Test def testSignedLong6 {
+  @Test def testSignedLong6: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xC0).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -255,7 +255,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expected, ml)
   }
 
-  @Test def testSignedLong7 {
+  @Test def testSignedLong7: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(2, finfo)
     assertEqualsTyped[Long](2, dis.bitPos0b)
@@ -266,7 +266,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expected, ml)
   }
 
-  @Test def testUnsignedLong1 {
+  @Test def testUnsignedLong1: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getUnsignedLong(32, finfo)
     assertEqualsTyped[Long](32, dis.bitPos0b)
@@ -274,7 +274,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testUnsignedLong2 {
+  @Test def testUnsignedLong2: Unit = {
     val dis = InputSourceDataInputStream(List(0xA5, 0xA5, 0xA5, 0xA5, 0xA5).map { _.toByte }.toArray)
     dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -284,7 +284,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testUnsignedLong3 {
+  @Test def testUnsignedLong3: Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getUnsignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -292,7 +292,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testSignedBigInt1 {
+  @Test def testSignedBigInt1: Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -300,7 +300,7 @@ class TestInputSourceDataInputStream {
     assertTrue(expected =:= ml)
   }
 
-  @Test def testSignedBigInt2 {
+  @Test def testSignedBigInt2: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(40, finfo)
     assertEqualsTyped[Long](40, dis.bitPos0b)
@@ -308,7 +308,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt1 {
+  @Test def testUnsignedBigInt1: Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(2, finfo)
     assertEqualsTyped(2, dis.bitPos0b)
@@ -316,7 +316,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt2 {
+  @Test def testUnsignedBigInt2: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(40, finfo)
     assertEqualsTyped(40, dis.bitPos0b)
@@ -324,7 +324,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt3 {
+  @Test def testUnsignedBigInt3: Unit = {
     val dat = "7766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
     val dats = dat.sliding(2, 2).toList.flatMap { Misc.hex2Bytes(_) }.toArray
     val dis = InputSourceDataInputStream(dats)
@@ -338,7 +338,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[String](expectedHex, actualHex)
   }
 
-  @Test def testUnsignedBigInt4 {
+  @Test def testUnsignedBigInt4: Unit = {
     val expectedHex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
     assertEqualsTyped(720, expectedHex.length)
     val expected = new JBigInt(expectedHex, 16)
@@ -364,7 +364,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[String](expectedHexNoLeadingZeros, actualHex)
   }
 
-  @Test def testAlignAndSkip1 {
+  @Test def testAlignAndSkip1: Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     assertTrue(dis.isAligned(1))
     assertTrue(dis.isAligned(43))
@@ -377,7 +377,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](7, dis.bitPos0b)
   }
 
-  @Test def testGetSomeString1 {
+  @Test def testGetSomeString1: Unit = {
     val dis = InputSourceDataInputStream("1".getBytes())
     val ms = dis.getSomeString(1, finfo)
     assertTrue(ms.isDefined)
@@ -387,7 +387,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Char]('1', s(0))
   }
 
-  @Test def testGetSomeString2 {
+  @Test def testGetSomeString2: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     val ms = dis.getSomeString(3, finfo)
     assertTrue(ms.isDefined)
@@ -399,7 +399,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](72, dis.bitPos0b)
   }
 
-  @Test def testgetSomeString3 {
+  @Test def testgetSomeString3: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong(8 * 6))
     val ms = dis.getSomeString(3, finfo)
@@ -413,7 +413,7 @@ class TestInputSourceDataInputStream {
 
   def unicodeReplacementCharacter = '\uFFFD'
 
-  @Test def testGetSomeStringErrors1 {
+  @Test def testGetSomeStringErrors1: Unit = {
     val data = List(0xFF.toByte).toArray ++ "年月日".getBytes("utf-8")
     assertEqualsTyped(10, data.length)
     val dis = InputSourceDataInputStream(data)
@@ -430,7 +430,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](80, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringErrors2 {
+  @Test def testGetSomeStringErrors2: Unit = {
     val badByte = List(0xFF.toByte).toArray
     val data = "abc".getBytes("utf-8") ++ badByte ++ "123".getBytes("utf-8") ++ badByte ++ badByte ++ "drm".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
@@ -460,7 +460,7 @@ class TestInputSourceDataInputStream {
   }
   */
 
-  @Test def testCharIterator1 {
+  @Test def testCharIterator1: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(finfo)
@@ -502,7 +502,7 @@ class TestInputSourceDataInputStream {
   }
   */
 
-  @Test def testLookingAt1 {
+  @Test def testLookingAt1: Unit = {
     val data = "abc".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
     val pattern = Pattern.compile("a")
@@ -519,7 +519,7 @@ class TestInputSourceDataInputStream {
    * Illustrates that you cannot restart a match that is
    * partway through the regex.
    */
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd1 {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd1: Unit = {
     val pat = Pattern.compile("a*")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaaaa")
@@ -548,7 +548,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](1, end)
   }
 
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2 {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2: Unit = {
     val pat = Pattern.compile("a*b")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaab")
@@ -586,7 +586,7 @@ class TestInputSourceDataInputStream {
    * the nBytesConsumed by the fillCharBuffer gives the right
    * length.
    */
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2a {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2a: Unit = {
     val pat = Pattern.compile("aaa*b")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaab")
@@ -609,7 +609,7 @@ class TestInputSourceDataInputStream {
     assertTrue(!hitEnd)
   }
 
-  @Test def testLookingAt2 {
+  @Test def testLookingAt2: Unit = {
     val data = "abc".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
     val pattern = Pattern.compile("a*b+c")
@@ -622,7 +622,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](24, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError1 {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError1: Unit = {
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes("utf-8")
     val badByte = List(0xFF.toByte).toArray
@@ -641,7 +641,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](data.length * 8, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError2 {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError2: Unit = {
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes("utf-8")
     val badByte = List(0xFF.toByte).toArray
@@ -661,7 +661,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expectedByteLength * 8, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError3 {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError3: Unit = {
     val enc = "utf-16BE"
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes(enc)
@@ -684,7 +684,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expectedByteLength * 8, dis.bitPos0b)
   }
 
-  @Test def testDotMatchesNewline1 {
+  @Test def testDotMatchesNewline1: Unit = {
     // val enc = "iso-8859-1"
     val dataURI = Misc.getRequiredResource("iso8859.doc.dat")
     val dataInput = dataURI.toURL.openStream()

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
@@ -30,7 +30,7 @@ class TestInputSourceDataInputStream2 {
   val twenty = twentyDigits.getBytes("utf-8")
   val finfo = FormatInfoForUnitTest()
 
-  @Test def testMark1 {
+  @Test def testMark1: Unit = {
     val dis = InputSourceDataInputStream(ten)
     val m1 = dis.mark("testMark1")
     var arr = dis.getByteArray(80, finfo)
@@ -52,7 +52,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(10, dis.bytePos0b)
   }
 
-  @Test def testMark2 {
+  @Test def testMark2: Unit = {
     val dis = InputSourceDataInputStream(twenty)
     var m1: DataInputStream.Mark = null
     dis.withBitLengthLimit(5 * 8) {
@@ -86,7 +86,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(10, dis.bytePos0b)
   }
 
-  @Test def testMark3 {
+  @Test def testMark3: Unit = {
     val dis = InputSourceDataInputStream(twenty).asInstanceOf[InputSourceDataInputStream]
     dis.setBitLimit0b(MaybeULong(5 * 8))
     var arr = dis.getByteArray(5 * 8, finfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3.scala
@@ -24,7 +24,7 @@ class TestInputSourceDataInputStream3 {
 
   val Dump = new DataDumper
 
-  @Test def dumpVisible1 {
+  @Test def dumpVisible1: Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)
@@ -42,7 +42,7 @@ class TestInputSourceDataInputStream3 {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def dumpVisible2 {
+  @Test def dumpVisible2: Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)
@@ -61,7 +61,7 @@ class TestInputSourceDataInputStream3 {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def dumpVisible3 {
+  @Test def dumpVisible3: Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3Bit.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3Bit.scala
@@ -111,7 +111,7 @@ class TestInputSourceDataInputStream3Bit {
   /*
    * Tests of unaligned char buffers (ie., 3-bit characters)
    */
-  @Test def testGetSomeStringOne3BitChar {
+  @Test def testGetSomeStringOne3BitChar: Unit = {
     val dis = InputSourceDataInputStream(BitsBitte.enc("01234567"))
     val cs = BitsCharsetOctalLSBF
     val finfo = FormatInfoForUnitTest()
@@ -125,7 +125,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals('0', s(0))
   }
 
-  @Test def testGetSomeString3BitString {
+  @Test def testGetSomeString3BitString: Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val dis = InputSourceDataInputStream(BitsBitte.enc(dat))
@@ -140,7 +140,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(dat, s)
   }
 
-  @Test def testGetSomeString3BitStringOffBy2 {
+  @Test def testGetSomeString3BitStringOffBy2: Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("11"), BitsBitte.encode3(dat)))
@@ -157,7 +157,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(2 + (cs.bitWidthOfACodeUnit * 8), dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte {
+  @Test def testGetSomeStringDataEndsMidByte: Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("11"), BitsBitte.encode3(dat)))
@@ -184,7 +184,7 @@ class TestInputSourceDataInputStream3Bit {
    * able to fetch another byte of source data (aka an "underflow"), yet there actually
    * are sufficient bits without that byte to decode a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte2 {
+  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("1"), BitsBitte.encode3(dat)))
@@ -207,7 +207,7 @@ class TestInputSourceDataInputStream3Bit {
    * enough bits to finish a character.
    */
 
-  @Test def testGetSomeStringrDataEndsMidByte3 {
+  @Test def testGetSomeStringrDataEndsMidByte3: Unit = {
     val dat = "56701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.encode3(dat)))
@@ -224,7 +224,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(3, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3a {
+  @Test def testGetSomeStringDataEndsMidByte3a: Unit = {
     val dat = "77756701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.encode3(dat)))
@@ -241,7 +241,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(12, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3b {
+  @Test def testGetSomeStringDataEndsMidByte3b: Unit = {
     val dat = "56701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("1"), BitsBitte.encode3(dat)))
@@ -270,7 +270,7 @@ class TestInputSourceDataInputStream3Bit {
    *
    * Also shows that hasNext() doesn't ever move the bitPos.
    */
-  @Test def testCharIteratorWithInterruptingBitSkips1 {
+  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
     val dis = InputSourceDataInputStream(BitsBitte.enc("01234567"))
     val cs = BitsCharsetOctalLSBF
     val finfo = FormatInfoForUnitTest()
@@ -299,7 +299,7 @@ class TestInputSourceDataInputStream3Bit {
     assertFalse(iter.hasNext)
   }
 
-  @Test def test3BitEncoderOverflowError {
+  @Test def test3BitEncoderOverflowError: Unit = {
     val encoder = BitsCharsetOctalLSBF.newEncoder
     val bb = ByteBuffer.allocate(1) // only big enough for a single byte
     val cb = CharBuffer.wrap("123") // 3 octal digits will cause overflow
@@ -307,7 +307,7 @@ class TestInputSourceDataInputStream3Bit {
     assertTrue(coderResult == CoderResult.OVERFLOW)
   }
 
-  @Test def test3BitEncoderMalformedError {
+  @Test def test3BitEncoderMalformedError: Unit = {
     val encoder = BitsCharsetOctalLSBF.newEncoder
     val bb = ByteBuffer.allocate(3)
     val cb = CharBuffer.wrap("12?") // ? is not encodable in octal

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream4.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream4.scala
@@ -27,7 +27,7 @@ class TestInputSourceDataInputStream4 {
   val leFinfo = FormatInfoForUnitTest()
   leFinfo.byteOrder = ByteOrder.LittleEndian
 
-  @Test def testLittleEndianFloat1() {
+  @Test def testLittleEndianFloat1(): Unit = {
     val bb = ByteBuffer.allocate(4)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asFloatBuffer()
@@ -42,7 +42,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(32, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianDouble1() {
+  @Test def testLittleEndianDouble1(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asDoubleBuffer()
@@ -56,7 +56,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong1() {
+  @Test def testLittleEndianLong1(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -70,7 +70,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong2() {
+  @Test def testLittleEndianLong2(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -84,7 +84,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(32, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong3() {
+  @Test def testLittleEndianLong3(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -98,7 +98,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong4() {
+  @Test def testLittleEndianLong4(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -112,7 +112,7 @@ class TestInputSourceDataInputStream4 {
     assertEquals(32, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong5() {
+  @Test def testLittleEndianLong5(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.BIG_ENDIAN)
     val fb = bb.asLongBuffer()

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream5.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream5.scala
@@ -28,7 +28,7 @@ class TestInputSourceDataInputStream5 {
   leFinfo.byteOrder = ByteOrder.LittleEndian
   leFinfo.bitOrder = BitOrder.LeastSignificantBitFirst
 
-  @Test def testLittleEndianLSBFirstLong1() {
+  @Test def testLittleEndianLSBFirstLong1(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -42,7 +42,7 @@ class TestInputSourceDataInputStream5 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLSBFirstLong2() {
+  @Test def testLittleEndianLSBFirstLong2(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -56,7 +56,7 @@ class TestInputSourceDataInputStream5 {
     assertEquals(32, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLSBFirstLong3() {
+  @Test def testLittleEndianLSBFirstLong3(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -70,7 +70,7 @@ class TestInputSourceDataInputStream5 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong4() {
+  @Test def testLittleEndianLong4(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -84,7 +84,7 @@ class TestInputSourceDataInputStream5 {
     assertEquals(32, dis.bitPos0b)
   }
 
-  @Test def testLittleEndianLong5() {
+  @Test def testLittleEndianLong5(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.BIG_ENDIAN)
     val fb = bb.asLongBuffer()

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream6.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream6.scala
@@ -36,7 +36,7 @@ class TestInputSourceDataInputStream6 {
   lsbfFinfo.byteOrder = ByteOrder.LittleEndian
   lsbfFinfo.bitOrder = BitOrder.LeastSignificantBitFirst
 
-  @Test def testUnalignedByteArrayMSBFirst() {
+  @Test def testUnalignedByteArrayMSBFirst(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.BIG_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -59,7 +59,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testUnalignedByteArrayLittleEndianMSBFirst() {
+  @Test def testUnalignedByteArrayLittleEndianMSBFirst(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -83,7 +83,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(64, dis.bitPos0b)
   }
 
-  @Test def testUnalignedByteArrayLittleEndianLSBFirst() {
+  @Test def testUnalignedByteArrayLittleEndianLSBFirst(): Unit = {
     val bb = ByteBuffer.allocate(8)
     bb.order(java.nio.ByteOrder.LITTLE_ENDIAN)
     val fb = bb.asLongBuffer()
@@ -112,7 +112,7 @@ class TestInputSourceDataInputStream6 {
    * These just ensure that we move over to the mandatory alignment before decoding
    * any characters.
    */
-  @Test def testGetSomeString1 {
+  @Test def testGetSomeString1: Unit = {
     val dis = InputSourceDataInputStream("01".getBytes())
     dis.getSignedLong(1, beFinfo)
     val ms = dis.getSomeString(1, beFinfo)
@@ -123,7 +123,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals('1', s(0))
   }
 
-  @Test def testgetSomeString2 {
+  @Test def testgetSomeString2: Unit = {
     val dis = InputSourceDataInputStream("0年月日".getBytes("utf-8"))
     dis.getSignedLong(4, beFinfo)
     val ms = dis.getSomeString(3, beFinfo)
@@ -136,7 +136,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(80, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte {
+  @Test def testGetSomeStringDataEndsMidByte: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 2)) // 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -148,7 +148,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(8 * 6, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte2 {
+  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 2)) // 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -162,7 +162,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(Maybe.Nope, ms2)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3 {
+  @Test def testGetSomeStringDataEndsMidByte3: Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 10)) // 1 more byte plus 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -185,7 +185,7 @@ class TestInputSourceDataInputStream6 {
    * any characters.
    */
 
-  @Test def testCharIteratorWithInterruptingBitSkips1 {
+  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
     val dis = InputSourceDataInputStream("0年1月2日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(beFinfo)
@@ -215,7 +215,7 @@ class TestInputSourceDataInputStream6 {
    * Also shows that hasNext() doesn't ever move the bitPos even
    * if it has to align to a mandatory character alignment boundary.
    */
-  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext {
+  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext: Unit = {
     val dis = InputSourceDataInputStream("0年1月2日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(beFinfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream7.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream7.scala
@@ -119,7 +119,7 @@ class TestInputSourceDataInputStream7 {
    *
    * The `getByteArray` call returns 3 bytes, but one is a fragment byte
    */
-  @Test def testGetByteArrayLengthLimit1 {
+  @Test def testGetByteArrayLengthLimit1: Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abc"))
     dis.setBitLimit0b(MaybeULong(21))
     val finfo = FormatInfoForUnitTest()
@@ -136,7 +136,7 @@ class TestInputSourceDataInputStream7 {
   /*
    * Tests of unaligned char buffers (ie., 7-bit characters)
    */
-  @Test def testGetSomeStringOne7BitChar {
+  @Test def testGetSomeStringOne7BitChar: Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abcdefgh"))
     val ms = dis.getSomeString(1, finfo)
     assertTrue(ms.isDefined)
@@ -146,7 +146,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals('a', s(0))
   }
 
-  @Test def testGetSomeString7BitString {
+  @Test def testGetSomeString7BitString: Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abcdefgh"))
     val ms = dis.getSomeString(8, finfo)
     assertTrue(ms.isDefined)
@@ -155,7 +155,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals(56, dis.bitPos0b)
     assertEquals("abcdefgh", s)
   }
-  @Test def testGetSomeString7BitStringOffBy3 {
+  @Test def testGetSomeString7BitStringOffBy3: Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.skip(3, finfo)
@@ -167,7 +167,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals(59, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte {
+  @Test def testGetSomeStringDataEndsMidByte: Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(25))
@@ -189,7 +189,7 @@ class TestInputSourceDataInputStream7 {
    * able to fetch another byte of source data (aka an "underflow"), yet there actually
    * are sufficient bits without that byte to decode a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte2 {
+  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(20))
@@ -206,7 +206,7 @@ class TestInputSourceDataInputStream7 {
    * Similar to above test, except the remaining partial byte does not provide
    * enough bits to finish a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte3 {
+  @Test def testGetSomeStringDataEndsMidByte3: Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(16))
@@ -227,7 +227,7 @@ class TestInputSourceDataInputStream7 {
    * any characters.
    */
 
-  @Test def testCharIteratorWithInterruptingBitSkips1 {
+  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("0a1b2c"))
     dis.setBitLimit0b(MaybeULong(42))
     val iter = dis.asIteratorChar
@@ -267,7 +267,7 @@ class TestInputSourceDataInputStream7 {
    * Also shows that hasNext() doesn't ever move the bitPos even
    * if it has to align to a mandatory character alignment boundary.
    */
-  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext {
+  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext: Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("0a1b2c"))
     dis.setBitLimit0b(MaybeULong(42))
     val iter = dis.asIteratorChar
@@ -290,7 +290,7 @@ class TestInputSourceDataInputStream7 {
 
   }
 
-  @Test def testUSASCII7BitEncoderOverflowError {
+  @Test def testUSASCII7BitEncoderOverflowError: Unit = {
     val encoder = BitsCharsetUSASCII7BitPacked.newEncoder
     val bb = ByteBuffer.allocate(1) // only big enough for a single byte
     val cb = CharBuffer.wrap("ab") // two characters will cause overflow
@@ -298,7 +298,7 @@ class TestInputSourceDataInputStream7 {
     assertTrue(coderResult == CoderResult.OVERFLOW)
   }
 
-  @Test def testUSASCII7BitEncoderMalformedError {
+  @Test def testUSASCII7BitEncoderMalformedError: Unit = {
     val encoder = BitsCharsetUSASCII7BitPacked.newEncoder
     val bb = ByteBuffer.allocate(3)
     val cb = CharBuffer.wrap("ab" + 128.toChar) // 128 is not encodable in 7 bits

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
@@ -55,7 +55,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
    */
   val b64TextExtraLFs = b64Text.split("Z").mkString("Z\r\n")
 
-  @Test def testBase64_01() {
+  @Test def testBase64_01(): Unit = {
     val input = text
     val expected = b64Text
     val encoded = java.util.Base64.getMimeEncoder.encodeToString(input.getBytes("ascii"))
@@ -77,7 +77,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
     if (failed) fail()
   }
 
-  @Test def testBase64_broken_data_01() {
+  @Test def testBase64_broken_data_01(): Unit = {
 
     val data = b64Text.tail
 
@@ -87,7 +87,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
 
   }
 
-  @Test def testBase64_broken_data_02() {
+  @Test def testBase64_broken_data_02(): Unit = {
 
     val data = b64Text.dropRight(3)
 
@@ -97,13 +97,13 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
 
   }
 
-  @Test def testBase64_tolerates_extra_CRLFs() {
+  @Test def testBase64_tolerates_extra_CRLFs(): Unit = {
     val data = b64TextExtraLFs
     val textDecoded = new String(java.util.Base64.getMimeDecoder.decode(data))
     assertEquals(text, textDecoded)
   }
 
-  @Test def testBase64_decode_consumes_final_CRLF() {
+  @Test def testBase64_decode_consumes_final_CRLF(): Unit = {
 
     val data = b64Text ++ "\r\n" // add extra CRLF
 
@@ -112,7 +112,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
     assertEquals(text, actual)
   }
 
-  @Test def testBase64_decode_consumes_final_LF() {
+  @Test def testBase64_decode_consumes_final_LF(): Unit = {
 
     val data = b64Text ++ "\n" // add extra LF
 
@@ -125,7 +125,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
    * Base64 decoder that decodes strings consumes any trailing CRLFs or LFs
    * and ignores them.
    */
-  @Test def testBase64_decode_consumes_final_LFLFLFLF() {
+  @Test def testBase64_decode_consumes_final_LFLFLFLF(): Unit = {
 
     val data = b64Text ++ "\n\n\n\n" // add extra LF
 
@@ -139,7 +139,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
    * java input stream, and read as much as we can from it, that it will stop
    * at an equals sign, and tolerates additional equals signs even.
    */
-  @Test def testBase64_decode_from_stream_consumes_nothing_extra() {
+  @Test def testBase64_decode_from_stream_consumes_nothing_extra(): Unit = {
 
     val additional = "====ABCD"
     val data = b64Text ++ additional // add extra characters
@@ -162,7 +162,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
    *
    * This tells us that base64 is, generally speaking, not self-delimiting.
    */
-  @Test def testBase64_decode_from_stream_does_not_stop_by_itself() {
+  @Test def testBase64_decode_from_stream_does_not_stop_by_itself(): Unit = {
 
     val data = "cGxlYXN1cmUu" ++ "=" // encoding of "pleasure."
 
@@ -181,7 +181,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
    *
    * It behaves as if it removes all the line endings first, and then decodes.
    */
-  @Test def testBase64_decode_from_stream_does_not_stop_by_itself2() {
+  @Test def testBase64_decode_from_stream_does_not_stop_by_itself2(): Unit = {
 
     val data = "cGxlYXN1cmUu" ++ "\n=" // encoding of "pleasure."
 
@@ -217,28 +217,28 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
   /**
    * Zero-length string encodes to zero length string.
    */
-  @Test def testBase64_0Byte() {
+  @Test def testBase64_0Byte(): Unit = {
     compare("", "")
   }
 
   /**
    * If length is 1 mod 3, then there will be "==" after.
    */
-  @Test def testBase64_1Byte() {
+  @Test def testBase64_1Byte(): Unit = {
     compare("Q", "UQ==")
   }
 
   /**
    * If length is 2 mod 3, then there will be "=" after.
    */
-  @Test def testBase64_2Byte() {
+  @Test def testBase64_2Byte(): Unit = {
     compare("QQ", "UVE=")
   }
 
   /**
    * If length is 0 mod 3, then there will be no trailing characters.
    */
-  @Test def testBase64_3Byte() {
+  @Test def testBase64_3Byte(): Unit = {
     compare("QQQ", "UVFR")
   }
 

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -80,7 +80,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
    * If the data happens to decode precisely (multiple of 3 characters long) without
    * any needed padding, then the decoder doesn't know to stop.
    */
-  @Test def testBase64MIMEDecoderWrapDoesNotPreBuffer() {
+  @Test def testBase64MIMEDecoderWrapDoesNotPreBuffer(): Unit = {
     val inputStream = IOUtils.toInputStream(b64Text + additionalText, StandardCharsets.ISO_8859_1)
     val expected = text
     val decodedStream = java.util.Base64.getMimeDecoder().wrap(inputStream)
@@ -98,7 +98,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
    * bytes. Again however, this only works because the base64 data happened
    * to end with an "=". That won't necessarily be the case.
    */
-  @Test def testBase64MIMEDecoderDetectsEndRobustly1() {
+  @Test def testBase64MIMEDecoderDetectsEndRobustly1(): Unit = {
     val inputStream = IOUtils.toInputStream(b64Text + b64Text, StandardCharsets.ISO_8859_1)
     val expected = text
     val decodedStream = java.util.Base64.getMimeDecoder().wrap(inputStream)
@@ -109,7 +109,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
     assertEquals(expected, additionalLines(0))
   }
 
-  @Test def testBase64ScanningForDelimiter1() {
+  @Test def testBase64ScanningForDelimiter1(): Unit = {
     val data = "cGxl" // encoding of "ple"
     val terminator = ";"
     val afterTerminator = "afterTerminator"
@@ -129,7 +129,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
    * It doesn't have precise ending behavior. It reads
    * ahead at least two bytes beyond the data it needs.
    */
-  @Test def testGZIPDecoderDoesPreBuffer1() {
+  @Test def testGZIPDecoderDoesPreBuffer1(): Unit = {
     val inputData = zipped ++ additionalText.getBytes(StandardCharsets.ISO_8859_1)
     val inputStream = new ByteArrayInputStream(inputData)
     val expected = text
@@ -158,7 +158,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
    * the length of the compressed data so that we can limit how many bytes the gzip
    * stream can read.
    */
-  @Test def testGZIPDecoderDoesPreBuffer2() {
+  @Test def testGZIPDecoderDoesPreBuffer2(): Unit = {
     val inputData = zipped ++ additionalText.getBytes(StandardCharsets.ISO_8859_1)
     val rawInput = new ByteArrayInputStream(inputData)
     val inputStream = new BufferedInputStream(rawInput)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
@@ -71,7 +71,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
 
   val additionalText = "This is text that shouldn't be read."
 
-  @Test def testBase64DecodeFromDelimitedStream1() {
+  @Test def testBase64DecodeFromDelimitedStream1(): Unit = {
     val data = "cGxlYXN1cmUu" // encoding of "pleasure."
     val terminator = "terminator"
     val afterTerminator = "afterTerminator"
@@ -87,7 +87,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
     assertEquals(afterTerminator, actualAfterData)
   }
 
-  @Test def testBase64DecodeFromDelimitedStream2() {
+  @Test def testBase64DecodeFromDelimitedStream2(): Unit = {
     val data = "cGxlYXN1cmUu" // encoding of "pleasure."
     val terminator = ";;;"
     val afterTerminator = "afterTerminator"
@@ -101,7 +101,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
     assertEquals(afterTerminator, actualAfterData)
   }
 
-  @Test def testBase64DecodeFromDelimitedStream3() {
+  @Test def testBase64DecodeFromDelimitedStream3(): Unit = {
     val data = "cGxl" // encoding of "ple"
     val terminator = ";"
     val afterTerminator = "afterTerminator"
@@ -124,7 +124,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
    * encoded data, GZIP doesn't do that. It seems to always read past the end. This
    * may be an artifact of the implementation, or inherent in the GZIP data format.
    */
-  @Test def testGZIPDecoderWithLimit1() {
+  @Test def testGZIPDecoderWithLimit1(): Unit = {
     val inputData = zipped ++ additionalText.getBytes(iso8859)
     val inputStream = new ByteArrayInputStream(inputData)
     val limitedStream = new ExplicitLengthLimitingStream(inputStream,

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -515,7 +515,7 @@ class DataProcessor private[japi] (private var dp: SDataProcessor)
    * @param flag true to enable debugging, false to disabled
    */
   @deprecated("Use withDebugging.", "2.6.0")
-  def setDebugging(flag: Boolean) {
+  def setDebugging(flag: Boolean): Unit = {
     dp = dp.withDebugging(flag)
   }
 
@@ -536,7 +536,7 @@ class DataProcessor private[japi] (private var dp: SDataProcessor)
    * @param dr debugger runner
    */
   @deprecated("Use withDebugger.", "2.6.0")
-  def setDebugger(dr: DebuggerRunner) {
+  def setDebugger(dr: DebuggerRunner): Unit = {
     val debugger = newDebugger(dr)
     dp = dp.withDebugger(debugger)
   }

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
@@ -97,7 +97,7 @@ private[japi] class JavaLogWriter(logWriter: LogWriter)
     //do nothing
   }
 
-  override def log(lvl: SLogLevel.Type, logID: String, msg: String, args: Seq[Any]) {
+  override def log(lvl: SLogLevel.Type, logID: String, msg: String, args: Seq[Any]): Unit = {
     if (logWriter != null) {
       logWriter.log(LoggingConversions.levelFromScala(lvl), logID, msg, args.asJava)
     }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
@@ -316,13 +316,13 @@ final class EntityReplacer {
     result
   }
 
-  private def errBadEntityLonePercent(ent: String, orig: String, context: Maybe[ThrowsSDE]) {
+  private def errBadEntityLonePercent(ent: String, orig: String, context: Maybe[ThrowsSDE]): Unit = {
     val msg = "Invalid DFDL Entity (%s) found in \"%s\". If a single percent was intended instead of a DFDL Entity, it must be self escaped (%%%%).".format(ent, orig)
     if (context.isDefined) context.get.SDE(msg)
     else throw new EntitySyntaxException(msg)
   }
 
-  private def errBadEntityNoSemi(ent: String, orig: String, context: Maybe[ThrowsSDE]) {
+  private def errBadEntityNoSemi(ent: String, orig: String, context: Maybe[ThrowsSDE]): Unit = {
     val msg = "Invalid DFDL Entity (%%%s) found in \"%s\". Missing semicolon at end of entity name?".format(stripLeadingPercent(ent), orig)
     if (context.isDefined) context.get.SDE(msg)
     else throw new EntitySyntaxException(msg)
@@ -544,14 +544,14 @@ class StringLiteral(pn: String, allowByteEntities: Boolean)
 
 sealed trait NonEmptyMixin { self: StringLiteralBase =>
 
-  protected def testCooked(cooked: String, context: ThrowsSDE) {
+  protected def testCooked(cooked: String, context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(cooked.length > 0, "Cannot be an empty string.")
   }
 }
 
 sealed trait SingleCharacterMixin { self: StringLiteralBase =>
 
-  override protected def testCooked(cooked: String, context: ThrowsSDE) {
+  override protected def testCooked(cooked: String, context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(cooked.length == 1 ||
       cooked =:= "%%", "For property dfdl:%s the length of string must be exactly 1 character.", propName)
   }
@@ -567,7 +567,7 @@ trait NoCharClassEntitiesMixin {
   /**
    * Override if set of prohibited class entities is different
    */
-  protected def noCharClassEntities(raw: String, context: ThrowsSDE) {
+  protected def noCharClassEntities(raw: String, context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(!raw.contains("%NL;"), "Property dfdl:%s cannot contain %%NL;", propName)
     context.schemaDefinitionUnless(!raw.contains("%ES;"), "Property dfdl:%s cannot contain %%ES;", propName)
     context.schemaDefinitionUnless(!raw.contains("%WSP;"), "Property dfdl:%s cannot contain %%WSP;", propName)
@@ -575,7 +575,7 @@ trait NoCharClassEntitiesMixin {
     context.schemaDefinitionUnless(!raw.contains("%WSP*;"), "Property dfdl:%s cannot contain %%WSP*;", propName)
   }
 
-  protected def testRaw(raw: String, context: ThrowsSDE) {
+  protected def testRaw(raw: String, context: ThrowsSDE): Unit = {
     noCharClassEntities(raw, context)
   }
 }
@@ -621,7 +621,7 @@ class StringLiteralESEntityWithByteEntities(pn: String)
   /**
    * Override Because ES is allowed.
    */
-  override protected def noCharClassEntities(raw: String, context: ThrowsSDE) {
+  override protected def noCharClassEntities(raw: String, context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(!raw.contains("%NL;"), "Property dfdl:%s cannot contain %%NL;", propName)
     // ES is allowed
     context.schemaDefinitionUnless(!raw.contains("%WSP;"), "Property dfdl:%s cannot contain %%WSP;", propName)
@@ -706,7 +706,7 @@ class ListOfString1OrMoreLiteral(pn: String, allowByteEntities: Boolean)
 
   override protected val oneLiteralCooker: StringLiteralBase = new StringLiteral(propName, allowByteEntities)
 
-  override protected def testCooked(cooked: List[String], context: ThrowsSDE) {
+  override protected def testCooked(cooked: List[String], context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(cooked.length > 0, "Property %s cannot be empty string.", propName)
   }
 }
@@ -753,7 +753,7 @@ class ListOfStringLiteralNoCharClass_NL_ES_EntitiesNoByteEntities(pn: String = n
       /**
        * fewer prohibited char class entities
        */
-      override protected def noCharClassEntities(raw: String, context: ThrowsSDE) {
+      override protected def noCharClassEntities(raw: String, context: ThrowsSDE): Unit = {
         context.schemaDefinitionUnless(!raw.contains("%NL;"), "Property dfdl:%s cannot contain %%NL;", propName)
         context.schemaDefinitionUnless(!raw.contains("%ES;"), "Property dfdl:%s cannot contain %%ES;", propName)
       }
@@ -772,7 +772,7 @@ class SingleCharacterLineEndingOrCRLF_NoCharClassEntitiesNoByteEntities(pn: Stri
   /**
    * Check that length is 1 (single char) except for CRLF case, and that it's a line ending char.
    */
-  override protected def testCooked(cooked: String, context: ThrowsSDE) {
+  override protected def testCooked(cooked: String, context: ThrowsSDE): Unit = {
     context.schemaDefinitionUnless(cooked.length == 1 || cooked =:= "\r\n",
       "For property dfdl:%s, the length of string must be exactly 1 character, except for CRLF case when it can be 2 characters.", propName)
     context.schemaDefinitionUnless(validNLs.contains(cooked(0)),
@@ -786,7 +786,7 @@ class NonEmptyListOfStringLiteralCharClass_ES_WithByteEntities(pn: String)
   override protected val oneLiteralCooker =
     new StringLiteral(propName, allowByteEntities = true) with NoCharClassEntitiesMixin {
 
-      override protected def noCharClassEntities(raw: String, context: ThrowsSDE) {
+      override protected def noCharClassEntities(raw: String, context: ThrowsSDE): Unit = {
         context.schemaDefinitionUnless(!raw.contains("%NL;"), "Property dfdl:%s cannot contain %%NL;", propName)
         context.schemaDefinitionUnless(!raw.contains("%WSP;"), "Property dfdl:%s cannot contain %%WSP;", propName)
         context.schemaDefinitionUnless(!raw.contains("%WSP+;"), "Property dfdl:%s cannot contain %%WSP+;", propName)
@@ -808,7 +808,7 @@ class DelimiterCookerNoES(pn: String) extends ListOfString1OrMoreLiteral(pn, tru
   override val oneLiteralCooker: StringLiteralBase =
     new StringLiteralNoCharClassEntities(propName, true) {
 
-      override protected def noCharClassEntities(raw: String, context: ThrowsSDE) {
+      override protected def noCharClassEntities(raw: String, context: ThrowsSDE): Unit = {
         // TODO: this isn't quite right, as it will allow combined delimiters
         // that still match the empty string, e.g. "%ES;%WSP*;". We could check
         // if raw.contains("%WSP*;"), but that is too general, preventing valid

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
@@ -143,7 +143,7 @@ object OOLAG extends Logging {
 
     private var oolagContextViaSet: Option[OOLAGHost] = None
 
-    final def setOOLAGContext(oolagContextArg: OOLAGHost) {
+    final def setOOLAGContext(oolagContextArg: OOLAGHost): Unit = {
       Assert.usage(nArgs == ZeroArgs, "Cannot set oolag context if it was provided as a constructor arg.")
       if (oolagContextViaSet != None)
         Assert.usageError("Cannot set oolag context more than once.")
@@ -300,7 +300,7 @@ object OOLAG extends Logging {
      * Unconditionally, evaluate the expression arg in order to insure all checks for this
      * object are performed.
      */
-    protected final def requiredEvaluationsAlways(arg: => Any) {
+    protected final def requiredEvaluationsAlways(arg: => Any): Unit = {
       requiredEvaluationsAlways(thunk(arg))
     }
 
@@ -447,12 +447,12 @@ object OOLAG extends Logging {
      * objects (Anything that ThrowsSDE)
      */
 
-    protected def oolagWarn(th: Diagnostic) {
+    protected def oolagWarn(th: Diagnostic): Unit = {
       if (!warnings_.contains(th))
         warnings_ :+= th
     }
 
-    protected def oolagError(th: Diagnostic) {
+    protected def oolagError(th: Diagnostic): Unit = {
       if (!errors_.contains(th))
         errors_ :+= th
     }
@@ -624,7 +624,7 @@ object OOLAG extends Logging {
       log(LogLevel.OOLAGDebug, " " * indent + "Evaluating %s", thisThing)
     }
 
-    protected final def oolagAfterValue(res: AnyRef) {
+    protected final def oolagAfterValue(res: AnyRef): Unit = {
       log(LogLevel.OOLAGDebug, " " * indent + "Evaluated %s", thisThing)
       value_ = Maybe(res)
     }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/Properties.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/Properties.scala
@@ -141,7 +141,7 @@ abstract class Enum[A] extends EnumBase with Converter[String, A] {
    * We need to force creation of our inner property case objects because constructing them also has
    * the side-effect of registering them in the _values list.
    */
-  def forceConstruction(obj: Any) {
+  def forceConstruction(obj: Any): Unit = {
     //Assert.invariant(obj.toString() != "") // TODO: is forceConstruction needed at all?
   }
 
@@ -185,7 +185,7 @@ trait PropertyMixin
     str
   }
 
-  def registerToStringFunction(f: (() => String)) {
+  def registerToStringFunction(f: (() => String)): Unit = {
     toStringFunctionList +:= f
   }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/BitOrder.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/BitOrder.scala
@@ -79,12 +79,12 @@ object Bits {
     asSignedByte(LSBitTable(asUnsignedByte(b)))
   }
 
-  def reverseBytesAndReverseBits(bb: ByteBuffer) {
+  def reverseBytesAndReverseBits(bb: ByteBuffer): Unit = {
     reverseBytes(bb)
     reverseBitsWithinBytes(bb)
   }
 
-  def reverseBitsWithinBytes(bb: ByteBuffer) {
+  def reverseBitsWithinBytes(bb: ByteBuffer): Unit = {
     Assert.usage(bb.position() == 0)
     var i: Int = 0
     val len = bb.remaining()
@@ -94,7 +94,7 @@ object Bits {
     }
   }
 
-  def reverseBytes(a: Array[Byte], length: Int) {
+  def reverseBytes(a: Array[Byte], length: Int): Unit = {
     var i: Int = 0
     var lowerIndex = 0
     var upperIndex = length - 1
@@ -107,7 +107,7 @@ object Bits {
     }
   }
 
-  def reverseBytes(bb: ByteBuffer) {
+  def reverseBytes(bb: ByteBuffer): Unit = {
     Assert.usage(bb.position() == 0)
     var i: Int = 0
     var lowerIndex = bb.position()
@@ -155,7 +155,7 @@ object Bits {
    * for non-negative values, etc. So we operate on byte buffers
    * instead.
    */
-  def shiftLeft(bb: ByteBuffer, n: Int) {
+  def shiftLeft(bb: ByteBuffer, n: Int): Unit = {
     Assert.usage(n < 8)
     Assert.usage(bb.position() == 0)
     var leftBits: Int = 0
@@ -175,7 +175,7 @@ object Bits {
    * Assumes MostSignificantBitFirst bit order. Shifts "right" meaning
    * Bits increase in position.
    */
-  def shiftRight(bb: ByteBuffer, n: Int) {
+  def shiftRight(bb: ByteBuffer, n: Int): Unit = {
     Assert.usage(n < 8 && n >= 0)
     Assert.usage(bb.position() == 0)
     if (n == 0) return // nothing to do
@@ -205,7 +205,7 @@ object Bits {
    * For LSBF, if you write the bytes in order right-to-left, then shiftToHigherBitPosition
    * becomes a leftward movement of the bits displayed this way.
    */
-  def shiftToHigherBitPosition(bitOrder: BitOrder, bb: ByteBuffer, n: Int) {
+  def shiftToHigherBitPosition(bitOrder: BitOrder, bb: ByteBuffer, n: Int): Unit = {
     if (bitOrder eq BitOrder.MostSignificantBitFirst) {
       shiftRight(bb, n)
     } else {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Logger.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Logger.scala
@@ -70,7 +70,7 @@ abstract class LogWriter {
     "]"
   }
 
-  def log(lvl: LogLevel.Type, logID: String, msg: String, args: Seq[Any]) {
+  def log(lvl: LogLevel.Type, logID: String, msg: String, args: Seq[Any]): Unit = {
     try {
       val mess = Glob.stringify(msg, args)
       val p = prefix(lvl, logID)
@@ -103,21 +103,21 @@ object ForUnitTestLogWriter extends LogWriter {
   //    Console.out.println("Was Logged: " + loggedMsg)
   //    Console.out.flush()
   //    } } }
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     loggedMsg = msg
   }
 }
 
 object NullLogWriter extends LogWriter {
   //protected val writer = actor { loop { react { case msg : String => } } }
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     // do nothing.
   }
 }
 
 object ConsoleWriter extends LogWriter {
 
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     Console.err.println(msg)
     Console.flush
   }
@@ -128,7 +128,7 @@ class FileWriter(val file: File) extends LogWriter {
   require(file.canWrite)
 
   // protected val writer = actor { loop { react { case msg : String => destFile.println(msg); destFile.flush case _ => } } }
-  def write(msg: String) {
+  def write(msg: String): Unit = {
     destFile.println(msg)
     destFile.flush
   }
@@ -191,14 +191,14 @@ trait Logging extends Identity {
   var logWriter: Maybe[LogWriter] = Nope
   var logLevel: Maybe[LogLevel.Type] = Nope
 
-  def setLoggingLevel(level: LogLevel.Type) { logLevel = One(level) }
+  def setLoggingLevel(level: LogLevel.Type): Unit = { logLevel = One(level) }
 
   final def getLoggingLevel(): LogLevel.Type = {
     if (logLevel.isDefined) logLevel.get
     else LoggingDefaults.logLevel
   }
 
-  def setLogWriter(lw: LogWriter) { logWriter = One(lw) }
+  def setLogWriter(lw: LogWriter): Unit = { logWriter = One(lw) }
 
   def getLogWriter(): LogWriter = {
     if (logWriter.isDefined) logWriter.get
@@ -232,9 +232,9 @@ object LoggingDefaults {
   var logLevel: LogLevel.Type = LogLevel.Info
   var logWriter: LogWriter = ConsoleWriter
 
-  def setLoggingLevel(level: LogLevel.Type) { logLevel = level }
+  def setLoggingLevel(level: LogLevel.Type): Unit = { logLevel = level }
 
-  def setLogWriter(lw: LogWriter) {
+  def setLogWriter(lw: LogWriter): Unit = {
     Assert.usage(lw != null)
     logWriter = lw
   }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -182,12 +182,12 @@ protected abstract class MStack[@specialized T] private[util] (
   private var index = 0
   private var table: Array[T] = null
 
-  def init {
+  def init: Unit = {
     index = 0
     table = arrayAllocator(32)
   }
 
-  def copyFrom(other: MStack[T]) {
+  def copyFrom(other: MStack[T]): Unit = {
     this.index = other.index
     if (this.table.length < other.index) {
       // the other table has too many items to fit into this table, so just
@@ -230,7 +230,7 @@ protected abstract class MStack[@specialized T] private[util] (
   /**
    *  resets stack top to where it was when mark was called.
    */
-  @inline final def reset(m: MStack.Mark) {
+  @inline final def reset(m: MStack.Mark): Unit = {
     index = m.v
   }
 
@@ -242,7 +242,7 @@ protected abstract class MStack[@specialized T] private[util] (
    *
    *  @param x The element to push
    */
-  @inline final def push(x: T) {
+  @inline final def push(x: T): Unit = {
     if (index == table.length) table = growArray(table)
     table(index) = x
     index += 1

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
@@ -431,7 +431,7 @@ object Misc {
    * characters will not look like spaces, nor all look like the same unicde replacement
    * character.
    */
-  def remapBytesToVisibleGlyphs(bb: ByteBuffer, cb: CharBuffer) {
+  def remapBytesToVisibleGlyphs(bb: ByteBuffer, cb: CharBuffer): Unit = {
     val numBytes = bb.remaining()
     bytesDecoder.decode(bb, cb, true)
     cb.flip

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/NonAllocatingMap.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/NonAllocatingMap.scala
@@ -43,7 +43,7 @@ class NonAllocatingMap[K, V <: AnyRef](javaMap: java.util.Map[K, V]) {
   /**
    * We do not allow null to be put into the map as key nor value.
    */
-  def put(k: K, v: V) {
+  def put(k: K, v: V): Unit = {
     k match {
       case ar: AnyRef => Assert.usage(ar ne null)
       case _ => //ok

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/OnStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/OnStack.scala
@@ -118,7 +118,7 @@ private[util] object An_example_of_OnStack_use {
 
   object withMatcher extends OnStack[Matcher](pattern.matcher(""))
 
-  def foo(str: String) {
+  def foo(str: String): Unit = {
     withMatcher { m =>
       //
       // we reset it here in our own code

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Pool.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Pool.scala
@@ -74,7 +74,7 @@ trait Pool[T <: Poolable] {
     instance
   }
 
-  final def returnToPool(thing: T) {
+  final def returnToPool(thing: T): Unit = {
     numOutstanding -= 1
     pool.push(thing)
     inUse -= thing
@@ -96,7 +96,7 @@ trait Pool[T <: Poolable] {
    * This is to help find resource leaks where items are taken from
    * the pool, but then dropped.
    */
-  final def finalCheck {
+  final def finalCheck: Unit = {
     if (!(numOutstanding =#= 0)) {
       val msg = "Pool " + Misc.getNameFromClass(this) + " leaked " + numOutstanding + " instance(s)." +
         "\n" + inUse.map { item => "poolDebugLabel = " + item.poolDebugLabel }.mkString("\n")

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Serialize.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Serialize.scala
@@ -52,7 +52,7 @@ trait PreSerialization extends Serializable {
   @throws(classOf[java.io.IOException])
   final private def writeObject(out: java.io.ObjectOutputStream): Unit = serializeObject(out)
 
-  protected final def serializeObject(out: java.io.ObjectOutputStream) {
+  protected final def serializeObject(out: java.io.ObjectOutputStream): Unit = {
     try {
       preSerializationOnlyOnce
       out.defaultWriteObject()

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Timer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Timer.scala
@@ -21,7 +21,7 @@ import collection.JavaConverters._
 
 object Timer extends Logging {
 
-  def printTime(message: String, nanos: Long, units: String) {
+  def printTime(message: String, nanos: Long, units: String): Unit = {
     val msg = message match {
       case null | "" => ""
       case s => " (%s)".format(s)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilConstructingLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilConstructingLoader.scala
@@ -112,7 +112,7 @@ class DaffodilConstructingLoader(uri: URI, errorHandler: org.xml.sax.ErrorHandle
     exc
   }
 
-  override def reportSyntaxError(pos: Int, msg: String) {
+  override def reportSyntaxError(pos: Int, msg: String): Unit = {
     val exc = makeSAXParseException(pos, msg)
     errorHandler.error(exc)
   }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilXMLLoader.scala
@@ -549,7 +549,7 @@ class DaffodilXMLLoader(val errorHandler: org.xml.sax.ErrorHandler) {
   //
   final var doValidation: Boolean = true
 
-  def setValidation(flag: Boolean) {
+  def setValidation(flag: Boolean): Unit = {
     doValidation = flag
   }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/PrettyPrinter.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/PrettyPrinter.scala
@@ -44,7 +44,7 @@ class PrettyPrinter(step: Int) {
    * @param n    the node to be serialized
    * @param sb   the stringbuffer to append to
    */
-  def format(n: Node, sb: StringBuilder) { // entry point
+  def format(n: Node, sb: StringBuilder): Unit = { // entry point
     val c = minimizeScopes(n)
     format(c, sb, 0)
   }
@@ -122,7 +122,7 @@ class PrettyPrinter(step: Int) {
 
   private val mtChild = <foo></foo>.child
 
-  private def format(n: Node, sb: StringBuilder, cur: Int) { // entry point
+  private def format(n: Node, sb: StringBuilder, cur: Int): Unit = { // entry point
     n match {
       case e: Elem => {
         sb.append(" " * cur)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/HowToUseJUnit.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/HowToUseJUnit.scala
@@ -36,18 +36,18 @@ import org.apache.daffodil.Implicits._
  */
 class HowToUseJUnit {
 
-  @Test def test() {
+  @Test def test(): Unit = {
     assertEquals(42, 6 * 7)
     assertTrue(42 == 6 * 7)
     if (42 != 6 * 7)
       fail("wrong answer")
   }
 
-  def somethingThatThrows() {
+  def somethingThatThrows(): Unit = {
     throw new NumberFormatException()
   }
 
-  @Test def testOfInterceptToTestExpectedThrows() {
+  @Test def testOfInterceptToTestExpectedThrows(): Unit = {
     intercept[NumberFormatException] {
       //println("here we are")
       somethingThatThrows()
@@ -55,7 +55,7 @@ class HowToUseJUnit {
   }
 
   // @Test
-  def testOfInterceptReturnedValue() {
+  def testOfInterceptReturnedValue(): Unit = {
     val nfe = intercept[NumberFormatException] {
       //println("here we are")
       somethingThatThrows()

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/TestImplicits.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/TestImplicits.scala
@@ -27,14 +27,14 @@ import org.junit.Assert._
 class TestImplicits {
 
   @Test
-  def testIntercept1() {
+  def testIntercept1(): Unit = {
     intercept[Abort] {
       Assert.abort("yadda")
     }
   }
 
   @Test
-  def testIntercept2() {
+  def testIntercept2(): Unit = {
     val e = intercept[InterceptFailedException] {
       intercept[Abort] {
         // this will not cause an abort exception
@@ -45,7 +45,7 @@ class TestImplicits {
   }
 
   @Test
-  def testIntercept3() {
+  def testIntercept3(): Unit = {
     val e = intercept[InterceptFailedException] {
       intercept[FileNotFoundException] {
         // an exception is caught, but not the right kind

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/exceptions/TestExceptions.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/exceptions/TestExceptions.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.Implicits._
 class TestExceptions {
 
   @Test
-  def testAssert() {
+  def testAssert(): Unit = {
     intercept[Abort] {
       Assert.abort("yadda")
     }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/functionality/icu/TestBigInteger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/functionality/icu/TestBigInteger.scala
@@ -49,7 +49,7 @@ class TestBigInteger {
    * PrimitivesTextNumber1.scala's CovnertTextNumberParser.parse method, the
    * line containing df.get.parse(str,pos).
    */
-  @Test def testBigInteger() {
+  @Test def testBigInteger(): Unit = {
     val pattern = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,000"
     
     val dfs = new DecimalFormatSymbols()

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/macros/TestAssertMacros.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/macros/TestAssertMacros.scala
@@ -27,7 +27,7 @@ class TestAssertMacros {
 
   var x = 0
 
-  @Test def testInvariant1Arg() {
+  @Test def testInvariant1Arg(): Unit = {
     val e = intercept[Abort] {
       Assert.invariant(if (1 == x) true else false)
     }
@@ -40,7 +40,7 @@ class TestAssertMacros {
     assertTrue(msg.contains("false"))
   }
 
-  @Test def testUsage1Arg() {
+  @Test def testUsage1Arg(): Unit = {
     val e = intercept[Abort] {
       Assert.usage(if (1 == x) true else false)
     }
@@ -53,7 +53,7 @@ class TestAssertMacros {
     assertTrue(msg.contains("false"))
   }
 
-  @Test def testUsage2Arg() {
+  @Test def testUsage2Arg(): Unit = {
     val e = intercept[Abort] {
       Assert.usage(if (1 == x) true else false, "foobar")
     }
@@ -72,11 +72,11 @@ class TestAssertMacros {
    * the 2nd argument is never evaluated at all and so can
    * be something expensive that computes a message string.
    */
-  @Test def testMacrosNotEvaluatedSecondArg() {
+  @Test def testMacrosNotEvaluatedSecondArg(): Unit = {
     Assert.usage(true, { fail(); "failed" })
   }
 
-  @Test def testNotYetImplemented0Arg() {
+  @Test def testNotYetImplemented0Arg(): Unit = {
     val e = intercept[NotYetImplementedException] {
       Assert.notYetImplemented()
     }
@@ -84,7 +84,7 @@ class TestAssertMacros {
     assertTrue(msg.contains("Not yet implemented"))
   }
 
-  @Test def testNotYetImplemented1Arg() {
+  @Test def testNotYetImplemented1Arg(): Unit = {
     val e = intercept[NotYetImplementedException] {
       Assert.notYetImplemented(if (0 == x) true else false)
     }
@@ -97,7 +97,7 @@ class TestAssertMacros {
     assertTrue(msg.contains("false"))
   }
 
-  @Test def testNotYetImplemented2Arg() {
+  @Test def testNotYetImplemented2Arg(): Unit = {
     val e = intercept[NotYetImplementedException] {
       Assert.notYetImplemented(if (0 == x) true else false, "foobar")
     }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/oolag/TestOOLAG.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/oolag/TestOOLAG.scala
@@ -126,13 +126,13 @@ class MyHost extends MyBase(null) {
 
 class TestOOLAG {
 
-  @Test def testPrettyName() {
+  @Test def testPrettyName(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     assertEquals("MyHost", h.diagnosticDebugName)
   }
 
-  @Test def testSuccessLazyVal() {
+  @Test def testSuccessLazyVal(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     // println("get the LV")
@@ -149,7 +149,7 @@ class TestOOLAG {
     assertFalse(h.isError)
   }
 
-  @Test def testFailLazyVal() {
+  @Test def testFailLazyVal(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
 
@@ -192,7 +192,7 @@ class TestOOLAG {
   /**
    * Make sure one LV calling another doesn't confuse things.
    */
-  @Test def testLVName2() {
+  @Test def testLVName2(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     var res: String = null
@@ -203,7 +203,7 @@ class TestOOLAG {
     assertEquals("a3 valuea3 value", res)
   }
 
-  @Test def testCircularDefinitionDetected() {
+  @Test def testCircularDefinitionDetected(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     var e: Exception = null
@@ -218,7 +218,7 @@ class TestOOLAG {
     assertTrue(msg.toLowerCase().contains("circ1"))
   }
 
-  @Test def testAlreadyTried() {
+  @Test def testAlreadyTried(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     assertTrue(h.a2_.isError)
@@ -234,7 +234,7 @@ class TestOOLAG {
     }
   }
 
-  @Test def testThrowToTopLevel() {
+  @Test def testThrowToTopLevel(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     intercept[Abort] {
@@ -244,7 +244,7 @@ class TestOOLAG {
     }
   }
 
-  @Test def testDivZeroInside() {
+  @Test def testDivZeroInside(): Unit = {
     // LoggingDefaults.setLoggingLevel(LogLevel.OOLAGDebug)
     val h = new MyHost
     h.setRequiredEvaluationsActive()
@@ -267,7 +267,7 @@ class TestOOLAG {
     // assertTrue(d.length == 1)
   }
 
-  @Test def testAutoTreeCreate() {
+  @Test def testAutoTreeCreate(): Unit = {
     val h = new MyHost
     h.setRequiredEvaluationsActive()
     OOLAG.keepGoing({}) {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/schema/annotation/props/TestGeneratedProperties.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/schema/annotation/props/TestGeneratedProperties.scala
@@ -109,7 +109,7 @@ class TestGeneratedProperties {
   }
 
   @Test
-  def testProps1() {
+  def testProps1(): Unit = {
     val hasProps = new HasLotsOfProperties
 
     //    comparePropValue(hasProps.encoding, "UTF-8")
@@ -219,7 +219,7 @@ class TestGeneratedProperties {
    * that's a schema definition error always.
    */
   @Test
-  def testPropsToString() {
+  def testPropsToString(): Unit = {
     val h = new HasLotsOfProperties
     h.ignoreCase
     val fl = h.toStringFunctionList

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/testEquality/TestEqualityOperators.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/testEquality/TestEqualityOperators.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.equality._
 class TestEqualityOperators {
 
   @Test
-  def testConveribleNumberEquality() {
+  def testConveribleNumberEquality(): Unit = {
     val x = 5
     val y = 6L
     assertFalse(x.toLong =#= y)
@@ -33,7 +33,7 @@ class TestEqualityOperators {
   }
 
   @Test
-  def testStronglyTypedEquality() {
+  def testStronglyTypedEquality(): Unit = {
     val x = List(1, 2, 3)
     val y = Seq(1, 2, 3)
     assertTrue(x =:= y) // allowed since they're subtypes
@@ -46,7 +46,7 @@ class TestEqualityOperators {
   val yObj = if (scala.math.random == -0.0) "bar" else "foo"
 
   @Test
-  def testStronglyTypedEqualityInlineAnyRef() {
+  def testStronglyTypedEqualityInlineAnyRef(): Unit = {
     if (TestEqualityOperators.compare(xObj, yObj))
       fail("equal")
   }
@@ -54,7 +54,7 @@ class TestEqualityOperators {
   private val ylong = scala.math.random.toLong
 
   @Test
-  def testStronglyTypedEqualityInline() {
+  def testStronglyTypedEqualityInline(): Unit = {
     val x = 5
     val y = ylong
     if (TestEqualityOperators.compareIntLong(x, y))

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits.scala
@@ -23,43 +23,43 @@ import java.nio.ByteBuffer
 
 class TestBits {
 
-  @Test def testShiftLeftByteArray1() {
+  @Test def testShiftLeftByteArray1(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte).toArray)
     Bits.shiftLeft(bb, 3)
     assertEquals(List(0xE0.toByte), bb.array.toList)
   }
 
-  @Test def testShiftLeftByteArray2() {
+  @Test def testShiftLeftByteArray2(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte, 0x3D.toByte).toArray)
     Bits.shiftLeft(bb, 3)
     assertEquals(List(0xE1.toByte, 0xE8.toByte), bb.array.toList)
   }
 
-  @Test def testShiftLeftByteArray3() {
+  @Test def testShiftLeftByteArray3(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte).toArray)
     Bits.shiftLeft(bb, 0)
     assertEquals(List(0x7c.toByte), bb.array.toList)
   }
 
-  @Test def testShiftRightByteArray1() {
+  @Test def testShiftRightByteArray1(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte).toArray)
     Bits.shiftRight(bb, 3)
     assertEquals(List(0x0F.toByte), bb.array.toList)
   }
 
-  @Test def testShiftRightByteArray2() {
+  @Test def testShiftRightByteArray2(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte).toArray)
     Bits.shiftRight(bb, 0)
     assertEquals(List(0x7C.toByte), bb.array.toList)
   }
 
-  @Test def testShiftRightByteArray3() {
+  @Test def testShiftRightByteArray3(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte, 0x3D.toByte).toArray)
     Bits.shiftRight(bb, 3)
     assertEquals(List(0x0F.toByte, 0x87.toByte), bb.array.toList)
   }
 
-  @Test def testShiftRightByteArray4() {
+  @Test def testShiftRightByteArray4(): Unit = {
     val bb = ByteBuffer.wrap(List(0x7C.toByte, 0x3D.toByte, 0x42.toByte).toArray)
     Bits.shiftRight(bb, 3)
     assertEquals(List(0x0F.toByte, 0x87.toByte, 0xA8.toByte), bb.array.toList)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits2.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestBits2.scala
@@ -27,37 +27,37 @@ class TestBits2 {
   val MSBF = BitOrder.MostSignificantBitFirst
   val LSBF = BitOrder.LeastSignificantBitFirst
 
-  @Test def testShiftHigher1MSBF() {
+  @Test def testShiftHigher1MSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 1)
     assertEquals(List(0x7F.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher1LSBF() {
+  @Test def testShiftHigher1LSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 1)
     assertEquals(List(0xFE.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher2MSBF() {
+  @Test def testShiftHigher2MSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 2)
     assertEquals(List(0x3F.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher2LSBF() {
+  @Test def testShiftHigher2LSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 2)
     assertEquals(List(0xFC.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher7MSBF() {
+  @Test def testShiftHigher7MSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 7)
     assertEquals(List(0x01.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher7LSBF() {
+  @Test def testShiftHigher7LSBF(): Unit = {
     val bb = ByteBuffer.wrap(List(0xFF.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 7)
     assertEquals(List(0x80.toByte), bb.array.toList)
@@ -65,37 +65,37 @@ class TestBits2 {
 
   ///////////////////////////////////////////////
 
-  @Test def testShiftHigher1MSBF2() {
+  @Test def testShiftHigher1MSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 1)
     assertEquals(List(0x52.toByte, 0xD2.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher1LSBF2() {
+  @Test def testShiftHigher1LSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 1)
     assertEquals(List(0x4A.toByte, 0x4B), bb.array.toList)
   }
 
-  @Test def testShiftHigher2MSBF2() {
+  @Test def testShiftHigher2MSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 2)
     assertEquals(List(0x29.toByte, 0x69.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher2LSBF2() {
+  @Test def testShiftHigher2LSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 2)
     assertEquals(List(0x94.toByte, 0x96.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher7MSBF2() {
+  @Test def testShiftHigher7MSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(MSBF, bb, 7)
     assertEquals(List(0x01.toByte, 0x4B.toByte), bb.array.toList)
   }
 
-  @Test def testShiftHigher7LSBF2() {
+  @Test def testShiftHigher7LSBF2(): Unit = {
     val bb = ByteBuffer.wrap(List(0xA5.toByte, 0xA5.toByte).toArray)
     Bits.shiftToHigherBitPosition(LSBF, bb, 7)
     assertEquals(List(0x80.toByte, 0xD2.toByte), bb.array.toList)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestDecimalUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestDecimalUtils.scala
@@ -26,7 +26,7 @@ import org.junit.Assert._
 
 class TestDecimalUtils {
 
-  @Test def packedInt1StrictPos() {
+  @Test def packedInt1StrictPos(): Unit = {
     val num = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -36,7 +36,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt2StrictPos() {
+  @Test def packedInt2StrictPos(): Unit = {
     val num = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -47,7 +47,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt3StrictPos() {
+  @Test def packedInt3StrictPos(): Unit = {
     val num = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -58,7 +58,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt4StrictPos() {
+  @Test def packedInt4StrictPos(): Unit = {
     val num = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -73,7 +73,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt5StrictPos() {
+  @Test def packedInt5StrictPos(): Unit = {
     val num = new Array[Byte](11)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -93,7 +93,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt1StrictNeg() {
+  @Test def packedInt1StrictNeg(): Unit = {
     val num = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -103,7 +103,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt2StrictNeg() {
+  @Test def packedInt2StrictNeg(): Unit = {
     val num = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -114,7 +114,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt3StrictNeg() {
+  @Test def packedInt3StrictNeg(): Unit = {
     val num = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -125,7 +125,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt4StrictNeg() {
+  @Test def packedInt4StrictNeg(): Unit = {
     val num = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -140,7 +140,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt5StrictNeg() {
+  @Test def packedInt5StrictNeg(): Unit = {
     val num = new Array[Byte](11)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -160,7 +160,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), num)
   }
 
-  @Test def packedInt1LaxPos() {
+  @Test def packedInt1LaxPos(): Unit = {
     val num = new Array[Byte](1)
     val expected = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -172,7 +172,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt2LaxPos() {
+  @Test def packedInt2LaxPos(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -186,7 +186,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt3LaxPos() {
+  @Test def packedInt3LaxPos(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -200,7 +200,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt4LaxPos() {
+  @Test def packedInt4LaxPos(): Unit = {
     val num = new Array[Byte](6)
     val expected = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -222,7 +222,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt5LaxPos() {
+  @Test def packedInt5LaxPos(): Unit = {
     val num = new Array[Byte](11)
     val expected = new Array[Byte](11)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -254,7 +254,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt1LaxNeg() {
+  @Test def packedInt1LaxNeg(): Unit = {
     val num = new Array[Byte](1)
     val expected = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -266,7 +266,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt2LaxNeg() {
+  @Test def packedInt2LaxNeg(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -280,7 +280,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt3LaxNeg() {
+  @Test def packedInt3LaxNeg(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -294,7 +294,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt4LaxNeg() {
+  @Test def packedInt4LaxNeg(): Unit = {
     val num = new Array[Byte](6)
     val expected = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -316,7 +316,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedInt5LaxNeg() {
+  @Test def packedInt5LaxNeg(): Unit = {
     val num = new Array[Byte](11)
     val expected = new Array[Byte](11)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Lax)
@@ -348,7 +348,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec1StrictPos() {
+  @Test def packedDec1StrictPos(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -359,7 +359,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec2StrictPos() {
+  @Test def packedDec2StrictPos(): Unit = {
     val num = new Array[Byte](2)
     val scale = 1
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -371,7 +371,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec3StrictPos() {
+  @Test def packedDec3StrictPos(): Unit = {
     val num = new Array[Byte](2)
     val scale = 3
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -383,7 +383,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec4StrictPos() {
+  @Test def packedDec4StrictPos(): Unit = {
     val num = new Array[Byte](6)
     val scale = 5
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -399,7 +399,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec5StrictPos() {
+  @Test def packedDec5StrictPos(): Unit = {
     val num = new Array[Byte](11)
     val scale = 19
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -420,7 +420,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec1StrictNeg() {
+  @Test def packedDec1StrictNeg(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -431,7 +431,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec2StrictNeg() {
+  @Test def packedDec2StrictNeg(): Unit = {
     val num = new Array[Byte](2)
     val scale = 1
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -443,7 +443,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec3StrictNeg() {
+  @Test def packedDec3StrictNeg(): Unit = {
     val num = new Array[Byte](2)
     val scale = 3
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -455,7 +455,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec4StrictNeg() {
+  @Test def packedDec4StrictNeg(): Unit = {
     val num = new Array[Byte](6)
     val scale = 5
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -471,7 +471,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec5StrictNeg() {
+  @Test def packedDec5StrictNeg(): Unit = {
     val num = new Array[Byte](11)
     val scale = 19
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
@@ -492,7 +492,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), num)
   }
 
-  @Test def packedDec1LaxPos() {
+  @Test def packedDec1LaxPos(): Unit = {
     val num = new Array[Byte](1)
     val expected = new Array[Byte](1)
     val scale = 0
@@ -505,7 +505,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec2LaxPos() {
+  @Test def packedDec2LaxPos(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val scale = 1
@@ -520,7 +520,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec3LaxPos() {
+  @Test def packedDec3LaxPos(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val scale = 3
@@ -535,7 +535,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec4LaxPos() {
+  @Test def packedDec4LaxPos(): Unit = {
     val num = new Array[Byte](6)
     val expected = new Array[Byte](6)
     val scale = 5
@@ -558,7 +558,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec5LaxPos() {
+  @Test def packedDec5LaxPos(): Unit = {
     val num = new Array[Byte](11)
     val expected = new Array[Byte](11)
     val scale = 19
@@ -591,7 +591,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec1LaxNeg() {
+  @Test def packedDec1LaxNeg(): Unit = {
     val num = new Array[Byte](1)
     val expected = new Array[Byte](1)
     val scale = 0
@@ -604,7 +604,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec2LaxNeg() {
+  @Test def packedDec2LaxNeg(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val scale = 1
@@ -619,7 +619,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec3LaxNeg() {
+  @Test def packedDec3LaxNeg(): Unit = {
     val num = new Array[Byte](2)
     val expected = new Array[Byte](2)
     val scale = 3
@@ -634,7 +634,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec4LaxNeg() {
+  @Test def packedDec4LaxNeg(): Unit = {
     val num = new Array[Byte](6)
     val expected = new Array[Byte](6)
     val scale = 5
@@ -657,7 +657,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def packedDec5LaxNeg() {
+  @Test def packedDec5LaxNeg(): Unit = {
     val num = new Array[Byte](11)
     val expected = new Array[Byte](11)
     val scale = 19
@@ -690,7 +690,7 @@ class TestDecimalUtils {
     assertArrayEquals(packedFromBigInteger(bignum.unscaledValue, num.length*8, signCodes), expected)
   }
 
-  @Test def ibm4690Int1Pos() {
+  @Test def ibm4690Int1Pos(): Unit = {
     val num = new Array[Byte](1)
 
     num(0) = 0xF1.toByte
@@ -699,7 +699,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int2Pos() {
+  @Test def ibm4690Int2Pos(): Unit = {
     val num = new Array[Byte](1)
 
     num(0) = 0x12.toByte
@@ -708,7 +708,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int3Pos() {
+  @Test def ibm4690Int3Pos(): Unit = {
     val num = new Array[Byte](2)
 
     num(0) = 0xF1.toByte
@@ -718,7 +718,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int4Pos() {
+  @Test def ibm4690Int4Pos(): Unit = {
     val num = new Array[Byte](5)
 
     num(0) = 0x12.toByte
@@ -731,7 +731,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int5Pos() {
+  @Test def ibm4690Int5Pos(): Unit = {
     val num = new Array[Byte](10)
 
     num(0) = 0xFF.toByte
@@ -749,7 +749,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int1Neg() {
+  @Test def ibm4690Int1Neg(): Unit = {
     val num = new Array[Byte](1)
 
     num(0) = 0xD1.toByte
@@ -758,7 +758,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int2Neg() {
+  @Test def ibm4690Int2Neg(): Unit = {
     val num = new Array[Byte](2)
 
     num(0) = 0xFD.toByte
@@ -768,7 +768,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int3Neg() {
+  @Test def ibm4690Int3Neg(): Unit = {
     val num = new Array[Byte](2)
 
     num(0) = 0xD1.toByte
@@ -778,7 +778,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int4Neg() {
+  @Test def ibm4690Int4Neg(): Unit = {
     val num = new Array[Byte](6)
 
     num(0) = 0xFD.toByte
@@ -792,7 +792,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Int5Neg() {
+  @Test def ibm4690Int5Neg(): Unit = {
     val num = new Array[Byte](11)
 
     num(0) = 0xFF.toByte
@@ -811,7 +811,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def ibm4690Dec1Pos() {
+  @Test def ibm4690Dec1Pos(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -821,7 +821,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec2Pos() {
+  @Test def ibm4690Dec2Pos(): Unit = {
     val num = new Array[Byte](1)
     val scale = 1
 
@@ -831,7 +831,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec3Pos() {
+  @Test def ibm4690Dec3Pos(): Unit = {
     val num = new Array[Byte](2)
     val scale = 3
 
@@ -842,7 +842,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec4Pos() {
+  @Test def ibm4690Dec4Pos(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -856,7 +856,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec5Pos() {
+  @Test def ibm4690Dec5Pos(): Unit = {
     val num = new Array[Byte](10)
     val scale = 19
 
@@ -875,7 +875,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec1Neg() {
+  @Test def ibm4690Dec1Neg(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -885,7 +885,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec2Neg() {
+  @Test def ibm4690Dec2Neg(): Unit = {
     val num = new Array[Byte](2)
     val scale = 1
 
@@ -896,7 +896,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec3Neg() {
+  @Test def ibm4690Dec3Neg(): Unit = {
     val num = new Array[Byte](2)
     val scale = 3
 
@@ -907,7 +907,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec4Neg() {
+  @Test def ibm4690Dec4Neg(): Unit = {
     val num = new Array[Byte](6)
     val scale = 5
 
@@ -922,7 +922,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def ibm4690Dec5Neg() {
+  @Test def ibm4690Dec5Neg(): Unit = {
     val num = new Array[Byte](11)
     val scale = 19
 
@@ -942,7 +942,7 @@ class TestDecimalUtils {
     assertArrayEquals(ibm4690FromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def bcdInt1Pos() {
+  @Test def bcdInt1Pos(): Unit = {
     val num = new Array[Byte](1)
 
     num(0) = 0x01.toByte
@@ -951,7 +951,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def bcdInt2Pos() {
+  @Test def bcdInt2Pos(): Unit = {
     val num = new Array[Byte](1)
 
     num(0) = 0x12.toByte
@@ -960,7 +960,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def bcdInt3Pos() {
+  @Test def bcdInt3Pos(): Unit = {
     val num = new Array[Byte](2)
 
     num(0) = 0x01.toByte
@@ -970,7 +970,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def bcdInt4Pos() {
+  @Test def bcdInt4Pos(): Unit = {
     val num = new Array[Byte](5)
 
     num(0) = 0x12.toByte
@@ -983,7 +983,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def bcdInt5Pos() {
+  @Test def bcdInt5Pos(): Unit = {
     val num = new Array[Byte](10)
 
     num(0) = 0x00.toByte
@@ -1001,7 +1001,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum, num.length*8), num)
   }
 
-  @Test def bcdDec1Pos() {
+  @Test def bcdDec1Pos(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -1011,7 +1011,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def bcdDec2Pos() {
+  @Test def bcdDec2Pos(): Unit = {
     val num = new Array[Byte](1)
     val scale = 1
 
@@ -1021,7 +1021,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def bcdDec3Pos() {
+  @Test def bcdDec3Pos(): Unit = {
     val num = new Array[Byte](2)
     val scale = 3
 
@@ -1032,7 +1032,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def bcdDec4Pos() {
+  @Test def bcdDec4Pos(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -1046,7 +1046,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def bcdDec5Pos() {
+  @Test def bcdDec5Pos(): Unit = {
     val num = new Array[Byte](10)
     val scale = 19
 
@@ -1065,7 +1065,7 @@ class TestDecimalUtils {
     assertArrayEquals(bcdFromBigInteger(bignum.unscaledValue, num.length*8), num)
   }
 
-  @Test def packedInvalidHighNibble1() {
+  @Test def packedInvalidHighNibble1(): Unit = {
     val num = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
     val scale = 0
@@ -1079,7 +1079,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def packedInvalidHighNibble2() {
+  @Test def packedInvalidHighNibble2(): Unit = {
     val num = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
     val scale = 5
@@ -1098,7 +1098,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def packedInvalidLowNibble1() {
+  @Test def packedInvalidLowNibble1(): Unit = {
     val num = new Array[Byte](1)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
 
@@ -1111,7 +1111,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def packedInvalidLowNibble2() {
+  @Test def packedInvalidLowNibble2(): Unit = {
     val num = new Array[Byte](6)
     val signCodes = PackedSignCodes("C D F C", BinaryNumberCheckPolicy.Strict)
     val scale = 5
@@ -1130,7 +1130,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def bcdInvalidHighNibble1() {
+  @Test def bcdInvalidHighNibble1(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -1143,7 +1143,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def bcdInvalidHighNibble2() {
+  @Test def bcdInvalidHighNibble2(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -1160,7 +1160,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def bcdInvalidLowNibble1() {
+  @Test def bcdInvalidLowNibble1(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -1173,7 +1173,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def bcdInvalidLowNibble2() {
+  @Test def bcdInvalidLowNibble2(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -1190,7 +1190,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def ibm4690InvalidHighNibble1() {
+  @Test def ibm4690InvalidHighNibble1(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -1203,7 +1203,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def ibm4690InvalidHighNibble2() {
+  @Test def ibm4690InvalidHighNibble2(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -1220,7 +1220,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def ibm4690InvalidLowNibble1() {
+  @Test def ibm4690InvalidLowNibble1(): Unit = {
     val num = new Array[Byte](1)
     val scale = 0
 
@@ -1233,7 +1233,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def ibm4690InvalidLowNibble2() {
+  @Test def ibm4690InvalidLowNibble2(): Unit = {
     val num = new Array[Byte](5)
     val scale = 5
 
@@ -1250,14 +1250,14 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def zonedIntAsciiStandardPos1() {
+  @Test def zonedIntAsciiStandardPos1(): Unit = {
     val num = "1"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiStandardPos2() {
+  @Test def zonedIntAsciiStandardPos2(): Unit = {
     val num = "12"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End)
     System.out.println("Result: " + result)
@@ -1265,63 +1265,63 @@ class TestDecimalUtils {
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiStandardPos3() {
+  @Test def zonedIntAsciiStandardPos3(): Unit = {
     val num = "123"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.None)
     assertEquals(result, "123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.None), num)
   }
 
-  @Test def zonedIntAsciiStandardPos4() {
+  @Test def zonedIntAsciiStandardPos4(): Unit = {
     val num = "1234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiStandardPos5() {
+  @Test def zonedIntAsciiStandardPos5(): Unit = {
     val num = "000000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), "000000000001234567890")
   }
 
-  @Test def zonedIntAsciiStandardNeg1() {
+  @Test def zonedIntAsciiStandardNeg1(): Unit = {
     val num = "q"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "-1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiStandardNeg2() {
+  @Test def zonedIntAsciiStandardNeg2(): Unit = {
     val num = "1r"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End)
     assertEquals(result, "-12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiStandardNeg3() {
+  @Test def zonedIntAsciiStandardNeg3(): Unit = {
     val num = "q23"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "-123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiStandardNeg4() {
+  @Test def zonedIntAsciiStandardNeg4(): Unit = {
     val num = "123456789p"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End)
     assertEquals(result, "-1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiStandardNeg5() {
+  @Test def zonedIntAsciiStandardNeg5(): Unit = {
     val num = "p00000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
     assertEquals(result, "-000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiStandardInvalidDigit() {
+  @Test def zonedIntAsciiStandardInvalidDigit(): Unit = {
     val num = "z123"
     try {
       val result = zonedToNumber(num, TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start)
@@ -1331,77 +1331,77 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICPos1() {
+  @Test def zonedIntAsciiTranslatedEBCDICPos1(): Unit = {
     val num = "A"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
     assertEquals(result, "1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICPos2() {
+  @Test def zonedIntAsciiTranslatedEBCDICPos2(): Unit = {
     val num = "1B"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End)
     assertEquals(result, "12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICPos3() {
+  @Test def zonedIntAsciiTranslatedEBCDICPos3(): Unit = {
     val num = "123"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.None)
     assertEquals(result, "123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.None), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICPos4() {
+  @Test def zonedIntAsciiTranslatedEBCDICPos4(): Unit = {
     val num = "A234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
     assertEquals(result, "1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICPos5() {
+  @Test def zonedIntAsciiTranslatedEBCDICPos5(): Unit = {
     val num = "00000000000123456789{"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End)
     assertEquals(result, "000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICNeg1() {
+  @Test def zonedIntAsciiTranslatedEBCDICNeg1(): Unit = {
     val num = "J"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
     assertEquals(result, "-1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICNeg2() {
+  @Test def zonedIntAsciiTranslatedEBCDICNeg2(): Unit = {
     val num = "1K"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End)
     assertEquals(result, "-12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICNeg3() {
+  @Test def zonedIntAsciiTranslatedEBCDICNeg3(): Unit = {
     val num = "J23"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
     assertEquals(result, "-123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICNeg4() {
+  @Test def zonedIntAsciiTranslatedEBCDICNeg4(): Unit = {
     val num = "123456789}"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End)
     assertEquals(result, "-1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICNeg5() {
+  @Test def zonedIntAsciiTranslatedEBCDICNeg5(): Unit = {
     val num = "}00000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
     assertEquals(result, "-000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICInvalidDigit() {
+  @Test def zonedIntAsciiTranslatedEBCDICInvalidDigit(): Unit = {
     val num = "z123"
     try {
       val result = zonedToNumber(num, TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start)
@@ -1411,77 +1411,77 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedPos1() {
+  @Test def zonedIntAsciiCARealiaModifiedPos1(): Unit = {
     val num = "1"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
     assertEquals(result, "1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedPos2() {
+  @Test def zonedIntAsciiCARealiaModifiedPos2(): Unit = {
     val num = "12"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End)
     assertEquals(result, "12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedPos3() {
+  @Test def zonedIntAsciiCARealiaModifiedPos3(): Unit = {
     val num = "123"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.None)
     assertEquals(result, "123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.None), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedPos4() {
+  @Test def zonedIntAsciiCARealiaModifiedPos4(): Unit = {
     val num = "1234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
     assertEquals(result, "1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedPos5() {
+  @Test def zonedIntAsciiCARealiaModifiedPos5(): Unit = {
     val num = "000000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End)
     assertEquals(result, "000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedNeg1() {
+  @Test def zonedIntAsciiCARealiaModifiedNeg1(): Unit = {
     val num = "!"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
     assertEquals(result, "-1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedNeg2() {
+  @Test def zonedIntAsciiCARealiaModifiedNeg2(): Unit = {
     val num = "1\""
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End)
     assertEquals(result, "-12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedNeg3() {
+  @Test def zonedIntAsciiCARealiaModifiedNeg3(): Unit = {
     val num = "!23"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
     assertEquals(result, "-123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedNeg4() {
+  @Test def zonedIntAsciiCARealiaModifiedNeg4(): Unit = {
     val num = "123456789 "
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End)
     assertEquals(result, "-1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedNeg5() {
+  @Test def zonedIntAsciiCARealiaModifiedNeg5(): Unit = {
     val num = " 00000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
     assertEquals(result, "-000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedInvalidDigit() {
+  @Test def zonedIntAsciiCARealiaModifiedInvalidDigit(): Unit = {
     val num = "z123"
     try {
       val result = zonedToNumber(num, TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start)
@@ -1491,77 +1491,77 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def zonedIntAsciiTandemModifiedPos1() {
+  @Test def zonedIntAsciiTandemModifiedPos1(): Unit = {
     val num = "1"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
     assertEquals(result, "1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedPos2() {
+  @Test def zonedIntAsciiTandemModifiedPos2(): Unit = {
     val num = "12"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End)
     assertEquals(result, "12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedPos3() {
+  @Test def zonedIntAsciiTandemModifiedPos3(): Unit = {
     val num = "123"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.None)
     assertEquals(result, "123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.None), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedPos4() {
+  @Test def zonedIntAsciiTandemModifiedPos4(): Unit = {
     val num = "1234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
     assertEquals(result, "1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedPos5() {
+  @Test def zonedIntAsciiTandemModifiedPos5(): Unit = {
     val num = "000000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End)
     assertEquals(result, "000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedNeg1() {
+  @Test def zonedIntAsciiTandemModifiedNeg1(): Unit = {
     val num = ""
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
     assertEquals(result, "-1")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedNeg2() {
+  @Test def zonedIntAsciiTandemModifiedNeg2(): Unit = {
     val num = "1"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End)
     assertEquals(result, "-12")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedNeg3() {
+  @Test def zonedIntAsciiTandemModifiedNeg3(): Unit = {
     val num = "23"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
     assertEquals(result, "-123")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedNeg4() {
+  @Test def zonedIntAsciiTandemModifiedNeg4(): Unit = {
     val num = "123456789"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End)
     assertEquals(result, "-1234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.End), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedNeg5() {
+  @Test def zonedIntAsciiTandemModifiedNeg5(): Unit = {
     val num = "00000000001234567890"
     val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
     assertEquals(result, "-000000000001234567890")
     assertEquals(zonedFromNumber(result, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), num)
   }
 
-  @Test def zonedIntAsciiTandemModifiedInvalidDigit() {
+  @Test def zonedIntAsciiTandemModifiedInvalidDigit(): Unit = {
     val num = "z123"
     try {
       val result = zonedToNumber(num, TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start)
@@ -1571,7 +1571,7 @@ class TestDecimalUtils {
     }
   }
 
-  @Test def zonedIntAsciiStandardAllDigits() {
+  @Test def zonedIntAsciiStandardAllDigits(): Unit = {
     assertEquals(zonedToNumber("0", TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), "0")
     assertEquals(zonedFromNumber("0", TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), "0")
     assertEquals(zonedToNumber("1", TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), "1")
@@ -1614,7 +1614,7 @@ class TestDecimalUtils {
     assertEquals(zonedFromNumber("-9", TextZonedSignStyle.AsciiStandard, OverpunchLocation.Start), "y")
   }
 
-  @Test def zonedIntAsciiTranslatedEBCDICAllDigits() {
+  @Test def zonedIntAsciiTranslatedEBCDICAllDigits(): Unit = {
     assertEquals(zonedToNumber("0", TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.None), "0")
     assertEquals(zonedFromNumber("0", TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.None), "0")
     assertEquals(zonedToNumber("1", TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.None), "1")
@@ -1677,7 +1677,7 @@ class TestDecimalUtils {
     assertEquals(zonedFromNumber("-9", TextZonedSignStyle.AsciiTranslatedEBCDIC, OverpunchLocation.Start), "R")
   }
 
-  @Test def zonedIntAsciiCARealiaModifiedAllDigits() {
+  @Test def zonedIntAsciiCARealiaModifiedAllDigits(): Unit = {
     assertEquals(zonedToNumber("0", TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), "0")
     assertEquals(zonedFromNumber("0", TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), "0")
     assertEquals(zonedToNumber("1", TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), "1")
@@ -1720,7 +1720,7 @@ class TestDecimalUtils {
     assertEquals(zonedFromNumber("-9", TextZonedSignStyle.AsciiCARealiaModified, OverpunchLocation.Start), ")")
   }
 
-  @Test def zonedIntAsciiTandemModifiedAllDigits() {
+  @Test def zonedIntAsciiTandemModifiedAllDigits(): Unit = {
     assertEquals(zonedToNumber("0", TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), "0")
     assertEquals(zonedFromNumber("0", TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), "0")
     assertEquals(zonedToNumber("1", TextZonedSignStyle.AsciiTandemModified, OverpunchLocation.Start), "1")

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
@@ -36,7 +36,7 @@ class MyClass extends Logging {
   lazy val bombArg: String = Assert.abort("bombArg should not be evaluated")
   lazy val bombMsg: String = Assert.abort("bombMsg should not be evaluated")
 
-  def logSomething() {
+  def logSomething(): Unit = {
 
     ForUnitTestLogWriter.loggedMsg = null
 
@@ -67,7 +67,7 @@ class MyClass extends Logging {
 
 class TestLogger {
 
-  @Test def test1() {
+  @Test def test1(): Unit = {
     val c = new MyClass
     c.setLoggingLevel(LogLevel.Error)
     c.logSomething()

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeInlineForeach.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeInlineForeach.scala
@@ -35,21 +35,21 @@ final class TestMaybeInlineForeach {
   /**
    * Disassemble to see that scala/java byte code does/does-not have a function object involved.
    */
-  def usesForeach(m: Maybe[String]) {
+  def usesForeach(m: Maybe[String]): Unit = {
     m._foreach { bar(_) }
   }
 
   /**
    * We want using foreach to behave exactly like this piece of code.
    */
-  def usesIfDefined(m: Maybe[String]) {
+  def usesIfDefined(m: Maybe[String]): Unit = {
     if (m.isDefined) bar(m.value)
   }
 
   /**
    * And that ifDefined test should behave exactly like this code.
    */
-  def usesIfNull(m: String) {
+  def usesIfNull(m: String): Unit = {
     if (m != null) bar(m)
   }
   /**
@@ -65,7 +65,7 @@ final class TestMaybeInlineForeach {
    */
   @inline private def limit = 1000000000L // 50000000000L runs for about a minute
 
-  def testForeach {
+  def testForeach: Unit = {
     var i: Long = 0
     while (i < limit) {
       i += 1
@@ -73,7 +73,7 @@ final class TestMaybeInlineForeach {
     }
   }
 
-  def testIfDefined {
+  def testIfDefined: Unit = {
     var i: Long = 0
     i = 0
     while (i < limit) {
@@ -82,7 +82,7 @@ final class TestMaybeInlineForeach {
     }
   }
 
-  def testIfNull {
+  def testIfNull: Unit = {
     var i: Long = 0
     i = 0
     while (i < limit) {
@@ -97,7 +97,7 @@ final class TestMaybeInlineForeach {
    * but there's no point waiting 2 seconds for this test to run all the time.
    */
   // @Test
-  def testForeachVersusIfDefined {
+  def testForeachVersusIfDefined: Unit = {
     val foreachNanos: Double = time(testForeach)
     val ifDefinedNanos: Double = time(testIfDefined)
     val ifNullNanos: Double = time(testIfNull)
@@ -134,7 +134,7 @@ final class TestMaybeInlineForeach {
     }
   }
 
-  def bar(s: String) {
+  def bar(s: String): Unit = {
     if (s == "won't equal this") println(s)
   }
 

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeTakPerf.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeTakPerf.scala
@@ -132,7 +132,7 @@ class TestMaybeTakPerf {
    * every time we run regression testing.
    */
   // @Test // can run as Scala application using companion object App below.
-  def testTak() {
+  def testTak(): Unit = {
 
     /**
      * We're going to use the same Tak arguments that are used to

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMisc.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMisc.scala
@@ -22,7 +22,7 @@ import org.junit.Assert._
 
 class TestMisc {
 
-  @Test def testIsAllUpper() {
+  @Test def testIsAllUpper(): Unit = {
     assertTrue(Misc.isAllUpper("A", 0))
     assertFalse(Misc.isAllUpper("a", 0))
     assertTrue(Misc.isAllUpper("AB", 0))
@@ -36,7 +36,7 @@ class TestMisc {
     assertFalse(Misc.isAllUpper("ABc", 1))
   }
 
-  @Test def testToInitialLowerUnlessAllUpper() {
+  @Test def testToInitialLowerUnlessAllUpper(): Unit = {
     assertEquals("fooBar", Misc.toInitialLowerCaseUnlessAllUpperCase("FooBar"))
     assertEquals("FOOBAR", Misc.toInitialLowerCaseUnlessAllUpperCase("FOOBAR"))
     assertEquals("fOOBAR", Misc.toInitialLowerCaseUnlessAllUpperCase("fOOBAR"))

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumberStuff.scala
@@ -37,7 +37,7 @@ import org.junit.Assert.assertTrue
 class TestNumberStuff {
 
   @Test
-  def test1() {
+  def test1(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val maxUL = "18446744073709551615"
@@ -46,7 +46,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test2() {
+  def test2(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val maxUL = "-18446744073709551615"
@@ -57,7 +57,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test3() {
+  def test3(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val tooBig = "18446744073709551616" // one larger than maxUL
@@ -70,7 +70,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test4() {
+  def test4(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val v = "1"
@@ -79,7 +79,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test5() {
+  def test5(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val maxUL = "-1"
@@ -90,7 +90,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test6() {
+  def test6(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val maxUL = "18446744073709551615"
@@ -100,7 +100,7 @@ class TestNumberStuff {
   }
 
   @Test
-  def test7() {
+  def test7(): Unit = {
     val dl = UnsignedLongConverter()
     val p = dl.parser
     val v = "definitelyNotANumber"
@@ -110,7 +110,7 @@ class TestNumberStuff {
     assertTrue(exc.getMessage().contains("not a valid"))
   }
 
-  @Test def test8() {
+  @Test def test8(): Unit = {
     val dl = LongConverter()
     val p = dl.parser
     val v = "definitelyNotANumber"
@@ -120,7 +120,7 @@ class TestNumberStuff {
     assertTrue(exc.getMessage().contains("not a valid"))
   }
 
-  @Test def test9() {
+  @Test def test9(): Unit = {
     val dl = LongConverter()
     val p = dl.parser
     val v = "1              " // lots of spaces after
@@ -130,12 +130,12 @@ class TestNumberStuff {
     assertTrue(exc.getMessage().contains("consume all"))
   }
 
-  @Test def testHex2Bits() {
+  @Test def testHex2Bits(): Unit = {
     val actual = Misc.hex2Bits("ab3")
     assertEquals("101010110011", actual)
   }
 
-  @Test def testBytesToBits() {
+  @Test def testBytesToBits(): Unit = {
     val xml = <foo>&#xA2;</foo>
     val bytes = xml.child(0).text.getBytes("utf-8")
     val actual = Misc.bytes2Bits(bytes)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumbers.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestNumbers.scala
@@ -24,7 +24,7 @@ import java.math.{ BigDecimal => JBigDecimal }
 import java.math.RoundingMode
 
 class TestNumbers {
-  @Test def testDecimalDivision1() {
+  @Test def testDecimalDivision1(): Unit = {
     val n = new JBigDecimal("90.0")
     assertEquals(1, n.scale())
     val m = new JBigDecimal("1048575.0")
@@ -34,7 +34,7 @@ class TestNumbers {
     assertEquals(expected, quotient)
   }
 
-  @Test def testDecimalDivision2() {
+  @Test def testDecimalDivision2(): Unit = {
     val n = new JBigDecimal("90.0000000000")
     assertEquals(10, n.scale())
     val m = new JBigDecimal("1048575.0000000000")
@@ -44,7 +44,7 @@ class TestNumbers {
     assertEquals(expected, quotient)
   }
 
-  @Test def testDoubleToDecimal1() {
+  @Test def testDoubleToDecimal1(): Unit = {
     val bd = new JBigDecimal(java.lang.Double.MIN_VALUE)
     // val bdString = bd.toPlainString()
     //
@@ -54,7 +54,7 @@ class TestNumbers {
     assertEquals(expected, bd)
   }
 
-  @Test def testDecimalAsDoubleDivision1() {
+  @Test def testDecimalAsDoubleDivision1(): Unit = {
     val n = (new JBigDecimal("90.0")).doubleValue()
     val m = (new JBigDecimal("1048575.0")).doubleValue()
     val quotient = n / m
@@ -76,7 +76,7 @@ class TestNumbers {
     assertEquals(expected1, double2, 1e-15)
   }
 
-  @Test def testDecimalAsDoubleDivision2() {
+  @Test def testDecimalAsDoubleDivision2(): Unit = {
     val n = (new JBigDecimal("90.0000000000")).doubleValue()
     val m = (new JBigDecimal("1048575.0000000000")).doubleValue()
     val quotient = n / m
@@ -91,14 +91,14 @@ class TestNumbers {
     assertEquals(expected2, decimalQuotient)
   }
 
-  @Test def testIsDecimalDouble() {
+  @Test def testIsDecimalDouble(): Unit = {
     val foo = new JBigDecimal("0.2")
     val bar = new JBigDecimal("0.200000000000")
     assertTrue(Numbers.isDecimalDouble(foo))
     assertFalse(Numbers.isDecimalDouble(bar))
   }
 
-  @Test def testIsDecimalDouble2() {
+  @Test def testIsDecimalDouble2(): Unit = {
     assertTrue(Numbers.isDecimalDouble(new JBigDecimal("90.0")))
     assertTrue(Numbers.isDecimalDouble(new JBigDecimal("1048575.0")))
     assertFalse(Numbers.isDecimalDouble(new JBigDecimal("90.0000000000")))

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSchemaUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSchemaUtils.scala
@@ -63,7 +63,7 @@ class TestSchemaUtils {
     }
   }
 
-  @Test def testDFDLTestSchema1() {
+  @Test def testDFDLTestSchema1(): Unit = {
     val incl = test1 \\ "include"
     val anns = test1 \\ "format"
     val elems = test1 \\ "element"

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSerializationAndLazy.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestSerializationAndLazy.scala
@@ -46,7 +46,7 @@ class ToSerialize extends Serializable {
 class TestSerializationAndLazy {
 
   @Test
-  def testSerializeBeforeLazyEval() {
+  def testSerializeBeforeLazyEval(): Unit = {
     val instance = new ToSerialize
     val baos = new ByteArrayOutputStream
     val stream = new ObjectOutputStream(baos)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestUtil.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestUtil.scala
@@ -24,12 +24,12 @@ import org.apache.daffodil.Implicits._
 
 class TestUtil {
 
-  @Test def testGetRequiredResourceSucceeds() {
+  @Test def testGetRequiredResourceSucceeds(): Unit = {
     val res = Misc.getRequiredResource("org/apache/daffodil/xsd/XMLSchema.xsd")
     assertNotNull(res)
   }
 
-  @Test def testGetRequiredResourceFails() {
+  @Test def testGetRequiredResourceFails(): Unit = {
     val e = intercept[Exception] {
       Misc.getRequiredResource("org/apache/daffodil/xsd/NotAResourceName.foo")
     }
@@ -37,12 +37,12 @@ class TestUtil {
   }
 
   @Test
-  def testStripQuotes() {
+  def testStripQuotes(): Unit = {
     assertEquals("foo", Misc.stripQuotes("\"foo\""))
   }
 
   @Test
-  def testAssert() {
+  def testAssert(): Unit = {
     try {
       Assert.abort("yadda")
       // fail()
@@ -53,14 +53,14 @@ class TestUtil {
   }
 
   @Test
-  def testBitsConverters1() {
+  def testBitsConverters1(): Unit = {
     val bytes = Misc.bits2Bytes("11")
     val theByte = bytes(0)
     assertEquals(3, theByte.toInt)
   }
 
   @Test
-  def testBitsConverters2() {
+  def testBitsConverters2(): Unit = {
     val bytes = Misc.bits2Bytes("110110110110")
     val byte0 = bytes(0)
     val byte1 = bytes(1)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestXMLCatalogAndValidate.scala
@@ -86,7 +86,7 @@ class TestXMLCatalogAndValidate {
     new File(fn)
   }
 
-  @Test def test1() {
+  @Test def test1(): Unit = {
 
     // lets make sure we're not using files that would naturally be on the classpath
     val tmpSchemaFileName = tempFileName("_sch.xsd")
@@ -146,7 +146,7 @@ class TestXMLCatalogAndValidate {
     }
   }
 
-  @Test def test2() {
+  @Test def test2(): Unit = {
 
     val tmpSchema1FileName = tempFileName("_sch1.xsd")
     val tmpSchema2FileName = tempFileName("_sch2.xsd")
@@ -223,7 +223,7 @@ class TestXMLCatalogAndValidate {
     }
   }
 
-  @Test def test3() {
+  @Test def test3(): Unit = {
     // lets make sure we're not using files that would naturally be on the classpath
     System.setProperty("xml.catalog.ignoreMissing", "true")
 
@@ -251,7 +251,7 @@ class TestXMLCatalogAndValidate {
     }
   }
 
-  @Test def test4() {
+  @Test def test4(): Unit = {
     // lets make sure we're not using files that would naturally be on the classpath
     System.setProperty("xml.catalog.ignoreMissing", "true")
 
@@ -309,7 +309,7 @@ class SchemaAwareFactoryAdapter()
   var saxLocator: org.xml.sax.Locator = _
 
   // Get location
-  override def setDocumentLocator(locator: org.xml.sax.Locator) {
+  override def setDocumentLocator(locator: org.xml.sax.Locator): Unit = {
     //    println("setDocumentLocator line=%s col=%s sysID=%s, pubID=%s".format(
     //      locator.getLineNumber, locator.getColumnNumber,
     //      locator.getSystemId, locator.getPublicId))

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestNamespaces.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestNamespaces.scala
@@ -31,7 +31,7 @@ class TestNamespaces {
   /**
    * basic namespace access from prefix.
    */
-  @Test def testScalaNamespace1() {
+  @Test def testScalaNamespace1(): Unit = {
     val xml = <bar xmlns:foo="fooNamespaceID">
                 <quux attr1="x"/>
               </bar>
@@ -42,7 +42,7 @@ class TestNamespaces {
   /**
    * Pass null (not "") to retrieve the default NS
    */
-  @Test def testScalaNamespace2() {
+  @Test def testScalaNamespace2(): Unit = {
     val xml = <bar xmlns="defaultNamespaceID">
                 <quux attr1="x"/>
               </bar>
@@ -54,7 +54,7 @@ class TestNamespaces {
    * When the prefix doesn't correspond to any ns definition
    * you get null back.
    */
-  @Test def testScalaNamespace3() {
+  @Test def testScalaNamespace3(): Unit = {
     val xml = <bar>
                 <quux attr1="x"/>
               </bar>
@@ -66,7 +66,7 @@ class TestNamespaces {
    * Pass null in order to retrieve the default namespace.
    * If there isn't one, you get null back.
    */
-  @Test def testScalaNamespace4() {
+  @Test def testScalaNamespace4(): Unit = {
     val xml = <bar>
                 <quux attr1="x"/>
               </bar>
@@ -77,7 +77,7 @@ class TestNamespaces {
   /**
    * Passing "" to getNamespace() is problematic.
    */
-  @Test def testScalaNamespace5() {
+  @Test def testScalaNamespace5(): Unit = {
     val xml = <bar>
                 <quux attr1="x"/>
               </bar>
@@ -88,7 +88,7 @@ class TestNamespaces {
   /**
    * Illustrates that you cannot use "" to access the default namespace.
    */
-  @Test def testScalaNamespace6() {
+  @Test def testScalaNamespace6(): Unit = {
     val xml = <bar xmlns="defaultNS">
                 <quux attr1="x"/>
               </bar>
@@ -100,7 +100,7 @@ class TestNamespaces {
    * This test illustrates the technique for constructing a new
    * xml element that has the same namespaces as some other XML context.
    */
-  @Test def testNewElementWithNamespaces() {
+  @Test def testNewElementWithNamespaces(): Unit = {
     val xml = <bar xmlns="defaultNS" xmlns:foo="fooNS" xmlns:bar="barNS">
                 <quux xmlns:baz="bazNS" attr1="x"/>
               </bar>

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestQName.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestQName.scala
@@ -32,7 +32,7 @@ import java.net.URISyntaxException
 
 class TestQName {
 
-  @Test def testQNameLongPrefix() {
+  @Test def testQNameLongPrefix(): Unit = {
     val bigPrefix = ("a" * 6000)
     val data = <xs:element name="one" type={ bigPrefix + ":b" }/>
     val qntext = (data \ "@type").text
@@ -47,7 +47,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName1() {
+  @Test def testExtQName1(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("local")
     tryrqn match {
       case Success(RefQName(None, "local", UnspecifiedNamespace)) => // ok
@@ -55,7 +55,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName2() {
+  @Test def testExtQName2(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("{}local")
     tryrqn match {
       case Success(RefQName(None, "local", NoNamespace)) => // ok
@@ -63,7 +63,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName3() {
+  @Test def testExtQName3(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("{uri}local")
     tryrqn match {
       case Success(RefQName(None, "local", ns)) => assertEquals("uri", ns.uri.toString)
@@ -71,7 +71,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName4() {
+  @Test def testExtQName4(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("pre:local")
     tryrqn match {
       case Success(RefQName(Some("pre"), "local", UnspecifiedNamespace)) => //ok
@@ -79,7 +79,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName5() {
+  @Test def testExtQName5(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("pre:{}local")
     tryrqn match {
       case Failure(exc: ExtendedQNameSyntaxException) => // ok
@@ -87,7 +87,7 @@ class TestQName {
     }
   }
 
-  @Test def testExtQName6() {
+  @Test def testExtQName6(): Unit = {
     val tryrqn = QName.refQNameFromExtendedSyntax("{http://<<notValidURI>>}local")
     tryrqn match {
       case Failure(exc: ExtendedQNameSyntaxException) => {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUTF8AndUTF16Conversions.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUTF8AndUTF16Conversions.scala
@@ -34,7 +34,7 @@ import org.junit.Test
 
 class TestUTF8AndUTF16Conversions {
 
-  @Test def testDecoding() {
+  @Test def testDecoding(): Unit = {
     // This is dollar sign, cents sign, euro symbol,
     // and a 3-byte unicode whitespace character (which has been problematic
     // some places we think)
@@ -45,13 +45,13 @@ class TestUTF8AndUTF16Conversions {
     assertEquals(9, bytes.length)
   }
 
-  @Test def testEquality() {
+  @Test def testEquality(): Unit = {
     val data = <data><d>&#x24;</d></data>
     val data2 = <data><d>$</d></data>
     assertEquals(data2, data)
   }
 
-  @Test def testSupplementalCharSurrogates() {
+  @Test def testSupplementalCharSurrogates(): Unit = {
     // U+1d420 is a script capital A which is part of the unicode supplemental characters
     // which requires a surrogate pair in the JVM/Java/Scala, and 4 bytes of UTF-8 representation.
     val data = <data>&#x1d420;</data>
@@ -71,7 +71,7 @@ class TestUTF8AndUTF16Conversions {
    * (total of 6 bytes for the character) instead of the more modern
    * (and required!) 4-byte utf-8 encoding.
    */
-  @Test def testReadSurrogateCodePointsLikeCharacters() {
+  @Test def testReadSurrogateCodePointsLikeCharacters(): Unit = {
 
     val data = <data>&#xd835;&#xdcd0;</data> //technically, this is illegal.
     val str = data.child.text

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUnicodeXMLI18N.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestUnicodeXMLI18N.scala
@@ -29,7 +29,7 @@ class TestUnicodeXMLI18N {
   /**
    * Let's characterize the behavior of XML Literals in Scala.
    */
-  @Test def testXMLEntities() {
+  @Test def testXMLEntities(): Unit = {
     val fragment = <x>abc&amp;def</x> // XML Entities disappear for us. We never see them. 
     val txt = fragment.text
     assertEquals("abc&def", txt)
@@ -38,7 +38,7 @@ class TestUnicodeXMLI18N {
   /**
    * Obscure corner about XML. XML isn't allowed to contain character code 0 no way no how, not even as an entity.
    */
-  @Test def testNUL1() {
+  @Test def testNUL1(): Unit = {
     val fragment = <x>abc&#x0000;def</x> // This isn't supposed to work in XML. character code 0 is never allowed in XML documents.
     // TODO: implement our own enforcement of disallowing NUL in XML infoset strings.
     // TODO: consider XML v1.0 versus v1.1 - infosets allow different character codes. 1.1 only disallows 0.
@@ -51,7 +51,7 @@ class TestUnicodeXMLI18N {
    * if this test doesn't pass, your environment is not adequately set up for Unicode and internationalized
    * characters
    */
-  @Test def testUnicodeElementAndAttributeNames() {
+  @Test def testUnicodeElementAndAttributeNames(): Unit = {
     //    val fragment = <Date 年月日="2003年08月27日">2003年08月27日<SUB2003年08月27日>hi</SUB2003年08月27日></Date> // <!-- element contains unicode in its name -->
     //    val txt = fragment.text
     //    assertEquals("2003年08月27日hi", txt)
@@ -74,37 +74,37 @@ class TestUnicodeXMLI18N {
   def isElement(elem: Node) = elem.label == "element" && isXS(elem)
 
   val xmlnsURI = XMLUtils.XSD_NAMESPACE
-  @Test def testRightElementRightPrefixRightNS() {
+  @Test def testRightElementRightPrefixRightNS(): Unit = {
     val xsSequence = <xs:sequence xmlns:xs={ xmlnsURI }/>
     assertTrue(isSequence(xsSequence))
   }
 
-  @Test def testRightElementWrongPrefixRightNS() {
+  @Test def testRightElementWrongPrefixRightNS(): Unit = {
     val xsSequence = <wrong:sequence xmlns:wrong={ xmlnsURI }/>
     assertTrue(isSequence(xsSequence))
   }
 
-  @Test def testRightElementRightPrefixWrongNS() {
+  @Test def testRightElementRightPrefixWrongNS(): Unit = {
     val xsSequence = <xs:sequence xmlns:xs="http://Not.the.right.namespace"/>
     assertFalse(isSequence(xsSequence))
   }
 
-  @Test def testRightElementWrongPrefixWrongNS() {
+  @Test def testRightElementWrongPrefixWrongNS(): Unit = {
     val xsSequence = <wrong:sequence xmlns:wrong="http://Not.the.right.namespace"/>
     assertFalse(isSequence(xsSequence))
   }
 
-  @Test def testWrongElementRightPrefixRightNS() {
+  @Test def testWrongElementRightPrefixRightNS(): Unit = {
     val xsSequence = <xs:idaho xmlns:xs={ xmlnsURI }/>
     assertFalse(isSequence(xsSequence))
   }
 
-  @Test def testIsSchema() {
+  @Test def testIsSchema(): Unit = {
     val xsSchema = <xs:schema xmlns:xs={ xmlnsURI }/>
     assertTrue(isSchema(xsSchema))
   }
 
-  @Test def testIsElement() {
+  @Test def testIsElement(): Unit = {
     val xsElement = <xs:element xmlns:xs={ xmlnsURI }/>
     assertTrue(isElement(xsElement))
   }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLiterals.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLiterals.scala
@@ -25,7 +25,7 @@ class TestXMLLiterals {
   /**
    * Characterize behavior of scala's xml literals w.r.t. CDATA preservation
    */
-  @Test def test_scala_literals_cdata_bug() {
+  @Test def test_scala_literals_cdata_bug(): Unit = {
     //
     // because we know scala's XML literals don't preserve CDATA as PCData nodes
     // we force it to have a PCData node by constructing one explicitly here.

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
@@ -28,7 +28,7 @@ class TestXMLLoader {
    * At the time of this testing. The basic scala xml loader uses Xerces (java)
    * under the hood. It seems hopelessly broken w.r.t CDATA region preservation.
    */
-  @Test def test_scala_loader_cdata_bug() {
+  @Test def test_scala_loader_cdata_bug(): Unit = {
 
     val data = """<x><![CDATA[a
 b&"<>]]></x>"""

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLPrettyPrinter.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLPrettyPrinter.scala
@@ -26,7 +26,7 @@ class TestXMLPrettyPrinter {
    * Characterize behavior of scala's xml pretty printer with respect to
    * CDATA region preservation.
    */
-  @Test def test_scala_xml_pretty_printer_normalizes_whitespace_inside_cdata_bug() {
+  @Test def test_scala_xml_pretty_printer_normalizes_whitespace_inside_cdata_bug(): Unit = {
     //
     // because we know scala's XML literals don't preserve CDATA as PCData nodes
     // we force it to have a PCData node by constructing one explicitly here.
@@ -50,7 +50,7 @@ class TestXMLPrettyPrinter {
    * Characterize behavior of daffodil's fixed pretty printer with respect to
    * CDATA region preservation.
    */
-  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly() {
+  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly(): Unit = {
     //
     // because we know scala's XML literals don't preserve CDATA as PCData nodes
     // we force it to have a PCData node by constructing one explicitly here.
@@ -67,7 +67,7 @@ class TestXMLPrettyPrinter {
     assertTrue(xmlString.contains("<x><![CDATA[a\nb]]></x>")) // right. Should preserve the newline.
   }
 
-  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_text() {
+  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_text(): Unit = {
 
     val str = """aaaaa
 bbbbb""".replace("\r\n", "\n")
@@ -82,7 +82,7 @@ bbbbb</zzzzz>
 </xxxxx>""".replace("\r\n", "\n"), xmlString)
   }
 
-  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly2() {
+  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly2(): Unit = {
     //
     // because we know scala's XML literals don't preserve CDATA as PCData nodes
     // we force it to have a PCData node by constructing one explicitly here.
@@ -103,7 +103,7 @@ bbbbb ]]></zzzzz>
 </xxxxx>""".replace("\r\n", "\n")))
   }
 
-  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly3() {
+  @Test def test_daffodil_pretty_printer_preserves_whitespace_inside_cdata_properly3(): Unit = {
     //
     // because we know scala's XML literals don't preserve CDATA as PCData nodes
     // we force it to have a PCData node by constructing one explicitly here.
@@ -143,7 +143,7 @@ bbbbb ]]></zzzzz>
     }
   }
 
-  @Test def test_daffodil_pretty_printer_preserves_simple_values1() {
+  @Test def test_daffodil_pretty_printer_preserves_simple_values1(): Unit = {
 
     val fragment = <xxxxx><yyyyy><zzzzz>aaaaa bbbbb ccccc ddddd eeeee fffff ggggg</zzzzz></yyyyy></xxxxx>
     val pp = new org.apache.daffodil.xml.PrettyPrinter(2)
@@ -158,7 +158,7 @@ bbbbb ]]></zzzzz>
     assertEquals(expected, actual)
   }
 
-  @Test def test_daffodil_pretty_printer_removes_redundant_xmlns_bindings() {
+  @Test def test_daffodil_pretty_printer_removes_redundant_xmlns_bindings(): Unit = {
 
     val fragment = <xxxxx xmlns="foobar"><yyyyy><zzzzz xmlns="foobar">aaaaa bbbbb ccccc ddddd eeeee fffff ggggg</zzzzz></yyyyy></xxxxx>
     val pp = new org.apache.daffodil.xml.PrettyPrinter(2)
@@ -172,7 +172,7 @@ bbbbb ]]></zzzzz>
     assertEquals(expected, xmlString)
   }
 
-  @Test def test_daffodil_pretty_printer_newlines_and_indents1() {
+  @Test def test_daffodil_pretty_printer_newlines_and_indents1(): Unit = {
 
     val fragment = <tns:row2 xmlns:tns="http://example.com"><cell>-9</cell><cell>-2</cell><cell>-8</cell></tns:row2>
     val pp = new org.apache.daffodil.xml.PrettyPrinter(2)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
@@ -35,7 +35,7 @@ import org.apache.daffodil.xml.XMLUtils
 
 class TestXMLUtils {
 
-  @Test def testDiff0() {
+  @Test def testDiff0(): Unit = {
     val d1 = new Text("a")
     val d2 = new Text("b")
     val diffs = XMLUtils.computeTextDiff("", d1, d2, None)
@@ -45,7 +45,7 @@ class TestXMLUtils {
     assertEquals("b", b)
   }
 
-  @Test def testDiff1() {
+  @Test def testDiff1(): Unit = {
     val d1 = <d>a</d>
     val d2 = <d>b</d>
     val diffs = XMLUtils.computeDiff(d1, d2)
@@ -55,7 +55,7 @@ class TestXMLUtils {
     assertEquals("b", b)
   }
 
-  @Test def testDiff2() {
+  @Test def testDiff2(): Unit = {
     val d1 = <a><d>a</d><d>x</d></a>
     val d2 = <a><d>a</d><d>y</d></a>
     val diffs = XMLUtils.computeDiff(d1, d2)
@@ -65,7 +65,7 @@ class TestXMLUtils {
     assertEquals("y", b)
   }
 
-  @Test def testDiff3() {
+  @Test def testDiff3(): Unit = {
     val d1 = <a><d>a</d><e>e</e><d>xxx</d><e>e</e></a>
     val d2 = <a><d>a</d><e>f</e><d>xxy</d><e>e</e></a>
     val diffs = XMLUtils.computeDiff(d1, d2)
@@ -79,7 +79,7 @@ class TestXMLUtils {
 
   }
 
-  @Test def testNilDiff1() {
+  @Test def testNilDiff1(): Unit = {
     val d1 = <a xmlns:xsi={ XMLUtils.XSI_NAMESPACE } xsi:nil="true" foo="bar"/>
     val d2 = <a dafint:col="30" xmlns:dafint={ XMLUtils.INT_NS }/>
     val diffs = XMLUtils.computeDiff(d1, d2)
@@ -91,42 +91,42 @@ class TestXMLUtils {
     assertEquals("", d2attribs)
   }
 
-  @Test def testIsNil() {
+  @Test def testIsNil(): Unit = {
     val d1 = JDOMUtils.elem2Element(<a xmlns:xsi={ XMLUtils.XSI_NAMESPACE } xsi:nil="true"/>)
     val d2 = JDOMUtils.elem2Element(<a xmlns:xsi={ XMLUtils.XSI_NAMESPACE }>foo</a>)
     assertTrue(JDOMUtils.isNil(d1))
     assertFalse(JDOMUtils.isNil(d2))
   }
 
-  @Test def testRemapXMLIllegalCharToPUA() {
+  @Test def testRemapXMLIllegalCharToPUA(): Unit = {
     val ec = XMLUtils.remapXMLIllegalCharToPUA(false)(0x0)
     assertEquals(0xE000, ec)
     val ed = XMLUtils.remapXMLIllegalCharToPUA(false)(0xd880)
     assertEquals(0xE880, ed)
   }
 
-  @Test def testRemapPUAToXMLIllegalChar() {
+  @Test def testRemapPUAToXMLIllegalChar(): Unit = {
     val ec = XMLUtils.remapPUAToXMLIllegalChar(false)(0xE000)
     assertEquals(0x0, ec)
     val ed = XMLUtils.remapPUAToXMLIllegalChar(false)(0xE880)
     assertEquals(0xD880, ed)
   }
 
-  @Test def testWalkUnicodeString1() {
+  @Test def testWalkUnicodeString1(): Unit = {
     val s = "abc"
     val Seq((ab, 'a', 'b'), ('a', 'b', 'c'), ('b', 'c', ca)) = XMLUtils.walkUnicodeString(s)((p, c, n) => (p, c, n))
     assertEquals(0.toChar, ab)
     assertEquals(0.toChar, ca)
   }
 
-  @Test def testWalkUnicodeString2() {
+  @Test def testWalkUnicodeString2(): Unit = {
     val s = ""
     XMLUtils.walkUnicodeString(s)((p, c, n) => (p, c, n)) match {
       case Seq() => // ok
     }
   }
 
-  @Test def testRemoveAttributes1() {
+  @Test def testRemoveAttributes1(): Unit = {
     val xml = <test:bar xmlns:test="http://test/" xmlns:test2="http://test2/" xmlns:dafint={ XMLUtils.INT_NS } xmlns:xsi={ XMLUtils.XSI_NAMESPACE }>
                 <test2:foo dafint:qaz="qaz" dafint:line="300" xsi:nil="true"/>
               </test:bar>
@@ -134,7 +134,7 @@ class TestXMLUtils {
     assertEquals(<bar><foo xsi:nil="true"/></bar>, Utility.trim(res))
   }
 
-  @Test def testRemoveAttributes2() {
+  @Test def testRemoveAttributes2(): Unit = {
     val xml = <test:bar xmlns:test="http://test/" xmlns:test2="http://test2/" xmlns:dafint={ XMLUtils.INT_NS } xmlns:xsi={ XMLUtils.XSI_NAMESPACE }>
                 <test2:foo dafint:qaz="qaz" test:raz="raz" xsi:nil="true"/>
               </test:bar>
@@ -142,7 +142,7 @@ class TestXMLUtils {
     assertEquals(<test:bar xmlns:test="http://test/" xmlns:xsi={ XMLUtils.XSI_NAMESPACE }><foo test:raz="raz" xsi:nil="true"/></test:bar>, Utility.trim(res))
   }
 
-  @Test def testRemoveAttributes3() {
+  @Test def testRemoveAttributes3(): Unit = {
     val xml = <foo xsi:nil="true"/>
 
     val res = XMLUtils.removeAttributes(xml)
@@ -155,7 +155,7 @@ class TestXMLUtils {
    * Turns out different ways of acquiring XML result in some
    * different behaviors.
    */
-  @Test def testScalaLiteralXMLCoalesceText() {
+  @Test def testScalaLiteralXMLCoalesceText(): Unit = {
     val xml = <foo>abc<![CDATA[&&&]]>def&#xE000;ghi</foo>
     assertEquals(5, xml.child.length)
     assertTrue(xml.child(0).isInstanceOf[Text])
@@ -176,7 +176,7 @@ class TestXMLUtils {
     assertEquals("def" + 0xE000.toChar + "ghi", res(2).text)
   }
 
-  @Test def testConstructingParserCoalesceText() {
+  @Test def testConstructingParserCoalesceText(): Unit = {
     val xmlRaw = """<foo>abc<![CDATA[&&&]]>def&#xE000;ghi</foo>"""
     import scala.xml.parsing.ConstructingParser
     //
@@ -202,7 +202,7 @@ class TestXMLUtils {
     assertEquals("abc&&&def" + 0xE000.toChar + "ghi", res.text)
   }
 
-  @Test def testStandardLoaderCoalesceText() {
+  @Test def testStandardLoaderCoalesceText(): Unit = {
     val xmlRaw = """<foo>abc<![CDATA[&&&]]>def&#xE000;ghi</foo>"""
     // This is the way we load XML for DFDL Schemas
     val xml = scala.xml.XML.loadString(xmlRaw)
@@ -217,7 +217,7 @@ class TestXMLUtils {
     assertEquals("abc&&&def" + 0xE000.toChar + "ghi", res(0).text)
   }
 
-  @Test def testOnePCData() {
+  @Test def testOnePCData(): Unit = {
     val xmlRaw = """<foo><![CDATA[&&&]]></foo>"""
     import scala.xml.parsing.ConstructingParser
     //
@@ -237,13 +237,13 @@ class TestXMLUtils {
     assertEquals("&&&", res(0).text)
   }
 
-  @Test def testEscapeLineEndings() {
+  @Test def testEscapeLineEndings(): Unit = {
     val input = "abc\r\ndef\rghi\njkl\tmno\u0085pqr"
     val actual = XMLUtils.escape(input).toString()
     assertEquals("abc&#xE00D;&#xA;def&#xE00D;ghi&#xA;jkl&#x9;mno&#x85;pqr", actual)
   }
 
-  @Test def testEscape0To127() {
+  @Test def testEscape0To127(): Unit = {
     val input = (0 to 127).map { _.toChar }.mkString
     val actual = XMLUtils.escape(input).toString()
     val expected = "&#xE000;&#xE001;&#xE002;&#xE003;&#xE004;&#xE005;&#xE006;&#xE007;&#xE008;" + // first batch of C0 controls
@@ -263,7 +263,7 @@ class TestXMLUtils {
     assertEquals(expected, actual)
   }
 
-  @Test def testEscape128To255() {
+  @Test def testEscape128To255(): Unit = {
     val input = (128 to 255).map { _.toChar }.mkString
     val actual = XMLUtils.escape(input).toString()
     val expected = "&#x80;&#x81;&#x82;&#x83;&#x84;&#x85;&#x86;&#x87;&#x88;&#x89;&#x8A;&#x8B;&#x8C;&#x8D;&#x8E;&#x8F;&#x90;&#x91;&#x92;&#x93;&#x94;&#x95;&#x96;&#x97;&#x98;&#x99;&#x9A;&#x9B;&#x9C;&#x9D;&#x9E;&#x9F;&#xA0;¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
@@ -281,7 +281,7 @@ class TestXMLUtils {
     path
   }
 
-  @Test def testBlobDiff01() {
+  @Test def testBlobDiff01(): Unit = {
     val path1 = createBlobFile("A1B2C3")
     val path2 = createBlobFile("A1B2C3")
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)
@@ -290,7 +290,7 @@ class TestXMLUtils {
     Files.delete(path2)
   }
 
-  @Test def testBlobDiff02() {
+  @Test def testBlobDiff02(): Unit = {
     val path1 = createBlobFile("A1B2C3D4")
     val path2 = createBlobFile("A1B1C3")
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)
@@ -301,7 +301,7 @@ class TestXMLUtils {
     Files.delete(path2)
   }
 
-  @Test def testBlobDiff03() {
+  @Test def testBlobDiff03(): Unit = {
     val path1 = createBlobFile("A1B2C3D4")
     val path2 = createBlobFile("")
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)
@@ -312,7 +312,7 @@ class TestXMLUtils {
     Files.delete(path2)
   }
 
-  @Test def testBlobDiff04() {
+  @Test def testBlobDiff04(): Unit = {
     val path1 = createBlobFile("A1B2C3D4")
     val path2 = Paths.get("does/not/exist")
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)
@@ -322,7 +322,7 @@ class TestXMLUtils {
     Files.delete(path1)
   }
 
-  @Test def testBlobDiff05() {
+  @Test def testBlobDiff05(): Unit = {
     val path1 = createBlobFile(("00" * 1024) + ("A1" * 41))
     val path2 = createBlobFile(("00" * 1024))
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)

--- a/daffodil-lib/src/test/scala/passera/test/TestULong.scala
+++ b/daffodil-lib/src/test/scala/passera/test/TestULong.scala
@@ -35,7 +35,7 @@ import passera.unsigned.ULong
 
 class TestULong {
 
-  @Test def testULongToString1 {
+  @Test def testULongToString1: Unit = {
     val mm1 = ULong(-1L)
     assertEquals("FFFFFFFFFFFFFFFF", mm1.toHexString.toUpperCase)
     assertEquals(ULong.MaxValueAsBigInt, mm1.toBigInt)
@@ -43,7 +43,7 @@ class TestULong {
   }
 
   // DAFFODIL-1714
-  @Test def testULongModulus1 {
+  @Test def testULongModulus1: Unit = {
     for (i <- 0 to 16 ) {
       val numerator = ULong(i)
       val denominator = ULong(8)
@@ -52,13 +52,13 @@ class TestULong {
     }
   }
 
-  @Test def testULongModulus2 {
+  @Test def testULongModulus2: Unit = {
     val mm1 = ULong(-1L)
     val remainder = mm1 % ULong(65536)
     assertEquals(ULong(0x0000FFFF), remainder)
   }
   
-  @Test def testULongModulus3 {
+  @Test def testULongModulus3: Unit = {
     val mm1 = ULong(-1L)
     val mm2 = ULong(-2L)
     val remainder = mm1 % mm2

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -670,7 +670,7 @@ import org.apache.daffodil.exceptions.ThrowsSDE
 
 """
 
-  def writeGeneratedCode(thunks: Seq[String], ow: java.io.FileWriter) {
+  def writeGeneratedCode(thunks: Seq[String], ow: java.io.FileWriter): Unit = {
     ow.write(preamble)
     for (thunk <- thunks) {
       ow.write(thunk)
@@ -698,7 +698,7 @@ import org.apache.daffodil.exceptions.ThrowsSDE
   /**
    * Main - run as a scala application to actually create a new GeneratedCode.scala file in the gen directory.
    */
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     if (args.length != 1) {
       System.exit(1);
     }

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -132,7 +132,7 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     .filter { st => (st \@ "name").startsWith("Tunable") }
     .filter { st => !excludedSimpleTypes.contains(st \@ "name") }
 
-  def writeGeneratedCode(w: java.io.FileWriter) {
+  def writeGeneratedCode(w: java.io.FileWriter): Unit = {
     val tunables =
       tunableNodes.map { tunableNode =>
         val schemaName = tunableNode \@ "name"

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
@@ -68,7 +68,7 @@ class WarnIDGenerator(schema: scala.xml.Node) {
   val ssdwNode = (schema \ "simpleType").find( _ \@ "name" == "TunableSuppressSchemaDefinitionWarnings").get
   val enumerationNodes = (ssdwNode \\ "enumeration")
 
-  def writeGeneratedCode(w: java.io.FileWriter) {
+  def writeGeneratedCode(w: java.io.FileWriter): Unit = {
     w.write(top)
     w.write("\n")
 

--- a/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
+++ b/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
@@ -22,7 +22,7 @@ import org.junit.Test
 
 class TestPropertyGenerator {
 
-  @Test def testGenEnum() {
+  @Test def testGenEnum(): Unit = {
     val sch = <xsd:simpleType name="NilKindEnum">
                 <xsd:restriction base="xsd:string">
                   <xsd:enumeration value="literalValue"/>
@@ -46,7 +46,7 @@ class TestPropertyGenerator {
    *
    * Test also looks for the registration of the toString function for the property.
    */
-  @Test def testGenPropMixins() {
+  @Test def testGenPropMixins(): Unit = {
     val sch =
       <xsd:attributeGroup name="LengthPropertiesAG">
         <xsd:attribute name="lengthKind" type="dfdl:LengthKindEnum"/>
@@ -71,7 +71,7 @@ class TestPropertyGenerator {
   /**
    * make sure we generate trait mixin for referenced attribute groups.
    */
-  @Test def testGenPropMixins2() {
+  @Test def testGenPropMixins2(): Unit = {
     val sch =
       <xsd:attributeGroup name="ElementAG">
         <xsd:attributeGroup ref="dfdl:SimpleTypeAG"></xsd:attributeGroup>
@@ -89,7 +89,7 @@ class TestPropertyGenerator {
    * verify that the right thing is generated when the type is xsd:NCName, i.e., a built-in type
    * not one defined in the XML Schema for DFDL annotations.
    */
-  @Test def testGenPropMixins3() {
+  @Test def testGenPropMixins3(): Unit = {
     val sch =
       <xsd:attributeGroup name="TextNumberFormatAG1">
         <xsd:attribute name="textNumberFormatRef" type="xsd:NCName"/>
@@ -99,7 +99,7 @@ class TestPropertyGenerator {
     assertTrue(mx.contains("""convertToNCName(findProperty("textNumberFormatRef")"""))
   }
 
-  @Test def testGenCT() {
+  @Test def testGenCT(): Unit = {
     val sch =
       <xsd:complexType name="DFDLSequenceType">
         <xsd:complexContent>
@@ -116,7 +116,7 @@ class TestPropertyGenerator {
     assertTrue(mx.contains("""with SequenceGroupsWithDelimitersAGMixin"""))
   }
 
-  @Test def testGenCT2() {
+  @Test def testGenCT2(): Unit = {
     val sch =
       <xsd:complexType name="DFDLDefineFormat">
         <xsd:all>
@@ -132,7 +132,7 @@ class TestPropertyGenerator {
     assertTrue(mx.contains("""convertToQName"""))
   }
 
-  @Test def testElement1() {
+  @Test def testElement1(): Unit = {
     val sch =
       <xsd:element name="defineFormat" type="dfdl:DFDLDefineFormat"/>
     val pg = new PropertyGenerator(sch)
@@ -140,7 +140,7 @@ class TestPropertyGenerator {
     assertTrue(mx.contains("""with DFDLDefineFormatMixin"""))
   }
 
-  @Test def testElementWithImmediateComplexType1() {
+  @Test def testElementWithImmediateComplexType1(): Unit = {
     val sch =
       <xsd:element name="defineVariable">
         <xsd:complexType>

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -58,7 +58,7 @@ class ElementUnspecifiedLengthUnparser(
 }
 
 sealed trait RepMoveMixin {
-  def move(start: UState) {
+  def move(start: UState): Unit = {
     val childIndex = start.childIndexStack.pop()
     start.childIndexStack.push(childIndex + 1)
   }
@@ -91,7 +91,7 @@ class ElementUnparserNoRep(
    * Move over in the element children, but not in the group.
    * This avoids separators for this IVC element.
    */
-  override def move(state: UState) {
+  override def move(state: UState): Unit = {
     val childIndex = state.childIndexStack.pop()
     state.childIndexStack.push(childIndex + 1)
   }
@@ -151,7 +151,7 @@ sealed abstract class ElementUnparserBase(
         "</Element>"
   }
 
-  final def computeSetVariables(state: UState) {
+  final def computeSetVariables(state: UState): Unit = {
     // variable assignment. Always after the element value, but
     // also still with this element itself as the context, so before
     // we end element.
@@ -164,17 +164,17 @@ sealed abstract class ElementUnparserBase(
     }
   }
 
-  protected def doBeforeContentUnparser(state: UState) {
+  protected def doBeforeContentUnparser(state: UState): Unit = {
     if (eBeforeUnparser.isDefined)
       eBeforeUnparser.get.unparse1(state)
   }
 
-  protected def doAfterContentUnparser(state: UState) {
+  protected def doAfterContentUnparser(state: UState): Unit = {
     if (eAfterUnparser.isDefined)
       eAfterUnparser.get.unparse1(state)
   }
 
-  protected def runContentUnparser(state: UState) {
+  protected def runContentUnparser(state: UState): Unit = {
     if (eReptypeUnparser.isDefined) {
       eReptypeUnparser.get.unparse1(state)
     } else if (eUnparser.isDefined)
@@ -264,7 +264,7 @@ trait ElementSpecifiedLengthMixin {
   //    mtlop
   //  }
 
-  protected def computeTargetLength(state: UState) {
+  protected def computeTargetLength(state: UState): Unit = {
     if (maybeTargetLengthEv.isDefined) {
       val tlEv = maybeTargetLengthEv.get
       if (tlEv.isConstant) {
@@ -302,7 +302,7 @@ class ElementSpecifiedLengthUnparser(
 
   override lazy val runtimeDependencies = maybeTargetLengthEv.toList.toVector
 
-  override def runContentUnparser(state: UState) {
+  override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(state) // must happen before run() so that we can take advantage of knowing the length
     super.runContentUnparser(state) // setup unparsing, which will block for no valu
   }
@@ -320,7 +320,7 @@ class ElementOVCSpecifiedLengthUnparserSuspendableExpresion(
 
   override lazy val expr = rd.outputValueCalcExpr.get
 
-  override final protected def processExpressionResult(state: UState, v: DataValuePrimitive) {
+  override final protected def processExpressionResult(state: UState, v: DataValuePrimitive): Unit = {
     val diSimple = state.currentInfosetNode.asSimple
 
     diSimple.setDataValue(v)
@@ -360,7 +360,7 @@ class ElementOVCSpecifiedLengthUnparser(
 
   Assert.invariant(context.outputValueCalcExpr.isDefined)
 
-  override def runContentUnparser(state: UState) {
+  override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(state) // must happen before run() so that we can take advantage of knowing the length
     suspendableExpression.run(state) // run the expression. It might or might not have a value.
     super.runContentUnparser(state) // setup unparsing, which will block for no valu
@@ -385,7 +385,7 @@ sealed trait ElementUnparserStartEndStrategy {
 
   protected def captureRuntimeValuedExpressionValues(ustate: UState): Unit
 
-  protected def move(start: UState)
+  protected def move(start: UState): Unit
 
   protected def erd: ElementRuntimeData
 
@@ -497,7 +497,7 @@ trait OVCStartEndStrategy
   /**
    * For OVC, the behavior w.r.t. consuming infoset events is different.
    */
-  protected final override def unparseBegin(state: UState) {
+  protected final override def unparseBegin(state: UState): Unit = {
     val elem =
       if (!state.withinHiddenNest) {
         // outputValueCalc elements are optional in the infoset. If the next event
@@ -537,7 +537,7 @@ trait OVCStartEndStrategy
     state.currentInfosetNodeStack.push(e)
   }
 
-  protected final override def unparseEnd(state: UState) {
+  protected final override def unparseEnd(state: UState): Unit = {
     state.currentInfosetNodeStack.pop
 
     // if an OVC element existed, the start AND end events were consumed in
@@ -597,7 +597,7 @@ trait OVCStartEndStrategy
   // delimiter stack, but probably could get a way with only top of stack for
   // many other things.
 
-  final override protected def captureRuntimeValuedExpressionValues(state: UState) {
+  final override protected def captureRuntimeValuedExpressionValues(state: UState): Unit = {
     //
     // Forces the evaluation of runtime-valued things, and this will cause those
     // that actually are runtime-expressions to be cached on the infoset element.

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
@@ -41,7 +41,7 @@ final class SetVariableSuspendableExpression(
   referencingContext: NonTermRuntimeData)
   extends SuspendableExpression {
 
-  override protected def processExpressionResult(ustate: UState, v: DataValuePrimitive) {
+  override protected def processExpressionResult(ustate: UState, v: DataValuePrimitive): Unit = {
       ustate.variableMap.setVariable(rd, v, referencingContext, ustate)
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
@@ -48,7 +48,7 @@ class AlignmentFillUnparserSuspendableOperation(
     dos.maybeAbsBitPos0b.isDefined
   }
 
-  override def continuation(state: UState) {
+  override def continuation(state: UState): Unit = {
     val dos = state.dataOutputStream
     val b4 = dos.relBitPos0b
     if (!dos.align(alignmentInBits, state))

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLength2.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLength2.scala
@@ -195,7 +195,7 @@ class SimpleTypeRetryUnparserSuspendableOperation(
     state.currentInfosetNode.asSimple.hasValue
   }
 
-  protected def continuation(state: UState) {
+  protected def continuation(state: UState): Unit = {
     vUnparser.unparse1(state)
   }
 }
@@ -220,7 +220,7 @@ class CaptureStartOfContentLengthUnparser(override val context: ElementRuntimeDa
 
   override lazy val runtimeDependencies = Vector()
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
@@ -236,7 +236,7 @@ class CaptureEndOfContentLengthUnparser(override val context: ElementRuntimeData
 
   override lazy val runtimeDependencies = Vector()
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream.asInstanceOf[DirectOrBufferedDataOutputStream]
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
 
@@ -265,7 +265,7 @@ class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData
 
   override lazy val runtimeDependencies = Vector()
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
@@ -281,7 +281,7 @@ class CaptureEndOfValueLengthUnparser(override val context: ElementRuntimeData)
 
   override lazy val runtimeDependencies = Vector()
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
@@ -324,7 +324,7 @@ class TargetLengthOperation(
     true
   }
 
-  override def continuation(state: UState) {
+  override def continuation(state: UState): Unit = {
     // once we have evaluated the targetLengthEv, nothing else to do
     // here
   }
@@ -413,7 +413,7 @@ trait SkipTheBits { self: SuspendableOperation =>
 
   protected val rd: RuntimeData
 
-  protected final def skipTheBits(ustate: UState, skipInBits: Long) {
+  protected final def skipTheBits(ustate: UState, skipInBits: Long): Unit = {
     if (skipInBits > 0) {
       val dos = ustate.dataOutputStream
       if (!dos.skip(skipInBits, ustate))
@@ -444,7 +444,7 @@ class ElementUnusedUnparserSuspendableOperation(
    *
    * and skip that many bits.
    */
-  override def continuation(ustate: UState) {
+  override def continuation(ustate: UState): Unit = {
     val skipInBits = getSkipBits(ustate)
     if (skipInBits < 0)
       UE(ustate, "Data too long by %s bits. Unable to truncate.", -skipInBits)
@@ -538,7 +538,7 @@ class ChoiceUnusedUnparserSuspendableOperation(
    *
    * and skip that many bits.
    */
-  override def continuation(ustate: UState) {
+  override def continuation(ustate: UState): Unit = {
     val startPos0b = dosToCheck_(0).relBitPos0b
     val endPos0b = dosToCheck_.last.relBitPos0b + startPos0b
     val vl = (endPos0b - startPos0b).toLong
@@ -588,7 +588,7 @@ trait PaddingUnparserMixin
     res
   }
 
-  override def continuation(state: UState) {
+  override def continuation(state: UState): Unit = {
     val skipInBits = getSkipBits(state)
     if (skipInBits <= 0) return // padding doesn't worry about data too long. RightFill and ElementUnused do.
     val cs = charset(state)
@@ -765,7 +765,7 @@ class RightFillUnparserSuspendableOperation(
   extends ElementUnusedUnparserSuspendableOperation(rd, targetLengthEv, maybeLengthEv, maybeCharsetEv, maybeLiteralNilEv)
   with PaddingUnparserMixin {
 
-  override def continuation(state: UState) {
+  override def continuation(state: UState): Unit = {
     val skipInBits = getSkipBits(state)
     if (skipInBits == 0L) return
     if (skipInBits > 0) {
@@ -824,7 +824,7 @@ class PrefixLengthSuspendableOperation(
     elem.valueLength.maybeLengthInBits.isDefined
   }
 
-  override def continuation(state: UState) {
+  override def continuation(state: UState): Unit = {
     val len = elem.valueLength.maybeLengthInBits.isDefined
     assignPrefixLength(elem, plElem)
   }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLengthUnparsers.scala
@@ -109,7 +109,7 @@ final class SpecifiedLengthExplicitImplicitUnparser(
    * of the string's characters fit within the available target length
    * bits.
    */
-  def unparseVarWidthCharactersInBits(state: UState) {
+  def unparseVarWidthCharactersInBits(state: UState): Unit = {
     val maybeTLBits = getMaybeTL(state, targetLengthInBitsEv)
 
     if (maybeTLBits.isDefined) {
@@ -157,7 +157,7 @@ final class SpecifiedLengthExplicitImplicitUnparser(
    * Encoding is variable width (e.g., utf-8). The target
    * length is expressed in characters.
    */
-  def unparseVarWidthCharactersInCharacters(state: UState) {
+  def unparseVarWidthCharactersInCharacters(state: UState): Unit = {
 
     //
     // variable-width encodings and lengthUnits characters, and lengthKind explicit
@@ -225,7 +225,7 @@ final class SpecifiedLengthExplicitImplicitUnparser(
    * Regardless of the type (text or binary), the target length
    * will be provided in bits.
    */
-  def unparseBits(state: UState) {
+  def unparseBits(state: UState): Unit = {
 
     val maybeTLBits = getMaybeTL(state, targetLengthInBitsEv)
 
@@ -290,7 +290,7 @@ final class SpecifiedLengthExplicitImplicitUnparser(
 // TODO: implement the capture length unparsers as just using this trait?
 trait CaptureUnparsingValueLength {
 
-  def captureValueLengthStart(state: UState, elem: DIElement) {
+  def captureValueLengthStart(state: UState, elem: DIElement): Unit = {
     val dos = state.dataOutputStream
     if (dos.maybeAbsBitPos0b.isDefined) {
       elem.valueLength.setAbsStartPos0bInBits(dos.maybeAbsBitPos0b.getULong)
@@ -299,7 +299,7 @@ trait CaptureUnparsingValueLength {
     }
   }
 
-  def captureValueLengthEnd(state: UState, elem: DIElement) {
+  def captureValueLengthEnd(state: UState, elem: DIElement): Unit = {
     val dos = state.dataOutputStream
     if (dos.maybeAbsBitPos0b.isDefined) {
       elem.valueLength.setAbsEndPos0bInBits(dos.maybeAbsBitPos0b.getULong)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StringLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StringLengthUnparsers.scala
@@ -49,7 +49,7 @@ class StringNoTruncateUnparser(
 
   override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
     val valueToWrite = contentString(state)
     val nCharsWritten = try {
@@ -162,7 +162,7 @@ class StringMaybeTruncateBitsUnparser(
     res
   }
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
 
     //
     // We have to stage the bits of the value just so as to be able to count them
@@ -249,7 +249,7 @@ class StringMaybeTruncateCharactersUnparser(
 
   override lazy val runtimeDependencies = Vector(lengthInCharactersEv)
 
-  override def unparse(state: UState) {
+  override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
     val valueString = contentString(state)
     val targetLengthInCharacters =

--- a/daffodil-runtime1/src/main/scala-2.11/org/apache/daffodil/infoset/DataValue.scala
+++ b/daffodil-runtime1/src/main/scala-2.11/org/apache/daffodil/infoset/DataValue.scala
@@ -213,7 +213,7 @@ object DataValue {
     override def toString = "UseNilForDefault"
   }
 
-  @inline def assertValueIsNotDataValue(v: AnyRef) {
+  @inline def assertValueIsNotDataValue(v: AnyRef): Unit = {
 
     /*
    *

--- a/daffodil-runtime1/src/main/scala-2.12/org/apache/daffodil/infoset/DataValue.scala
+++ b/daffodil-runtime1/src/main/scala-2.12/org/apache/daffodil/infoset/DataValue.scala
@@ -206,7 +206,7 @@ object DataValue {
     override def toString = "UseNilForDefault"
   }
 
-  @inline def assertValueIsNotDataValue(v: AnyRef) {
+  @inline def assertValueIsNotDataValue(v: AnyRef): Unit = {
 
     /*
    *

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -99,10 +99,10 @@ object DFDL {
      * if that is unambiguous, it will use it as the root.
      */
     @deprecated("Use arguments to compileSource, or compileFile method.", "2.6.0")
-    def setDistinguishedRootNode(name: String, namespace: String)
+    def setDistinguishedRootNode(name: String, namespace: String): Unit
 
     @deprecated("Use DataProcessor.withExternalVariables.", "2.6.0")
-    def setExternalDFDLVariable(name: String, namespace: String, value: String)
+    def setExternalDFDLVariable(name: String, namespace: String, value: String): Unit
 
     /**
      * Compilation returns a parser factory, which must be interrogated for diagnostics
@@ -233,7 +233,7 @@ object DFDL {
       (diagnostics.toSet ++ resultState.diagnostics.toSet ++ resultStatusDiagnostics.toSet).toSeq
     }
 
-    def addDiagnostic(d: Diagnostic) {
+    def addDiagnostic(d: Diagnostic): Unit = {
       diagnostics = d +: diagnostics
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -139,23 +139,23 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
 
   var debugState: DebugState.Type = DebugState.Pause
 
-  override def init(parser: Parser) {
+  override def init(parser: Parser): Unit = {
     runner.init(this)
   }
 
-  override def init(unparser: Unparser) {
+  override def init(unparser: Unparser): Unit = {
     runner.init(this)
   }
 
-  override def fini(parser: Parser) {
+  override def fini(parser: Parser): Unit = {
     runner.fini
   }
 
-  override def fini(unparser: Unparser) {
+  override def fini(unparser: Unparser): Unit = {
     runner.fini
   }
 
-  def debugStep(before: StateForDebugger, after: ParseOrUnparseState, processor: Processor, ignoreBreakpoints: Boolean) {
+  def debugStep(before: StateForDebugger, after: ParseOrUnparseState, processor: Processor, ignoreBreakpoints: Boolean): Unit = {
     ExecutionMode.usingUnrestrictedMode {
       debugState = debugState match {
         case _ if ((after.processorStatus ne Success) && DebuggerConfig.breakOnFailure) => DebugState.Pause
@@ -211,22 +211,22 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     interesting
   }
 
-  override def startElement(state: PState, parser: Parser) {
+  override def startElement(state: PState, parser: Parser): Unit = {
     debugStep(state, state, parser, false)
   }
 
-  override def endElement(state: UState, unparser: Unparser) {
+  override def endElement(state: UState, unparser: Unparser): Unit = {
     debugStep(state, state, unparser, false)
   }
 
   private val parseStack = new mutable.ArrayStack[(StateForDebugger, Parser)]
 
-  override def before(before: PState, parser: Parser) {
+  override def before(before: PState, parser: Parser): Unit = {
     if (isInteresting(parser)) {
       parseStack.push((before.copyStateForDebugger, parser))
     }
   }
-  override def after(after: PState, parser: Parser) {
+  override def after(after: PState, parser: Parser): Unit = {
     if (isInteresting(parser)) {
       val (before, beforeParser) = parseStack.pop
       Assert.invariant(beforeParser eq parser)
@@ -234,11 +234,11 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     }
   }
 
-  override def beforeRepetition(before: PState, processor: Parser) {
+  override def beforeRepetition(before: PState, processor: Parser): Unit = {
     parseStack.push((before.copyStateForDebugger, processor))
   }
 
-  override def afterRepetition(after: PState, processor: Parser) {
+  override def afterRepetition(after: PState, processor: Parser): Unit = {
     val (_, beforeParser) = parseStack.pop
     Assert.invariant(beforeParser eq processor)
   }
@@ -249,7 +249,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
 
   private val unparseStack = new mutable.ArrayStack[(StateForDebugger, Unparser)]
 
-  override def before(before: UState, unparser: Unparser) {
+  override def before(before: UState, unparser: Unparser): Unit = {
     if (isInteresting(unparser)) {
       unparseStack.push((before.copyStateForDebugger, unparser))
     }
@@ -259,7 +259,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     }
   }
 
-  override def after(after: UState, unparser: Unparser) {
+  override def after(after: UState, unparser: Unparser): Unit = {
     if (isInteresting(unparser)) {
       val (before, beforeUnparser) = unparseStack.pop
       Assert.invariant(beforeUnparser eq unparser)
@@ -442,7 +442,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     }
   }
 
-  private def debugPrintln(obj: Any = "", prefix: String = "") {
+  private def debugPrintln(obj: Any = "", prefix: String = ""): Unit = {
     obj.toString.split("\n").foreach { line =>
       {
         val out = "%s%s".format(prefix, line)
@@ -451,7 +451,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     }
   }
 
-  private def debugPrettyPrintXML(ie: InfosetElement) {
+  private def debugPrettyPrintXML(ie: InfosetElement): Unit = {
     val bos = new java.io.ByteArrayOutputStream()
     val xml = new XMLTextInfosetOutputter(bos, true)
     ie.visit(xml, DebuggerConfig.removeHidden)
@@ -606,7 +606,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   //DebugCommandBase.checkNameConflicts
 
   trait DebugCommandValidateSubcommands { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.size == 0) {
         throw new DebugException("no command specified")
       }
@@ -622,7 +622,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   trait DebugCommandValidateZeroArgs { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.length != 0) {
         throw new DebugException("%s command requires zero arguments".format(name))
       }
@@ -630,7 +630,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   trait DebugCommandValidateSingleArg { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.length != 1) {
         throw new DebugException("%s command requires a single argument".format(name))
       }
@@ -638,7 +638,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   trait DebugCommandValidateBoolean { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.size != 1) {
         throw new DebugException("%s command requires a single argument".format(name))
       } else {
@@ -651,7 +651,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   trait DebugCommandValidateInt { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.size != 1) {
         throw new DebugException("%s command requires a single argument".format(name))
       } else {
@@ -665,7 +665,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
   }
 
   trait DebugCommandValidateOptionalArg { self: DebugCommand =>
-    override def validate(args: Seq[String]) {
+    override def validate(args: Seq[String]): Unit = {
       if (args.size > 1) {
         throw new DebugException("%s command zero or one arguments".format(name))
       }
@@ -768,7 +768,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
                         |Example: condition 1 dfdl:occursIndex() eq 3""".stripMargin
       override lazy val short = "cond"
 
-      override def validate(args: Seq[String]) {
+      override def validate(args: Seq[String]): Unit = {
         if (args.length < 2) {
           throw new DebugException("condition command requires a breakpoint id and a DFDL expression")
         }
@@ -1018,7 +1018,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
                         |
                         |Example: eval dfdl:occursIndex()""".stripMargin
 
-      override def validate(args: Seq[String]) {
+      override def validate(args: Seq[String]): Unit = {
         if (args.size == 0) {
           throw new DebugException("eval requires a DFDL expression")
         }
@@ -1118,7 +1118,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
                         |Example: help info""".stripMargin
       override val subcommands = Seq(Break, Clear, Complete, Condition, Continue, Delete, Disable, Display, Enable, Eval, History, Info, Quit, Set, Step, Trace)
 
-      override def validate(args: Seq[String]) {
+      override def validate(args: Seq[String]): Unit = {
         // no validation
       }
 
@@ -1207,7 +1207,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
           InfoParser,
           InfoUnparser)
 
-      override def validate(args: Seq[String]) {
+      override def validate(args: Seq[String]): Unit = {
         if (args.size == 0) {
           throw new DebugException("one or more commands are required")
         }
@@ -1315,7 +1315,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
         val desc = "display the input/output data"
         val longDesc = desc
 
-        def printData(rep: Option[Representation], l: Int, prestate: StateForDebugger, state: ParseOrUnparseState, processor: Processor) {
+        def printData(rep: Option[Representation], l: Int, prestate: StateForDebugger, state: ParseOrUnparseState, processor: Processor): Unit = {
           val dataLoc = prestate.currentLocation.asInstanceOf[DataLoc]
           val lines = dataLoc.dump(rep, prestate.currentLocation, state)
           debugPrintln(lines, "  ")
@@ -1773,7 +1773,7 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
                           |Example: set representation binary""".stripMargin
         override lazy val short = "rp"
 
-        override def validate(args: Seq[String]) {
+        override def validate(args: Seq[String]): Unit = {
           if (args.size != 1) {
             throw new DebugException("a single argument is required")
           } else {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ArrayRelated.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ArrayRelated.scala
@@ -25,7 +25,7 @@ case class FNCount(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe)
   with ExistsKind {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val res = exists(recipe, dstate)
     if (res) {
       dstate.mode match {
@@ -49,7 +49,7 @@ case class FNCount(recipe: CompiledDPath, argType: NodeInfo.Kind)
  * Returns \$arg if it contains exactly one item. Otherwise, raises an error
  */
 case object FNExactlyOne extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
 
     // This was commented out in 6c9612e9f711beb1d8e4239ef9a473eb9c64a32f, which as the commit message:
     //
@@ -79,7 +79,7 @@ case object FNExactlyOne extends RecipeOp {
 }
 
 case object DFDLOccursIndex extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     Assert.invariant(dstate.arrayPos >= 1)
     if (dstate.isCompile)
       throw new InfosetNoInfosetException(Nope)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLFunctions.scala
@@ -27,7 +27,7 @@ import org.apache.daffodil.infoset.DataValue.DataValueString
 import org.apache.daffodil.infoset.DataValue.DataValueShort
 
 case class DFDLCheckConstraints(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     recipe.run(dstate)
     if (dstate.currentElement.valid.isDefined) {
       dstate.setCurrentValue(dstate.currentElement.valid.get)
@@ -125,7 +125,7 @@ case class DFDLTimeZoneFromDFDLCalendar(recipe: CompiledDPath, argType: NodeInfo
 case class DFDLTestBit(dataRecipe: CompiledDPath, bitPos1bRecipe: CompiledDPath)
   extends RecipeOpWithSubRecipes(dataRecipe, bitPos1bRecipe) {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val saved = dstate.currentNode
     dataRecipe.run(dstate)
     val dataVal = dstate.intValue
@@ -155,7 +155,7 @@ case class DFDLTestBit(dataRecipe: CompiledDPath, bitPos1bRecipe: CompiledDPath)
 
 case class DFDLSetBits(bitRecipes: List[CompiledDPath]) extends RecipeOpWithSubRecipes(bitRecipes) {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     var byteVal: Int = 0
 
     Assert.invariant(bitRecipes.length == 8)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXFunctions.scala
@@ -66,7 +66,7 @@ case class DFDLXTrace(recipe: CompiledDPath, msg: String)
 
 case object DAFError extends RecipeOp {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val maybeSFL =
       if (dstate.runtimeData.isDefined) One(dstate.runtimeData.get.schemaFileLocation)
       else Nope

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
@@ -213,7 +213,7 @@ final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kin
     value
   }
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     recipe.run(dstate)
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPathRuntime.scala
@@ -56,7 +56,7 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
   /**
    * For parsing or for backward-referencing expressions when unparsing.
    */
-  def runExpression(state: ParseOrUnparseState, dstate: DState) {
+  def runExpression(state: ParseOrUnparseState, dstate: DState): Unit = {
     dstate.opIndex = 0
     dstate.setCurrentNode(state.thisElement.asInstanceOf[DINode])
     dstate.setVMap(state.variableMap)
@@ -125,7 +125,7 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
     res
   }
 
-  def run(dstate: DState) {
+  def run(dstate: DState): Unit = {
     // We are running a subexpression. The currentNode may have been changed by
     // previous expressions, so we need to reset the currentNode back to the
     // original contextNode. It is up to the caller of this subexpression to
@@ -180,7 +180,7 @@ abstract class RecipeOpWithSubRecipes(recipes: List[CompiledDPath]) extends Reci
 case class VRef(vrd: VariableRuntimeData, context: ThrowsSDE)
   extends RecipeOp {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     Assert.invariant(dstate.vmap != null)
     dstate.setCurrentValue(dstate.vmap.readVariable(vrd, context, dstate.parseOrUnparseState))
   }
@@ -190,7 +190,7 @@ case class VRef(vrd: VariableRuntimeData, context: ThrowsSDE)
 }
 
 case class Literal(v: DataValuePrimitive) extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     dstate.setCurrentValue(v)
   }
   override def toXML = toXML(v.toString)
@@ -200,7 +200,7 @@ case class Literal(v: DataValuePrimitive) extends RecipeOp {
 case class IF(predRecipe: CompiledDPath, thenPartRecipe: CompiledDPath, elsePartRecipe: CompiledDPath)
   extends RecipeOpWithSubRecipes(predRecipe, thenPartRecipe, elsePartRecipe) {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     predRecipe.run(dstate)
     val predValue = dstate.currentValue.getBoolean
@@ -237,7 +237,7 @@ case class CompareOperator(cop: CompareOpBase, left: CompiledDPath, right: Compi
 
   override def op = Misc.getNameFromClass(cop)
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     left.run(dstate)
     val leftValue = dstate.currentValue.getNonNullable
@@ -254,7 +254,7 @@ case class NumericOperator(nop: NumericOp, left: CompiledDPath, right: CompiledD
 
   override def op = Misc.getNameFromClass(nop)
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     left.run(dstate)
     val leftValue = dstate.currentValue.getNumber
@@ -286,7 +286,7 @@ abstract class Converter extends RecipeOp {
     (fromTypeName, toTypeName)
   }
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val arg = dstate.currentValue.getNonNullable
     val res =
       try {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DState.scala
@@ -148,7 +148,7 @@ case class DState(
   /**
    * Set to UnparserBlocking for forward-referencing expressions during unparsing.
    */
-  def setMode(m: EvalMode) {
+  def setMode(m: EvalMode): Unit = {
     _mode = m
   }
   def mode = _mode
@@ -198,7 +198,7 @@ case class DState(
   //    coroutineToResumeIfBlocked_
   //  }
 
-  def resetValue() {
+  def resetValue(): Unit = {
     _currentValue = DataValue.NoValue
   }
 
@@ -210,15 +210,15 @@ case class DState(
     else _currentValue
   }
 
-  def setCurrentValue(v: DataValuePrimitiveNullable) {
+  def setCurrentValue(v: DataValuePrimitiveNullable): Unit = {
     _currentValue = v
     _currentNode = null
   }
-  def setCurrentValue(v: Long) {
+  def setCurrentValue(v: Long): Unit = {
     _currentValue = v
     _currentNode = null
   }
-  def setCurrentValue(v: Boolean) {
+  def setCurrentValue(v: Boolean): Unit = {
     _currentValue = v
     _currentNode = null
   }
@@ -274,7 +274,7 @@ case class DState(
   private var _currentNode: DINode = null
 
   def currentNode = _currentNode
-  def setCurrentNode(n: DINode) {
+  def setCurrentNode(n: DINode): Unit = {
     _currentNode = n
     _currentValue = DataValue.NoValue
   }
@@ -326,7 +326,7 @@ case class DState(
    * changes to the vmap easy. Just don't copy the vmap back from the DState
    * into the PState, and the changes are gone.
    */
-  def setVMap(m: VariableMap) {
+  def setVMap(m: VariableMap): Unit = {
     if (_vbox eq null) {
       _vbox = new VariableBox(m)
     } else {
@@ -338,7 +338,7 @@ case class DState(
    * Used by UState, where we want to shared the vmap as modified by the
    * expression evaluations that use the DState.
    */
-  def setVBox(box: VariableBox) {
+  def setVBox(box: VariableBox): Unit = {
     _vbox = box
   }
 
@@ -353,7 +353,7 @@ case class DState(
 
   private var _contextNode: Maybe[DINode] = Nope
   def contextNode = _contextNode
-  def setContextNode(node: DINode) {
+  def setContextNode(node: DINode): Unit = {
     _contextNode = One(node)
   }
 
@@ -381,19 +381,19 @@ case class DState(
 
   private var _savesErrorsAndWarnings: Maybe[SavesErrorsAndWarnings] = Nope
   def errorOrWarn = _savesErrorsAndWarnings
-  def setErrorOrWarn(s: SavesErrorsAndWarnings) {
+  def setErrorOrWarn(s: SavesErrorsAndWarnings): Unit = {
     _savesErrorsAndWarnings = One(s)
   }
 
   private var _arrayPos: Long = -1L // init to -1L so that we must set before use.
   def arrayPos = _arrayPos
-  def setArrayPos(arrayPos1b: Long) {
+  def setArrayPos(arrayPos1b: Long): Unit = {
     _arrayPos = arrayPos1b
   }
 
   private var _parseOrUnparseState: Maybe[ParseOrUnparseState] = Nope
   def parseOrUnparseState = _parseOrUnparseState
-  def setParseOrUnparseState(state: ParseOrUnparseState) {
+  def setParseOrUnparseState(state: ParseOrUnparseState): Unit = {
     _parseOrUnparseState = One(state)
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNBases.scala
@@ -61,7 +61,7 @@ trait StringCompareOp extends CompareOpBase {
 abstract class CompareOp
   extends RecipeOp with BinaryOpMixin {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     left.run(dstate)
     val leftValue = dstate.currentValue.getNonNullable
@@ -78,7 +78,7 @@ abstract class CompareOp
 
 case class BooleanOp(op: String, left: CompiledDPath, right: CompiledDPath)
   extends RecipeOp with BinaryOpMixin {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     left.run(dstate)
     val leftValue = dstate.currentValue.getBoolean
@@ -98,7 +98,7 @@ case class BooleanOp(op: String, left: CompiledDPath, right: CompiledDPath)
   }
 }
 case class NegateOp(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     recipe.run(dstate)
     val value: DataValuePrimitive = dstate.currentValue.getAnyRef match {
       case i: JInt => i * -1
@@ -116,7 +116,7 @@ case class NegateOp(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe
 
 abstract class FNOneArg(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     recipe.run(dstate)
     val arg = dstate.currentValue.getNonNullable
     dstate.setCurrentValue(computeValue(arg, dstate))
@@ -129,7 +129,7 @@ abstract class FNOneArg(recipe: CompiledDPath, argType: NodeInfo.Kind)
 
 abstract class FNTwoArgs(recipes: List[CompiledDPath])
   extends RecipeOpWithSubRecipes(recipes) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
 
     val recipe1 = recipes(0)
     val recipe2 = recipes(1)
@@ -155,7 +155,7 @@ abstract class FNTwoArgs(recipes: List[CompiledDPath])
 
 abstract class FNTwoArgsNodeAndValue(recipes: List[CompiledDPath])
   extends RecipeOpWithSubRecipes(recipes) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
 
     val recipe1 = recipes(0)
     val recipe2 = recipes(1)
@@ -178,7 +178,7 @@ abstract class FNTwoArgsNodeAndValue(recipes: List[CompiledDPath])
 }
 
 abstract class FNThreeArgs(recipes: List[CompiledDPath]) extends RecipeOpWithSubRecipes(recipes) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
 
     val recipe1 = recipes(0)
     val recipe2 = recipes(1)
@@ -204,7 +204,7 @@ abstract class FNThreeArgs(recipes: List[CompiledDPath]) extends RecipeOpWithSub
 }
 
 abstract class FNArgsList(recipes: List[CompiledDPath]) extends RecipeOpWithSubRecipes(recipes) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
 
     val savedNode = dstate.currentNode
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
@@ -333,7 +333,7 @@ case class FNDateTime(recipes: List[CompiledDPath]) extends FNTwoArgs(recipes) {
 case class FNRoundHalfToEven(recipeNum: CompiledDPath, recipePrecision: CompiledDPath)
   extends RecipeOpWithSubRecipes(recipeNum, recipePrecision) {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedNode = dstate.currentNode
     recipeNum.run(dstate)
     val unrounded = dstate.currentValue
@@ -507,7 +507,7 @@ case class FNNot(recipe: CompiledDPath, argType: NodeInfo.Kind = null)
 case class FNNilled(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe) {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // FNNilled wants to use FNOneArg. However, the run() method in FNOneArg
     // attempts to get currentValue of the argument, and then it calls
     // computeValue() passing in the value. However, with FNNilled, we cannot
@@ -624,7 +624,7 @@ trait ExistsKind {
 case class FNExists(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe)
   with ExistsKind {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val res = exists(recipe, dstate)
     dstate.setCurrentValue(res)
   }
@@ -636,7 +636,7 @@ case class FNExists(recipe: CompiledDPath, argType: NodeInfo.Kind)
 case class FNEmpty(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe)
   with ExistsKind {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val res = exists(recipe, dstate)
     dstate.setCurrentValue(!res)
   }
@@ -660,7 +660,7 @@ case class FNEmpty(recipe: CompiledDPath, argType: NodeInfo.Kind)
  */
 case class FNLocalName0(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // Same as using "." to denote self.
     val localName = dstate.currentElement.name
 
@@ -682,7 +682,7 @@ case class FNLocalName1(recipe: CompiledDPath, argType: NodeInfo.Kind)
     Assert.usageError("not to be called. DPath compiler should be answering this without runtime calls.")
   }
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // Save off original node, which is the original
     // element/node that calls fn:local-name
     val savedNode = dstate.currentNode
@@ -716,7 +716,7 @@ case class FNLocalName1(recipe: CompiledDPath, argType: NodeInfo.Kind)
  */
 case class FNNamespaceUri0(recipe: CompiledDPath, argType: NodeInfo.Kind)
   extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // Insist this is non-constant at compile time (to avoid a NPE)
     if (dstate.isCompile)
       throw new IllegalStateException()
@@ -750,7 +750,7 @@ case class FNNamespaceUri1(recipe: CompiledDPath, argType: NodeInfo.Kind)
     Assert.usageError("not to be called. DPath compiler should be answering this without runtime calls.")
   }
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // Insist this is non-constant at compile time (to avoid a NPE)
     if (dstate.isCompile)
       throw new IllegalStateException()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/SuspendableExpression.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/SuspendableExpression.scala
@@ -43,7 +43,7 @@ trait SuspendableExpression
 
   protected def processExpressionResult(ustate: UState, v: DataValuePrimitive): Unit
 
-  override protected final def doTask(ustate: UState) {
+  override protected final def doTask(ustate: UState): Unit = {
     var v: DataValuePrimitiveNullable = DataValue.NoValue
     if (!isBlocked) {
       log(LogLevel.Debug, "Starting suspendable expression for %s, expr=%s", rd.diagnosticDebugName, expr.prettyExpr)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/UpDownMoves.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/UpDownMoves.scala
@@ -30,13 +30,13 @@ import org.apache.daffodil.xml.NamedQName
  * the root element.
  */
 case object ToRoot extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val rootDoc = dstate.currentElement.toRootDoc
     dstate.setCurrentNode(rootDoc)
   }
 }
 case object SelfMove extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     // do this entirely so it will fail at constant compile time
     // also serves as a sort of assertion check.
     dstate.selfMove()
@@ -44,7 +44,7 @@ case object SelfMove extends RecipeOp {
 }
 
 case object UpMove extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val now = dstate.currentElement
     val n = now.toParent
     dstate.setCurrentNode(n)
@@ -52,7 +52,7 @@ case object UpMove extends RecipeOp {
 }
 
 case object UpMoveArray extends RecipeOp {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val now = dstate.currentElement
     Assert.invariant(now.toParent.array.isDefined)
     val n = now.toParent.array.get
@@ -65,7 +65,7 @@ case object UpMoveArray extends RecipeOp {
  */
 case class DownElement(nqn: NamedQName) extends RecipeOp {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val now = dstate.currentComplex
     // TODO PE ? if doesn't exist should be a processing error.
     // It will throw and so will be a PE, but may be poor diagnostic.
@@ -87,7 +87,7 @@ case class DownArrayOccurrence(nqn: NamedQName, indexRecipe: CompiledDPath)
 
   val childNamedQName = nqn
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val savedCurrentElement = dstate.currentComplex
     indexRecipe.run(dstate)
     val index = dstate.index
@@ -113,7 +113,7 @@ case class DownArrayOccurrence(nqn: NamedQName, indexRecipe: CompiledDPath)
  */
 case class DownArray(nqn: NamedQName) extends RecipeOp {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val now = dstate.currentComplex
     val arr = dstate.withRetryIfBlocking(now.getChildArray(nqn, dstate.tunable))
     Assert.invariant(arr ne null)
@@ -128,7 +128,7 @@ case class DownArray(nqn: NamedQName) extends RecipeOp {
 
 case class DownArrayExists(nqn: NamedQName) extends RecipeOp {
 
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     val now = dstate.currentComplex
     val arr = dstate.withRetryIfBlocking(now.getChildArray(nqn, dstate.tunable))
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSConstructors.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSConstructors.scala
@@ -27,7 +27,7 @@ import org.apache.daffodil.infoset.DataValue.DataValueTime
 import org.apache.daffodil.util.Numbers.asInt
 
 case class XSInt(recipe: CompiledDPath) extends RecipeOpWithSubRecipes(recipe) {
-  override def run(dstate: DState) {
+  override def run(dstate: DState): Unit = {
     recipe.run(dstate)
     val basicValue = dstate.currentValue
     val value = asInt(basicValue.getAnyRef)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/events/ParseEventHandler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/events/ParseEventHandler.scala
@@ -134,7 +134,7 @@ trait MultipleEventHandler extends EventHandler with Serializable {
     handlers_
   }
 
-  final def addEventHandler(h: EventHandler) {
+  final def addEventHandler(h: EventHandler): Unit = {
     if (!handlers.contains(h))
       handlers_ = h +: handlers
   }
@@ -142,54 +142,54 @@ trait MultipleEventHandler extends EventHandler with Serializable {
   /**
    * Parser Events
    */
-  override def init(processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
+  override def init(processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
 
-  override def before(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
+  override def before(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
 
-  override def after(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.after(state, processor) } }
+  override def after(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.after(state, processor) } }
 
-  override def beforeRepetition(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.beforeRepetition(state, processor) } }
+  override def beforeRepetition(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.beforeRepetition(state, processor) } }
 
-  override def afterRepetition(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.afterRepetition(state, processor) } }
+  override def afterRepetition(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.afterRepetition(state, processor) } }
 
-  override def startElement(state: PState, processor: Parser) {
+  override def startElement(state: PState, processor: Parser): Unit = {
     if (!(handlers eq Nil)) handlers.foreach {
       _.startElement(state, processor)
     }
   }
 
-  override def endElement(state: PState, processor: Parser) {
+  override def endElement(state: PState, processor: Parser): Unit = {
     if (!(handlers eq Nil)) handlers.foreach {
       _.endElement(state, processor)
     }
   }
 
-  override def startArray(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.startArray(state, processor) } }
+  override def startArray(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.startArray(state, processor) } }
 
-  override def endArray(state: PState, processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.endArray(state, processor) } }
+  override def endArray(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.endArray(state, processor) } }
 
-  override def fini(processor: Parser) { if (!(handlers eq Nil)) handlers.foreach { _.fini(processor) } }
+  override def fini(processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.fini(processor) } }
 
   /**
    * Unparser Events
    */
-  override def init(processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
+  override def init(processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
 
-  override def before(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
+  override def before(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
 
-  override def after(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.after(state, processor) } }
+  override def after(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.after(state, processor) } }
 
-  override def beforeRepetition(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.beforeRepetition(state, processor) } }
+  override def beforeRepetition(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.beforeRepetition(state, processor) } }
 
-  override def afterRepetition(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.afterRepetition(state, processor) } }
+  override def afterRepetition(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.afterRepetition(state, processor) } }
 
-  override def startElement(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.startElement(state, processor) } }
+  override def startElement(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.startElement(state, processor) } }
 
-  override def endElement(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.endElement(state, processor) } }
+  override def endElement(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.endElement(state, processor) } }
 
-  override def startArray(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.startArray(state, processor) } }
+  override def startArray(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.startArray(state, processor) } }
 
-  override def endArray(state: UState, processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.endArray(state, processor) } }
+  override def endArray(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.endArray(state, processor) } }
 
-  override def fini(processor: Unparser) { if (!(handlers eq Nil)) handlers.foreach { _.fini(processor) } }
+  override def fini(processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.fini(processor) } }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -106,7 +106,7 @@ sealed trait DINode {
   def contents: IndexedSeq[DINode]
   final def numChildren = contents.length
 
-  def visit(handler: InfosetOutputter, removeHidden: Boolean = true)
+  def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit
 
 }
 
@@ -330,7 +330,7 @@ sealed abstract class LengthState(ie: DIElement)
   var maybeEndPos0bInBits: MaybeULong = MaybeULong.Nope
   var maybeComputedLength: MaybeULong = MaybeULong.Nope
 
-  def copyFrom(other: LengthState) {
+  def copyFrom(other: LengthState): Unit = {
     this.maybeStartDataOutputStream = other.maybeStartDataOutputStream
     this.maybeStartPos0bInBits = other.maybeStartPos0bInBits
     this.maybeEndDataOutputStream = other.maybeEndDataOutputStream
@@ -338,7 +338,7 @@ sealed abstract class LengthState(ie: DIElement)
     this.maybeComputedLength = other.maybeComputedLength
   }
 
-  def clear() {
+  def clear(): Unit = {
     maybeStartDataOutputStream = Nope
     maybeStartPos0bInBits = MaybeULong.Nope
     maybeEndDataOutputStream = Nope
@@ -354,7 +354,7 @@ sealed abstract class LengthState(ie: DIElement)
    * position information, then we bring that up here so that it can be used
    * to compute the value or content length.
    */
-  private def recheckStreams() {
+  private def recheckStreams(): Unit = {
     if (maybeStartDataOutputStream.isDefined) {
       Assert.invariant(maybeStartPos0bInBits.isDefined)
       val dos = this.maybeStartDataOutputStream.get.asInstanceOf[DirectOrBufferedDataOutputStream]
@@ -521,22 +521,22 @@ sealed abstract class LengthState(ie: DIElement)
     else throwUnknown
   }
 
-  def setAbsStartPos0bInBits(absPosInBits0b: ULong) {
+  def setAbsStartPos0bInBits(absPosInBits0b: ULong): Unit = {
     maybeStartPos0bInBits = MaybeULong(absPosInBits0b.longValue)
     maybeStartDataOutputStream = Nope
   }
 
-  def setRelStartPos0bInBits(relPosInBits0b: ULong, dos: DataOutputStream) {
+  def setRelStartPos0bInBits(relPosInBits0b: ULong, dos: DataOutputStream): Unit = {
     maybeStartPos0bInBits = MaybeULong(relPosInBits0b.longValue)
     maybeStartDataOutputStream = One(dos)
   }
 
-  def setAbsEndPos0bInBits(absPosInBits0b: ULong) {
+  def setAbsEndPos0bInBits(absPosInBits0b: ULong): Unit = {
     maybeEndPos0bInBits = MaybeULong(absPosInBits0b.longValue)
     maybeStartDataOutputStream = Nope
   }
 
-  def setRelEndPos0bInBits(relPosInBits0b: ULong, dos: DataOutputStream) {
+  def setRelEndPos0bInBits(relPosInBits0b: ULong, dos: DataOutputStream): Unit = {
     maybeEndPos0bInBits = MaybeULong(relPosInBits0b.longValue)
     maybeEndDataOutputStream = One(dos)
   }
@@ -606,7 +606,7 @@ sealed trait DIElementSharedMembersMixin {
    * Copy method keeps these objects null
    * to avoid allocation unless they are really needed.
    */
-  final protected def copyContentLengthFrom(e: DIElementSharedMembersMixin) {
+  final protected def copyContentLengthFrom(e: DIElementSharedMembersMixin): Unit = {
     if (e._contentLength eq null)
       if (this._contentLength eq null) {
         // do nothing
@@ -625,7 +625,7 @@ sealed trait DIElementSharedMembersMixin {
    * Copy method keeps these objects null
    * to avoid allocation unless they are really needed.
    */
-  final protected def copyValueLengthFrom(e: DIElementSharedMembersMixin) {
+  final protected def copyValueLengthFrom(e: DIElementSharedMembersMixin): Unit = {
     if (e._valueLength eq null)
       if (this._valueLength eq null) {
         // do nothing
@@ -682,7 +682,7 @@ sealed trait DIElementSharedImplMixin
   extends DIElementSharedInterface
   with DIElementSharedMembersMixin {
 
-  override def restoreInto(e: DIElement) {
+  override def restoreInto(e: DIElement): Unit = {
     e._isNilled = this._isNilled
     e._validity = this._validity
 
@@ -690,7 +690,7 @@ sealed trait DIElementSharedImplMixin
     e.copyValueLengthFrom(this)
   }
 
-  override def captureFrom(e: DIElement) {
+  override def captureFrom(e: DIElement): Unit = {
     this._isNilled = e._isNilled
     this._validity = e._validity
 
@@ -698,7 +698,7 @@ sealed trait DIElementSharedImplMixin
     this.copyValueLengthFrom(e)
   }
 
-  override def clear() {
+  override def clear(): Unit = {
     this._isNilled = false
     this._validity = MaybeBoolean.Nope
     clearContentLength()
@@ -717,21 +717,21 @@ sealed trait DIComplexSharedImplMixin
   extends DIElementSharedInterface
   with DIComplexSharedMembersMixin {
 
-  abstract override def restoreInto(e: DIElement) {
+  abstract override def restoreInto(e: DIElement): Unit = {
     val c = e.asInstanceOf[DIComplex]
     c.restoreFrom(this)
     c._numChildren = this._numChildren
     super.restoreInto(e)
   }
 
-  abstract override def captureFrom(e: DIElement) {
+  abstract override def captureFrom(e: DIElement): Unit = {
     val c = e.asInstanceOf[DIComplex]
     c.captureInto(this)
     this._numChildren = c._numChildren
     super.captureFrom(e)
   }
 
-  abstract override def clear() {
+  abstract override def clear(): Unit = {
     _numChildren = 0
     _arraySize = MaybeInt.Nope
     super.clear()
@@ -760,7 +760,7 @@ sealed trait DISimpleSharedImplMixin
   extends DIElementSharedInterface
   with DISimpleSharedMembersMixin {
 
-  abstract override def restoreInto(e: DIElement) {
+  abstract override def restoreInto(e: DIElement): Unit = {
     super.restoreInto(e)
     val s = e.asInstanceOf[DISimple]
     s._isDefaulted = this._isDefaulted
@@ -768,7 +768,7 @@ sealed trait DISimpleSharedImplMixin
     s._unionMemberRuntimeData = this._unionMemberRuntimeData
   }
 
-  abstract override def captureFrom(e: DIElement) {
+  abstract override def captureFrom(e: DIElement): Unit = {
     super.captureFrom(e)
     val s = e.asInstanceOf[DISimple]
     this._isDefaulted = s._isDefaulted
@@ -776,7 +776,7 @@ sealed trait DISimpleSharedImplMixin
     this._unionMemberRuntimeData = s._unionMemberRuntimeData
   }
 
-  abstract override def clear() {
+  abstract override def clear(): Unit = {
     super.clear()
     _isDefaulted = false
     _value = DataValue.NoValue
@@ -881,7 +881,7 @@ sealed trait DIElement
 
   def diParent = _parent.asInstanceOf[DIComplex]
 
-  override def setParent(p: InfosetComplexElement) {
+  override def setParent(p: InfosetComplexElement): Unit = {
     Assert.invariant(_parent eq null)
     _parent = p
   }
@@ -925,7 +925,7 @@ sealed trait DIElement
    * valid = One(false) means invalid
    */
   override def valid = _validity
-  override def setValid(validity: Boolean) { _validity = MaybeBoolean(validity) }
+  override def setValid(validity: Boolean): Unit = { _validity = MaybeBoolean(validity) }
 }
 
 // This is not a mutable collection class on purpose.
@@ -949,7 +949,7 @@ final class DIArray(
 
   private lazy val nfe = new InfosetArrayNotFinalException(this)
 
-  override def requireFinal {
+  override def requireFinal: Unit = {
     if (!isFinal) {
       // If this DIArray isn't final, either we haven't gotten all of its
       // children yet, or the array is empty and we'll never get its children.
@@ -982,7 +982,7 @@ final class DIArray(
   /**
    * Used to shorten array when backtracking out of having appended elements.
    */
-  def reduceToSize(n: Int) {
+  def reduceToSize(n: Int): Unit = {
     _contents.reduceToSize(n)
   }
 
@@ -1031,7 +1031,7 @@ final class DIArray(
     a
   }
 
-  final def visit(handler: InfosetOutputter, removeHidden: Boolean = true) {
+  final def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit = {
     // Do not create an event if there's nothing in the array or if the array
     // is hidden. Unfortunately, there is no way to tell if an array is hidden,
     // only its elements. But if the first element is hidden, they are all
@@ -1087,12 +1087,12 @@ sealed class DISimple(override val erd: ElementRuntimeData)
    * Parsing of a text number first does setDataValue to a string, then a conversion does overwrite data value
    * with a number. Unparsing does setDataValue to a value, then overwriteDataValue to a string.
    */
-  override def setDataValue(x: DataValuePrimitiveNullable) {
+  override def setDataValue(x: DataValuePrimitiveNullable): Unit = {
     Assert.invariant(!hasValue)
     overwriteDataValue(x)
   }
 
-  def overwriteDataValue(x: DataValuePrimitiveNullable) {
+  def overwriteDataValue(x: DataValuePrimitiveNullable): Unit = {
     //
     // let's find places where we're putting a string in the infoset
     // but the simple type is not string. That happens when parsing or unparsing text Numbers, text booleans, text Date/Times.
@@ -1297,7 +1297,7 @@ sealed class DISimple(override val erd: ElementRuntimeData)
 
   override def totalElementCount = 1L
 
-  final def visit(handler: InfosetOutputter, removeHidden: Boolean = true) {
+  final def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit = {
     if (!this.isHidden || !removeHidden) {
       handler.startSimple(this)
       handler.endSimple(this)
@@ -1315,7 +1315,7 @@ sealed class DISimple(override val erd: ElementRuntimeData)
 sealed trait DIFinalizable {
   private var _isFinal: Boolean = false
 
-  def setFinal() { _isFinal = true }
+  def setFinal(): Unit = { _isFinal = true }
   def isFinal = _isFinal
 
   /**
@@ -1369,7 +1369,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
 
   private lazy val nfe = new InfosetComplexElementNotFinalException(this)
 
-  override def requireFinal {
+  override def requireFinal: Unit = {
     if (!isFinal) throw nfe
   }
 
@@ -1574,7 +1574,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
     }
   }
 
-  final def captureInto(cs: DIComplexSharedImplMixin) {
+  final def captureInto(cs: DIComplexSharedImplMixin): Unit = {
     Assert.invariant(_arraySize == MaybeInt.Nope)
     Assert.invariant(cs._arraySize == MaybeInt.Nope)
 
@@ -1586,7 +1586,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
     } else { MaybeInt.Nope }
   }
 
-  final def restoreFrom(cs: DIComplexSharedImplMixin) {
+  final def restoreFrom(cs: DIComplexSharedImplMixin): Unit = {
     var i = childNodes.length - 1
 
     // for each child we will remove, remove it from the fastLookup map.
@@ -1622,7 +1622,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
     a
   }
 
-  override def visit(handler: InfosetOutputter, removeHidden: Boolean = true) {
+  override def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit = {
     if (!this.isHidden || !removeHidden) {
       handler.startComplex(this)
       childNodes.foreach(node => node.visit(handler, removeHidden))
@@ -1648,7 +1648,7 @@ final class DIDocument(
    */
   var isCompileExprFalseRoot: Boolean = false
 
-  def setRootElement(rootElement: InfosetElement, tunable: DaffodilTunables) {
+  def setRootElement(rootElement: InfosetElement, tunable: DaffodilTunables): Unit = {
     root = rootElement.asInstanceOf[DIElement]
     addChild(root, tunable)
   }
@@ -1656,7 +1656,7 @@ final class DIDocument(
   override def addChild(child: InfosetElement, tunable: DaffodilTunables) =
     addChild(child)
 
-  def addChild(child: InfosetElement) {
+  def addChild(child: InfosetElement): Unit = {
     /*
      * DIDocument normally only has a single child.
      * However, if said child wants to create a quasi-element (eg. if it is a simpleType with a typeCalc),
@@ -1679,7 +1679,7 @@ final class DIDocument(
     root
   }
 
-  override def visit(handler: InfosetOutputter, removeHidden: Boolean = true) {
+  override def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit = {
     assert(root != null)
     handler.startDocument()
     root.visit(handler, removeHidden)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -235,7 +235,7 @@ abstract class InfosetInputter
   private def queueArrayStart(arrayERD: ERD) =
     queueEventInfo_(InfosetEventKind.StartArray, Info(arrayERD))
 
-  private def queueEventInfo_(kind: InfosetEventKind, info: Info) {
+  private def queueEventInfo_(kind: InfosetEventKind, info: Info): Unit = {
     Assert.invariant(pendingLength < MaxPendingQueueSize)
     pendingInfos(pendingLength) = info
     pendingStartOrEnd(pendingLength) = kind
@@ -436,7 +436,7 @@ abstract class InfosetInputter
     elem
   }
 
-  private def handleEndElement() {
+  private def handleEndElement(): Unit = {
     val top = infoStack.top
 
     if (top.isSimpleElement) {
@@ -471,7 +471,7 @@ abstract class InfosetInputter
   /**
    * Fill current accessor with appropriate event information
    */
-  private def startElement(node: DIElement) {
+  private def startElement(node: DIElement): Unit = {
     accessor.kind = InfosetEventKind.StartElement
     accessor.info = Info(node)
   }
@@ -479,7 +479,7 @@ abstract class InfosetInputter
   /**
    * Fill current accessor with appropriate event information
    */
-  private def endElement(node: DIElement) {
+  private def endElement(node: DIElement): Unit = {
     accessor.kind = InfosetEventKind.EndElement
     accessor.info = Info(node)
   }
@@ -487,7 +487,7 @@ abstract class InfosetInputter
   /**
    * Fill current accessor with appropriate event information
    */
-  private def startArray(arrayERD: ERD) {
+  private def startArray(arrayERD: ERD): Unit = {
     accessor.kind = InfosetEventKind.StartArray
     accessor.info = Info(arrayERD)
   }
@@ -495,7 +495,7 @@ abstract class InfosetInputter
   /**
    * Fill current accessor with appropriate event information
    */
-  private def endArray(arrayERD: ERD) {
+  private def endArray(arrayERD: ERD): Unit = {
     accessor.kind = InfosetEventKind.EndArray
     accessor.info = Info(arrayERD)
   }
@@ -596,7 +596,7 @@ class InfosetAccessor private (
   def isArray = erd.isArray
 
   override def cpy() = new InfosetAccessor(kind, info)
-  override def assignFrom(other: InfosetAccessor) {
+  override def assignFrom(other: InfosetAccessor): Unit = {
     kind = other.kind
     info = other.info
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
@@ -230,7 +230,7 @@ class JavaIOInputStream(s: InputSourceDataInputStream, finfo: FormatInfo)
 
   private var maybeSavedMark: Maybe[Mark] = Nope
 
-  override def reset() {
+  override def reset(): Unit = {
     Assert.usage(maybeSavedMark.isDefined)
     s.reset(maybeSavedMark.get)
     maybeSavedMark = Nope
@@ -253,7 +253,7 @@ class JavaIOOutputStream(dos: DataOutputStream, finfo: FormatInfo)
     if (wasWritten) nBytes += 1
   }
 
-  override def close() {
+  override def close(): Unit = {
     if (!closed) {
       dos.setFinished(finfo)
       closed = true

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DFDLDelimiter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DFDLDelimiter.scala
@@ -412,7 +412,7 @@ class Delimiter {
 
 abstract class DelimBase extends Base {
   def typeName: String
-  def print
+  def print: Unit
   def printStr: String
   def allChars: Seq[Char]
   override def toString(): String = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -237,7 +237,7 @@ class DataProcessor private (
   }
 
   @deprecated("Use withDebugger.", "2.6.0")
-  def setDebugger(dbg: AnyRef) {
+  def setDebugger(dbg: AnyRef): Unit = {
     val optDbg = if (dbg eq null) None else Some(dbg.asInstanceOf[Debugger])
     optDebugger = optDbg
   }
@@ -248,7 +248,7 @@ class DataProcessor private (
   }
 
   @deprecated("Use withDebugging.", "2.6.0")
-  def setDebugging(flag: Boolean) {
+  def setDebugging(flag: Boolean): Unit = {
     areDebugging = flag
     tunables = tunables.setTunable("allowExternalPathExpressions", flag.toString)
   }
@@ -437,7 +437,7 @@ class DataProcessor private (
     }
   }
 
-  private def doParse(p: Parser, state: PState) {
+  private def doParse(p: Parser, state: PState): Unit = {
     var optThrown: Maybe[Throwable] = None
     try {
       try {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DelimiterIterator.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DelimiterIterator.scala
@@ -25,21 +25,21 @@ import org.apache.daffodil.processors.parsers.DelimiterTextType
 import org.apache.daffodil.util.MStackOfInt
 
 trait DelimitersRangeLocal { this: DelimiterIterator =>
-  override def reset() {
+  override def reset(): Unit = {
     currentIndex = this.firstLocalIndex - 1
     indexLimit = this.delimiters.length
   }
 }
 
 trait DelmitersRangeRemote { this: DelimiterIterator =>
-  override def reset() {
+  override def reset(): Unit = {
     currentIndex = -1
     indexLimit = this.firstLocalIndex
   }
 }
 
 trait DelimitersRangeAll { this: DelimiterIterator =>
-  override def reset() {
+  override def reset(): Unit = {
     currentIndex = -1
     indexLimit = this.delimiters.length
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvEncoding.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvEncoding.scala
@@ -83,7 +83,7 @@ abstract class CharsetEvBase(encodingEv: EncodingEvBase, tci: DPathCompileInfo)
 
   override lazy val runtimeDependencies = Seq(encodingEv)
 
-  private def checkCharset(state: ParseOrUnparseState, bitsCharset: BitsCharset) {
+  private def checkCharset(state: ParseOrUnparseState, bitsCharset: BitsCharset): Unit = {
     if (bitsCharset.bitWidthOfACodeUnit != 8) {
       tci.schemaDefinitionError("Only encodings with byte-sized code units are allowed to be specified using a runtime-valued expression. " +
         "Encodings with 7 or fewer bits in their code units must be specified as a literal encoding name in the DFDL schema. " +

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
@@ -144,11 +144,11 @@ trait ManuallyCachedEvaluatable[T <: AnyRef] { self: Evaluatable[T] =>
     }
   }
 
-  def newCache(state: State) {
+  def newCache(state: State): Unit = {
     getCacheStack(state).push(Nope)
   }
 
-  def invalidateCache(state: State) {
+  def invalidateCache(state: State): Unit = {
     getCacheStack(state).pop
   }
 }
@@ -181,7 +181,7 @@ abstract class Evaluatable[+T <: AnyRef](protected val ci: DPathCompileInfo, qNa
 
   @inline final def isCompiled = isCompiled_
 
-  @inline final def ensureCompiled {
+  @inline final def ensureCompiled: Unit = {
     if (!isCompiled)
       Assert.invariantFailed("not compiled Ev: " + this.qName)
   }
@@ -358,7 +358,7 @@ final class EvalCache {
     res
   }
 
-  def put[T <: AnyRef](ev: Evaluatable[T], thing: T) {
+  def put[T <: AnyRef](ev: Evaluatable[T], thing: T): Unit = {
     if (thing.isInstanceOf[DINode]) return // happens in the interactive debugger due to expression ".." being compiled & run.
     Assert.usage(!thing.isInstanceOf[DINode])
     Assert.usage(thing ne null)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorBases.scala
@@ -25,11 +25,11 @@ object Processor {
    * This insures that it is not, for example, being multi-threaded. If called from the runtime module, compilation might
    * actually end up happening at run time.
    */
-  def initialize(proc: Processor) {
+  def initialize(proc: Processor): Unit = {
     ensureCompiled(proc)
   }
 
-  private def ensureCompiled(proc: Processor) {
+  private def ensureCompiled(proc: Processor): Unit = {
     if (!proc.isInitialized) {
       proc.isInitialized = true
       proc.runtimeDependencies.foreach { ensureCompiled }
@@ -37,7 +37,7 @@ object Processor {
     }
   }
 
-  private def ensureCompiled(ev: Evaluatable[AnyRef]) {
+  private def ensureCompiled(ev: Evaluatable[AnyRef]): Unit = {
     ev.ensureCompiled
     ev.runtimeDependencies.foreach { ensureCompiled }
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -105,11 +105,11 @@ trait SetProcessorMixin {
    * information and that has to be obtained via the runtime data for the
    * term - whether element or model group. The
    */
-  final def setProcessor(p: Processor) {
+  final def setProcessor(p: Processor): Unit = {
     maybeProcessor_ = One(p)
   }
 
-  final def setMaybeProcessor(mp: Maybe[Processor]) {
+  final def setMaybeProcessor(mp: Maybe[Processor]): Unit = {
     maybeProcessor_ = mp
   }
 }
@@ -351,7 +351,7 @@ abstract class ParseOrUnparseState protected (
    * Variable map provides access to variable bindings.
    */
   final def variableMap = variableBox.vmap
-  final def setVariableMap(newMap: VariableMap) {
+  final def setVariableMap(newMap: VariableMap): Unit = {
     variableBox.setVMap(newMap)
   }
 
@@ -364,7 +364,7 @@ abstract class ParseOrUnparseState protected (
   final def isSuccess = processorStatus.isSuccess
   final def isFailure = processorStatus.isFailure
 
-  final def setFailed(failureDiagnostic: Diagnostic) {
+  final def setFailed(failureDiagnostic: Diagnostic): Unit = {
     // threadCheck()
     if (!diagnostics.contains(failureDiagnostic)) {
       _processorStatus = new Failure(failureDiagnostic)
@@ -374,7 +374,7 @@ abstract class ParseOrUnparseState protected (
     }
   }
 
-  final def validationError(msg: String, args: Any*) {
+  final def validationError(msg: String, args: Any*): Unit = {
     val ctxt = getContext()
     val vde = new ValidationError(Maybe(ctxt.schemaFileLocation), this, msg, args: _*)
     _validationStatus = false
@@ -393,7 +393,7 @@ abstract class ParseOrUnparseState protected (
    *
    * This happens, for example, in the debugger when it is evaluating expressions.
    */
-  final def setSuccess() {
+  final def setSuccess(): Unit = {
     _processorStatus = Success
   }
 
@@ -401,7 +401,7 @@ abstract class ParseOrUnparseState protected (
    * Used when errors are caught by interactive debugger expression evaluation.
    * We don't want to accumulate the diagnostics that we're suppressing.
    */
-  final def suppressDiagnosticAndSucceed(d: Diagnostic) {
+  final def suppressDiagnosticAndSucceed(d: Diagnostic): Unit = {
     Assert.usage(diagnostics.contains(d))
     diagnostics = diagnostics.filterNot { _ eq d }
     setSuccess()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspendableOperation.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspendableOperation.scala
@@ -54,7 +54,7 @@ trait SuspendableOperation
    */
   protected def continuation(ustate: UState): Unit
 
-  override protected final def doTask(ustate: UState) {
+  override protected final def doTask(ustate: UState): Unit = {
     if (isBlocked) {
       setUnblocked()
       log(LogLevel.Debug, "retrying %s", this)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
@@ -79,7 +79,7 @@ trait Suspension
    *
    * This status is needed to implement circular deadlock detection
    */
-  final def runSuspension() {
+  final def runSuspension(): Unit = {
     doTask(savedUstate)
     if (isDone && !isReadOnly) {
       try {
@@ -100,14 +100,14 @@ trait Suspension
    * Run the first time.
    *
    */
-  final def run(ustate: UState) {
+  final def run(ustate: UState): Unit = {
     doTask(ustate)
     if (!isDone) {
       prepareToSuspend(ustate)
     }
   }
 
-  private def prepareToSuspend(ustate: UState) {
+  private def prepareToSuspend(ustate: UState): Unit = {
     val mkl = maybeKnownLengthInBits(ustate)
     //
     // It seems like we have too many splits going on.
@@ -132,7 +132,7 @@ trait Suspension
   private def splitDOS(
     ustate: UState,
     maybeKnownLengthInBits: MaybeULong,
-    original: DirectOrBufferedDataOutputStream) {
+    original: DirectOrBufferedDataOutputStream): Unit = {
     Assert.usage(ustate.currentInfosetNodeMaybe.isDefined)
 
     val buffered = original.addBuffered
@@ -167,7 +167,7 @@ trait Suspension
     ustate.dataOutputStream = buffered
   }
 
-  private def suspend(ustate: UState, original: DirectOrBufferedDataOutputStream) {
+  private def suspend(ustate: UState, original: DirectOrBufferedDataOutputStream): Unit = {
     //
     // clone the ustate for use when evaluating the expression
     //
@@ -185,7 +185,7 @@ trait Suspension
     ustate.asInstanceOf[UStateMain].addSuspension(this)
   }
 
-  final def explain() {
+  final def explain(): Unit = {
     val t = this
     Assert.invariant(t.isBlocked)
     log(LogLevel.Warning, "%s", t.blockedLocation)
@@ -204,7 +204,7 @@ trait Suspension
   private var done_ : Boolean = false
   private var isBlocked_ = false
 
-  final def setDone {
+  final def setDone: Unit = {
     done_ = true
   }
 
@@ -212,7 +212,7 @@ trait Suspension
 
   final def isBlocked = isBlocked_
 
-  final def setUnblocked() {
+  final def setUnblocked(): Unit = {
     isBlocked_ = false
   }
 
@@ -224,7 +224,7 @@ trait Suspension
 
   final def isMakingProgress = isMakingProgress_
 
-  final def block(nodeOrVar: AnyRef, info: AnyRef, index: Long, exc: AnyRef) {
+  final def block(nodeOrVar: AnyRef, info: AnyRef, index: Long, exc: AnyRef): Unit = {
     log(LogLevel.Debug, "blocking %s due to %s", this, exc)
 
     Assert.usage(nodeOrVar ne null)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
@@ -150,7 +150,7 @@ final class VariableBox(initialVMap: VariableMap) {
 
   def vmap = vmap_
 
-  def setVMap(newMap: VariableMap) {
+  def setVMap(newMap: VariableMap): Unit = {
     vmap_ = newMap
   }
 }
@@ -293,7 +293,7 @@ class VariableMap private(vTable: Map[GlobalQName, MStackOf[VariableInstance]])
     stack.get.push(vrd.createVariableInstance)
   }
 
-  def removeVariableInstance(vrd: VariableRuntimeData) {
+  def removeVariableInstance(vrd: VariableRuntimeData): Unit = {
     val varQName = vrd.globalQName
     val stack = vTable.get(varQName)
     Assert.invariant(stack.isDefined)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Parser.scala
@@ -38,7 +38,7 @@ class LongestMatchTracker {
   var longestMatchedStartPos: Int = Int.MaxValue
   var longestMatchedString: String = null
 
-  def successfulMatch(matchedStartPos: Int, matchedString: StringBuilder, dfa: DFADelimiter, dfaIndex: Int) {
+  def successfulMatch(matchedStartPos: Int, matchedString: StringBuilder, dfa: DFADelimiter, dfaIndex: Int): Unit = {
     if (longestMatches.isEmpty) {
       // first match, make it the longest
       longestMatchedStartPos = matchedStartPos

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
@@ -58,7 +58,7 @@ class Registers() extends Poolable with Serializable {
    * and then reset before first use. I.e.,
    * reset() is also init().
    */
-  def reset(finfo: FormatInfo, input: DataInputStream, delimIter: DelimiterIterator, m: DataInputStream.MarkPos = DataInputStream.MarkPos.NoMarkPos) {
+  def reset(finfo: FormatInfo, input: DataInputStream, delimIter: DelimiterIterator, m: DataInputStream.MarkPos = DataInputStream.MarkPos.NoMarkPos): Unit = {
     dataInputStream = input
     if (m !=#= DataInputStream.MarkPos.NoMarkPos)
       dataInputStream.resetPos(m)
@@ -77,7 +77,7 @@ class Registers() extends Poolable with Serializable {
     delimitersIter = delimIter
   }
 
-  def resetChars(finfo: FormatInfo) {
+  def resetChars(finfo: FormatInfo): Unit = {
     charIterator = dataInputStream.asIteratorChar
     charIterator.setFormatInfo(finfo)
     data0 = charIterator.peek()
@@ -91,7 +91,7 @@ class Registers() extends Poolable with Serializable {
    * This allows this Registers to pick-up where the other
    * left off.
    */
-  def copy1(that: Registers) {
+  def copy1(that: Registers): Unit = {
     Registers.this.dataInputStream = that.dataInputStream
     Registers.this.data0 = that.data0
     Registers.this.data1 = that.data1
@@ -131,7 +131,7 @@ class Registers() extends Poolable with Serializable {
     data1 = charIterator.peek2()
   }
 
-  def commitOneChar {
+  def commitOneChar: Unit = {
     if (charIterator.hasNext) charIterator.next()
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Runtime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Runtime.scala
@@ -63,7 +63,7 @@ trait DFA {
    */
   def run(r: Registers): Unit
 
-  final protected def runLoop(r: Registers, terminateLoopOnState: Int, finalStatus: StateKind.StateKind) {
+  final protected def runLoop(r: Registers, terminateLoopOnState: Int, finalStatus: StateKind.StateKind): Unit = {
     Assert.invariant(r.actionNum >= 0)
     r.status = StateKind.Parsing
     while (r.state != terminateLoopOnState) { // Terminates on FinalState

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
@@ -238,7 +238,7 @@ class ElementParser(
     eAfterParser,
     eRepTypeParser) {
 
-  def move(start: PState) {
+  def move(start: PState): Unit = {
     start.mpstate.moveOverOneElementChildOnly
     ()
   }
@@ -322,7 +322,7 @@ class ElementParserNoRep(
   // but we don't create anything new as far as the group is concerned, and we don't want
   // the group 'thinking' that there's a prior sibling inside the group and placing a
   // separator after it. So in the case of NoRep, we don't advance group child, just element child.
-  override def move(state: PState) {
+  override def move(state: PState): Unit = {
     state.mpstate.moveOverOneElementChildOnly
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilParsers.scala
@@ -40,7 +40,7 @@ abstract class LiteralNilOfSpecifiedLengthParserBase(
 
   def isFieldNilLit(field: String): Boolean
 
-  override def parse(start: PState) {
+  override def parse(start: PState): Unit = {
 
     val field = parseString(start)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -87,19 +87,19 @@ object MPState {
 
     clear()
 
-    def clear() {
+    def clear(): Unit = {
       arrayIndexStackMark = MStack.nullMark
       groupIndexStackMark = MStack.nullMark
       childIndexStackMark = MStack.nullMark
       occursBoundsStackMark = MStack.nullMark
     }
 
-    def captureFrom(mp: MPState) {
+    def captureFrom(mp: MPState): Unit = {
       arrayIndexStackMark = mp.arrayIndexStack.mark
       groupIndexStackMark = mp.groupIndexStack.mark
       childIndexStackMark = mp.childIndexStack.mark
     }
-    def restoreInto(mp: MPState) {
+    def restoreInto(mp: MPState): Unit = {
       mp.arrayIndexStack.reset(this.arrayIndexStackMark)
       mp.groupIndexStack.reset(this.groupIndexStackMark)
       mp.childIndexStack.reset(this.childIndexStackMark)
@@ -134,7 +134,7 @@ class MPState private () {
 
   val escapeSchemeEVCache = new MStackOfMaybe[EscapeSchemeParserHelper]
 
-  private def init {
+  private def init: Unit = {
     arrayIndexStack.push(1L)
     groupIndexStack.push(1L)
     childIndexStack.push(1L)
@@ -179,12 +179,12 @@ final class PState private (
 
   override def dataStream = One(dataInputStream)
 
-  def saveDelimitedParseResult(result: Maybe[dfa.ParseResult]) {
+  def saveDelimitedParseResult(result: Maybe[dfa.ParseResult]): Unit = {
     // threadCheck()
     this.delimitedParseResult = result
   }
 
-  def clearDelimitedParseResult() {
+  def clearDelimitedParseResult(): Unit = {
     // threadCheck()
     this.delimitedParseResult = Nope
   }
@@ -211,7 +211,7 @@ final class PState private (
 
   def dataInputStreamIsValid = dataInputStream.inputSource.isValid
 
-  def reset(m: PState.Mark) {
+  def reset(m: PState.Mark): Unit = {
     // threadCheck()
     m.restoreInto(this)
     m.clear()
@@ -230,7 +230,7 @@ final class PState private (
     changedVariablesStack.top.clear
   }
 
-  def discard(m: PState.Mark) {
+  def discard(m: PState.Mark): Unit = {
     dataInputStream.discard(m.disMark)
     m.clear()
     markPool.returnToPool(m)
@@ -269,7 +269,7 @@ final class PState private (
   }
   def parentDocument = infoset.asInstanceOf[InfosetDocument]
 
-  def setEndBitLimit(bitLimit0b: Long) {
+  def setEndBitLimit(bitLimit0b: Long): Unit = {
     dataInputStream.setBitLimit0b(MaybeULong(bitLimit0b))
   }
 
@@ -283,11 +283,11 @@ final class PState private (
    * Document which is the parent of the root element. So there's no time when there
    * isn't a parent there.
    */
-  def setParent(newParent: DIElement) {
+  def setParent(newParent: DIElement): Unit = {
     this.infoset = newParent
   }
 
-  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: VariableRuntimeData, pstate: PState) {
+  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: VariableRuntimeData, pstate: PState): Unit = {
     variableMap.setVariable(vrd, newValue, referringContext, pstate)
     changedVariablesStack.top += vrd.globalQName
   }
@@ -296,42 +296,42 @@ final class PState private (
    * Note that this function does not actually read the variable, it is used
    * just to track that the variable was read in case we need to backtrack.
    */
-  def markVariableRead(vrd: VariableRuntimeData) {
+  def markVariableRead(vrd: VariableRuntimeData): Unit = {
     changedVariablesStack.top += vrd.globalQName
   }
 
-  def newVariableInstance(vrd: VariableRuntimeData) {
+  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
     variableMap.newVariableInstance(vrd)
     changedVariablesStack.top += vrd.globalQName
   }
 
-  def removeVariableInstance(vrd: VariableRuntimeData) {
+  def removeVariableInstance(vrd: VariableRuntimeData): Unit = {
     variableMap.removeVariableInstance(vrd)
   }
 
-  def pushPointOfUncertainty {
+  def pushPointOfUncertainty: Unit = {
     // threadCheck()
     discriminatorStack.push(false)
     changedVariablesStack.push(mutable.MutableList[GlobalQName]())
   }
 
-  def popPointOfUncertainty {
+  def popPointOfUncertainty: Unit = {
     // threadCheck()
     discriminatorStack.pop
     changedVariablesStack.pop
   }
 
-  def setDiscriminator(disc: Boolean) {
+  def setDiscriminator(disc: Boolean): Unit = {
     // threadCheck()
     discriminatorStack.pop()
     discriminatorStack.push(disc)
   }
 
-  def addBlobPath(path: Path) {
+  def addBlobPath(path: Path): Unit = {
     blobPaths = path +: blobPaths
   }
 
-  final def notifyDebugging(flag: Boolean) {
+  final def notifyDebugging(flag: Boolean): Unit = {
     // threadCheck()
     dataInputStream.setDebugging(flag)
   }
@@ -452,7 +452,7 @@ object PState {
 
     val mpStateMark = new MPState.Mark
 
-    def clear() {
+    def clear(): Unit = {
       simpleElementState.clear()
       complexElementState.clear()
       disMark = null
@@ -466,7 +466,7 @@ object PState {
       // DO NOT clear requestorId. It is there to help us debug if we try to repeatedly reset/discard a mark already discarded.
     }
 
-    def captureFrom(ps: PState, requestorID: String) {
+    def captureFrom(ps: PState, requestorID: String): Unit = {
       val e = ps.thisElement
       if (e.isSimple)
         simpleElementState.captureFrom(e)
@@ -489,7 +489,7 @@ object PState {
       }
     }
 
-    def restoreInto(ps: PState) {
+    def restoreInto(ps: PState): Unit = {
       restoreInfoset(ps)
       ps.dataInputStream.reset(this.disMark)
       ps.setVariableMap(this.variableMap)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SpecifiedLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SpecifiedLengthParsers.scala
@@ -273,7 +273,7 @@ class CaptureStartOfContentLengthParser(override val context: ElementRuntimeData
 
   override val runtimeDependencies = Vector()
 
-  override def parse(state: PState) {
+  override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
     val elem = state.infoset
     elem.contentLength.setAbsStartPos0bInBits(ULong(dis.bitPos0b))
@@ -285,7 +285,7 @@ class CaptureEndOfContentLengthParser(override val context: ElementRuntimeData)
 
   override val runtimeDependencies = Vector()
 
-  override def parse(state: PState) {
+  override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
     val elem = state.infoset
     elem.contentLength.setAbsEndPos0bInBits(ULong(dis.bitPos0b))
@@ -297,7 +297,7 @@ class CaptureStartOfValueLengthParser(override val context: ElementRuntimeData)
 
   override val runtimeDependencies = Vector()
 
-  override def parse(state: PState) {
+  override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
     val elem = state.infoset
     elem.valueLength.setAbsStartPos0bInBits(ULong(dis.bitPos0b))
@@ -309,7 +309,7 @@ class CaptureEndOfValueLengthParser(override val context: ElementRuntimeData)
 
   override val runtimeDependencies = Vector()
 
-  override def parse(state: PState) {
+  override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
     val elem = state.infoset
     elem.valueLength.setAbsEndPos0bInBits(ULong(dis.bitPos0b))

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/StringLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/StringLengthParsers.scala
@@ -49,7 +49,7 @@ final class StringOfSpecifiedLengthParser(
     "<" + eName + " parser='" + Misc.getNameFromClass(this) + "' />"
   }
 
-  override def parse(start: PState) {
+  override def parse(start: PState): Unit = {
     val field = parseString(start)
     start.simpleElement.setDataValue(field)
   }
@@ -59,13 +59,13 @@ final class StringOfSpecifiedLengthParser(
 trait CaptureParsingValueLength {
   def charsetEv: CharsetEv
 
-  final def captureValueLength(state: PState, startBitPos0b: ULong, endBitPos0b: ULong) {
+  final def captureValueLength(state: PState, startBitPos0b: ULong, endBitPos0b: ULong): Unit = {
     val elem = state.infoset
     elem.valueLength.setAbsStartPos0bInBits(startBitPos0b)
     elem.valueLength.setAbsEndPos0bInBits(endBitPos0b)
   }
 
-  final def captureValueLengthOfString(state: PState, str: String) {
+  final def captureValueLengthOfString(state: PState, str: String): Unit = {
     val lengthInBits = state.lengthInBits(str, charsetEv.evaluate(state))
     // TODO: this is a hack, it doesn't actually set the correct start/end
     // pos due to padding. But it does set the correct information so that

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -183,11 +183,11 @@ abstract class UState(
 
   def charPos = -1L
 
-  final def notifyDebugging(flag: Boolean) {
+  final def notifyDebugging(flag: Boolean): Unit = {
     dataOutputStream.setDebugging(flag)
   }
 
-  def addUnparseError(ue: UnparseError) {
+  def addUnparseError(ue: UnparseError): Unit = {
     diagnostics = ue :: diagnostics
     _processorStatus = new Failure(ue)
   }
@@ -345,11 +345,11 @@ abstract class UState(
 
   def documentElement: DIDocument
 
-  def newVariableInstance(vrd: VariableRuntimeData) {
+  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
     variableMap.newVariableInstance(vrd)
   }
 
-  def removeVariableInstance(vrd: VariableRuntimeData) {
+  def removeVariableInstance(vrd: VariableRuntimeData): Unit = {
     variableMap.removeVariableInstance(vrd)
   }
 }
@@ -613,11 +613,11 @@ final class UStateMain private (
    */
   private val suspensions = initialSuspendedExpressions
 
-  def addSuspension(se: Suspension) {
+  def addSuspension(se: Suspension): Unit = {
     suspensions.enqueue(se)
   }
 
-  def evalSuspensions(ustate: UState) {
+  def evalSuspensions(ustate: UState): Unit = {
     var countOfNotMakingProgress = 0
     while (!suspensions.isEmpty &&
       countOfNotMakingProgress < suspensions.length) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/Unparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/Unparser.scala
@@ -144,7 +144,7 @@ final class ErrorUnparser(override val context: TermRuntimeData = null) extends 
 
   override lazy val runtimeDependencies = Vector()
 
-  def unparse(ustate: UState) {
+  def unparse(ustate: UState): Unit = {
     Assert.abort("Error Unparser")
   }
   override lazy val childProcessors = Vector()

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetBehavior.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetBehavior.scala
@@ -89,7 +89,7 @@ object Converter {
 
 class TestUnicodeErrorTolerance {
 
-  @Test def testIntArrayToByteArray() {
+  @Test def testIntArrayToByteArray(): Unit = {
     val ia = Array[Int](1, 127, 128, 255, 0)
     val actualByteArray = Converter.intArrayToByteArray(ia)
     val expectedByteArray = Array[Byte](1, 127, -128, -1, 0)
@@ -102,7 +102,7 @@ class TestUnicodeErrorTolerance {
   /**
    * Scala, like Java, tolerates isolated broken surrogate halves.
    */
-  @Test def testScalaAllowsBadUnicode() {
+  @Test def testScalaAllowsBadUnicode(): Unit = {
     val exp = "@@@\udcd0@@@" // that's the 2nd half of a surrogate pair for U+1d4d0 sandwiched between @@@
     val codepoint = exp.charAt(3)
     assertEquals(0xdcd0, codepoint)
@@ -112,7 +112,7 @@ class TestUnicodeErrorTolerance {
    * This test shows that we're not tolerating 3-byte encodings of surrogates if they are
    * isolated.
    */
-  @Test def testUTF8Decode3ByteSurrogateIsMalformed() {
+  @Test def testUTF8Decode3ByteSurrogateIsMalformed(): Unit = {
     //    val exp = "\udcd0" // that's the trailing surrogate in the surrogate pair for U+1d4d0
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
@@ -133,7 +133,7 @@ class TestUnicodeErrorTolerance {
    * This test shows that Java isn't tolerating 3-byte encodings of surrogates if they are
    * isolated. It is substituting for them.
    */
-  @Test def testUTF8Decode3ByteSurrogateReplacement() {
+  @Test def testUTF8Decode3ByteSurrogateReplacement(): Unit = {
     val inBuf = Array[Int](0xED, 0xB3, 0x90)
     val act = replaceBadCharacters(inBuf)
     assertEquals("\uFFFD", act)
@@ -143,7 +143,7 @@ class TestUnicodeErrorTolerance {
    * This test shows that Java substitutes on encoding/output also when an isolated surrogate
    * is presented to the encoder.
    */
-  @Test def testUTF8Encode3ByteSurrogateReplacement() {
+  @Test def testUTF8Encode3ByteSurrogateReplacement(): Unit = {
     val s = "\ud800"
     val act = replaceBadCharactersEncoding(s)
     val exp = Array[Int](0xEF, 0xBF, 0xBD) // the 3-byte UTF-8 replacement sequence
@@ -163,7 +163,7 @@ class TestUnicodeErrorTolerance {
    * Also, the "length" of the malformed input is 1, as in one character that we're encoding.
    * I.e., not measured in bytes here.
    */
-  @Test def testUTF8Encode3ByteSurrogateIsMalformed() {
+  @Test def testUTF8Encode3ByteSurrogateIsMalformed(): Unit = {
     val s = "\udcd0\udcd0\udcd0\udcd0" // that's the 2nd half of a surrogate pair for U+1d4d0
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
@@ -182,7 +182,7 @@ class TestUnicodeErrorTolerance {
   /**
    * shows that the codepoints that require surrogate pairs do in fact create two Java/Scala string codepoints.
    */
-  @Test def testUTF8ToSurrogatePair() {
+  @Test def testUTF8ToSurrogatePair(): Unit = {
     val exp = "\ud800\udc00" // surrogate pair for U+010000
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
@@ -203,7 +203,7 @@ class TestUnicodeErrorTolerance {
    * Of course this is really extreme as there is clearly no surrogate pair represntation
    * of this code point possible.
    */
-  @Test def testUTF8Extreme6ByteToSurrogatePair() {
+  @Test def testUTF8Extreme6ByteToSurrogatePair(): Unit = {
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
     assertEquals("UTF-8", dn)
@@ -218,7 +218,7 @@ class TestUnicodeErrorTolerance {
     assertEquals(1, e.getInputLength()) // However, it doesn't say there are 6 bad bytes here.
   }
 
-  @Test def testUTF8Extreme4ByteToSurrogatePair() {
+  @Test def testUTF8Extreme4ByteToSurrogatePair(): Unit = {
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
     assertEquals("UTF-8", dn)
@@ -237,7 +237,7 @@ class TestUnicodeErrorTolerance {
    * This test shows that Java isn't tolerating 3-byte encodings (CESU-8 encoding) of surrogates at all, it's not
    * accepting them if they are properly matched even.
    */
-  @Test def testUTF8Decode6ByteSurrogatePairIsMalformed() {
+  @Test def testUTF8Decode6ByteSurrogatePairIsMalformed(): Unit = {
     // val exp = "\ud4d0" // that's the 2nd half of a surrogate pair for U+1d4d0
     val cs = Charset.forName("utf-8")
     val dn = cs.displayName()
@@ -269,7 +269,7 @@ class TestUnicodeErrorTolerance {
    * ICU string handling functions (including append, substring, etc.) do not automatically protect
    * against producing malformed UTF-16 strings.
    */
-  @Test def testUTF16DecodeBadSurrogate() {
+  @Test def testUTF16DecodeBadSurrogate(): Unit = {
     val exp = "\ud4d0" // that's the 2nd half of a surrogate pair for U+1d4d0
     val cs = Charset.forName("utf-16BE")
     val dn = cs.displayName()
@@ -284,7 +284,7 @@ class TestUnicodeErrorTolerance {
   /**
    * BOM's in middle of UTF-16 strings cause no problems.
    */
-  @Test def testUTF16DecodeBOMsInMidString() {
+  @Test def testUTF16DecodeBOMsInMidString(): Unit = {
     val exp = "\uFEFF@\uFEFF@" // BOM, then @ then ZWNBS (aka BOM), then @
     val cs = Charset.forName("utf-16BE")
     val dn = cs.displayName()
@@ -317,25 +317,25 @@ class TestUnicodeErrorTolerance {
     counter
   }
 
-  @Test def testHowManyBadBytes1() {
+  @Test def testHowManyBadBytes1(): Unit = {
     val inBuf = Array[Int](0xFF, 0xFF, 0xFF) // 0xFF is always illegal utf-8
     val count = howManyBadBytes(inBuf)
     assertEquals(1, count)
   }
 
-  @Test def testHowManyBadBytes2() {
+  @Test def testHowManyBadBytes2(): Unit = {
     val inBuf = Array[Int](0xC2, 0x00) // a bad 2-byte sequence 2nd byte bad = 1 error
     val count = howManyBadBytes(inBuf)
     assertEquals(1, count)
   }
 
-  @Test def testHowManyBadBytes3() {
+  @Test def testHowManyBadBytes3(): Unit = {
     val inBuf = Array[Int](0xE2, 0xA2, 0xCC) // a bad 3-byte sequence 3rd byte bad = 1 error
     val count = howManyBadBytes(inBuf)
     assertEquals(2, count)
   }
 
-  @Test def testHowManyBadBytes4() {
+  @Test def testHowManyBadBytes4(): Unit = {
     val inBuf = Array[Int](0xF0, 0xA4, 0xAD, 0xC2) // a bad 4-byte sequence - 4th byte bad = 1 error
     val count = howManyBadBytes(inBuf)
     assertEquals(3, count)
@@ -349,7 +349,7 @@ class TestUnicodeErrorTolerance {
    * Then it should pick up at the last byte. BF by itself is not valid alone or as first byte of
    * a multi-byte character, so that's an error also. Two errors total.
    */
-  @Test def testHowManyBadBytes5() { // That's character U+10FFFF, but with an error
+  @Test def testHowManyBadBytes5(): Unit = { // That's character U+10FFFF, but with an error
     val inBuf = Array[Int](0xF4, 0xCF, 0xBF, 0xBF)
     val count = howManyBadBytes(inBuf)
     assertEquals(1, count)
@@ -378,31 +378,31 @@ class TestUnicodeErrorTolerance {
     act
   }
 
-  @Test def testHowManyReplacements1() {
+  @Test def testHowManyReplacements1(): Unit = {
     val inBuf = Array[Int](0xFF, 0xFF, 0xFF) // 0xFF is always illegal utf-8
     val act = replaceBadCharacters(inBuf)
     assertEquals("\uFFFD\uFFFD\uFFFD", act)
   }
 
-  @Test def testHowManyReplacements2() {
+  @Test def testHowManyReplacements2(): Unit = {
     val inBuf = Array[Int](0xC2, 0x40) // a bad 2-byte sequence 2nd byte bad = 1 error
     val act = replaceBadCharacters(inBuf)
     assertEquals("\uFFFD@", act)
   }
 
-  @Test def testHowManyReplacements3() {
+  @Test def testHowManyReplacements3(): Unit = {
     val inBuf = Array[Int](0xE2, 0xA2, 0xCC) // a bad 3-byte sequence. 3rd byte bad
     val act = replaceBadCharacters(inBuf)
     assertEquals("\uFFFD\uFFFD", act)
   }
 
-  @Test def testHowManyReplacements4() {
+  @Test def testHowManyReplacements4(): Unit = {
     val inBuf = Array[Int](0xF0, 0xA4, 0xAD, 0xC2) // a bad 4-byte sequence - 4th byte bad
     val act = replaceBadCharacters(inBuf)
     assertEquals("\uFFFD\uFFFD", act)
   }
 
-  @Test def testHowManyReplacements5() {
+  @Test def testHowManyReplacements5(): Unit = {
     // That's character U+10FFFF, but with an error
     // a bad 4-byte sequence, 2nd byte doesn't go with first.
     // 2nd and 3rd bytes go together, but fourth is illegal on its own.
@@ -412,7 +412,7 @@ class TestUnicodeErrorTolerance {
     assertEquals("\uFFFD\u03ff\uFFFD", act)
   }
 
-  @Test def testHowManyReplacements6() {
+  @Test def testHowManyReplacements6(): Unit = {
     // Gibberish. 1st byte of a 3-byte sequence, 2nd byte doesn't go with it,
     // but the sequence of 2nd and 3rd byte is valid (U+03FF). 4th byte invalid alone.
     val inBuf = Array[Int](0xE2, 0xCF, 0xBF, 0xBF) // a bad 4-byte sequence, but bad in 2nd byte. = 3 errors
@@ -423,7 +423,7 @@ class TestUnicodeErrorTolerance {
   /**
    * This test shows that Java ISO-8859-1 can decode any byte at all.
    */
-  @Test def testISO8859HandlesAllBytes() {
+  @Test def testISO8859HandlesAllBytes(): Unit = {
     val cs = Charset.forName("iso-8859-1")
     val decoder = cs.newDecoder()
 

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetDecoder2.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetDecoder2.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.processors.charset.CharsetUtils
 
 class TestCharsetDecoder2 {
 
-  @Test def testIfHasJava7DecoderBug {
+  @Test def testIfHasJava7DecoderBug: Unit = {
     if (CharsetUtils.hasJava7DecoderBug) fail("Java 7 Decoder bug detected. Daffodil requires Java 8 (or higher)")
   }
 }

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
@@ -1348,7 +1348,7 @@ class TestRegex extends RegexParsers {
 
   lazy val parsed0 = parseAll(t0, rdr0)
 
-  @Test def testParsingDelims() {
+  @Test def testParsingDelims(): Unit = {
     skipWS = false // keep all the whitespace
     assertTrue(parsed0.successful)
     val a = parsed0.get
@@ -1378,7 +1378,7 @@ class TestRegex extends RegexParsers {
 
   lazy val parsed1 = parseAll(t1, rdr1)
 
-  @Test def testRegexNoWSLongestMatch() {
+  @Test def testRegexNoWSLongestMatch(): Unit = {
     skipWS = true // this is the default setting for scala comb. parsers, but we have no ws so it doesn't matter really.
     assertTrue(parsed1.successful)
     val a = parsed1.get
@@ -1409,7 +1409,7 @@ class TestRegex extends RegexParsers {
 
   lazy val parsed2 = parseAll(t2, rdr2)
 
-  @Test def testRegexWSLongestMatch() {
+  @Test def testRegexWSLongestMatch(): Unit = {
     skipWS = false // we want our delimiters to contain the whitespace.
     // (parsed2)
     assertTrue(parsed2.successful)
@@ -1433,7 +1433,7 @@ class TestRegex extends RegexParsers {
    * Tests a regular experssion to match a delimiter but taking
    * into account escape characters and padChar trimming.
    */
-  @Test def testRegexToMatchOneDelimiterWithEscapeChars() {
+  @Test def testRegexToMatchOneDelimiterWithEscapeChars(): Unit = {
 
     /**
      * tester regexps and postprocessing algorithms are different
@@ -1555,7 +1555,7 @@ class TestRegex extends RegexParsers {
    *
    * Special case for when EEC and EC are same.
    */
-  @Test def testRegexToMatchOneDelimiterWithEscapeCharsWhenEECAndECAreSame() {
+  @Test def testRegexToMatchOneDelimiterWithEscapeCharsWhenEECAndECAreSame(): Unit = {
 
     /**
      * tester regexps and postprocessing algorithms are different
@@ -1676,7 +1676,7 @@ class TestRegex extends RegexParsers {
    * Also illustrates how one would add padChar absorbing into the mix on the left, right, or both
    *
    */
-  @Test def testRegexToMatchOneDelimiterWithBlockEscapesAndPaddingCharacters() {
+  @Test def testRegexToMatchOneDelimiterWithBlockEscapesAndPaddingCharacters(): Unit = {
 
     def tester(bStart: String, bEnd: String, escapeEscape: String, escape: String, delim: String, padChar: String) = {
       Assert.usage(padChar.length == 1)

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -474,7 +474,7 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    * @param flag true to enable debugging, false to disabled
    */
   @deprecated("Use withDebugging.", "2.6.0")
-  def setDebugging(flag: Boolean) {
+  def setDebugging(flag: Boolean): Unit = {
     dp = dp.withDebugging(flag)
   }
 
@@ -495,7 +495,7 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    * @param dr debugger runner
    */
   @deprecated("Use withDebugger.", "2.6.0")
-  def setDebugger(dr: DebuggerRunner) {
+  def setDebugger(dr: DebuggerRunner): Unit = {
     val debugger = newDebugger(dr)
     dp = dp.withDebugger(debugger)
   }

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/packageprivate/Utils.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/packageprivate/Utils.scala
@@ -95,7 +95,7 @@ private[sapi] class JavaLogWriter(logWriter: LogWriter)
     //do nothing
   }
 
-  override def log(lvl: SLogLevel.Type, logID: String, msg: String, args: Seq[Any]) {
+  override def log(lvl: SLogLevel.Type, logID: String, msg: String, args: Seq[Any]): Unit = {
     if (logWriter != null) {
       logWriter.log(LoggingConversions.levelFromScala(lvl), logID, msg, args)
     }

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/DebuggerRunnerForSAPITest.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/DebuggerRunnerForSAPITest.scala
@@ -33,10 +33,10 @@ class DebuggerRunnerForSAPITest extends DebuggerRunner {
     "trace"
   ).iterator
 
-  def init() {
+  def init(): Unit = {
   }
 
-  def fini() {
+  def fini(): Unit = {
   }
 
   def getCommand(): String = {
@@ -52,7 +52,7 @@ class DebuggerRunnerForSAPITest extends DebuggerRunner {
     cmd
   }
 
-  def lineOutput(line: String) {
+  def lineOutput(line: String): Unit = {
     lines.append(line + "\n")
   }
 }

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/LogWriterForSAPITest.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/LogWriterForSAPITest.scala
@@ -26,7 +26,7 @@ class LogWriterForSAPITest extends LogWriter {
   val infos = new ListBuffer[String]()
   val others = new ListBuffer[String]()
 
-  def write(level: LogLevel.Value, logID: String, msg: String) {
+  def write(level: LogLevel.Value, logID: String, msg: String): Unit = {
     level match {
       case LogLevel.Error => errors.append(msg)
       case LogLevel.Warning => warnings.append(msg)
@@ -53,7 +53,7 @@ class LogWriterForSAPITest extends LogWriter {
     " [END]"
   }
 
-  override def log(level: LogLevel.Value, logID: String, msg: String, args: Seq[Any]) {
+  override def log(level: LogLevel.Value, logID: String, msg: String, args: Seq[Any]): Unit = {
     val message = if (args.size > 0) {
       msg.format(args:_*)
     } else {

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/LogWriterForSAPITest2.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/LogWriterForSAPITest2.scala
@@ -27,7 +27,7 @@ class LogWriterForSAPITest2 extends LogWriter {
   val infos = new ListBuffer[String]()
   val others = new ListBuffer[String]()
 
-  def write(level: LogLevel.Value, logID: String, msg: String) {
+  def write(level: LogLevel.Value, logID: String, msg: String): Unit = {
     level match {
       case LogLevel.Error => errors.append(msg)
       case LogLevel.Warning => warnings.append(msg)

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -100,7 +100,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI1() {
+  def testScalaAPI1(): Unit = {
     val lw = new LogWriterForSAPITest()
     val debugger = new DebuggerRunnerForSAPITest()
 
@@ -150,7 +150,7 @@ class TestScalaAPI {
   // This is a duplicate of test testScalaAPI1 that serializes the parser
   // before executing the test.
   @Test
-  def testScalaAPI1_A() {
+  def testScalaAPI1_A(): Unit = {
     val lw = new LogWriterForSAPITest()
     val debugger = new DebuggerRunnerForSAPITest()
 
@@ -209,7 +209,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI2() {
+  def testScalaAPI2(): Unit = {
     val lw = new LogWriterForSAPITest()
 
     Daffodil.setLogWriter(lw)
@@ -257,7 +257,7 @@ class TestScalaAPI {
    * @throws IOException
    */
   @Test
-  def testScalaAPI3() {
+  def testScalaAPI3(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
@@ -289,7 +289,7 @@ class TestScalaAPI {
   // This is a duplicate of test testScalaAPI3 that serializes the parser
   // before executing the test.
   @Test
-  def testScalaAPI3_A() {
+  def testScalaAPI3_A(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/sapi/mySchema3.dfdl.xsd")
@@ -328,7 +328,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI4b() {
+  def testScalaAPI4b(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFileName = getResource("/test/sapi/mySchema3.dfdl.xsd")
@@ -357,7 +357,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI5() {
+  def testScalaAPI5(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFileName = getResource("/test/sapi/mySchema3.dfdl.xsd")
@@ -395,7 +395,7 @@ class TestScalaAPI {
    * @throws IOException
    */
   @Test
-  def testScalaAPI6() {
+  def testScalaAPI6(): Unit = {
     val lw = new LogWriterForSAPITest()
 
     Daffodil.setLogWriter(lw)
@@ -423,7 +423,7 @@ class TestScalaAPI {
    * @throws IOException
    */
   @Test
-  def testScalaAPI7() {
+  def testScalaAPI7(): Unit = {
     // TODO: This is due to the fact that we are doing several conversions
     // back and forth between Scala.xml.Node and JDOM. And the conversions
     // both use XMLOutputter to format the result (which escapes the
@@ -471,7 +471,7 @@ class TestScalaAPI {
    * @throws IOException
    */
   @Test
-  def testScalaAPI8() {
+  def testScalaAPI8(): Unit = {
     val lw = new LogWriterForSAPITest()
 
     Daffodil.setLogWriter(lw)
@@ -511,7 +511,7 @@ class TestScalaAPI {
    * error.
    */
   @Test
-  def testScalaAPI9() {
+  def testScalaAPI9(): Unit = {
     val lw = new LogWriterForSAPITest()
 
     Daffodil.setLogWriter(lw)
@@ -561,7 +561,7 @@ class TestScalaAPI {
    * Verify that hidden elements do not appear in the resulting infoset
    */
   @Test
-  def testScalaAPI10() {
+  def testScalaAPI10(): Unit = {
 
     val c = Daffodil.compiler()
 
@@ -587,7 +587,7 @@ class TestScalaAPI {
    * Verify that nested elements do not appear as duplicates
    */
   @Test
-  def testScalaAPI11() {
+  def testScalaAPI11(): Unit = {
 
     val c = Daffodil.compiler()
 
@@ -618,7 +618,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI12() {
+  def testScalaAPI12(): Unit = {
     val lw2 = new LogWriterForSAPITest2()
     val debugger = new DebuggerRunnerForSAPITest()
 
@@ -661,7 +661,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI13() {
+  def testScalaAPI13(): Unit = {
     // Demonstrates here that we can set external variables
     // after compilation but before parsing via Compiler.
     val lw = new LogWriterForSAPITest()
@@ -703,7 +703,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI14() {
+  def testScalaAPI14(): Unit = {
     // Demonstrates here that we can set external variables
     // after compilation but before parsing via DataProcessor.
     val lw = new LogWriterForSAPITest()
@@ -758,7 +758,7 @@ class TestScalaAPI {
   // Demonstrates that setting validation to Full for a saved parser fails.
   //
   @Test
-  def testScalaAPI1_A_FullFails() {
+  def testScalaAPI1_A_FullFails(): Unit = {
     val lw = new LogWriterForSAPITest()
     val debugger = new DebuggerRunnerForSAPITest()
 
@@ -794,7 +794,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI15() {
+  def testScalaAPI15(): Unit = {
     val lw = new LogWriterForSAPITest()
     val debugger = new DebuggerRunnerForSAPITest()
 
@@ -832,7 +832,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI16() {
+  def testScalaAPI16(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
@@ -859,7 +859,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI17() {
+  def testScalaAPI17(): Unit = {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/sapi/mySchema1.dfdl.xsd")
@@ -895,7 +895,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI18() {
+  def testScalaAPI18(): Unit = {
     // Demonstrate that we can use the API to continue a parse where we left off
     val c = Daffodil.compiler()
 
@@ -937,7 +937,7 @@ class TestScalaAPI {
   }
 
   @Test
-  def testScalaAPI19() {
+  def testScalaAPI19(): Unit = {
     // Demonstrate that we cannot use the API to continue a parse with an invalid InputSource
     // ie. after a runtime SDE. This test needs to be run with an input file larger than 256MB
     val c = Daffodil.compiler()

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/Tak.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/Tak.scala
@@ -57,7 +57,7 @@ object Tak {
       z
   }
 
-  def testTak {
+  def testTak: Unit = {
     println("Calibrating takeon units")
     callCount = 0
     val nanos = Timer.getTimeNS { tak(21, 3, 21) }
@@ -68,7 +68,7 @@ object Tak {
     println("Done calibrating")
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     testTak
   }
 }

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -147,7 +147,7 @@ class Runner private (elem: scala.xml.Elem, dir: String, file: String,
       getTS.setDebugging(false)
     }
 
-  def runOneTest(testName: String) {
+  def runOneTest(testName: String): Unit = {
     runOneTest(testName, None, false)
   }
 
@@ -155,7 +155,7 @@ class Runner private (elem: scala.xml.Elem, dir: String, file: String,
    *  Call this from an @AfterClass method
    *  to drop any state (like the test suite object) so we don't leak
    */
-  def reset {
+  def reset: Unit = {
     try {
       tl_ts.set(null)
     } catch {

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -292,7 +292,7 @@ class DFDLTestSuite private[tdml] (
 
   var checkAllTopLevel: Boolean = compileAllTopLevel
 
-  def setCheckAllTopLevel(flag: Boolean) {
+  def setCheckAllTopLevel(flag: Boolean): Unit = {
     checkAllTopLevel = flag
   }
 
@@ -352,7 +352,7 @@ class DFDLTestSuite private[tdml] (
     embeddedSchemasRaw
   }
 
-  def runAllTests(schema: Option[Node] = None) {
+  def runAllTests(schema: Option[Node] = None): Unit = {
     if (isTDMLFileValid)
       testCases.map { _.run(schema) }
     else {
@@ -376,7 +376,7 @@ class DFDLTestSuite private[tdml] (
     daffodilDebugger = db
   }
 
-  def runOneTest(testName: String, schema: Option[Node] = None, leakCheck: Boolean = false) {
+  def runOneTest(testName: String, schema: Option[Node] = None, leakCheck: Boolean = false): Unit = {
     if (leakCheck) {
       System.gc()
       Thread.sleep(1) // needed to give tools like jvisualvm ability to "grab on" quickly
@@ -780,7 +780,7 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite)
     diagnostics: Seq[Throwable],
     errors: ExpectedErrors,
     optWarnings: Option[ExpectedWarnings],
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
     Assert.usage(this.isNegativeTest)
 
     // check for any test-specified errors or warnings
@@ -1050,7 +1050,7 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
     validationErrors: Option[ExpectedValidationErrors],
     validationMode: ValidationMode.Type,
     roundTripArg: RoundTrip,
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
 
     val roundTrip = roundTripArg // change to OnePassRoundTrip to force all parse tests to round trip (to see which fail to round trip)
 
@@ -1282,7 +1282,7 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
     expectedData: InputStream,
     optWarnings: Option[ExpectedWarnings],
     roundTrip: RoundTrip,
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
 
     Assert.usage(roundTrip ne TwoPassRoundTrip) // not supported for unparser test cases.
 
@@ -1393,7 +1393,7 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
     optExpectedData: Option[InputStream],
     errors: ExpectedErrors,
     optWarnings: Option[ExpectedWarnings],
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
 
     val optExtVarDiag =
       try {
@@ -1461,7 +1461,7 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
 }
 
 object VerifyTestCase {
-  def verifyParserTestData(actual: Node, infoset: Infoset, implString: Option[String]) {
+  def verifyParserTestData(actual: Node, infoset: Infoset, implString: Option[String]): Unit = {
 
     val expected = infoset.contents
 
@@ -1474,7 +1474,7 @@ object VerifyTestCase {
   }
 
   def verifyUnparserTestData(expectedData: InputStream, actualOutStream: java.io.ByteArrayOutputStream,
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
     val actualBytes = actualOutStream.toByteArray
 
     val expectedBytes = IOUtils.toByteArray(expectedData)
@@ -1607,7 +1607,7 @@ object VerifyTestCase {
   }
 
   def verifyTextData(expectedData: InputStream, actualOutStream: java.io.ByteArrayOutputStream, encodingName: String,
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
     // Getting this decoder and decoding the bytes to text this way is
     // necessary, as opposed to toString(encodingName), because it is possible
     // that encodingName is a custom DFDL specific decoder (e.g. 7-bit ASCII)
@@ -1663,7 +1663,7 @@ object VerifyTestCase {
   private val cs8859 = JavaCharset.forName("iso-8859-1")
 
   def verifyBinaryOrMixedData(expectedData: InputStream, actualOutStream: java.io.ByteArrayOutputStream,
-    implString: Option[String]) {
+    implString: Option[String]): Unit = {
     val actualBytes = actualOutStream.toByteArray
     lazy val actual8859String = cs8859.newDecoder().decode(ByteBuffer.wrap(actualBytes)).toString()
     lazy val displayableActual = Misc.remapControlsAndLineEndingsToVisibleGlyphs(actual8859String)
@@ -1882,7 +1882,7 @@ case class Document(d: NodeSeq, parent: TestCase) {
   /**
    * A method because it is easier to unit test it
    */
-  private def checkForBadBitOrderTransitions(dps: Seq[DataDocumentPart]) {
+  private def checkForBadBitOrderTransitions(dps: Seq[DataDocumentPart]): Unit = {
     if (dps.length <= 1) return
     // these are the total lengths BEFORE the component
     val lengths = dps.map {

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/processors/charset/TestLSBFirstAndUSASCII7BitPacked.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/processors/charset/TestLSBFirstAndUSASCII7BitPacked.scala
@@ -35,7 +35,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
   lsbfFinfo.byteOrder = ByteOrder.BigEndian
   lsbfFinfo.bitOrder = BitOrder.LeastSignificantBitFirst
 
-  @Test def testOne7Bit() {
+  @Test def testOne7Bit(): Unit = {
     val dec = BitsCharsetUSASCII7BitPacked.newDecoder()
     val doc = new Document(
       <document>
@@ -52,7 +52,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("4", outstr)
   }
 
-  @Test def test7Bit42() {
+  @Test def test7Bit42(): Unit = {
     val dec = BitsCharsetUSASCII7BitPacked.newDecoder()
     val doc = new Document(
       <document>
@@ -69,7 +69,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("42", outstr)
   }
 
-  @Test def test7Bit1234567890() {
+  @Test def test7Bit1234567890(): Unit = {
     val dec = BitsCharsetUSASCII7BitPacked.newDecoder()
     val doc = new Document(
       <document>
@@ -86,7 +86,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("1234567890", outstr)
   }
 
-  @Test def testEncode7Bit12345678() {
+  @Test def testEncode7Bit12345678(): Unit = {
     val doc = new Document(
       <document>
         <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst"><![CDATA[12345678]]></documentPart>
@@ -95,7 +95,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD70", hex)
   }
 
-  @Test def testEncode7Bit123456789() {
+  @Test def testEncode7Bit123456789(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED"><![CDATA[123456789]]></documentPart>
@@ -104,7 +104,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD7039", hex)
   }
 
-  @Test def testEncode7Bit1234567899() {
+  @Test def testEncode7Bit1234567899(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst"><![CDATA[1234567899]]></documentPart>
@@ -113,7 +113,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD70B91C", hex)
   }
 
-  @Test def testEncode7Bit1234567899RTL() {
+  @Test def testEncode7Bit1234567899RTL(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[
@@ -124,7 +124,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD70B91C", hex)
   }
 
-  @Test def testEncode7Bit1234567899RTLHex() {
+  @Test def testEncode7Bit1234567899RTLHex(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="byte" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[
@@ -135,7 +135,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD70B91C", hex)
   }
 
-  @Test def test7Bit42LSBFirst() {
+  @Test def test7Bit42LSBFirst(): Unit = {
     val dec = BitsCharsetUSASCII7BitPacked.newDecoder()
     val doc = new Document(
       <document bitOrder="LSBFirst">
@@ -152,7 +152,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("42", outstr)
   }
 
-  @Test def test7Bit1234567890LSBFirst() {
+  @Test def test7Bit1234567890LSBFirst(): Unit = {
     val dec = BitsCharsetUSASCII7BitPacked.newDecoder()
     val doc = new Document(
       <document bitOrder="LSBFirst">
@@ -169,7 +169,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("1234567890", outstr)
   }
 
-  @Test def testEncode7Bit12345678LSBFirst() {
+  @Test def testEncode7Bit12345678LSBFirst(): Unit = {
     val doc = new Document(
       <document>
         <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst"><![CDATA[12345678]]></documentPart>
@@ -178,7 +178,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD70", hex)
   }
 
-  @Test def testEncode7Bit123456789LSBFirst() {
+  @Test def testEncode7Bit123456789LSBFirst(): Unit = {
     val doc = new Document(
       <document>
         <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst"><![CDATA[123456789]]></documentPart>
@@ -187,7 +187,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals("31D98C56B3DD7039", hex)
   }
 
-  @Test def testMix1() {
+  @Test def testMix1(): Unit = {
     val doc = new Document(
       <document>
         <documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[110]]></documentPart>
@@ -206,7 +206,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals(doc2bits, doc1bits)
   }
 
-  @Test def testMIL2045_47001D_Page70_TableB_I() {
+  @Test def testMIL2045_47001D_Page70_TableB_I(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="bits" byteOrder="RTL">Version                         XXXX 0011</documentPart>
@@ -244,7 +244,7 @@ class TestLSBFirstAndUSASCII7BitPacked {
     assertEquals(doc2bits, doc1bits)
   }
 
-  @Test def testMIL2045_47001D_Page70_TableB_I_with_string() {
+  @Test def testMIL2045_47001D_Page70_TableB_I_with_string(): Unit = {
     val doc = new Document(
       <document bitOrder="LSBFirst">
         <documentPart type="bits" byteOrder="RTL">Version                         XXXX 0011</documentPart>

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/TestMoreEncodings.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/TestMoreEncodings.scala
@@ -23,7 +23,7 @@ import org.junit.Assert.assertEquals
 
 class TestMoreEncodings {
 
-  @Test def testBitsEncoding1() {
+  @Test def testBitsEncoding1(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-BITS-LSBF">1</documentPart>
               </document>
@@ -34,7 +34,7 @@ class TestMoreEncodings {
     assertEquals(1, doc.nBits)
   }
 
-  @Test def testBitsEncoding2() {
+  @Test def testBitsEncoding2(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-BITS-LSBF">10</documentPart>
               </document>
@@ -45,7 +45,7 @@ class TestMoreEncodings {
     assertEquals(2, doc.nBits)
   }
 
-  @Test def testBitsEncoding8() {
+  @Test def testBitsEncoding8(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-BITS-LSBF">00110101</documentPart>
               </document>
@@ -56,7 +56,7 @@ class TestMoreEncodings {
     assertEquals(8, doc.nBits)
   }
 
-  @Test def testBitsEncoding9() {
+  @Test def testBitsEncoding9(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-BITS-LSBF">001101011</documentPart>
               </document>
@@ -67,7 +67,7 @@ class TestMoreEncodings {
     assertEquals(9, doc.nBits)
   }
 
-  @Test def testSixBitEncoding1() {
+  @Test def testSixBitEncoding1(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-6-BIT-DFI-264-DUI-001"><![CDATA[0]]></documentPart>
               </document>
@@ -78,7 +78,7 @@ class TestMoreEncodings {
     assertEquals(6, doc.nBits)
   }
 
-  @Test def testSixBitEncoding2() {
+  @Test def testSixBitEncoding2(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-6-BIT-DFI-264-DUI-001"><![CDATA[00]]></documentPart>
               </document>
@@ -89,7 +89,7 @@ class TestMoreEncodings {
     assertEquals(12, doc.nBits)
   }
 
-  @Test def testSixBitEncoding40() {
+  @Test def testSixBitEncoding40(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-6-BIT-DFI-264-DUI-001"><![CDATA[0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ012]]></documentPart>
               </document>
@@ -98,7 +98,7 @@ class TestMoreEncodings {
     assertEquals(30, actual.length)
   }
 
-  @Test def testSixBitEncoding39() {
+  @Test def testSixBitEncoding39(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-6-BIT-DFI-264-DUI-001"><![CDATA[0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ00]]></documentPart>
               </document>

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
@@ -37,7 +37,7 @@ class UnitTestTDMLRunner {
   val tns = example
   // val sub = XMLUtils.DFDL_XMLSCHEMASUBSET_NAMESPACE
 
-  @Test def testDocPart1() {
+  @Test def testDocPart1(): Unit = {
     val xml = <documentPart type="text">abcde</documentPart>
     val dp = new TextDocumentPart(xml, null)
     val actual = Misc.bits2Bytes(dp.dataBits).toList
@@ -45,7 +45,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testDocPart2() {
+  @Test def testDocPart2(): Unit = {
     val xml = <document><documentPart type="byte">123abc</documentPart></document>
     val doc = new Document(xml, null)
     val dp = doc.documentParts.collect { case x: ByteDocumentPart => x }
@@ -56,7 +56,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testHexOddNumberOfNibbles() {
+  @Test def testHexOddNumberOfNibbles(): Unit = {
     val xml = <document><documentPart type="byte">123</documentPart></document>
     val doc = new Document(xml, null)
     val dp = doc.documentParts.collect { case x: ByteDocumentPart => x }
@@ -68,7 +68,7 @@ class UnitTestTDMLRunner {
     assertEquals(12, doc.nBits)
   }
 
-  @Test def testDocPart3() {
+  @Test def testDocPart3(): Unit = {
     val xml = <document>
                 <documentPart type="byte">12</documentPart>
                 <documentPart type="byte">3abc</documentPart>
@@ -85,7 +85,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testDocWithMultiByteUnicode() {
+  @Test def testDocWithMultiByteUnicode(): Unit = {
     val xml = <document>
                 <documentPart type="text">&#x24;&#xA2;&#x20AC;&#x2028;</documentPart>
               </document>
@@ -98,7 +98,7 @@ class UnitTestTDMLRunner {
     assertEquals("$¢€\u2028", str)
   }
 
-  @Test def testDocWithDFDLEntities() {
+  @Test def testDocWithDFDLEntities(): Unit = {
     val xml = <document>
                 <documentPart replaceDFDLEntities="true" type="text">\%#x24;%#xA2;%#x20AC;%%%NUL;%LS;%%#IGNORED;</documentPart>
               </document>
@@ -111,7 +111,7 @@ class UnitTestTDMLRunner {
     assertEquals("\\$¢€%%\u0000\u2028%%#IGNORED;", orig)
   }
 
-  @Test def testDocWithTextFile() {
+  @Test def testDocWithTextFile(): Unit = {
     val xml = <testSuite xmlns={ tdml } ID="suite identifier" suiteName="theSuiteName" description="Some Test Suite Description">
                 <parserTestCase name="test1" root="byte1" model="test-suite/ibm-contributed/dpanum.dfdl.xsd" description="Some test case description.">
                   <document>
@@ -134,7 +134,7 @@ class UnitTestTDMLRunner {
     assertEquals("test\n1\n2\n3\n", actual)
   }
 
-  @Test def testDocWithBinaryFile() {
+  @Test def testDocWithBinaryFile(): Unit = {
     val xml = <testSuite xmlns={ tdml } ID="suite identifier" suiteName="theSuiteName" description="Some Test Suite Description">
                 <parserTestCase name="test1" root="byte1" model="test-suite/ibm-contributed/dpanum.dfdl.xsd" description="Some test case description.">
                   <document>
@@ -158,7 +158,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def test1() {
+  @Test def test1(): Unit = {
     val xml = <testSuite xmlns={ tdml } ID="suite identifier" suiteName="theSuiteName" description="Some Test Suite Description">
                 <parserTestCase name="test1" root="byte1" model="test-suite/ibm-contributed/dpanum.dfdl.xsd" description="Some test case description.">
                   <document>0123</document>
@@ -187,7 +187,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, trimmed)
   }
 
-  @Test def test2() {
+  @Test def test2(): Unit = {
     val xml = <testSuite xmlns={ tdml } suiteName="theSuiteName">
                 <parserTestCase ID="some identifier" name="test2" root="byte1" model="test-suite/ibm-contributed/dpanum.dfdl.xsd">
                   <document>0123</document>
@@ -219,7 +219,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, trimmed)
   }
   /////////////////////////////////////////////////////////////////////////////////////////////////////
-  @Test def testTDMLResource() {
+  @Test def testTDMLResource(): Unit = {
     lazy val res = Misc.getRequiredResource("/test-suite/ibm-contributed/dpaext1-2.tdml")
     lazy val ts = new DFDLTestSuite(new File(res))
     val mf = ts.findTDMLResource("./fvt/ext/dpa/dpaspc121_01.dfdl.xsd")
@@ -242,7 +242,7 @@ class UnitTestTDMLRunner {
       </parserTestCase>
     </tdml:testSuite>
 
-  @Test def testEmbeddedSchemaValidates() {
+  @Test def testEmbeddedSchemaValidates(): Unit = {
     val testSuite = tdmlWithEmbeddedSchemaInvalid
     assertFalse(ts.isTDMLFileValid)
     lazy val ts = new DFDLTestSuite(testSuite)
@@ -253,7 +253,7 @@ class UnitTestTDMLRunner {
     assertTrue(hasMsg)
     assertFalse(ts.isTDMLFileValid)
   }
-  @Test def testTDMLSelfContainedFileValidates() {
+  @Test def testTDMLSelfContainedFileValidates(): Unit = {
     val tmpTDMLFileName = getClass.getName() + ".tdml"
     val testSuite = tdmlWithEmbeddedSchemaInvalid
     try {
@@ -273,7 +273,7 @@ class UnitTestTDMLRunner {
     }
   }
 
-  @Test def testBits() {
+  @Test def testBits(): Unit = {
     val doc = new Document(<document><documentPart type="bits">111</documentPart></document>, null)
     // val bits = doc.documentParts(0)
     val bytes = doc.documentBytes.toList
@@ -288,7 +288,7 @@ class UnitTestTDMLRunner {
    * sees the CR in that case because the XML loader being used to load the
    * tdml file has removed the CRLF and replaced it with just LF.
    */
-  @Test def testDocWithDoubleNewlines() {
+  @Test def testDocWithDoubleNewlines(): Unit = {
     val xml = <tdml:document>
                 <tdml:documentPart type="text">ab</tdml:documentPart>
                 <tdml:documentPart type="byte">0d0a0d0a</tdml:documentPart>
@@ -304,7 +304,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual.toList)
   }
 
-  @Test def testLSB1() {
+  @Test def testLSB1(): Unit = {
     val xml = <document bitOrder="LSBFirst">
                 <documentPart type="bits">00000010</documentPart>
               </document>
@@ -318,7 +318,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testLSB2() {
+  @Test def testLSB2(): Unit = {
     val xml = <document>
                 <documentPart type="bits" bitOrder="LSBFirst">010</documentPart>
               </document>
@@ -330,7 +330,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testLSB3_utf8_1char() {
+  @Test def testLSB3_utf8_1char(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst">1</documentPart>
               </document>
@@ -342,7 +342,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testLSB3_7bit_1char() {
+  @Test def testLSB3_7bit_1char(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-US-ASCII-7-BIT-PACKED">1</documentPart>
               </document>
@@ -354,7 +354,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testLSB3_7bit_2char() {
+  @Test def testLSB3_7bit_2char(): Unit = {
     val xml = <document>
                 <documentPart type="text" bitOrder="LSBFirst" encoding="X-DFDL-US-ASCII-7-BIT-PACKED">12</documentPart>
               </document>
@@ -366,7 +366,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testLSB4() {
+  @Test def testLSB4(): Unit = {
     val xml = <document>
                 <documentPart type="bits" bitOrder="LSBFirst">00110011 110</documentPart>
               </document>
@@ -378,7 +378,7 @@ class UnitTestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testCheckForBadBitOrderTransitions1() {
+  @Test def testCheckForBadBitOrderTransitions1(): Unit = {
     val xml = <document>
                 <documentPart type="bits" bitOrder="LSBFirst">1</documentPart>
                 <documentPart type="bits" bitOrder="MSBFirst">1</documentPart>
@@ -390,7 +390,7 @@ class UnitTestTDMLRunner {
     assertTrue(exc.getMessage().contains("bitOrder"))
   }
 
-  @Test def testCheckForBadBitOrderTransitions2() {
+  @Test def testCheckForBadBitOrderTransitions2(): Unit = {
     val xml = <document>
                 <documentPart type="bits" bitOrder="LSBFirst">1</documentPart>
                 <documentPart type="bits" bitOrder="LSBFirst">111 1111</documentPart>
@@ -402,7 +402,7 @@ class UnitTestTDMLRunner {
     assertEquals(3, dp.length)
   }
 
-  @Test def testCheckForBadBitOrderTransitions3() {
+  @Test def testCheckForBadBitOrderTransitions3(): Unit = {
     val xml = <document>
                 <documentPart type="bits" bitOrder="LSBFirst">1111 1111</documentPart>
                 <documentPart type="bits" bitOrder="MSBFirst">111 1111</documentPart>
@@ -414,7 +414,7 @@ class UnitTestTDMLRunner {
     assertEquals(3, dp.length)
   }
 
-  @Test def testCheckForBadBitOrderTransitions4() {
+  @Test def testCheckForBadBitOrderTransitions4(): Unit = {
     val xml = <document>
                 <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst">abcdefgh</documentPart>
                 <documentPart type="bits" bitOrder="MSBFirst">111 1111</documentPart>
@@ -426,7 +426,7 @@ class UnitTestTDMLRunner {
     assertEquals(3, dp.length)
   }
 
-  @Test def testCheckForBadBitOrderTransitions5() {
+  @Test def testCheckForBadBitOrderTransitions5(): Unit = {
     val xml = <document>
                 <documentPart type="text" encoding="X-DFDL-US-ASCII-7-BIT-PACKED" bitOrder="LSBFirst">abc</documentPart>
                 <documentPart type="bits" bitOrder="MSBFirst">111 1111</documentPart>

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/SchemaCache.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/SchemaCache.scala
@@ -61,7 +61,7 @@ class SchemaCache[CachedType, DiagnosticType] {
 
   private val compiledSchemaCache = new Cache
 
-  def resetCache {
+  def resetCache: Unit = {
     compiledSchemaCache.clear()
   }
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestSchemaCache.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestSchemaCache.scala
@@ -35,7 +35,7 @@ class TestSchemaCache {
   var newUSS: URISchemaSource = null
   var tempFile: File = null
 
-  @Before def setup {
+  @Before def setup: Unit = {
     compileCount = 0
     SCache.resetCache
     tempFile = java.io.File.createTempFile("tdml", "tdml")
@@ -51,7 +51,7 @@ class TestSchemaCache {
    * Touches the file, insures it happens far enough in the future
    * that the file modification times are different.
    */
-  def touchFile() {
+  def touchFile(): Unit = {
     val startingModTime = tempFile.lastModified()
     var iters = 0
     while (tempFile.lastModified() <= startingModTime) {
@@ -65,7 +65,7 @@ class TestSchemaCache {
     // println("iters = " + iters)
   }
 
-  def compileTheSchema(uss: URISchemaSource) {
+  def compileTheSchema(uss: URISchemaSource): Unit = {
     SCache.compileAndCache(uss, false, false, null, null) {
       compileCount += 1
       uss.newInputSource().getByteStream().close()
@@ -73,19 +73,19 @@ class TestSchemaCache {
     }
   }
 
-  @Test def testReset {
+  @Test def testReset: Unit = {
     compileTheSchema(originalUSS)
     SCache.resetCache
   }
 
-  @Test def testSameFileCompiledOnce {
+  @Test def testSameFileCompiledOnce: Unit = {
     compileTheSchema(originalUSS)
     assertEquals(1, compileCount)
     compileTheSchema(newUSS) // file has not been touched, so this should hit the cache.
     assertEquals(1, compileCount)
   }
 
-  @Test def testSameFileCompiledTwice {
+  @Test def testSameFileCompiledTwice: Unit = {
     compileTheSchema(originalUSS)
     assertEquals(1, compileCount)
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
@@ -33,7 +33,7 @@ class TestTDMLCrossTest {
   val tns = example
   val fn = XMLUtils.XPATH_FUNCTION_NAMESPACE
 
-  @Test def testUnrecognizedImpl1() {
+  @Test def testUnrecognizedImpl1(): Unit = {
 
     val testSuite =
       <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName" defaultImplementations="notAnImplName">

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
@@ -33,7 +33,7 @@ class TestTDMLRoundTrips {
   val tns = example
   val fn = XMLUtils.XPATH_FUNCTION_NAMESPACE
 
-  @Test def testOnePassPass1() {
+  @Test def testOnePassPass1(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:defineSchema name="s">
@@ -71,7 +71,7 @@ class TestTDMLRoundTrips {
    * The output from the one pass unparse will have the semicolon, and so will fail
    * to match the original input.
    */
-  @Test def testOnePassFail1() {
+  @Test def testOnePassFail1(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:defineSchema name="s">
@@ -137,7 +137,7 @@ class TestTDMLRoundTrips {
    * A test defined to show that we need two-passes, so that we re-parse
    * the canonical data from the unparse and then get a matching infoset.
    */
-  @Test def testTwoPass1() {
+  @Test def testTwoPass1(): Unit = {
 
     val testSuite = needsTwoPassesOnlyTDML("twoPass")
     lazy val ts = new DFDLTestSuite(testSuite)
@@ -146,7 +146,7 @@ class TestTDMLRoundTrips {
   /**
    * Tests windows style (CRLF) line endings for two pass
    */
-  @Test def testTwoPass2() {
+  @Test def testTwoPass2(): Unit = {
 
     val testSuite =
       <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
@@ -197,7 +197,7 @@ New Line]]></bar>
   /**
    * Tests mac style (CR) line endings for two pass
    */
-  @Test def testTwoPass3() {
+  @Test def testTwoPass3(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:defineSchema name="s">
@@ -278,7 +278,7 @@ New Line]]></bar>
    * This means test authors have to know if the test is parse-only, one pass parse/unparse round trip,
    * or two-pass, and label the test accordingly.
    */
-  @Test def testTwoPassNotNeeded1() {
+  @Test def testTwoPassNotNeeded1(): Unit = {
     val testSuite = nPassNotNeededTDML("twoPass")
     lazy val ts = new DFDLTestSuite(testSuite)
     val e = intercept[TDMLException] {
@@ -293,7 +293,7 @@ New Line]]></bar>
    * the canonical data from the unparse and then still do not get a matching infoset,
    * but unparsing that infoset finally does give us matching unparsed data.
    */
-  @Test def testThreePass1() {
+  @Test def testThreePass1(): Unit = {
     val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:xsi={ xsi } xmlns:fn={ fn } xmlns:ex={ example } xmlns:ts={ tdml } xmlns:daf={ daf } suiteName="theSuiteName">
                       <ts:defineSchema name="s" elementFormDefault="unqualified">
                         <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
@@ -337,7 +337,7 @@ New Line]]></bar>
    * unparse data in fact matches the original (i.e., we didn't
    * even really need two passes, that it is detected and reported.
    */
-  @Test def testThreePassNotNeeded1() {
+  @Test def testThreePassNotNeeded1(): Unit = {
     val testSuite = nPassNotNeededTDML("threePass")
     lazy val ts = new DFDLTestSuite(testSuite)
     val e = intercept[TDMLException] {

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
@@ -38,7 +38,7 @@ class TestTDMLRunner {
   val tns = example
   // val sub = XMLUtils.DFDL_XMLSCHEMASUBSET_NAMESPACE
 
-  @Test def test3() {
+  @Test def test3(): Unit = {
     // This tests when there are parseTestCases in the same suite that use the
     // same DFDL schema but have different validation modes. The non-validation
     // test should compile the processor, serialize it, and cache it.
@@ -94,7 +94,7 @@ class TestTDMLRunner {
     <dfdl:format ref="tns:GeneralFormat"/>,
     <xs:element name="data" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(2) }"/>)
 
-  @Test def testTDMLParseSuccess() {
+  @Test def testTDMLParseSuccess(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLParseSuccess" root="data">
@@ -110,7 +110,7 @@ class TestTDMLRunner {
     ts.runOneTest("testTDMLParseSuccess", Some(testSchema))
   }
 
-  @Test def testTDMLParseDetectsErrorWithSpecificMessage() {
+  @Test def testTDMLParseDetectsErrorWithSpecificMessage(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLParseDetectsErrorWithSpecificMessage" root="data">
@@ -125,7 +125,7 @@ class TestTDMLRunner {
     ts.runOneTest("testTDMLParseDetectsErrorWithSpecificMessage", Some(testSchema))
   }
 
-  @Test def testTDMLParseDetectsErrorWithPartMessage() {
+  @Test def testTDMLParseDetectsErrorWithPartMessage(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLParseDetectsErrorWithPartMessage" root="data">
@@ -143,7 +143,7 @@ class TestTDMLRunner {
     assertTrue(exc.getMessage().contains("""message "xs:float""""))
   }
 
-  @Test def testTDMLParseDetectsErrorAnyMessage() {
+  @Test def testTDMLParseDetectsErrorAnyMessage(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLParseDetectsErrorAnyMessage" root="data">
@@ -157,7 +157,7 @@ class TestTDMLRunner {
     ts.runOneTest("testTDMLParseDetectsErrorAnyMessage", Some(testSchema))
   }
 
-  @Test def testTDMLParseDetectsNoError() {
+  @Test def testTDMLParseDetectsNoError(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLParseDetectsNoError" root="data">
@@ -199,7 +199,7 @@ class TestTDMLRunner {
   //    assertTrue(exc.getMessage().contains("Did not find"))
   //  }
 
-  @Test def testTDMLParseRunAll() {
+  @Test def testTDMLParseRunAll(): Unit = {
     val testSuite = <testSuite xmlns={ tdml } suiteName="theSuiteName" xmlns:tns={ example }>
                       <parserTestCase name="testTDMLParseRunAll1" root="data">
                         <document>37</document>
@@ -222,7 +222,7 @@ class TestTDMLRunner {
     ts.runAllTests(Some(testSchema))
   }
 
-  @Test def testInfosetFromFile() {
+  @Test def testInfosetFromFile(): Unit = {
     val xml = <testSuite xmlns={ tdml } ID="suite identifier" suiteName="theSuiteName" description="Some Test Suite Description">
                 <parserTestCase name="test1" root="byte1" model="test-suite/ibm-contributed/dpanum.dfdl.xsd" description="Some test case description.">
                   <document>
@@ -241,7 +241,7 @@ class TestTDMLRunner {
     assertEquals(expected, actual)
   }
 
-  @Test def testRunModelFile() {
+  @Test def testRunModelFile(): Unit = {
     val tmp = File.createTempFile(getClass.getName(), ".dfdl.xsd")
     tmp.deleteOnExit()
     val testSuite = <testSuite xmlns={ tdml } suiteName="theSuiteName">
@@ -263,7 +263,7 @@ class TestTDMLRunner {
     ts.runOneTest("testRunModelFile")
   }
 
-  @Test def testRunTDMLFileReferencingModelFile() {
+  @Test def testRunTDMLFileReferencingModelFile(): Unit = {
     val tmpFileName = getClass.getName() + ".dfdl.xsd"
     val tmpTDMLFileName = getClass.getName() + ".tdml"
     val testSuite = <testSuite xmlns={ tdml } suiteName="theSuiteName">
@@ -315,13 +315,13 @@ class TestTDMLRunner {
       </parserTestCase>
     </tdml:testSuite>
 
-  @Test def testEmbeddedSchemaWorks() {
+  @Test def testEmbeddedSchemaWorks(): Unit = {
     val testSuite = tdmlWithEmbeddedSchema
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("testEmbeddedSchemaWorks")
   }
 
-  @Test def testRunTDMLSelfContainedFile() {
+  @Test def testRunTDMLSelfContainedFile(): Unit = {
     val tmpTDMLFileName = getClass.getName() + ".tdml"
     val testSuite = tdmlWithEmbeddedSchema
     try {
@@ -355,7 +355,7 @@ class TestTDMLRunner {
       </parserTestCase>
     </tdml:testSuite>
 
-  @Test def testMultiByteUnicodeWorks() {
+  @Test def testMultiByteUnicodeWorks(): Unit = {
     val testSuite = tdmlWithUnicode2028
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("testMultiByteUnicodeWorks")
@@ -378,7 +378,7 @@ class TestTDMLRunner {
       </parserTestCase>
     </tdml:testSuite>
 
-  @Test def testMultiByteUnicodeWithCDATAWorks() {
+  @Test def testMultiByteUnicodeWithCDATAWorks(): Unit = {
     val testSuite = tdmlWithUnicode5E74AndCDATA
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("testMultiByteUnicodeWithCDATAWorks")
@@ -517,7 +517,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testNilCompare")
   }
 
-  @Test def test_tdmlNamespaces1() {
+  @Test def test_tdmlNamespaces1(): Unit = {
     val testDir = "/test/tdml/"
     val t0 = testDir + "tdmlNamespaces.tdml"
     lazy val r = new DFDLTestSuite(Misc.getRequiredResource(t0))
@@ -546,7 +546,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     <dfdl:format ref="tns:GeneralFormat"/>,
     <xs:element name="data" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="4"/>)
 
-  @Test def testTDMLHexBinaryTypeAwareSuccess_01() {
+  @Test def testTDMLHexBinaryTypeAwareSuccess_01(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLHexBinaryTypeAwareSuccess"
                         root="data">
@@ -565,7 +565,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLHexBinaryTypeAwareSuccess", Some(testHexBinarySchema))
   }
 
-  @Test def testTDMLHexBinaryTypeAwareSuccess_02() {
+  @Test def testTDMLHexBinaryTypeAwareSuccess_02(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLHexBinaryTypeAwareSuccess"
                         root="data">
@@ -584,7 +584,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLHexBinaryTypeAwareSuccess", Some(testHexBinarySchema))
   }
 
-  @Test def testTDMLHexBinaryTypeAwareFailure() {
+  @Test def testTDMLHexBinaryTypeAwareFailure(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLHexBinaryTypeAwareFailure"
                         root="data">
@@ -617,7 +617,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
       dfdl:calendarPatternKind="explicit"
       dfdl:calendarPattern="uuuu-MM-dd'T'HH:mm:ss.SSSSSSxxxxx" />)
 
-  @Test def testTDMLDateTimeTypeAwareSuccess_01() {
+  @Test def testTDMLDateTimeTypeAwareSuccess_01(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLDateTimeTypeAwareSuccess"
                         root="data">
@@ -634,7 +634,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
-  @Test def testTDMLDateTimeTypeAwareSuccess_02() {
+  @Test def testTDMLDateTimeTypeAwareSuccess_02(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLDateTimeTypeAwareSuccess"
                         root="data">
@@ -651,7 +651,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
-  @Test def testTDMLDateTimeTypeAwareSuccess_03() {
+  @Test def testTDMLDateTimeTypeAwareSuccess_03(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLDateTimeTypeAwareSuccess"
                         root="data">
@@ -668,7 +668,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
-  @Test def testTDMLDateTimeTypeAwareSuccess_04() {
+  @Test def testTDMLDateTimeTypeAwareSuccess_04(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLDateTimeTypeAwareSuccess"
                         root="data">
@@ -685,7 +685,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
-  @Test def testTDMLDateTimeTypeAwareFailure() {
+  @Test def testTDMLDateTimeTypeAwareFailure(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:parserTestCase ID="some identifier" name="testTDMLDateTimeTypeAwareFailure"
                         root="data">

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
@@ -448,7 +448,7 @@ abc # a comment
     runner.reset
   }
 
-  @Test def testTDMLUnparse() {
+  @Test def testTDMLUnparse(): Unit = {
     val testSuite = <ts:testSuite xmlns:ts={ tdml } xmlns:tns={ tns } xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:xsi={ xsi } suiteName="theSuiteName">
                       <ts:defineSchema name="unparseTestSchema1">
                         <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
@@ -494,7 +494,7 @@ abc # a comment
     </tdml:testSuite>
 
   // @Test // other places should test tracing.
-  def testTrace() {
+  def testTrace(): Unit = {
     val tmpTDMLFileName = getClass.getName() + ".tdml"
     val testSuite = tdmlWithEmbeddedSchema
     try {

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerTutorial.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerTutorial.scala
@@ -94,13 +94,13 @@ class TestTDMLRunnerTutorial {
       </tdml:tutorial>
     </tdml:testSuite>
 
-  @Test def testTutorialElementsParse() {
+  @Test def testTutorialElementsParse(): Unit = {
     val testSuite = tdmlWithTutorial
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("testTutorialElementsParse")
   }
 
-  @Test def testTutorialElementsUnparse() {
+  @Test def testTutorialElementsUnparse(): Unit = {
     val testSuite = tdmlWithTutorial
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("testTutorialElementsUnparse")

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -25,7 +25,7 @@ import org.junit.Assert.fail
 object TestTDMLRunnerWarnings {
   val runner = Runner("/test/tdml/", "testWarnings.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
@@ -31,7 +31,7 @@ class TestTDMLUnparseCases {
   val example = XMLUtils.EXAMPLE_NAMESPACE
   val tns = example
 
-  @Test def testUnparseSuite1() {
+  @Test def testUnparseSuite1(): Unit = {
 
     val testSuite = <ts:testSuite xmlns:dfdl={ dfdl } xmlns:xs={ xsd } xmlns:ex={ example } xmlns:ts={ tdml } suiteName="theSuiteName">
                       <ts:defineSchema name="s">

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
@@ -34,58 +34,58 @@ object IBMTestsThatPass {
 class IBMTestsThatPass {
   import IBMTestsThatPass._
 
-  @Test def test_syntax_entities_6_04() { runner1.runOneTest("syntax_entities_6_04") }
+  @Test def test_syntax_entities_6_04(): Unit = { runner1.runOneTest("syntax_entities_6_04") }
 
-  @Test def test_alignment_bytes_12_01() { runner1.runOneTest("alignment_bytes_12_01") }
-  @Test def test_alignment_bytes_12_02() { runner1.runOneTest("alignment_bytes_12_02") }
-  @Test def test_alignment_bytes_12_03() { runner1.runOneTest("alignment_bytes_12_03") }
-  @Test def test_alignment_bytes_12_06() { runner1.runOneTest("alignment_bytes_12_06") }
+  @Test def test_alignment_bytes_12_01(): Unit = { runner1.runOneTest("alignment_bytes_12_01") }
+  @Test def test_alignment_bytes_12_02(): Unit = { runner1.runOneTest("alignment_bytes_12_02") }
+  @Test def test_alignment_bytes_12_03(): Unit = { runner1.runOneTest("alignment_bytes_12_03") }
+  @Test def test_alignment_bytes_12_06(): Unit = { runner1.runOneTest("alignment_bytes_12_06") }
 
-  @Test def test_length_delimited_12_01() { runner1.runOneTest("length_delimited_12_01") }
-  @Test def test_length_delimited_12_04() { runner1.runOneTest("length_delimited_12_04") }
+  @Test def test_length_delimited_12_01(): Unit = { runner1.runOneTest("length_delimited_12_01") }
+  @Test def test_length_delimited_12_04(): Unit = { runner1.runOneTest("length_delimited_12_04") }
 
   // Doesn't work for a user, possible locale issue (DAFFODIL-1945)
   // @Test def test_simple_type_properties_text_calendar_13_01() { runner2.runOneTest("simple_type_properties_text_calendar_13_01") }
-  @Test def test_simple_type_properties_text_calendar_13_02() { runner2.runOneTest("simple_type_properties_text_calendar_13_02") }
-  @Test def test_simple_type_properties_text_calendar_13_03() { runner2.runOneTest("simple_type_properties_text_calendar_13_03") }
-  @Test def test_simple_type_properties_text_calendar_13_04() { runner2.runOneTest("simple_type_properties_text_calendar_13_04") }
+  @Test def test_simple_type_properties_text_calendar_13_02(): Unit = { runner2.runOneTest("simple_type_properties_text_calendar_13_02") }
+  @Test def test_simple_type_properties_text_calendar_13_03(): Unit = { runner2.runOneTest("simple_type_properties_text_calendar_13_03") }
+  @Test def test_simple_type_properties_text_calendar_13_04(): Unit = { runner2.runOneTest("simple_type_properties_text_calendar_13_04") }
 
-  @Test def test_simple_type_properties_bin_calendar_13_01() { runner2.runOneTest("simple_type_properties_bin_calendar_13_01") }
-  @Test def test_simple_type_properties_bin_calendar_13_02() { runner2.runOneTest("simple_type_properties_bin_calendar_13_02") }
+  @Test def test_simple_type_properties_bin_calendar_13_01(): Unit = { runner2.runOneTest("simple_type_properties_bin_calendar_13_01") }
+  @Test def test_simple_type_properties_bin_calendar_13_02(): Unit = { runner2.runOneTest("simple_type_properties_bin_calendar_13_02") }
 
-  @Test def test_introduction_1_01() { runner1.runOneTest("introduction_1_01") }
+  @Test def test_introduction_1_01(): Unit = { runner1.runOneTest("introduction_1_01") }
 
-  @Test def test_property_syntax_7_04() { runner1.runOneTest("property_syntax_7_04") }
+  @Test def test_property_syntax_7_04(): Unit = { runner1.runOneTest("property_syntax_7_04") }
 
-  @Test def test_scoping_default_format_8_01() { runner1.runOneTest("scoping_default_format_8_01") }
-  @Test def test_scoping_define_format_8_01() { runner1.runOneTest("scoping_define_format_8_01") }
-  @Test def test_scoping_define_format_8_02() { runner1.runOneTest("scoping_define_format_8_02") }
-  @Test def test_scoping_define_format_8_03() { runner1.runOneTest("scoping_define_format_8_03") }
-  @Test def test_scoping_define_format_8_04() { runner1.runOneTest("scoping_define_format_8_04") }
-  @Test def test_scoping_define_format_8_05() { runner1.runOneTest("scoping_define_format_8_05") }
+  @Test def test_scoping_default_format_8_01(): Unit = { runner1.runOneTest("scoping_default_format_8_01") }
+  @Test def test_scoping_define_format_8_01(): Unit = { runner1.runOneTest("scoping_define_format_8_01") }
+  @Test def test_scoping_define_format_8_02(): Unit = { runner1.runOneTest("scoping_define_format_8_02") }
+  @Test def test_scoping_define_format_8_03(): Unit = { runner1.runOneTest("scoping_define_format_8_03") }
+  @Test def test_scoping_define_format_8_04(): Unit = { runner1.runOneTest("scoping_define_format_8_04") }
+  @Test def test_scoping_define_format_8_05(): Unit = { runner1.runOneTest("scoping_define_format_8_05") }
 
-  @Test def test_encoding_11_01() { runner1.runOneTest("encoding_11_01") }
+  @Test def test_encoding_11_01(): Unit = { runner1.runOneTest("encoding_11_01") }
 
-  @Test def test_length_implicit_12_01() { runner1.runOneTest("length_implicit_12_01") }
+  @Test def test_length_implicit_12_01(): Unit = { runner1.runOneTest("length_implicit_12_01") }
 
-  @Test def test_length_explicit_12_03() { runner1.runOneTest("length_explicit_12_03") }
+  @Test def test_length_explicit_12_03(): Unit = { runner1.runOneTest("length_explicit_12_03") }
 
-  @Test def test_simple_type_properties_pad_trim_13_01() { runner2.runOneTest("simple_type_properties_pad_trim_13_01") } // pad/trim
-  @Test def test_simple_type_properties_pad_trim_13_02() { runner2.runOneTest("simple_type_properties_pad_trim_13_02") } // xs:integer type
-  @Test def test_simple_type_properties_pad_trim_13_03() { runner2.runOneTest("simple_type_properties_pad_trim_13_03") } // pad/trim
-  @Test def test_simple_type_properties_pad_trim_13_04() { runner2.runOneTest("simple_type_properties_pad_trim_13_04") } // pad/trim
+  @Test def test_simple_type_properties_pad_trim_13_01(): Unit = { runner2.runOneTest("simple_type_properties_pad_trim_13_01") } // pad/trim
+  @Test def test_simple_type_properties_pad_trim_13_02(): Unit = { runner2.runOneTest("simple_type_properties_pad_trim_13_02") } // xs:integer type
+  @Test def test_simple_type_properties_pad_trim_13_03(): Unit = { runner2.runOneTest("simple_type_properties_pad_trim_13_03") } // pad/trim
+  @Test def test_simple_type_properties_pad_trim_13_04(): Unit = { runner2.runOneTest("simple_type_properties_pad_trim_13_04") } // pad/trim
 
-  @Test def test_simple_type_properties_text_number_13_02() { runner2.runOneTest("simple_type_properties_text_number_13_02") }
+  @Test def test_simple_type_properties_text_number_13_02(): Unit = { runner2.runOneTest("simple_type_properties_text_number_13_02") }
 
-  @Test def test_simple_type_properties_binary_number_13_01() { runner2.runOneTest("simple_type_properties_binary_number_13_01") }
-  @Test def test_simple_type_properties_binary_number_13_02() { runner2.runOneTest("simple_type_properties_binary_number_13_02") }
+  @Test def test_simple_type_properties_binary_number_13_01(): Unit = { runner2.runOneTest("simple_type_properties_binary_number_13_01") }
+  @Test def test_simple_type_properties_binary_number_13_02(): Unit = { runner2.runOneTest("simple_type_properties_binary_number_13_02") }
 
-  @Test def test_sequences_separated_14_01() { runner2.runOneTest("sequences_separated_14_01") }
-  @Test def test_sequences_separated_14_02() { runner2.runOneTest("sequences_separated_14_02") }
-  @Test def test_sequences_separated_14_07() { runner2.runOneTest("sequences_separated_14_07") }
-  @Test def test_sequences_separated_14_08() { runner2.runOneTest("sequences_separated_14_08") }
+  @Test def test_sequences_separated_14_01(): Unit = { runner2.runOneTest("sequences_separated_14_01") }
+  @Test def test_sequences_separated_14_02(): Unit = { runner2.runOneTest("sequences_separated_14_02") }
+  @Test def test_sequences_separated_14_07(): Unit = { runner2.runOneTest("sequences_separated_14_07") }
+  @Test def test_sequences_separated_14_08(): Unit = { runner2.runOneTest("sequences_separated_14_08") }
 
-  @Test def test_delimiter_12_02() { runner1.runOneTest("delimiter_12_02") }
+  @Test def test_delimiter_12_02(): Unit = { runner1.runOneTest("delimiter_12_02") }
 
   // DAFFODIL-1541 Need support for handling delimited data with encoding other than ISO-8859-1
   //@Test def test_length_delimited_12_05() { runner1.runOneTest("length_delimited_12_05") }
@@ -94,7 +94,7 @@ class IBMTestsThatPass {
   //@Test def test_simple_type_properties_text_number_13_01() { runner2.runOneTest("simple_type_properties_text_number_13_01") }
 
   // DAFFODIL-840 textStandardBase (base 16)
-  @Test def test_simple_type_properties_text_number_13_03() { runner2.runOneTest("simple_type_properties_text_number_13_03") }
+  @Test def test_simple_type_properties_text_number_13_03(): Unit = { runner2.runOneTest("simple_type_properties_text_number_13_03") }
 
   // DAFFODIL-551 Needs dfdl:utf16Width='variable' implementation
   //@Test def test_syntax_entities_6_03() { runner1.runOneTest("syntax_entities_6_03") }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests3.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests3.scala
@@ -33,70 +33,70 @@ object IBMTestsThatPass2 {
 class IBMTestsThatPass2 {
   import IBMTestsThatPass2._
 
-  @Test def test_simple_type_properties_text_boolean_13_01() { runner2.runOneTest("simple_type_properties_text_boolean_13_01") } // DFDL-462 boolean type
-  @Test def test_simple_type_properties_text_boolean_13_02() { runner2.runOneTest("simple_type_properties_text_boolean_13_02") } // DFDL-462 boolean type
+  @Test def test_simple_type_properties_text_boolean_13_01(): Unit = { runner2.runOneTest("simple_type_properties_text_boolean_13_01") } // DFDL-462 boolean type
+  @Test def test_simple_type_properties_text_boolean_13_02(): Unit = { runner2.runOneTest("simple_type_properties_text_boolean_13_02") } // DFDL-462 boolean type
 
-  @Test def test_alignment_bytes_12_04() { runner1.runOneTest("alignment_bytes_12_04") } //DFDL-461 binary boolean
+  @Test def test_alignment_bytes_12_04(): Unit = { runner1.runOneTest("alignment_bytes_12_04") } //DFDL-461 binary boolean
 
-  @Test def test_schema_types_5_01() { runner1.runOneTest("schema_types_5_01") }
-  @Test def test_schema_types_5_02() { runner1.runOneTest("schema_types_5_02") }
-  @Test def test_schema_types_5_03() { runner1.runOneTest("schema_types_5_03") }
-  @Test def test_schema_types_5_04() { runner1.runOneTest("schema_types_5_04") }
-  @Test def test_schema_types_5_05() { runner1.runOneTest("schema_types_5_05") }
+  @Test def test_schema_types_5_01(): Unit = { runner1.runOneTest("schema_types_5_01") }
+  @Test def test_schema_types_5_02(): Unit = { runner1.runOneTest("schema_types_5_02") }
+  @Test def test_schema_types_5_03(): Unit = { runner1.runOneTest("schema_types_5_03") }
+  @Test def test_schema_types_5_04(): Unit = { runner1.runOneTest("schema_types_5_04") }
+  @Test def test_schema_types_5_05(): Unit = { runner1.runOneTest("schema_types_5_05") }
 
-  @Test def test_sequences_separated_14_03() { runner2.runOneTest("sequences_separated_14_03") }
-  @Test def test_sequences_separated_14_05() { runner2.runOneTest("sequences_separated_14_05") }
-  @Test def test_sequences_separated_14_06() { runner2.runOneTest("sequences_separated_14_06") }
+  @Test def test_sequences_separated_14_03(): Unit = { runner2.runOneTest("sequences_separated_14_03") }
+  @Test def test_sequences_separated_14_05(): Unit = { runner2.runOneTest("sequences_separated_14_05") }
+  @Test def test_sequences_separated_14_06(): Unit = { runner2.runOneTest("sequences_separated_14_06") }
 
-  @Test def test_multiple_delimiters2() { runner1.runOneTest("multiple_delimiters2") }
-  @Test def test_multiple_delimiters2err() { runner1.runOneTest("multiple_delimiters2_err") }
+  @Test def test_multiple_delimiters2(): Unit = { runner1.runOneTest("multiple_delimiters2") }
+  @Test def test_multiple_delimiters2err(): Unit = { runner1.runOneTest("multiple_delimiters2_err") }
 
   // Fails on IBM DFDL
   // @Test def test_multiple_delimiters2_ibm() { runner1.runOneTest("multiple_delimiters2_ibm") }
 
-  @Test def test_syntax_entities_6_01() { runner1.runOneTest("syntax_entities_6_01") }
-  @Test def test_syntax_entities_6_02() { runner1.runOneTest("syntax_entities_6_02") }
+  @Test def test_syntax_entities_6_01(): Unit = { runner1.runOneTest("syntax_entities_6_01") }
+  @Test def test_syntax_entities_6_02(): Unit = { runner1.runOneTest("syntax_entities_6_02") }
   //
   // Needs DFDL-1559 - CR;LF output
   //  @Test def test_syntax_entities_6_03() { runner1.runOneTest("syntax_entities_6_03") }
 
-  @Test def test_property_syntax_7_01() { runner1.runOneTest("property_syntax_7_01") }
-  @Test def test_property_syntax_7_02() { runner1.runOneTest("property_syntax_7_02") }
-  @Test def test_property_syntax_7_03() { runner1.runOneTest("property_syntax_7_03") }
+  @Test def test_property_syntax_7_01(): Unit = { runner1.runOneTest("property_syntax_7_01") }
+  @Test def test_property_syntax_7_02(): Unit = { runner1.runOneTest("property_syntax_7_02") }
+  @Test def test_property_syntax_7_03(): Unit = { runner1.runOneTest("property_syntax_7_03") }
 
-  @Test def test_choices_basic_15_01() { runner2.runOneTest("choices_basic_15_01") }
-  @Test def test_choices_basic_15_02() { runner2.runOneTest("choices_basic_15_02") }
-  @Test def test_choices_basic_15_03() { runner2.runOneTest("choices_basic_15_03") }
+  @Test def test_choices_basic_15_01(): Unit = { runner2.runOneTest("choices_basic_15_01") }
+  @Test def test_choices_basic_15_02(): Unit = { runner2.runOneTest("choices_basic_15_02") }
+  @Test def test_choices_basic_15_03(): Unit = { runner2.runOneTest("choices_basic_15_03") }
 
-  @Test def test_arrays_16_01() { runner2.runOneTest("arrays_16_01") }
+  @Test def test_arrays_16_01(): Unit = { runner2.runOneTest("arrays_16_01") }
 
-  @Test def test_introduction_1_02() { runner1.runOneTest("introduction_1_02") }
-  @Test def test_length_delimited_12_03() { runner1.runOneTest("length_delimited_12_03") }
-  @Test def test_length_delimited_12_02() { runner1.runOneTest("length_delimited_12_02") }
-  @Test def test_multiple_delimiters() { runner1.runOneTest("multiple_delimiters") }
+  @Test def test_introduction_1_02(): Unit = { runner1.runOneTest("introduction_1_02") }
+  @Test def test_length_delimited_12_03(): Unit = { runner1.runOneTest("length_delimited_12_03") }
+  @Test def test_length_delimited_12_02(): Unit = { runner1.runOneTest("length_delimited_12_02") }
+  @Test def test_multiple_delimiters(): Unit = { runner1.runOneTest("multiple_delimiters") }
 
-  @Test def test_encoding_11_01() { runner1.runOneTest("encoding_11_01") }
-  @Test def test_encoding_11_02() { runner1.runOneTest("encoding_11_02") }
-  @Test def test_encoding_11_03() { runner1.runOneTest("encoding_11_03") }
+  @Test def test_encoding_11_01(): Unit = { runner1.runOneTest("encoding_11_01") }
+  @Test def test_encoding_11_02(): Unit = { runner1.runOneTest("encoding_11_02") }
+  @Test def test_encoding_11_03(): Unit = { runner1.runOneTest("encoding_11_03") }
 
-  @Test def test_delimiter_12_01() { runner1.runOneTest("delimiter_12_01") }
-  @Test def test_delimiter_12_02() { runner1.runOneTest("delimiter_12_02") }
-  @Test def test_delimiter_12_03() { runner1.runOneTest("delimiter_12_03") }
-  @Test def test_delimiter_12_04() { runner1.runOneTest("delimiter_12_04") }
+  @Test def test_delimiter_12_01(): Unit = { runner1.runOneTest("delimiter_12_01") }
+  @Test def test_delimiter_12_02(): Unit = { runner1.runOneTest("delimiter_12_02") }
+  @Test def test_delimiter_12_03(): Unit = { runner1.runOneTest("delimiter_12_03") }
+  @Test def test_delimiter_12_04(): Unit = { runner1.runOneTest("delimiter_12_04") }
 
   // uses lengthUnits bytes with lengthKind explicit and utf-8
-  @Test def test_length_explicit_12_01() { runner1.runOneTest("length_explicit_12_01") }
-  @Test def test_length_explicit_12_02() { runner1.runOneTest("length_explicit_12_02") }
-  @Test def test_length_delimited_12_06() { runner1.runOneTest("length_delimited_12_06") }
+  @Test def test_length_explicit_12_01(): Unit = { runner1.runOneTest("length_explicit_12_01") }
+  @Test def test_length_explicit_12_02(): Unit = { runner1.runOneTest("length_explicit_12_02") }
+  @Test def test_length_delimited_12_06(): Unit = { runner1.runOneTest("length_delimited_12_06") }
 
-  @Test def test_alignment_bytes_12_05() { runner1.runOneTest("alignment_bytes_12_05") } //DFDL-99 binary dateTime
+  @Test def test_alignment_bytes_12_05(): Unit = { runner1.runOneTest("alignment_bytes_12_05") } //DFDL-99 binary dateTime
 
-  @Test def test_length_implicit_12_02() { runner1.runOneTest("length_implicit_12_02") } // implicit length string - bug in IBM test (doesn't have minLength - both are required)
-  @Test def test_simple_type_properties_text_boolean_13_03() { runner2.runOneTest("simple_type_properties_text_boolean_13_03") } // DFDL-462 boolean type
-  @Test def test_simple_type_properties_bin_boolean_13_01() { runner2.runOneTest("simple_type_properties_bin_boolean_13_01") } // DFDL-461 boolean type
+  @Test def test_length_implicit_12_02(): Unit = { runner1.runOneTest("length_implicit_12_02") } // implicit length string - bug in IBM test (doesn't have minLength - both are required)
+  @Test def test_simple_type_properties_text_boolean_13_03(): Unit = { runner2.runOneTest("simple_type_properties_text_boolean_13_03") } // DFDL-462 boolean type
+  @Test def test_simple_type_properties_bin_boolean_13_01(): Unit = { runner2.runOneTest("simple_type_properties_bin_boolean_13_01") } // DFDL-461 boolean type
 
-  @Test def test_simple_type_properties_text_calendar_13_01() { runner2.runOneTest("simple_type_properties_text_calendar_13_01") } // DAFFODIL-1945
+  @Test def test_simple_type_properties_text_calendar_13_01(): Unit = { runner2.runOneTest("simple_type_properties_text_calendar_13_01") } // DAFFODIL-1945
 
-  @Test def test_sequences_separated_14_04() { runner2.runOneTest("sequences_separated_14_04") } // left over data
+  @Test def test_sequences_separated_14_04(): Unit = { runner2.runOneTest("sequences_separated_14_04") } // left over data
 
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
@@ -24,7 +24,7 @@ object TestNilled {
   val testDir = "/test-suite/tresys-contributed/"
   lazy val runner = Runner(testDir, "nilled.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
@@ -24,7 +24,7 @@ object TestSepSuppression {
   val testDir = "/test-suite/tresys-contributed/"
   lazy val runner = Runner(testDir, "sepSuppression.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
@@ -24,7 +24,7 @@ object TestSepSuppression2 {
   val testDir = "/test-suite/tresys-contributed/"
   lazy val runner2 = Runner(testDir, "sepSuppression2.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner2.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestUnseparated.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestUnseparated.scala
@@ -24,7 +24,7 @@ object TestUnseparated {
   val testDir = "/test-suite/tresys-contributed/"
   lazy val runner = Runner(testDir, "unseparated.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -92,7 +92,7 @@ object TresysTests {
   val bd = testDir + "BD.tdml"
   lazy val runnerBD = new DFDLTestSuite(Misc.getRequiredResource(bd))
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runnerDelimited.reset
     runnerMD.reset
     runnerMD_NV.reset
@@ -103,62 +103,62 @@ object TresysTests {
 class TresysTests {
   import TresysTests._
 
-  @Test def test_length_delimited_12_03_controversial() { runnerDelimited.runOneTest("length_delimited_12_03_controversial") }
+  @Test def test_length_delimited_12_03_controversial(): Unit = { runnerDelimited.runOneTest("length_delimited_12_03_controversial") }
 
   @Test def test_AX000() = { runnerAX.runOneTest("AX000") } // escape schemes
 
-  @Test def test_AV000() { runnerAV000.runOneTest("AV000") } // needs date
+  @Test def test_AV000(): Unit = { runnerAV000.runOneTest("AV000") } // needs date
 
-  @Test def test_AV001() { runnerAV001.runOneTest("AV001") } // needs date
+  @Test def test_AV001(): Unit = { runnerAV001.runOneTest("AV001") } // needs date
 
-  @Test def test_AV002() { runnerAV002.runOneTest("AV002") }
+  @Test def test_AV002(): Unit = { runnerAV002.runOneTest("AV002") }
 
-  @Test def test_AV003() { runnerAV003.runOneTest("AV003") } // needs date
+  @Test def test_AV003(): Unit = { runnerAV003.runOneTest("AV003") } // needs date
 
-  @Test def test_multiple_diagnostics1() { runnerMD.runOneTest("twoMissingTypeDefErrors") }
-  @Test def test_multiple_diagnostics2() { runnerMD.runOneTest("manyErrors1") }
-  @Test def test_multiple_diagnostics3() { runnerMD_NV.runOneTest("manyErrors2") }
+  @Test def test_multiple_diagnostics1(): Unit = { runnerMD.runOneTest("twoMissingTypeDefErrors") }
+  @Test def test_multiple_diagnostics2(): Unit = { runnerMD.runOneTest("manyErrors1") }
+  @Test def test_multiple_diagnostics3(): Unit = { runnerMD_NV.runOneTest("manyErrors2") }
 
-  @Test def test_nested_separator_delimited_baseline() { runnerNSD.runOneTest("baseline") }
+  @Test def test_nested_separator_delimited_baseline(): Unit = { runnerNSD.runOneTest("baseline") }
 
   // Fails in IBM DFDL - ambiguous separator/terminator not accepted.
-  @Test def test_nested_separator_delimited_baseline_ibm() { runnerNSD.runOneTest("baseline_ibm") }
+  @Test def test_nested_separator_delimited_baseline_ibm(): Unit = { runnerNSD.runOneTest("baseline_ibm") }
 
-  @Test def test_nested_separator_delimited_basicNest() { runnerNSD.runOneTest("basicNest") }
-  @Test def test_nested_separator_delimited_basicNest2() { runnerNSD.runOneTest("basicNest2")}
+  @Test def test_nested_separator_delimited_basicNest(): Unit = { runnerNSD.runOneTest("basicNest") }
+  @Test def test_nested_separator_delimited_basicNest2(): Unit = { runnerNSD.runOneTest("basicNest2")}
 
   // Nested delimiter issues - DAFFODIL-2101
   // @Test def test_nested_separator_delimited_nest1() { runnerNSD.runOneTest("nest1")}
   // Nested delimiter issues - DAFFODIL-2101
   // @Test def test_nested_separator_delimited_nest2() { runnerNSD.runOneTest("nest2")}
-  @Test def test_nested_separator_delimited_nest3() { runnerNSD.runOneTest("nest3")}
+  @Test def test_nested_separator_delimited_nest3(): Unit = { runnerNSD.runOneTest("nest3")}
 
-  @Test def test_runtime_diagnostics1() { runnerRD.runOneTest("PE1") }
+  @Test def test_runtime_diagnostics1(): Unit = { runnerRD.runOneTest("PE1") }
 
-  @Test def test_seq1() { runnerSQ.runOneTest("seq1") }
+  @Test def test_seq1(): Unit = { runnerSQ.runOneTest("seq1") }
 
   // DFDL-935
   // @Test def test_encodingErrorPolicy_error() { runnerMB.runOneTest("encodingErrorPolicy_error") }
   // @Test def test_t2() { runnerMB.runOneTest("t2") }
   // @Test def test_t3() { runnerMB.runOneTest("t3") }
-  @Test def test_t1() { runnerMB.runOneTest("t1") }
+  @Test def test_t1(): Unit = { runnerMB.runOneTest("t1") }
 
-  @Test def test_nested_group_refs1() { runnerNG.runOneTest("nestedGroupRefs1") }
+  @Test def test_nested_group_refs1(): Unit = { runnerNG.runOneTest("nestedGroupRefs1") }
 
-  @Test def test_AF000() { runnerAF.runOneTest("AF000") }
-  @Test def test_AF001() { runnerAF.runOneTest("AF001") }
-  @Test def test_AF002() { runnerAF.runOneTest("AF002") }
+  @Test def test_AF000(): Unit = { runnerAF.runOneTest("AF000") }
+  @Test def test_AF001(): Unit = { runnerAF.runOneTest("AF001") }
+  @Test def test_AF002(): Unit = { runnerAF.runOneTest("AF002") }
 
-  @Test def test_AG000() { runnerAG.runOneTest("AG000") } // OK
-  @Test def test_AG001() { runnerAG.runOneTest("AG001") } // OK
-  @Test def test_AG002() { runnerAG.runOneTest("AG002") } // OK
+  @Test def test_AG000(): Unit = { runnerAG.runOneTest("AG000") } // OK
+  @Test def test_AG001(): Unit = { runnerAG.runOneTest("AG001") } // OK
+  @Test def test_AG002(): Unit = { runnerAG.runOneTest("AG002") } // OK
 
-  @Test def test_AW000() { runnerAW.runOneTest("AW000") } // escape schemes
-  @Test def test_AW001() { runnerAW.runOneTest("AW001") }
+  @Test def test_AW000(): Unit = { runnerAW.runOneTest("AW000") } // escape schemes
+  @Test def test_AW001(): Unit = { runnerAW.runOneTest("AW001") }
 
-  @Test def test_AY000() { runnerAY.runOneTest("AY000") } // escape schemes
+  @Test def test_AY000(): Unit = { runnerAY.runOneTest("AY000") } // escape schemes
 
-  @Test def test_AZ000() { runnerAZ.runOneTest("AZ000") } // escape schemes
+  @Test def test_AZ000(): Unit = { runnerAZ.runOneTest("AZ000") } // escape schemes
 
   // Jira DFDL-1392 - Issue with escapeEscape character that is first and precedes an escape-block start.
   // Is being removed, but should be preserved as it does not precede an escape character, nor an escape block end.
@@ -166,17 +166,17 @@ class TresysTests {
   //@Test def test_BB000() { runnerBB.runOneTest("BB000") } // occursCountKind stopValue
 
   //DFDL-1010
-  @Test def test_BE000() { runnerBE.runOneTest("BE000") } // unordered sequences
-  @Test def test_BE001() { runnerBE.runOneTest("BE001") }
+  @Test def test_BE000(): Unit = { runnerBE.runOneTest("BE000") } // unordered sequences
+  @Test def test_BE001(): Unit = { runnerBE.runOneTest("BE001") }
 
   //DFDL-1010
-  @Test def test_BF000() { runnerBF1.runOneTest("BF000") } // unordered sequences
-  @Test def test_BF001() { runnerBF1.runOneTest("BF001") }
+  @Test def test_BF000(): Unit = { runnerBF1.runOneTest("BF000") } // unordered sequences
+  @Test def test_BF001(): Unit = { runnerBF1.runOneTest("BF001") }
 
-  @Test def test_BG000() { runnerBG.runOneTest("BG000") }
+  @Test def test_BG000(): Unit = { runnerBG.runOneTest("BG000") }
 
-  @Test def test_BC000() { runnerBC.runOneTest("BC000") } // text boolean type
-  @Test def test_BD000() { runnerBD.runOneTest("BD000") } // binary boolean type
+  @Test def test_BC000(): Unit = { runnerBC.runOneTest("BC000") } // text boolean type
+  @Test def test_BD000(): Unit = { runnerBD.runOneTest("BD000") } // binary boolean type
 
   // @Test def test_AP000() { runnerAP.runOneTest("AP000") } // lengthKind endOfParent - DAFFODIL-567
 

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
@@ -37,7 +37,7 @@ object TresysTests3 {
   lazy val runnerBC = Runner(testDir, "BC.tdml")
   lazy val runnerBD = Runner(testDir, "BD.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runnerBF.reset
     runnerAH.reset
     runnerAM.reset
@@ -51,12 +51,12 @@ class TresysTests3 {
   import TresysTests3._
 
   @Test def test_testNone() = { runnerBF.runOneTest("testNone") }
-  @Test def test_testOne() { runnerBF.runOneTest("testOne") }
-  @Test def test_testMany() { runnerBF.runOneTest("testMany") }
+  @Test def test_testOne(): Unit = { runnerBF.runOneTest("testOne") }
+  @Test def test_testMany(): Unit = { runnerBF.runOneTest("testMany") }
 
-  @Test def test_AH000() { runnerAH.runOneTest("AH000") }
-  @Test def test_AH001() { runnerAH.runOneTest("AH001") }
-  @Test def test_AH002() { runnerAH.runOneTest("AH002") }
+  @Test def test_AH000(): Unit = { runnerAH.runOneTest("AH000") }
+  @Test def test_AH001(): Unit = { runnerAH.runOneTest("AH001") }
+  @Test def test_AH002(): Unit = { runnerAH.runOneTest("AH002") }
 
   // AM is a MIME style example
   // Wasn't working for lack of occursCountKind, and
@@ -73,9 +73,9 @@ class TresysTests3 {
   // dfdlx:parseUnparsePolicy="parseOnly", which suppresses the check for this
   // constraint.
 
-  @Test def test_AM000() { runnerAM.runOneTest("AM000") }
-  @Test def test_AM001() { runnerAM.runOneTest("AM001") }
+  @Test def test_AM000(): Unit = { runnerAM.runOneTest("AM000") }
+  @Test def test_AM001(): Unit = { runnerAM.runOneTest("AM001") }
 
-  @Test def test_AU000() { runnerAU.runOneTest("AU000") } // packed and bcd
+  @Test def test_AU000(): Unit = { runnerAU.runOneTest("AU000") } // packed and bcd
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
@@ -25,7 +25,7 @@ object TestChoiceBranchKeyRanges {
 
   val runner = Runner(testDir, "choiceBranchKeyRanges.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -34,12 +34,12 @@ object TestChoiceBranchKeyRanges {
 class TestChoiceBranchKeyRanges {
   import TestChoiceBranchKeyRanges._
 
-  @Test def test_choiceBranchKeyRanges_01() { runner.runOneTest("choiceBranchKeyRanges_01") }
-  @Test def test_choiceBranchKeyRanges_overlap_01() { runner.runOneTest("choiceBranchKeyRanges_overlap_01") }
-  @Test def test_choiceBranchKeyRanges_overlap_02() { runner.runOneTest("choiceBranchKeyRanges_overlap_02") }
-  @Test def test_choiceBranchKeyRanges_overlap_03() { runner.runOneTest("choiceBranchKeyRanges_overlap_03") }
-  @Test def test_choiceBranchKeyRanges_oddLength_01() { runner.runOneTest("choiceBranchKeyRanges_oddLength_01") }
-  @Test def test_choiceBranchKeyRanges_badOrder_01() { runner.runOneTest("choiceBranchKeyRanges_badOrder_01") }
-  @Test def test_choiceBranchKeyRanges_nonintDispatch_01() { runner.runOneTest("choiceBranchKeyRanges_nonintDispatch_01") }
-  @Test def test_choiceBranchKeyRanges_nonintDispatch_02() { runner.runOneTest("choiceBranchKeyRanges_nonintDispatch_02") }
+  @Test def test_choiceBranchKeyRanges_01(): Unit = { runner.runOneTest("choiceBranchKeyRanges_01") }
+  @Test def test_choiceBranchKeyRanges_overlap_01(): Unit = { runner.runOneTest("choiceBranchKeyRanges_overlap_01") }
+  @Test def test_choiceBranchKeyRanges_overlap_02(): Unit = { runner.runOneTest("choiceBranchKeyRanges_overlap_02") }
+  @Test def test_choiceBranchKeyRanges_overlap_03(): Unit = { runner.runOneTest("choiceBranchKeyRanges_overlap_03") }
+  @Test def test_choiceBranchKeyRanges_oddLength_01(): Unit = { runner.runOneTest("choiceBranchKeyRanges_oddLength_01") }
+  @Test def test_choiceBranchKeyRanges_badOrder_01(): Unit = { runner.runOneTest("choiceBranchKeyRanges_badOrder_01") }
+  @Test def test_choiceBranchKeyRanges_nonintDispatch_01(): Unit = { runner.runOneTest("choiceBranchKeyRanges_nonintDispatch_01") }
+  @Test def test_choiceBranchKeyRanges_nonintDispatch_02(): Unit = { runner.runOneTest("choiceBranchKeyRanges_nonintDispatch_02") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -29,7 +29,7 @@ object TestInputTypeValueCalc {
   val fnRunner = Runner(testDir, "typeCalcFunctions.tdml", validateTDMLFile = false)
   val fnErrRunner = Runner(testDir, "typeCalcFunctionErrors.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     exprRunner.reset
     fnRunner.reset
@@ -40,67 +40,67 @@ object TestInputTypeValueCalc {
 
 class TestInputTypeValueCalc {
   import TestInputTypeValueCalc._
-  @Test def test_InputTypeCalc_keysetValue_00() { runner.runOneTest("InputTypeCalc_keysetValue_00") }
-  @Test def test_InputTypeCalc_keysetValue_01() { runner.runOneTest("InputTypeCalc_keysetValue_01") }
-  @Test def test_InputTypeCalc_keysetValue_02() { runner.runOneTest("InputTypeCalc_keysetValue_02") }
+  @Test def test_InputTypeCalc_keysetValue_00(): Unit = { runner.runOneTest("InputTypeCalc_keysetValue_00") }
+  @Test def test_InputTypeCalc_keysetValue_01(): Unit = { runner.runOneTest("InputTypeCalc_keysetValue_01") }
+  @Test def test_InputTypeCalc_keysetValue_02(): Unit = { runner.runOneTest("InputTypeCalc_keysetValue_02") }
 
-  @Test def test_InputTypeCalc_unparse_keysetValue_00() { runner.runOneTest("InputTypeCalc_unparse_keysetValue_00") }
-  @Test def test_InputTypeCalc_unparse_keysetValue_01() { runner.runOneTest("InputTypeCalc_unparse_keysetValue_01") }
-  @Test def test_InputTypeCalc_unparse_keysetValue_02() { runner.runOneTest("InputTypeCalc_unparse_keysetValue_02") }
+  @Test def test_InputTypeCalc_unparse_keysetValue_00(): Unit = { runner.runOneTest("InputTypeCalc_unparse_keysetValue_00") }
+  @Test def test_InputTypeCalc_unparse_keysetValue_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_keysetValue_01") }
+  @Test def test_InputTypeCalc_unparse_keysetValue_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_keysetValue_02") }
 
-  @Test def test_InputTypeCalc_choiceDispatchByType_01() { runner.runOneTest("InputTypeCalc_choiceDispatchByType_01") }
-  @Test def test_InputTypeCalc_choiceDispatchByType_02() { runner.runOneTest("InputTypeCalc_choiceDispatchByType_02") }
-  @Test def test_InputTypeCalc_choiceDispatchByType_03() { runner.runOneTest("InputTypeCalc_choiceDispatchByType_03") }
+  @Test def test_InputTypeCalc_choiceDispatchByType_01(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_01") }
+  @Test def test_InputTypeCalc_choiceDispatchByType_02(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_02") }
+  @Test def test_InputTypeCalc_choiceDispatchByType_03(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_03") }
 
-  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_01() { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_01") }
-  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_02() { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_02") }
+  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_01") }
+  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_02") }
 
-  @Test def test_InputTypeCalc_choiceBranchKeyByType_01() { runner.runOneTest("InputTypeCalc_choiceBranchKeyByType_01") }
+  @Test def test_InputTypeCalc_choiceBranchKeyByType_01(): Unit = { runner.runOneTest("InputTypeCalc_choiceBranchKeyByType_01") }
 
-  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_01() { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_01") }
-  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_01() { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_01") }
+  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_01(): Unit = { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_01") }
+  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_01") }
 
-  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_02() { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_02") }
-  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_02() { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_02") }
+  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_02(): Unit = { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_02") }
+  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_02") }
 
-  @Test def test_InputTypeCalc_expression_01() { exprRunner.runOneTest("InputTypeCalc_expression_01") }
-  @Test def test_OutputTypeCalc_expression_01() { exprRunner.runOneTest("OutputTypeCalc_expression_01") }
-  @Test def test_InputTypeCalc_expression_02() { exprRunner.runOneTest("InputTypeCalc_expression_02") }
-  @Test def test_OutputTypeCalc_expression_02() { exprRunner.runOneTest("OutputTypeCalc_expression_02") }
+  @Test def test_InputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("InputTypeCalc_expression_01") }
+  @Test def test_OutputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("OutputTypeCalc_expression_01") }
+  @Test def test_InputTypeCalc_expression_02(): Unit = { exprRunner.runOneTest("InputTypeCalc_expression_02") }
+  @Test def test_OutputTypeCalc_expression_02(): Unit = { exprRunner.runOneTest("OutputTypeCalc_expression_02") }
 
-  @Test def test_inputTypeCalcInt_01() { fnRunner.runOneTest("inputTypeCalcInt_01") }
-  @Test def test_inputTypeCalcString_01() { fnRunner.runOneTest("inputTypeCalcString_01") }
-  @Test def test_outputTypeCalcInt_01() { fnRunner.runOneTest("outputTypeCalcInt_01") }
-  @Test def test_outputTypeCalcString_01() { fnRunner.runOneTest("outputTypeCalcString_01") }
-  @Test def test_repTypeValueInt_01() { fnRunner.runOneTest("repTypeValueInt_01") }
-  @Test def test_logicalTypeValueInt_01() { fnRunner.runOneTest("logicalTypeValueInt_01") }
-  @Test def test_repTypeValueString_01() { fnRunner.runOneTest("repTypeValueString_01") }
-  @Test def test_logicalTypeValueString_01() { fnRunner.runOneTest("logicalTypeValueString_01") }
-  @Test def test_outputTypeCalcNextSiblingInt_01() { fnRunner.runOneTest("outputTypeCalcNextSiblingInt_01") }
-  @Test def test_outputTypeCalcNextSiblingString_01() { fnRunner.runOneTest("outputTypeCalcNextSiblingString_01") }
-  @Test def test_abstractIntToStringByKeyset_01() { fnRunner.runOneTest("abstractIntToStringByKeyset_01") }
-  @Test def test_sparse_enum_01() { fnRunner.runOneTest("sparse_enum_01") }
+  @Test def test_inputTypeCalcInt_01(): Unit = { fnRunner.runOneTest("inputTypeCalcInt_01") }
+  @Test def test_inputTypeCalcString_01(): Unit = { fnRunner.runOneTest("inputTypeCalcString_01") }
+  @Test def test_outputTypeCalcInt_01(): Unit = { fnRunner.runOneTest("outputTypeCalcInt_01") }
+  @Test def test_outputTypeCalcString_01(): Unit = { fnRunner.runOneTest("outputTypeCalcString_01") }
+  @Test def test_repTypeValueInt_01(): Unit = { fnRunner.runOneTest("repTypeValueInt_01") }
+  @Test def test_logicalTypeValueInt_01(): Unit = { fnRunner.runOneTest("logicalTypeValueInt_01") }
+  @Test def test_repTypeValueString_01(): Unit = { fnRunner.runOneTest("repTypeValueString_01") }
+  @Test def test_logicalTypeValueString_01(): Unit = { fnRunner.runOneTest("logicalTypeValueString_01") }
+  @Test def test_outputTypeCalcNextSiblingInt_01(): Unit = { fnRunner.runOneTest("outputTypeCalcNextSiblingInt_01") }
+  @Test def test_outputTypeCalcNextSiblingString_01(): Unit = { fnRunner.runOneTest("outputTypeCalcNextSiblingString_01") }
+  @Test def test_abstractIntToStringByKeyset_01(): Unit = { fnRunner.runOneTest("abstractIntToStringByKeyset_01") }
+  @Test def test_sparse_enum_01(): Unit = { fnRunner.runOneTest("sparse_enum_01") }
 
-  @Test def test_typeCalcDispatch_typeError_01() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_01") }
-  @Test def test_typeCalcDispatch_typeError_02() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_02") }
-  @Test def test_typeCalcDispatch_typeError_03() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_03") }
-  @Test def test_typeCalcDispatch_typeError_04() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_04") }
-  @Test def test_typeCalcDispatch_typeError_05() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_05") }
-  @Test def test_typeCalcDispatch_typeError_06() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_06") }
-  @Test def test_typeCalcDispatch_typeError_07() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_07") }
-  @Test def test_typeCalcDispatch_typeError_08() { fnErrRunner.runOneTest("typeCalcDispatch_typeError_08") }
-  @Test def test_repTypeValue_bad_context_01() { fnErrRunner.runOneTest("repTypeValue_bad_context_01") }
-  @Test def test_repTypeValue_bad_context_02() { fnErrRunner.runOneTest("repTypeValue_bad_context_02") }
-  @Test def test_logicalTypeValue_bad_context_01() { fnErrRunner.runOneTest("logicalTypeValue_bad_context_01") }
-  @Test def test_logicalTypeValue_bad_context_02() { fnErrRunner.runOneTest("logicalTypeValue_bad_context_02") }
-  @Test def test_nextSibling_01() { fnErrRunner.runOneTest("nextSibling_01") }
-  @Test def test_nextSibling_02() { fnErrRunner.runOneTest("nextSibling_02") }
-  @Test def test_nextSibling_03() { fnErrRunner.runOneTest("nextSibling_03") }
-  @Test def test_nextSibling_04() { fnErrRunner.runOneTest("nextSibling_04") }
-  @Test def test_nonexistant_reptype_01() { fnErrRunner.runOneTest("nonexistant_reptype_01") }
-  @Test def test_nonexistantOutputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantOutputTypeCalc_01") }
-  @Test def test_nonexistantInputTypeCalc_01() { fnErrRunner.runOneTest("nonexistantInputTypeCalc_01") }
-  @Test def test_nonexistantTypeCalcType_01() { fnErrRunner.runOneTest("nonexistantTypeCalcType_01") }
-  @Test def test_nonexistantTypeCalcType_02() { fnErrRunner.runOneTest("nonexistantTypeCalcType_02") }
+  @Test def test_typeCalcDispatch_typeError_01(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_01") }
+  @Test def test_typeCalcDispatch_typeError_02(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_02") }
+  @Test def test_typeCalcDispatch_typeError_03(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_03") }
+  @Test def test_typeCalcDispatch_typeError_04(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_04") }
+  @Test def test_typeCalcDispatch_typeError_05(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_05") }
+  @Test def test_typeCalcDispatch_typeError_06(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_06") }
+  @Test def test_typeCalcDispatch_typeError_07(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_07") }
+  @Test def test_typeCalcDispatch_typeError_08(): Unit = { fnErrRunner.runOneTest("typeCalcDispatch_typeError_08") }
+  @Test def test_repTypeValue_bad_context_01(): Unit = { fnErrRunner.runOneTest("repTypeValue_bad_context_01") }
+  @Test def test_repTypeValue_bad_context_02(): Unit = { fnErrRunner.runOneTest("repTypeValue_bad_context_02") }
+  @Test def test_logicalTypeValue_bad_context_01(): Unit = { fnErrRunner.runOneTest("logicalTypeValue_bad_context_01") }
+  @Test def test_logicalTypeValue_bad_context_02(): Unit = { fnErrRunner.runOneTest("logicalTypeValue_bad_context_02") }
+  @Test def test_nextSibling_01(): Unit = { fnErrRunner.runOneTest("nextSibling_01") }
+  @Test def test_nextSibling_02(): Unit = { fnErrRunner.runOneTest("nextSibling_02") }
+  @Test def test_nextSibling_03(): Unit = { fnErrRunner.runOneTest("nextSibling_03") }
+  @Test def test_nextSibling_04(): Unit = { fnErrRunner.runOneTest("nextSibling_04") }
+  @Test def test_nonexistant_reptype_01(): Unit = { fnErrRunner.runOneTest("nonexistant_reptype_01") }
+  @Test def test_nonexistantOutputTypeCalc_01(): Unit = { fnErrRunner.runOneTest("nonexistantOutputTypeCalc_01") }
+  @Test def test_nonexistantInputTypeCalc_01(): Unit = { fnErrRunner.runOneTest("nonexistantInputTypeCalc_01") }
+  @Test def test_nonexistantTypeCalcType_01(): Unit = { fnErrRunner.runOneTest("nonexistantTypeCalcType_01") }
+  @Test def test_nonexistantTypeCalcType_02(): Unit = { fnErrRunner.runOneTest("nonexistantTypeCalcType_02") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
@@ -25,7 +25,7 @@ object TestLookAhead {
 
   val runner = Runner(testDir, "lookAhead.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -34,16 +34,16 @@ object TestLookAhead {
 class TestLookAhead {
   import TestLookAhead._
 
-  @Test def test_lookAhead_01() { runner.runOneTest("lookAhead_01") }
-  @Test def test_lookAhead_02() { runner.runOneTest("lookAhead_02") }
-  @Test def test_lookAhead_03() { runner.runOneTest("lookAhead_03") }
-  @Test def test_lookAhead_04() { runner.runOneTest("lookAhead_04") }
-  @Test def test_lookAhead_05() { runner.runOneTest("lookAhead_05") }
-  @Test def test_lookAhead_06() { runner.runOneTest("lookAhead_06") }
-  @Test def test_lookAhead_tooFar_01() { runner.runOneTest("lookAhead_tooFar_01") }
-  @Test def test_lookAhead_tooFar_02() { runner.runOneTest("lookAhead_tooFar_02") }
-  @Test def test_lookAhead_tooFar_03() { runner.runOneTest("lookAhead_tooFar_03") }
-  @Test def test_lookAhead_negativeOffset_01() { runner.runOneTest("lookAhead_negativeOffset_01") }
-  @Test def test_lookAhead_negativeBitsize_01() { runner.runOneTest("lookAhead_negativeBitsize_01") }
-  @Test def test_lookAhead_zeroBitsize_01() { runner.runOneTest("lookAhead_zeroBitsize_01") }
+  @Test def test_lookAhead_01(): Unit = { runner.runOneTest("lookAhead_01") }
+  @Test def test_lookAhead_02(): Unit = { runner.runOneTest("lookAhead_02") }
+  @Test def test_lookAhead_03(): Unit = { runner.runOneTest("lookAhead_03") }
+  @Test def test_lookAhead_04(): Unit = { runner.runOneTest("lookAhead_04") }
+  @Test def test_lookAhead_05(): Unit = { runner.runOneTest("lookAhead_05") }
+  @Test def test_lookAhead_06(): Unit = { runner.runOneTest("lookAhead_06") }
+  @Test def test_lookAhead_tooFar_01(): Unit = { runner.runOneTest("lookAhead_tooFar_01") }
+  @Test def test_lookAhead_tooFar_02(): Unit = { runner.runOneTest("lookAhead_tooFar_02") }
+  @Test def test_lookAhead_tooFar_03(): Unit = { runner.runOneTest("lookAhead_tooFar_03") }
+  @Test def test_lookAhead_negativeOffset_01(): Unit = { runner.runOneTest("lookAhead_negativeOffset_01") }
+  @Test def test_lookAhead_negativeBitsize_01(): Unit = { runner.runOneTest("lookAhead_negativeBitsize_01") }
+  @Test def test_lookAhead_zeroBitsize_01(): Unit = { runner.runOneTest("lookAhead_zeroBitsize_01") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/functionality/TestFunctionality.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/functionality/TestFunctionality.scala
@@ -28,7 +28,7 @@ import com.ibm.icu.util.GregorianCalendar
 
 class TestFunctionality {
 
-  @Test def test_calendar_format_timezone() {
+  @Test def test_calendar_format_timezone(): Unit = {
     /* Test where bug was found:
      * TestSimpleTypes.scala -> test_timeZoneFormats6
      * Modify the test to be roundTrip="true"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestAIS.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestAIS.scala
@@ -29,7 +29,7 @@ object TestAISPayloadArmoring {
   lazy val testDir = "/org/apache/daffodil/layers/"
   lazy val runner = Runner(testDir, "ais.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -38,6 +38,6 @@ class TestAISPayloadArmoring {
 
   import TestAISPayloadArmoring._
 
-  @Test def test_ais1() { runner.runOneTest("ais1") }
+  @Test def test_ais1(): Unit = { runner.runOneTest("ais1") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -29,7 +29,7 @@ object TestLayers {
   lazy val testDir = "/org/apache/daffodil/layers/"
   lazy val runner = Runner(testDir, "layers.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -38,11 +38,11 @@ class TestLayers {
 
   import TestLayers._
 
-  @Test def test_layers1() { runner.runOneTest("layers1") }
-  @Test def test_layers2() { runner.runOneTest("layers2") }
-  @Test def test_layers3() { runner.runOneTest("layers3") }
-  @Test def test_layers3_deprecated() { runner.runOneTest("layers3_deprecated") }
-  @Test def test_layersErr1() { runner.runOneTest("layersErr1") }
-  @Test def test_layers4() { runner.runOneTest("layers4") }
+  @Test def test_layers1(): Unit = { runner.runOneTest("layers1") }
+  @Test def test_layers2(): Unit = { runner.runOneTest("layers2") }
+  @Test def test_layers3(): Unit = { runner.runOneTest("layers3") }
+  @Test def test_layers3_deprecated(): Unit = { runner.runOneTest("layers3_deprecated") }
+  @Test def test_layersErr1(): Unit = { runner.runOneTest("layersErr1") }
+  @Test def test_layers4(): Unit = { runner.runOneTest("layers4") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestElementFormDefaultGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestElementFormDefaultGeneral.scala
@@ -27,7 +27,7 @@ object TestElementFormDefaultGeneral {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testElementFormDefault.tdml")
 
-  @AfterClass def shutDown() { 
+  @AfterClass def shutDown(): Unit = { 
     runner.reset
   }
 
@@ -36,19 +36,19 @@ object TestElementFormDefaultGeneral {
 class TestElementFormDefaultGeneral {
   import TestElementFormDefaultGeneral._
  
-  @Test def test_delimOptPresentQualified01() { runner.runOneTest("delimOptPresentQualified01") }
-  @Test def test_delimOptPresentQualified02() { runner.runOneTest("delimOptPresentQualified02") }
-  @Test def test_delimOptPresentQualified03() { runner.runOneTest("delimOptPresentQualified03") }
-  @Test def test_delimOptPresentQualified04() { runner.runOneTest("delimOptPresentQualified04") }
-  @Test def test_delimOptPresentQualified05() { runner.runOneTest("delimOptPresentQualified05") }
+  @Test def test_delimOptPresentQualified01(): Unit = { runner.runOneTest("delimOptPresentQualified01") }
+  @Test def test_delimOptPresentQualified02(): Unit = { runner.runOneTest("delimOptPresentQualified02") }
+  @Test def test_delimOptPresentQualified03(): Unit = { runner.runOneTest("delimOptPresentQualified03") }
+  @Test def test_delimOptPresentQualified04(): Unit = { runner.runOneTest("delimOptPresentQualified04") }
+  @Test def test_delimOptPresentQualified05(): Unit = { runner.runOneTest("delimOptPresentQualified05") }
 
-  @Test def test_delimOptPresentUnqualified01() { runner.runOneTest("delimOptPresentUnqualified01") }
-  @Test def test_delimOptPresentUnqualified02() { runner.runOneTest("delimOptPresentUnqualified02") }
-  @Test def test_delimOptPresentUnqualified03() { runner.runOneTest("delimOptPresentUnqualified03") }
-  @Test def test_delimOptPresentUnqualified04() { runner.runOneTest("delimOptPresentUnqualified04") }
-  @Test def test_delimOptPresentMissing() { runner.runOneTest("delimOptPresentMissing") }
+  @Test def test_delimOptPresentUnqualified01(): Unit = { runner.runOneTest("delimOptPresentUnqualified01") }
+  @Test def test_delimOptPresentUnqualified02(): Unit = { runner.runOneTest("delimOptPresentUnqualified02") }
+  @Test def test_delimOptPresentUnqualified03(): Unit = { runner.runOneTest("delimOptPresentUnqualified03") }
+  @Test def test_delimOptPresentUnqualified04(): Unit = { runner.runOneTest("delimOptPresentUnqualified04") }
+  @Test def test_delimOptPresentMissing(): Unit = { runner.runOneTest("delimOptPresentMissing") }
 
-  @Test def test_delimOptPresentGlobalQualified01() { runner.runOneTest("delimOptPresentGlobalQualified01") }
-  @Test def test_delimOptPresentGlobalQualified02() { runner.runOneTest("delimOptPresentGlobalQualified02") }
+  @Test def test_delimOptPresentGlobalQualified01(): Unit = { runner.runOneTest("delimOptPresentGlobalQualified01") }
+  @Test def test_delimOptPresentGlobalQualified02(): Unit = { runner.runOneTest("delimOptPresentGlobalQualified02") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestFileBuffering.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestFileBuffering.scala
@@ -25,7 +25,7 @@ object TestUnparserFileBuffering {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testUnparserFileBuffering.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }
@@ -33,36 +33,36 @@ class TestUnparserFileBuffering {
 
   import TestUnparserFileBuffering._
 
-  @Test def test_puaInfosetChars_01() { runner.runOneTest("puaInfosetChars_01") }
-  @Test def test_puaInfosetChars_02() { runner.runOneTest("puaInfosetChars_02") }
+  @Test def test_puaInfosetChars_01(): Unit = { runner.runOneTest("puaInfosetChars_01") }
+  @Test def test_puaInfosetChars_02(): Unit = { runner.runOneTest("puaInfosetChars_02") }
 
-  @Test def test_unparseFixedLengthString01() { runner.runOneTest("unparseFixedLengthString01") }
-  @Test def test_unparseFixedLengthString02() { runner.runOneTest("unparseFixedLengthString02") }
-  @Test def test_unparseFixedLengthString03() { runner.runOneTest("unparseFixedLengthString03") }
+  @Test def test_unparseFixedLengthString01(): Unit = { runner.runOneTest("unparseFixedLengthString01") }
+  @Test def test_unparseFixedLengthString02(): Unit = { runner.runOneTest("unparseFixedLengthString02") }
+  @Test def test_unparseFixedLengthString03(): Unit = { runner.runOneTest("unparseFixedLengthString03") }
 
-  @Test def test_parseFixedLengthString01() { runner.runOneTest("parseFixedLengthString01") }
-  @Test def test_parseFixedLengthStringLength0() { runner.runOneTest("parseFixedLengthStringLength0") }
+  @Test def test_parseFixedLengthString01(): Unit = { runner.runOneTest("parseFixedLengthString01") }
+  @Test def test_parseFixedLengthStringLength0(): Unit = { runner.runOneTest("parseFixedLengthStringLength0") }
 
-  @Test def test_negativeUnparseTest01() { runner.runOneTest("negativeUnparseTest01") }
-  @Test def test_negativeUnparseTest02() { runner.runOneTest("negativeUnparseTest02") }
-  @Test def test_negativeUnparseTest03() { runner.runOneTest("negativeUnparseTest03") }
-  @Test def test_negativeUnparseTest04() { runner.runOneTest("negativeUnparseTest04") }
-  @Test def test_negativeUnparseTest05() { runner.runOneTest("negativeUnparseTest05") }
+  @Test def test_negativeUnparseTest01(): Unit = { runner.runOneTest("negativeUnparseTest01") }
+  @Test def test_negativeUnparseTest02(): Unit = { runner.runOneTest("negativeUnparseTest02") }
+  @Test def test_negativeUnparseTest03(): Unit = { runner.runOneTest("negativeUnparseTest03") }
+  @Test def test_negativeUnparseTest04(): Unit = { runner.runOneTest("negativeUnparseTest04") }
+  @Test def test_negativeUnparseTest05(): Unit = { runner.runOneTest("negativeUnparseTest05") }
 
-  @Test def test_unparseDelimitedString01() { runner.runOneTest("unparseDelimitedString01") }
-  @Test def test_unparseDelimitedString02() { runner.runOneTest("unparseDelimitedString02") }
-  @Test def test_unparseDelimitedString03() { runner.runOneTest("unparseDelimitedString03") }
-  @Test def test_unparseDelimitedString04() { runner.runOneTest("unparseDelimitedString04") }
-  @Test def test_unparseDelimitedString05() { runner.runOneTest("unparseDelimitedString05") }
-  @Test def test_unparseDelimitedString06() { runner.runOneTest("unparseDelimitedString06") }
-  @Test def test_unparseDelimitedString07() { runner.runOneTest("unparseDelimitedString07") }
+  @Test def test_unparseDelimitedString01(): Unit = { runner.runOneTest("unparseDelimitedString01") }
+  @Test def test_unparseDelimitedString02(): Unit = { runner.runOneTest("unparseDelimitedString02") }
+  @Test def test_unparseDelimitedString03(): Unit = { runner.runOneTest("unparseDelimitedString03") }
+  @Test def test_unparseDelimitedString04(): Unit = { runner.runOneTest("unparseDelimitedString04") }
+  @Test def test_unparseDelimitedString05(): Unit = { runner.runOneTest("unparseDelimitedString05") }
+  @Test def test_unparseDelimitedString06(): Unit = { runner.runOneTest("unparseDelimitedString06") }
+  @Test def test_unparseDelimitedString07(): Unit = { runner.runOneTest("unparseDelimitedString07") }
 
-  @Test def test_parseDelimitedString01() { runner.runOneTest("parseDelimitedString01") }
+  @Test def test_parseDelimitedString01(): Unit = { runner.runOneTest("parseDelimitedString01") }
 
   // DFDL-1650
-  @Test def test_alignmentPaddingOVC1() { runner.runOneTest("alignmentPaddingOVC1") }
-  @Test def test_alignmentPaddingOVC2() { runner.runOneTest("alignmentPaddingOVC2") }
-  @Test def test_alignmentPaddingOVC3() { runner.runOneTest("alignmentPaddingOVC3") }
-  @Test def test_alignmentPaddingOVC4() { runner.runOneTest("alignmentPaddingOVC4") }
+  @Test def test_alignmentPaddingOVC1(): Unit = { runner.runOneTest("alignmentPaddingOVC1") }
+  @Test def test_alignmentPaddingOVC2(): Unit = { runner.runOneTest("alignmentPaddingOVC2") }
+  @Test def test_alignmentPaddingOVC3(): Unit = { runner.runOneTest("alignmentPaddingOVC3") }
+  @Test def test_alignmentPaddingOVC4(): Unit = { runner.runOneTest("alignmentPaddingOVC4") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -41,7 +41,7 @@ object TestGeneral {
 
   lazy val tunables_runner = Runner(testDir, "tunables.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner1.reset
     runnerA_B.reset
@@ -54,20 +54,20 @@ class TestGeneral {
 
   import TestGeneral._
 
-  @Test def test_check_no_namespace_message() { runner.runOneTest("check_no_namespace_message") }
+  @Test def test_check_no_namespace_message(): Unit = { runner.runOneTest("check_no_namespace_message") }
 
-  @Test def test_capitalization() { runner.runOneTest("capitalization") }
+  @Test def test_capitalization(): Unit = { runner.runOneTest("capitalization") }
 
-  @Test def test_litNil1() { runner.runOneTest("litNil1") }
-  @Test def test_litNil1FullPath() { runner.runOneTest("litNil1FullPath") }
-  @Test def test_referentialIntegrity() { runner.runOneTest("referentialIntegrity") }
+  @Test def test_litNil1(): Unit = { runner.runOneTest("litNil1") }
+  @Test def test_litNil1FullPath(): Unit = { runner.runOneTest("litNil1FullPath") }
+  @Test def test_referentialIntegrity(): Unit = { runner.runOneTest("referentialIntegrity") }
 
   // Test causes exception as the file is not found
   // @Test def test_fileDNE() { runner.runOneTest("fileDNE") }
 
-  @Test def test_largeInput_01() { runner1.runOneTest("largeInput_01") }
+  @Test def test_largeInput_01(): Unit = { runner1.runOneTest("largeInput_01") }
 
-  @Test def test_dir_and_file_with_spaces() {
+  @Test def test_dir_and_file_with_spaces(): Unit = {
     try {
       val e = intercept[Exception] {
         runnerA_B.runOneTest("AB006")
@@ -82,7 +82,7 @@ class TestGeneral {
     }
   }
 
-  @Test def test_no_namespace_02() {
+  @Test def test_no_namespace_02(): Unit = {
     val e = intercept[Exception] {
       runner_ns.runOneTest("no_namespace_02")
     }
@@ -93,19 +93,19 @@ class TestGeneral {
   }
 
   // DFDL-1143
-  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_01() { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_01") }
-  @Test def test_unqualifiedPathStepPolicy_noNamespace_test_02() { tunables_runner.runOneTest("unqualifiedPathStepPolicy_noNamespace_test_02") }
-  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_02() { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_02") }
+  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_01(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_01") }
+  @Test def test_unqualifiedPathStepPolicy_noNamespace_test_02(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_noNamespace_test_02") }
+  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_02(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_02") }
   
-  @Test def test_maxOccursBoundsExceeded() { tunables_runner.runOneTest("maxOccursBoundsExceeded") }
-  @Test def test_textBidiYes() { tunables_runner.runOneTest("textBidiYes") }
-  @Test def test_requireTextBidiTrue() { tunables_runner.runOneTest("requireTextBidiTrue") }
-  @Test def test_requireTextBidiFalse() { tunables_runner.runOneTest("requireTextBidiFalse") }
-  @Test def test_floatingYes() { tunables_runner.runOneTest("floatingYes") }
-  @Test def test_requireFloatingTrue() { tunables_runner.runOneTest("requireFloatingTrue") }
-  @Test def test_requireFloatingFalse() { tunables_runner.runOneTest("requireFloatingFalse") }
-  @Test def test_encodingErrorPolicyError() { tunables_runner.runOneTest("encodingErrorPolicyError") }
-  @Test def test_requireEncodingErrorPolicyTrue() { tunables_runner.runOneTest("requireEncodingErrorPolicyTrue") }
-  @Test def test_requireEncodingErrorPolicyFalse() { tunables_runner.runOneTest("requireEncodingErrorPolicyFalse") }
+  @Test def test_maxOccursBoundsExceeded(): Unit = { tunables_runner.runOneTest("maxOccursBoundsExceeded") }
+  @Test def test_textBidiYes(): Unit = { tunables_runner.runOneTest("textBidiYes") }
+  @Test def test_requireTextBidiTrue(): Unit = { tunables_runner.runOneTest("requireTextBidiTrue") }
+  @Test def test_requireTextBidiFalse(): Unit = { tunables_runner.runOneTest("requireTextBidiFalse") }
+  @Test def test_floatingYes(): Unit = { tunables_runner.runOneTest("floatingYes") }
+  @Test def test_requireFloatingTrue(): Unit = { tunables_runner.runOneTest("requireFloatingTrue") }
+  @Test def test_requireFloatingFalse(): Unit = { tunables_runner.runOneTest("requireFloatingFalse") }
+  @Test def test_encodingErrorPolicyError(): Unit = { tunables_runner.runOneTest("encodingErrorPolicyError") }
+  @Test def test_requireEncodingErrorPolicyTrue(): Unit = { tunables_runner.runOneTest("requireEncodingErrorPolicyTrue") }
+  @Test def test_requireEncodingErrorPolicyFalse(): Unit = { tunables_runner.runOneTest("requireEncodingErrorPolicyFalse") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneralNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneralNew.scala
@@ -30,7 +30,7 @@ object TestGeneralNew {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "general.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
@@ -25,7 +25,7 @@ object TestImportOtherAnnotationSchema {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testImportOtherAnnotationSchema.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }
@@ -35,7 +35,7 @@ class TestImportOtherAnnotationSchema {
   import TestImportOtherAnnotationSchema._
 
   //DFDL-1907
-  @Test def test_importOtherAnnotationSchema1() { runner.runOneTest("importOtherAnnotationSchema1") }
-  @Test def test_importOtherAnnotationSchema2() { runner.runOneTest("importOtherAnnotationSchema2") }
+  @Test def test_importOtherAnnotationSchema1(): Unit = { runner.runOneTest("importOtherAnnotationSchema1") }
+  @Test def test_importOtherAnnotationSchema2(): Unit = { runner.runOneTest("importOtherAnnotationSchema2") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestParseUnparsePolicy.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestParseUnparsePolicy.scala
@@ -29,7 +29,7 @@ object TestParseUnparsePolicy {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "parseUnparsePolicy.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -38,20 +38,20 @@ object TestParseUnparsePolicy {
 class TestParseUnparsePolicy {
   import TestParseUnparsePolicy._
 
-  @Test def test_pb_parse()   { runner.runOneTest("pb_parse") }
-  @Test def test_pb_unparse() { runner.runOneTest("pb_unparse") }
-  @Test def test_pp_parse()   { runner.runOneTest("pp_parse") }
-  @Test def test_pp_unparse() { runner.runOneTest("pp_unparse") }
-  @Test def test_pu()         { runner.runOneTest("pu") }
+  @Test def test_pb_parse(): Unit =   { runner.runOneTest("pb_parse") }
+  @Test def test_pb_unparse(): Unit = { runner.runOneTest("pb_unparse") }
+  @Test def test_pp_parse(): Unit =   { runner.runOneTest("pp_parse") }
+  @Test def test_pp_unparse(): Unit = { runner.runOneTest("pp_unparse") }
+  @Test def test_pu(): Unit =         { runner.runOneTest("pu") }
 
-  @Test def test_ub_parse()   { runner.runOneTest("ub_parse") }
-  @Test def test_ub_unparse() { runner.runOneTest("ub_unparse") }
-  @Test def test_uu_parse()   { runner.runOneTest("uu_parse") }
-  @Test def test_uu_unparse() { runner.runOneTest("uu_unparse") }
-  @Test def test_up()         { runner.runOneTest("up") }
+  @Test def test_ub_parse(): Unit =   { runner.runOneTest("ub_parse") }
+  @Test def test_ub_unparse(): Unit = { runner.runOneTest("ub_unparse") }
+  @Test def test_uu_parse(): Unit =   { runner.runOneTest("uu_parse") }
+  @Test def test_uu_unparse(): Unit = { runner.runOneTest("uu_unparse") }
+  @Test def test_up(): Unit =         { runner.runOneTest("up") }
 
-  @Test def test_bb() { runner.runOneTest("bb") }
-  @Test def test_bp() { runner.runOneTest("bp") }
-  @Test def test_bu() { runner.runOneTest("bu") }
+  @Test def test_bb(): Unit = { runner.runOneTest("bb") }
+  @Test def test_bp(): Unit = { runner.runOneTest("bp") }
+  @Test def test_bu(): Unit = { runner.runOneTest("bu") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
@@ -25,7 +25,7 @@ object TestUnparserGeneral {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testUnparserGeneral.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }
@@ -40,36 +40,36 @@ class TestUnparserGeneral {
   //@Test def test_puaInfosetChars_03() { runner.runOneTest("puaInfosetChars_03") }
   //@Test def test_puaInfosetChars_04() { runner.runOneTest("puaInfosetChars_04") }
 
-  @Test def test_puaInfosetChars_01() { runner.runOneTest("puaInfosetChars_01") }
-  @Test def test_puaInfosetChars_02() { runner.runOneTest("puaInfosetChars_02") }
+  @Test def test_puaInfosetChars_01(): Unit = { runner.runOneTest("puaInfosetChars_01") }
+  @Test def test_puaInfosetChars_02(): Unit = { runner.runOneTest("puaInfosetChars_02") }
 
-  @Test def test_unparseFixedLengthString01() { runner.runOneTest("unparseFixedLengthString01") }
-  @Test def test_unparseFixedLengthString02() { runner.runOneTest("unparseFixedLengthString02") }
-  @Test def test_unparseFixedLengthString03() { runner.runOneTest("unparseFixedLengthString03") }
+  @Test def test_unparseFixedLengthString01(): Unit = { runner.runOneTest("unparseFixedLengthString01") }
+  @Test def test_unparseFixedLengthString02(): Unit = { runner.runOneTest("unparseFixedLengthString02") }
+  @Test def test_unparseFixedLengthString03(): Unit = { runner.runOneTest("unparseFixedLengthString03") }
 
-  @Test def test_parseFixedLengthString01() { runner.runOneTest("parseFixedLengthString01") }
-  @Test def test_parseFixedLengthStringLength0() { runner.runOneTest("parseFixedLengthStringLength0") }
+  @Test def test_parseFixedLengthString01(): Unit = { runner.runOneTest("parseFixedLengthString01") }
+  @Test def test_parseFixedLengthStringLength0(): Unit = { runner.runOneTest("parseFixedLengthStringLength0") }
 
-  @Test def test_negativeUnparseTest01() { runner.runOneTest("negativeUnparseTest01") }
-  @Test def test_negativeUnparseTest02() { runner.runOneTest("negativeUnparseTest02") }
-  @Test def test_negativeUnparseTest03() { runner.runOneTest("negativeUnparseTest03") }
-  @Test def test_negativeUnparseTest04() { runner.runOneTest("negativeUnparseTest04") }
-  @Test def test_negativeUnparseTest05() { runner.runOneTest("negativeUnparseTest05") }
+  @Test def test_negativeUnparseTest01(): Unit = { runner.runOneTest("negativeUnparseTest01") }
+  @Test def test_negativeUnparseTest02(): Unit = { runner.runOneTest("negativeUnparseTest02") }
+  @Test def test_negativeUnparseTest03(): Unit = { runner.runOneTest("negativeUnparseTest03") }
+  @Test def test_negativeUnparseTest04(): Unit = { runner.runOneTest("negativeUnparseTest04") }
+  @Test def test_negativeUnparseTest05(): Unit = { runner.runOneTest("negativeUnparseTest05") }
 
-  @Test def test_unparseDelimitedString01() { runner.runOneTest("unparseDelimitedString01") }
-  @Test def test_unparseDelimitedString02() { runner.runOneTest("unparseDelimitedString02") }
-  @Test def test_unparseDelimitedString03() { runner.runOneTest("unparseDelimitedString03") }
-  @Test def test_unparseDelimitedString04() { runner.runOneTest("unparseDelimitedString04") }
-  @Test def test_unparseDelimitedString05() { runner.runOneTest("unparseDelimitedString05") }
-  @Test def test_unparseDelimitedString06() { runner.runOneTest("unparseDelimitedString06") }
-  @Test def test_unparseDelimitedString07() { runner.runOneTest("unparseDelimitedString07") }
+  @Test def test_unparseDelimitedString01(): Unit = { runner.runOneTest("unparseDelimitedString01") }
+  @Test def test_unparseDelimitedString02(): Unit = { runner.runOneTest("unparseDelimitedString02") }
+  @Test def test_unparseDelimitedString03(): Unit = { runner.runOneTest("unparseDelimitedString03") }
+  @Test def test_unparseDelimitedString04(): Unit = { runner.runOneTest("unparseDelimitedString04") }
+  @Test def test_unparseDelimitedString05(): Unit = { runner.runOneTest("unparseDelimitedString05") }
+  @Test def test_unparseDelimitedString06(): Unit = { runner.runOneTest("unparseDelimitedString06") }
+  @Test def test_unparseDelimitedString07(): Unit = { runner.runOneTest("unparseDelimitedString07") }
 
-  @Test def test_parseDelimitedString01() { runner.runOneTest("parseDelimitedString01") }
+  @Test def test_parseDelimitedString01(): Unit = { runner.runOneTest("parseDelimitedString01") }
 
   // DFDL-1650
-  @Test def test_alignmentPaddingOVC1() { runner.runOneTest("alignmentPaddingOVC1") }
-  @Test def test_alignmentPaddingOVC2() { runner.runOneTest("alignmentPaddingOVC2") }
-  @Test def test_alignmentPaddingOVC3() { runner.runOneTest("alignmentPaddingOVC3") }
-  @Test def test_alignmentPaddingOVC4() { runner.runOneTest("alignmentPaddingOVC4") }
+  @Test def test_alignmentPaddingOVC1(): Unit = { runner.runOneTest("alignmentPaddingOVC1") }
+  @Test def test_alignmentPaddingOVC2(): Unit = { runner.runOneTest("alignmentPaddingOVC2") }
+  @Test def test_alignmentPaddingOVC3(): Unit = { runner.runOneTest("alignmentPaddingOVC3") }
+  @Test def test_alignmentPaddingOVC4(): Unit = { runner.runOneTest("alignmentPaddingOVC4") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral2.scala
@@ -25,7 +25,7 @@ object TestUnparserGeneral2 {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner2 = Runner(testDir, "testUnparserBitOrderOVC.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner2.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
@@ -29,7 +29,7 @@ object TestProcessingErrors {
   val runner02 = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
   val runner02Validate = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner02.reset
     runner02Validate.reset
@@ -41,12 +41,12 @@ class TestProcessingErrors {
 
   import TestProcessingErrors._
 
-  @Test def test_twoDFDLSchemaValidationErrors() { runner.runOneTest("twoDFDLSchemaValidationErrors") }
-  @Test def test_twoDFDLSchemaValidationErrors2() { runner.runOneTest("twoDFDLSchemaValidationErrors2") }
-  @Test def test_fiveDFDLSchemaValidationErrors() { runner.runOneTest("fiveDFDLSchemaValidationErrors") }
+  @Test def test_twoDFDLSchemaValidationErrors(): Unit = { runner.runOneTest("twoDFDLSchemaValidationErrors") }
+  @Test def test_twoDFDLSchemaValidationErrors2(): Unit = { runner.runOneTest("twoDFDLSchemaValidationErrors2") }
+  @Test def test_fiveDFDLSchemaValidationErrors(): Unit = { runner.runOneTest("fiveDFDLSchemaValidationErrors") }
 
-  @Test def test_upaInvalidSchema() { runner02Validate.runOneTest("upaInvalidSchema") }
-  @Test def test_upaInvalidSchema2() { runner02Validate.runOneTest("upaInvalidSchema2") }
+  @Test def test_upaInvalidSchema(): Unit = { runner02Validate.runOneTest("upaInvalidSchema") }
+  @Test def test_upaInvalidSchema2(): Unit = { runner02Validate.runOneTest("upaInvalidSchema2") }
 
   //  DFDL-756
   //  @Test def test_delimiterNotFound01() { runner02.runOneTest("delimiterNotFound01") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
@@ -28,7 +28,7 @@ object TestProcessingErrorsUnparse {
   val runner02Validate = Runner(testDir, "ProcessingErrorsUnparse.tdml", validateTDMLFile = true, validateDFDLSchemas = true,
     compileAllTopLevel = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner02.reset
     runner02Validate.reset
   }
@@ -39,12 +39,12 @@ class TestProcessingErrorsUnparse {
 
   import TestProcessingErrorsUnparse._
 
-  @Test def test_roundTripErrorHalfwayThrough() { runner02Validate.runOneTest("roundTripErrorHalfwayThrough") }
+  @Test def test_roundTripErrorHalfwayThrough(): Unit = { runner02Validate.runOneTest("roundTripErrorHalfwayThrough") }
 
-  @Test def test_upaInvalidSchemaUnparse() { runner02Validate.runOneTest("upaInvalidSchemaUnparse") }
-  @Test def test_upaInvalidSchemaUnparse2() { runner02Validate.runOneTest("upaInvalidSchemaUnparse2") }
-  @Test def test_missingNamespacePrefixUnparse() { runner02.runOneTest("missingNamespacePrefixUnparse") }
+  @Test def test_upaInvalidSchemaUnparse(): Unit = { runner02Validate.runOneTest("upaInvalidSchemaUnparse") }
+  @Test def test_upaInvalidSchemaUnparse2(): Unit = { runner02Validate.runOneTest("upaInvalidSchemaUnparse2") }
+  @Test def test_missingNamespacePrefixUnparse(): Unit = { runner02.runOneTest("missingNamespacePrefixUnparse") }
 
-  @Test def test_incorrectNamespaceUnparse() { runner02.runOneTest("incorrectNamespaceUnparse") }
+  @Test def test_incorrectNamespaceUnparse(): Unit = { runner02.runOneTest("incorrectNamespaceUnparse") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -26,7 +26,7 @@ object TestSDE {
   val testDir = "/org/apache/daffodil/section02/schema_definition_errors/"
   val runner = Runner(testDir, "SchemaDefinitionErrors.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 
@@ -36,13 +36,13 @@ class TestSDE {
 
   import TestSDE._
 
-  @Test def test_AS000_rev() { runner.runOneTest("AS000_rev") }
+  @Test def test_AS000_rev(): Unit = { runner.runOneTest("AS000_rev") }
 
-  @Test def test_schema_component_err() { runner.runOneTest("schema_component_err") }
+  @Test def test_schema_component_err(): Unit = { runner.runOneTest("schema_component_err") }
 
-  @Test def test_schema_line_number() { runner.runOneTest("schema_line_number") }
-  @Test def test_schema_warning() { runner.runOneTest("schema_warning") }
-  @Test def test_missing_appinfo_source() { runner.runOneTest("missing_appinfo_source") }
-  @Test def test_missing_closing_tag() { runner.runOneTest("missing_closing_tag") }
-  @Test def test_ignoreAttributeFormDefault() { runner.runOneTest("ignoreAttributeFormDefault") }
+  @Test def test_schema_line_number(): Unit = { runner.runOneTest("schema_line_number") }
+  @Test def test_schema_warning(): Unit = { runner.runOneTest("schema_warning") }
+  @Test def test_missing_appinfo_source(): Unit = { runner.runOneTest("missing_appinfo_source") }
+  @Test def test_missing_closing_tag(): Unit = { runner.runOneTest("missing_closing_tag") }
+  @Test def test_ignoreAttributeFormDefault(): Unit = { runner.runOneTest("ignoreAttributeFormDefault") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDENew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDENew.scala
@@ -26,6 +26,6 @@ class TestSDENew {
   val aa = testDir + "SchemaDefinitionErrors.tdml"
   lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
 
-  @Test def test_schema_component_err() { runner.runOneTest("schema_component_err") }
+  @Test def test_schema_component_err(): Unit = { runner.runOneTest("schema_component_err") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
@@ -25,68 +25,68 @@ object TestValidationErr {
   val testDir = "/org/apache/daffodil/section02/validation_errors/"
   val runner = Runner(testDir, "Validation.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
 class TestValidationErr {
   import TestValidationErr._
-  @Test def test_facetPattern01_validation_off() { runner.runOneTest("facetPattern01_validation_off") }
-  @Test def test_facetPattern01_fail_limited() { runner.runOneTest("facetPattern01_fail_limited") }
-  @Test def test_facetPattern01_fail_full() { runner.runOneTest("facetPattern01_fail_full") }
-  @Test def test_facetPattern01_success_limited() { runner.runOneTest("facetPattern01_success_limited") }
-  @Test def test_facetPattern01_success_full() { runner.runOneTest("facetPattern01_success_full") }
+  @Test def test_facetPattern01_validation_off(): Unit = { runner.runOneTest("facetPattern01_validation_off") }
+  @Test def test_facetPattern01_fail_limited(): Unit = { runner.runOneTest("facetPattern01_fail_limited") }
+  @Test def test_facetPattern01_fail_full(): Unit = { runner.runOneTest("facetPattern01_fail_full") }
+  @Test def test_facetPattern01_success_limited(): Unit = { runner.runOneTest("facetPattern01_success_limited") }
+  @Test def test_facetPattern01_success_full(): Unit = { runner.runOneTest("facetPattern01_success_full") }
 
-  @Test def test_arrayElements_fail_limited() { runner.runOneTest("arrayElements_fail_limited") }
-  @Test def test_arrayElements_fail_full() { runner.runOneTest("arrayElements_fail_full") }
+  @Test def test_arrayElements_fail_limited(): Unit = { runner.runOneTest("arrayElements_fail_limited") }
+  @Test def test_arrayElements_fail_full(): Unit = { runner.runOneTest("arrayElements_fail_full") }
 
-  @Test def test_checkMinLength_Fail_Combining_limited() { runner.runOneTest("checkMinLength_Fail_Combining_limited") }
-  @Test def test_checkEnumeration_Pass_limited() { runner.runOneTest("checkEnumeration_Pass_limited") }
-  @Test def test_checkEnumeration_Fail_limited() { runner.runOneTest("checkEnumeration_Fail_limited") }
-  @Test def test_checkEnumeration_Fail_on() { runner.runOneTest("checkEnumeration_Fail_on") }
-  @Test def test_checkMaxInclusive_Fail_DateTime_limited() { runner.runOneTest("checkMaxInclusive_Fail_DateTime_limited") }
+  @Test def test_checkMinLength_Fail_Combining_limited(): Unit = { runner.runOneTest("checkMinLength_Fail_Combining_limited") }
+  @Test def test_checkEnumeration_Pass_limited(): Unit = { runner.runOneTest("checkEnumeration_Pass_limited") }
+  @Test def test_checkEnumeration_Fail_limited(): Unit = { runner.runOneTest("checkEnumeration_Fail_limited") }
+  @Test def test_checkEnumeration_Fail_on(): Unit = { runner.runOneTest("checkEnumeration_Fail_on") }
+  @Test def test_checkMaxInclusive_Fail_DateTime_limited(): Unit = { runner.runOneTest("checkMaxInclusive_Fail_DateTime_limited") }
 
-  @Test def test_checkMinExclusive_Fail_off() { runner.runOneTest("checkMinExclusive_Fail_off") }
-  @Test def test_checkMinExclusive_Fail_limited() { runner.runOneTest("checkMinExclusive_Fail_limited") }
-  @Test def test_checkMinExclusive_Fail_on() { runner.runOneTest("checkMinExclusive_Fail_on") }
+  @Test def test_checkMinExclusive_Fail_off(): Unit = { runner.runOneTest("checkMinExclusive_Fail_off") }
+  @Test def test_checkMinExclusive_Fail_limited(): Unit = { runner.runOneTest("checkMinExclusive_Fail_limited") }
+  @Test def test_checkMinExclusive_Fail_on(): Unit = { runner.runOneTest("checkMinExclusive_Fail_on") }
 
-  @Test def test_checkCombining_Fail_off() { runner.runOneTest("checkCombining_Fail_off") }
-  @Test def test_checkCombining_Fail_limited() { runner.runOneTest("checkCombining_Fail_limited") }
-  @Test def test_checkCombining_Fail_on() { runner.runOneTest("checkCombining_Fail_on") }
+  @Test def test_checkCombining_Fail_off(): Unit = { runner.runOneTest("checkCombining_Fail_off") }
+  @Test def test_checkCombining_Fail_limited(): Unit = { runner.runOneTest("checkCombining_Fail_limited") }
+  @Test def test_checkCombining_Fail_on(): Unit = { runner.runOneTest("checkCombining_Fail_on") }
 
-  @Test def test_checkMaxLength_Fail_Combining_limited() { runner.runOneTest("checkMaxLength_Fail_Combining_limited") }
+  @Test def test_checkMaxLength_Fail_Combining_limited(): Unit = { runner.runOneTest("checkMaxLength_Fail_Combining_limited") }
 
-  @Test def test_checkTotalDigits_Fail_off() { runner.runOneTest("checkTotalDigits_Fail_off") }
-  @Test def test_checkTotalDigits_Fail_limited() { runner.runOneTest("checkTotalDigits_Fail_limited") }
-  @Test def test_checkTotalDigits_Fail_on() { runner.runOneTest("checkTotalDigits_Fail_on") }
+  @Test def test_checkTotalDigits_Fail_off(): Unit = { runner.runOneTest("checkTotalDigits_Fail_off") }
+  @Test def test_checkTotalDigits_Fail_limited(): Unit = { runner.runOneTest("checkTotalDigits_Fail_limited") }
+  @Test def test_checkTotalDigits_Fail_on(): Unit = { runner.runOneTest("checkTotalDigits_Fail_on") }
 
-  @Test def test_facetCombos_fail_off() { runner.runOneTest("facetCombos_fail_off") }
-  @Test def test_facetCombos_fail_limited() { runner.runOneTest("facetCombos_fail_limited") }
-  @Test def test_facetCombos_fail_on() { runner.runOneTest("facetCombos_fail_on") }
+  @Test def test_facetCombos_fail_off(): Unit = { runner.runOneTest("facetCombos_fail_off") }
+  @Test def test_facetCombos_fail_limited(): Unit = { runner.runOneTest("facetCombos_fail_limited") }
+  @Test def test_facetCombos_fail_on(): Unit = { runner.runOneTest("facetCombos_fail_on") }
 
-  @Test def test_facetCombos_fail_off_02() { runner.runOneTest("facetCombos_fail_off_02") }
-  @Test def test_facetCombos_fail_limited_02() { runner.runOneTest("facetCombos_fail_limited_02") }
-  @Test def test_facetCombos_fail_on_02() { runner.runOneTest("facetCombos_fail_on_02") }
+  @Test def test_facetCombos_fail_off_02(): Unit = { runner.runOneTest("facetCombos_fail_off_02") }
+  @Test def test_facetCombos_fail_limited_02(): Unit = { runner.runOneTest("facetCombos_fail_limited_02") }
+  @Test def test_facetCombos_fail_on_02(): Unit = { runner.runOneTest("facetCombos_fail_on_02") }
 
-  @Test def test_assert_validation_on() { runner.runOneTest("assert_validation_on") }
-  @Test def test_assert_validation_limited() { runner.runOneTest("assert_validation_limited") }
-  @Test def test_assert_validation_off() { runner.runOneTest("assert_validation_off") }
+  @Test def test_assert_validation_on(): Unit = { runner.runOneTest("assert_validation_on") }
+  @Test def test_assert_validation_limited(): Unit = { runner.runOneTest("assert_validation_limited") }
+  @Test def test_assert_validation_off(): Unit = { runner.runOneTest("assert_validation_off") }
 
-  @Test def test_minOccurs_notValidationErr_limited() { runner.runOneTest("minOccurs_notValidationErr_limited") }
-  @Test def test_choice_ignoreValidationErr_01() { runner.runOneTest("choice_ignoreValidationErr_01") }
-  @Test def test_choice_ignoreValidationErr_02() { runner.runOneTest("choice_ignoreValidationErr_02") }
-  @Test def test_choice_ignoreValidationErr_03() { runner.runOneTest("choice_ignoreValidationErr_03") }
+  @Test def test_minOccurs_notValidationErr_limited(): Unit = { runner.runOneTest("minOccurs_notValidationErr_limited") }
+  @Test def test_choice_ignoreValidationErr_01(): Unit = { runner.runOneTest("choice_ignoreValidationErr_01") }
+  @Test def test_choice_ignoreValidationErr_02(): Unit = { runner.runOneTest("choice_ignoreValidationErr_02") }
+  @Test def test_choice_ignoreValidationErr_03(): Unit = { runner.runOneTest("choice_ignoreValidationErr_03") }
 
-  @Test def test_choice_errorNotSuppressed_01() { runner.runOneTest("choice_errorNotSuppressed_01") }
-  @Test def test_choice_errorNotSuppressed_02() { runner.runOneTest("choice_errorNotSuppressed_02") }
-  @Test def test_choice_errorNotSuppressed_03() { runner.runOneTest("choice_errorNotSuppressed_03") }
-  @Test def test_choice_errorNotSuppressed_04() { runner.runOneTest("choice_errorNotSuppressed_04") }
-  @Test def test_choice_errorNotSuppressed_05() { runner.runOneTest("choice_errorNotSuppressed_05") }
+  @Test def test_choice_errorNotSuppressed_01(): Unit = { runner.runOneTest("choice_errorNotSuppressed_01") }
+  @Test def test_choice_errorNotSuppressed_02(): Unit = { runner.runOneTest("choice_errorNotSuppressed_02") }
+  @Test def test_choice_errorNotSuppressed_03(): Unit = { runner.runOneTest("choice_errorNotSuppressed_03") }
+  @Test def test_choice_errorNotSuppressed_04(): Unit = { runner.runOneTest("choice_errorNotSuppressed_04") }
+  @Test def test_choice_errorNotSuppressed_05(): Unit = { runner.runOneTest("choice_errorNotSuppressed_05") }
 
   // DFDL-903
   //  @Test def test_choice_errorNotSuppressed_validationErrorCheck() { runner.runOneTest("choice_errorNotSuppressed_validationErrorCheck") }
 
-  @Test def test_validation_inputValueCalc_01() { runner.runOneTest("validation_inputValueCalc_01") }
-  @Test def test_validation_inputValueCalc_02() { runner.runOneTest("validation_inputValueCalc_02") }
-  @Test def test_validation_inputValueCalc_03() { runner.runOneTest("validation_inputValueCalc_03") }
+  @Test def test_validation_inputValueCalc_01(): Unit = { runner.runOneTest("validation_inputValueCalc_01") }
+  @Test def test_validation_inputValueCalc_02(): Unit = { runner.runOneTest("validation_inputValueCalc_02") }
+  @Test def test_validation_inputValueCalc_03(): Unit = { runner.runOneTest("validation_inputValueCalc_03") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/dfdl_xsdl_subset/TestDFDLSubset.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/dfdl_xsdl_subset/TestDFDLSubset.scala
@@ -27,7 +27,7 @@ object TestDFDLSubset {
   val runner = Runner(testDir, "DFDLSubset.tdml")
   val runnerNV = Runner(testDir, "DFDLSubset.tdml", validateDFDLSchemas=false)
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
     runnerNV.reset
   }
@@ -38,12 +38,12 @@ class TestDFDLSubset {
 
   import TestDFDLSubset._
 
-  @Test def test_groupRefGroupRef() { { runner.runOneTest("groupRefGroupRef") } }
-  @Test def test_refInitiator3() { { runner.runOneTest("refInitiator3") } }
-  @Test def test_groupRef() { { runnerNV.runOneTest("groupRef") } }
-  @Test def test_groupRefChoice() { runnerNV.runOneTest("groupRefChoice") }
-  @Test def test_badGroupRef() { { runner.runOneTest("badGroupRef") } }
-  @Test def test_badSeq() { { runner.runOneTest("badSeq") } }
+  @Test def test_groupRefGroupRef(): Unit = { { runner.runOneTest("groupRefGroupRef") } }
+  @Test def test_refInitiator3(): Unit = { { runner.runOneTest("refInitiator3") } }
+  @Test def test_groupRef(): Unit = { { runnerNV.runOneTest("groupRef") } }
+  @Test def test_groupRefChoice(): Unit = { runnerNV.runOneTest("groupRefChoice") }
+  @Test def test_badGroupRef(): Unit = { { runner.runOneTest("badGroupRef") } }
+  @Test def test_badSeq(): Unit = { { runner.runOneTest("badSeq") } }
 
-  @Test def test_groupRefDFDL() { runner.runOneTest("groupRefDFDL") }
+  @Test def test_groupRefDFDL(): Unit = { runner.runOneTest("groupRefDFDL") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
@@ -28,7 +28,7 @@ object TestFacets {
   val runner = Runner(testDir, "Facets.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
   val runnerV = Runner(testDir, "Facets.tdml", validateTDMLFile = false, validateDFDLSchemas = true)
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
     runnerV.reset
   }
@@ -38,195 +38,195 @@ object TestFacets {
 class TestFacets {
   import TestFacets._
 
-  @Test def test_minMaxInExdateTime01() { runner.runOneTest("minMaxInExdateTime01") }
-  @Test def test_minMaxInExdateTime02() { runner.runOneTest("minMaxInExdateTime02") }
-  @Test def test_minMaxInExdateTime03() { runner.runOneTest("minMaxInExdateTime03") }
-  @Test def test_minMaxInExdateTime04() { runner.runOneTest("minMaxInExdateTime04") }
-  @Test def test_minMaxInExdateTime05() { runner.runOneTest("minMaxInExdateTime05") }
-  @Test def test_minMaxInExdateTime06() { runner.runOneTest("minMaxInExdateTime06") }
+  @Test def test_minMaxInExdateTime01(): Unit = { runner.runOneTest("minMaxInExdateTime01") }
+  @Test def test_minMaxInExdateTime02(): Unit = { runner.runOneTest("minMaxInExdateTime02") }
+  @Test def test_minMaxInExdateTime03(): Unit = { runner.runOneTest("minMaxInExdateTime03") }
+  @Test def test_minMaxInExdateTime04(): Unit = { runner.runOneTest("minMaxInExdateTime04") }
+  @Test def test_minMaxInExdateTime05(): Unit = { runner.runOneTest("minMaxInExdateTime05") }
+  @Test def test_minMaxInExdateTime06(): Unit = { runner.runOneTest("minMaxInExdateTime06") }
 
-  @Test def test_minMaxInEx08b() { runner.runOneTest("minMaxInEx08b") }
-  @Test def test_minMaxInEx15() { runner.runOneTest("minMaxInEx15") }
-  @Test def test_minMaxInEx16() { runner.runOneTest("minMaxInEx16") }
+  @Test def test_minMaxInEx08b(): Unit = { runner.runOneTest("minMaxInEx08b") }
+  @Test def test_minMaxInEx15(): Unit = { runner.runOneTest("minMaxInEx15") }
+  @Test def test_minMaxInEx16(): Unit = { runner.runOneTest("minMaxInEx16") }
 
-  @Test def test_maxLength07() { runner.runOneTest("maxLength07") }
-  @Test def test_maxLength08() { runnerV.runOneTest("maxLength08") }
-  @Test def test_maxLength09() { runnerV.runOneTest("maxLength09") }
-  @Test def test_maxLength10() { runner.runOneTest("maxLength10") }
-  @Test def test_maxLength11() { runner.runOneTest("maxLength11") }
+  @Test def test_maxLength07(): Unit = { runner.runOneTest("maxLength07") }
+  @Test def test_maxLength08(): Unit = { runnerV.runOneTest("maxLength08") }
+  @Test def test_maxLength09(): Unit = { runnerV.runOneTest("maxLength09") }
+  @Test def test_maxLength10(): Unit = { runner.runOneTest("maxLength10") }
+  @Test def test_maxLength11(): Unit = { runner.runOneTest("maxLength11") }
 
-  @Test def test_minMaxInExChoice01() { runner.runOneTest("minMaxInExChoice01") }
-  @Test def test_minMaxInExChoice02() { runner.runOneTest("minMaxInExChoice02") }
-  @Test def test_minMaxInEx17() { runner.runOneTest("minMaxInEx17") }
-  @Test def test_minMaxInEx18() { runner.runOneTest("minMaxInEx18") }
+  @Test def test_minMaxInExChoice01(): Unit = { runner.runOneTest("minMaxInExChoice01") }
+  @Test def test_minMaxInExChoice02(): Unit = { runner.runOneTest("minMaxInExChoice02") }
+  @Test def test_minMaxInEx17(): Unit = { runner.runOneTest("minMaxInEx17") }
+  @Test def test_minMaxInEx18(): Unit = { runner.runOneTest("minMaxInEx18") }
 
-  @Test def test_facetEnum09() { runner.runOneTest("facetEnum09") }
-  @Test def test_facetEnum10() { runner.runOneTest("facetEnum10") }
-  @Test def test_facetEnum11() { runner.runOneTest("facetEnum11") }
-  @Test def test_facetEnum12() { runner.runOneTest("facetEnum12") }
-  @Test def test_facetCombo01() { runner.runOneTest("facetCombo01") }
-  @Test def test_facetCombo02() { runner.runOneTest("facetCombo02") }
-  @Test def test_facetCombo03() { runner.runOneTest("facetCombo03") }
-  @Test def test_facetCombo04() { runner.runOneTest("facetCombo04") }
-  @Test def test_facetEnumChoice01() { runner.runOneTest("facetEnumChoice01") }
-  @Test def test_facetEnumChoice02() { runner.runOneTest("facetEnumChoice02") }
-  @Test def test_facetEnumChoice03() { runner.runOneTest("facetEnumChoice03") }
+  @Test def test_facetEnum09(): Unit = { runner.runOneTest("facetEnum09") }
+  @Test def test_facetEnum10(): Unit = { runner.runOneTest("facetEnum10") }
+  @Test def test_facetEnum11(): Unit = { runner.runOneTest("facetEnum11") }
+  @Test def test_facetEnum12(): Unit = { runner.runOneTest("facetEnum12") }
+  @Test def test_facetCombo01(): Unit = { runner.runOneTest("facetCombo01") }
+  @Test def test_facetCombo02(): Unit = { runner.runOneTest("facetCombo02") }
+  @Test def test_facetCombo03(): Unit = { runner.runOneTest("facetCombo03") }
+  @Test def test_facetCombo04(): Unit = { runner.runOneTest("facetCombo04") }
+  @Test def test_facetEnumChoice01(): Unit = { runner.runOneTest("facetEnumChoice01") }
+  @Test def test_facetEnumChoice02(): Unit = { runner.runOneTest("facetEnumChoice02") }
+  @Test def test_facetEnumChoice03(): Unit = { runner.runOneTest("facetEnumChoice03") }
 
-  @Test def test_facetPattern01() { runner.runOneTest("facetPattern01") }
-  @Test def test_facetPattern02() { runner.runOneTest("facetPattern02") }
-  @Test def test_facetPattern03() { runner.runOneTest("facetPattern03") }
-  @Test def test_facetPattern04() { runner.runOneTest("facetPattern04") }
-  @Test def test_facetPattern05() { runner.runOneTest("facetPattern05") }
-  @Test def test_facetPattern06() { runner.runOneTest("facetPattern06") }
-  @Test def test_facetPattern07() { runner.runOneTest("facetPattern07") }
-  @Test def test_facetPattern08() { runner.runOneTest("facetPattern08") }
-  @Test def test_facetPattern09() { runner.runOneTest("facetPattern09") }
-  @Test def test_facetPattern10() { runner.runOneTest("facetPattern10") }
+  @Test def test_facetPattern01(): Unit = { runner.runOneTest("facetPattern01") }
+  @Test def test_facetPattern02(): Unit = { runner.runOneTest("facetPattern02") }
+  @Test def test_facetPattern03(): Unit = { runner.runOneTest("facetPattern03") }
+  @Test def test_facetPattern04(): Unit = { runner.runOneTest("facetPattern04") }
+  @Test def test_facetPattern05(): Unit = { runner.runOneTest("facetPattern05") }
+  @Test def test_facetPattern06(): Unit = { runner.runOneTest("facetPattern06") }
+  @Test def test_facetPattern07(): Unit = { runner.runOneTest("facetPattern07") }
+  @Test def test_facetPattern08(): Unit = { runner.runOneTest("facetPattern08") }
+  @Test def test_facetPattern09(): Unit = { runner.runOneTest("facetPattern09") }
+  @Test def test_facetPattern10(): Unit = { runner.runOneTest("facetPattern10") }
 
-  @Test def test_facetEnum01() { runner.runOneTest("facetEnum01") }
-  @Test def test_facetEnum02() { runner.runOneTest("facetEnum02") }
-  @Test def test_facetEnum03() { runner.runOneTest("facetEnum03") }
-  @Test def test_facetEnum04() { runner.runOneTest("facetEnum04") }
-  @Test def test_facetEnum05() { runner.runOneTest("facetEnum05") }
-  @Test def test_facetEnum06() { runner.runOneTest("facetEnum06") }
-  @Test def test_facetEnum07() { runner.runOneTest("facetEnum07") }
-  @Test def test_facetEnum08() { runner.runOneTest("facetEnum08") }
+  @Test def test_facetEnum01(): Unit = { runner.runOneTest("facetEnum01") }
+  @Test def test_facetEnum02(): Unit = { runner.runOneTest("facetEnum02") }
+  @Test def test_facetEnum03(): Unit = { runner.runOneTest("facetEnum03") }
+  @Test def test_facetEnum04(): Unit = { runner.runOneTest("facetEnum04") }
+  @Test def test_facetEnum05(): Unit = { runner.runOneTest("facetEnum05") }
+  @Test def test_facetEnum06(): Unit = { runner.runOneTest("facetEnum06") }
+  @Test def test_facetEnum07(): Unit = { runner.runOneTest("facetEnum07") }
+  @Test def test_facetEnum08(): Unit = { runner.runOneTest("facetEnum08") }
 
-  @Test def test_maxLength01() { runner.runOneTest("maxLength01") }
-  @Test def test_maxLength02() { runner.runOneTest("maxLength02") }
-  @Test def test_maxLength03() { runner.runOneTest("maxLength03") }
-  @Test def test_maxLength04() { runner.runOneTest("maxLength04") }
-  @Test def test_maxLength05() { runner.runOneTest("maxLength05") }
-  @Test def test_maxLength06() { runner.runOneTest("maxLength06") }
+  @Test def test_maxLength01(): Unit = { runner.runOneTest("maxLength01") }
+  @Test def test_maxLength02(): Unit = { runner.runOneTest("maxLength02") }
+  @Test def test_maxLength03(): Unit = { runner.runOneTest("maxLength03") }
+  @Test def test_maxLength04(): Unit = { runner.runOneTest("maxLength04") }
+  @Test def test_maxLength05(): Unit = { runner.runOneTest("maxLength05") }
+  @Test def test_maxLength06(): Unit = { runner.runOneTest("maxLength06") }
 
-  @Test def test_totalDigits03() { runnerV.runOneTest("totalDigits03") }
-  @Test def test_totalDigits04() { runnerV.runOneTest("totalDigits04") }
-  @Test def test_totalDigits05() { runnerV.runOneTest("totalDigits05") }
-  @Test def test_totalDigits06() { runnerV.runOneTest("totalDigits06") }
-  @Test def test_totalDigits07() { runnerV.runOneTest("totalDigits07") }
-  @Test def test_totalDigits08() { runnerV.runOneTest("totalDigits08") }
+  @Test def test_totalDigits03(): Unit = { runnerV.runOneTest("totalDigits03") }
+  @Test def test_totalDigits04(): Unit = { runnerV.runOneTest("totalDigits04") }
+  @Test def test_totalDigits05(): Unit = { runnerV.runOneTest("totalDigits05") }
+  @Test def test_totalDigits06(): Unit = { runnerV.runOneTest("totalDigits06") }
+  @Test def test_totalDigits07(): Unit = { runnerV.runOneTest("totalDigits07") }
+  @Test def test_totalDigits08(): Unit = { runnerV.runOneTest("totalDigits08") }
 
-  @Test def test_fractionDigitsFailNeg() { runnerV.runOneTest("fractionDigitsFailNeg") }
-  @Test def test_fractionTotalDigitsFail() { runner.runOneTest("fractionTotalDigitsFail") }
-  @Test def test_fractionDigitsFailNotInt() { runnerV.runOneTest("fractionDigitsFailNotInt") }
+  @Test def test_fractionDigitsFailNeg(): Unit = { runnerV.runOneTest("fractionDigitsFailNeg") }
+  @Test def test_fractionTotalDigitsFail(): Unit = { runner.runOneTest("fractionTotalDigitsFail") }
+  @Test def test_fractionDigitsFailNotInt(): Unit = { runnerV.runOneTest("fractionDigitsFailNotInt") }
 
-  @Test def test_arraysMinOccursZero() { runner.runOneTest("arraysMinOccursZero") }
-  @Test def test_arraysOccursInRange_01() { runner.runOneTest("arraysOccursInRange_01") }
-  @Test def test_arraysOccursInRange_02() { runner.runOneTest("arraysOccursInRange_02") }
-  @Test def test_arraysOccursInRange_03() { runner.runOneTest("arraysOccursInRange_03") }
-  @Test def test_arraysOccursInRange_04() { runner.runOneTest("arraysOccursInRange_04") }
-  @Test def test_arraysOccursInRange_05() { runner.runOneTest("arraysOccursInRange_05") }
-  @Test def test_arraysOccursOutOfRange_01() { runner.runOneTest("arraysOccursOutOfRange_01") }
-  @Test def test_arraysOccursOutOfRange_02() { runner.runOneTest("arraysOccursOutOfRange_02") }
+  @Test def test_arraysMinOccursZero(): Unit = { runner.runOneTest("arraysMinOccursZero") }
+  @Test def test_arraysOccursInRange_01(): Unit = { runner.runOneTest("arraysOccursInRange_01") }
+  @Test def test_arraysOccursInRange_02(): Unit = { runner.runOneTest("arraysOccursInRange_02") }
+  @Test def test_arraysOccursInRange_03(): Unit = { runner.runOneTest("arraysOccursInRange_03") }
+  @Test def test_arraysOccursInRange_04(): Unit = { runner.runOneTest("arraysOccursInRange_04") }
+  @Test def test_arraysOccursInRange_05(): Unit = { runner.runOneTest("arraysOccursInRange_05") }
+  @Test def test_arraysOccursOutOfRange_01(): Unit = { runner.runOneTest("arraysOccursOutOfRange_01") }
+  @Test def test_arraysOccursOutOfRange_02(): Unit = { runner.runOneTest("arraysOccursOutOfRange_02") }
 
-  @Test def test_checkMinInclusive_Pass { runner.runOneTest("checkMinInclusive_Pass") }
-  @Test def test_checkMaxInclusive_Pass { runner.runOneTest("checkMaxInclusive_Pass") }
-  @Test def test_checkMinInclusive_Fail { runner.runOneTest("checkMinInclusive_Fail") }
-  @Test def test_checkMaxInclusive_Fail { runner.runOneTest("checkMaxInclusive_Fail") }
-  @Test def test_checkMaxInclusive_Pass_MaxInt { runner.runOneTest("checkMaxInclusive_Pass_MaxInt") }
-  @Test def test_checkMaxInclusive_Fail_MaxInt { runner.runOneTest("checkMaxInclusive_Fail_MaxInt") }
-  @Test def test_checkMinInclusive_Fail_MinInt { runner.runOneTest("checkMinInclusive_Fail_MinInt") }
+  @Test def test_checkMinInclusive_Pass: Unit = { runner.runOneTest("checkMinInclusive_Pass") }
+  @Test def test_checkMaxInclusive_Pass: Unit = { runner.runOneTest("checkMaxInclusive_Pass") }
+  @Test def test_checkMinInclusive_Fail: Unit = { runner.runOneTest("checkMinInclusive_Fail") }
+  @Test def test_checkMaxInclusive_Fail: Unit = { runner.runOneTest("checkMaxInclusive_Fail") }
+  @Test def test_checkMaxInclusive_Pass_MaxInt: Unit = { runner.runOneTest("checkMaxInclusive_Pass_MaxInt") }
+  @Test def test_checkMaxInclusive_Fail_MaxInt: Unit = { runner.runOneTest("checkMaxInclusive_Fail_MaxInt") }
+  @Test def test_checkMinInclusive_Fail_MinInt: Unit = { runner.runOneTest("checkMinInclusive_Fail_MinInt") }
 
-  @Test def test_checkMinInclusiveDecimal_Pass { runner.runOneTest("checkMinInclusiveDecimal_Pass") }
-  @Test def test_checkMaxInclusiveDecimal_Pass { runner.runOneTest("checkMaxInclusiveDecimal_Pass") }
-  @Test def test_checkMinInclusiveDecimal_Fail { runner.runOneTest("checkMinInclusiveDecimal_Fail") }
-  @Test def test_checkMaxInclusiveDecimal_Fail { runner.runOneTest("checkMaxInclusiveDecimal_Fail") }
+  @Test def test_checkMinInclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMinInclusiveDecimal_Pass") }
+  @Test def test_checkMaxInclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Pass") }
+  @Test def test_checkMinInclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMinInclusiveDecimal_Fail") }
+  @Test def test_checkMaxInclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Fail") }
 
-  @Test def test_checkMinExclusiveDecimal_Pass { runner.runOneTest("checkMinExclusiveDecimal_Pass") }
-  @Test def test_checkMaxExclusiveDecimal_Pass { runner.runOneTest("checkMaxExclusiveDecimal_Pass") }
-  @Test def test_checkMinExclusiveDecimal_Fail { runner.runOneTest("checkMinExclusiveDecimal_Fail") }
-  @Test def test_checkMaxExclusiveDecimal_Fail { runner.runOneTest("checkMaxExclusiveDecimal_Fail") }
+  @Test def test_checkMinExclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMinExclusiveDecimal_Pass") }
+  @Test def test_checkMaxExclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Pass") }
+  @Test def test_checkMinExclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMinExclusiveDecimal_Fail") }
+  @Test def test_checkMaxExclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Fail") }
 
-  @Test def test_checkMinExclusive_Fail { runner.runOneTest("checkMinExclusive_Fail") }
-  @Test def test_checkMaxExclusive_Fail { runner.runOneTest("checkMaxExclusive_Fail") }
-  @Test def test_checkMinExclusive_Pass { runner.runOneTest("checkMinExclusive_Pass") }
-  @Test def test_checkMaxExclusive_Pass { runner.runOneTest("checkMaxExclusive_Pass") }
-  @Test def test_checkCombining_Pass { runner.runOneTest("checkCombining_Pass") }
-  @Test def test_checkCombining_Fail { runner.runOneTest("checkCombining_Fail") }
-  @Test def test_checkCombining_Fail_1 { runner.runOneTest("checkCombining_Fail_1") }
+  @Test def test_checkMinExclusive_Fail: Unit = { runner.runOneTest("checkMinExclusive_Fail") }
+  @Test def test_checkMaxExclusive_Fail: Unit = { runner.runOneTest("checkMaxExclusive_Fail") }
+  @Test def test_checkMinExclusive_Pass: Unit = { runner.runOneTest("checkMinExclusive_Pass") }
+  @Test def test_checkMaxExclusive_Pass: Unit = { runner.runOneTest("checkMaxExclusive_Pass") }
+  @Test def test_checkCombining_Pass: Unit = { runner.runOneTest("checkCombining_Pass") }
+  @Test def test_checkCombining_Fail: Unit = { runner.runOneTest("checkCombining_Fail") }
+  @Test def test_checkCombining_Fail_1: Unit = { runner.runOneTest("checkCombining_Fail_1") }
 
-  @Test def test_checkEnumeration_Pass { runner.runOneTest("checkEnumeration_Pass") }
-  @Test def test_checkEnumeration_Fail { runner.runOneTest("checkEnumeration_Fail") }
-  @Test def test_checkEnumeration_Pass_Subset { runner.runOneTest("checkEnumeration_Pass_Subset") }
-  @Test def test_checkEnumeration_Fail_Subset { runner.runOneTest("checkEnumeration_Fail_Subset") }
+  @Test def test_checkEnumeration_Pass: Unit = { runner.runOneTest("checkEnumeration_Pass") }
+  @Test def test_checkEnumeration_Fail: Unit = { runner.runOneTest("checkEnumeration_Fail") }
+  @Test def test_checkEnumeration_Pass_Subset: Unit = { runner.runOneTest("checkEnumeration_Pass_Subset") }
+  @Test def test_checkEnumeration_Fail_Subset: Unit = { runner.runOneTest("checkEnumeration_Fail_Subset") }
 
   // Satisfied that Date and Time should also work if DateTime works.
-  @Test def test_maxInclusive_Pass_DateTime { runner.runOneTest("checkMaxInclusive_Pass_DateTime") }
-  @Test def test_maxInclusive_Fail_DateTime { runner.runOneTest("checkMaxInclusive_Fail_DateTime") }
+  @Test def test_maxInclusive_Pass_DateTime: Unit = { runner.runOneTest("checkMaxInclusive_Pass_DateTime") }
+  @Test def test_maxInclusive_Fail_DateTime: Unit = { runner.runOneTest("checkMaxInclusive_Fail_DateTime") }
 
-  @Test def test_checkMinLength_Pass { runner.runOneTest("checkMinLength_Pass") }
-  @Test def test_checkMinLength_Fail { runner.runOneTest("checkMinLength_Fail") }
-  @Test def test_checkMinLength_Fail_NotString { runner.runOneTest("checkMinLength_Fail_NotString") }
-  @Test def test_checkMinLength_Fail_Combining { runner.runOneTest("checkMinLength_Fail_Combining") }
-  @Test def test_checkMinLength_Pass_Combining { runner.runOneTest("checkMinLength_Pass_Combining") }
-  @Test def test_checkMaxLength_Pass { runner.runOneTest("checkMaxLength_Pass") }
-  @Test def test_checkMaxLength_Fail { runner.runOneTest("checkMaxLength_Fail") }
-  @Test def test_checkMaxLength_Fail_NotString { runner.runOneTest("checkMaxLength_Fail_NotString") }
-  @Test def test_checkMaxLength_Fail_Combining { runner.runOneTest("checkMaxLength_Fail_Combining") }
-  @Test def test_checkMaxLength_Pass_Combining { runner.runOneTest("checkMaxLength_Pass_Combining") }
-  @Test def test_checkTotalDigits_Pass { runner.runOneTest("checkTotalDigits_Pass") }
-  @Test def test_checkTotalDigits_Fail { runner.runOneTest("checkTotalDigits_Fail") }
+  @Test def test_checkMinLength_Pass: Unit = { runner.runOneTest("checkMinLength_Pass") }
+  @Test def test_checkMinLength_Fail: Unit = { runner.runOneTest("checkMinLength_Fail") }
+  @Test def test_checkMinLength_Fail_NotString: Unit = { runner.runOneTest("checkMinLength_Fail_NotString") }
+  @Test def test_checkMinLength_Fail_Combining: Unit = { runner.runOneTest("checkMinLength_Fail_Combining") }
+  @Test def test_checkMinLength_Pass_Combining: Unit = { runner.runOneTest("checkMinLength_Pass_Combining") }
+  @Test def test_checkMaxLength_Pass: Unit = { runner.runOneTest("checkMaxLength_Pass") }
+  @Test def test_checkMaxLength_Fail: Unit = { runner.runOneTest("checkMaxLength_Fail") }
+  @Test def test_checkMaxLength_Fail_NotString: Unit = { runner.runOneTest("checkMaxLength_Fail_NotString") }
+  @Test def test_checkMaxLength_Fail_Combining: Unit = { runner.runOneTest("checkMaxLength_Fail_Combining") }
+  @Test def test_checkMaxLength_Pass_Combining: Unit = { runner.runOneTest("checkMaxLength_Pass_Combining") }
+  @Test def test_checkTotalDigits_Pass: Unit = { runner.runOneTest("checkTotalDigits_Pass") }
+  @Test def test_checkTotalDigits_Fail: Unit = { runner.runOneTest("checkTotalDigits_Fail") }
 
-  @Test def test_minMaxInEx01() { runner.runOneTest("minMaxInEx01") }
+  @Test def test_minMaxInEx01(): Unit = { runner.runOneTest("minMaxInEx01") }
 
-  @Test def test_minMaxInEx02() { runner.runOneTest("minMaxInEx02") }
-  @Test def test_minMaxInEx03() { runner.runOneTest("minMaxInEx03") }
-  @Test def test_minMaxInEx04() { runner.runOneTest("minMaxInEx04") }
-  @Test def test_minMaxInEx05() { runner.runOneTest("minMaxInEx05") }
-  @Test def test_minMaxInEx06() { runner.runOneTest("minMaxInEx06") }
-  @Test def test_minMaxInEx07() { runner.runOneTest("minMaxInEx07") }
-  @Test def test_minMaxInEx08() { runner.runOneTest("minMaxInEx08") }
-  @Test def test_minMaxInEx09() { runner.runOneTest("minMaxInEx09") }
-  @Test def test_minMaxInEx10() { runner.runOneTest("minMaxInEx10") }
-  @Test def test_minMaxInEx11() { runner.runOneTest("minMaxInEx11") }
-  @Test def test_minMaxInEx12() { runner.runOneTest("minMaxInEx12") }
-  @Test def test_minMaxInEx13() { runner.runOneTest("minMaxInEx13") }
-  @Test def test_minMaxInEx14() { runner.runOneTest("minMaxInEx14") }
+  @Test def test_minMaxInEx02(): Unit = { runner.runOneTest("minMaxInEx02") }
+  @Test def test_minMaxInEx03(): Unit = { runner.runOneTest("minMaxInEx03") }
+  @Test def test_minMaxInEx04(): Unit = { runner.runOneTest("minMaxInEx04") }
+  @Test def test_minMaxInEx05(): Unit = { runner.runOneTest("minMaxInEx05") }
+  @Test def test_minMaxInEx06(): Unit = { runner.runOneTest("minMaxInEx06") }
+  @Test def test_minMaxInEx07(): Unit = { runner.runOneTest("minMaxInEx07") }
+  @Test def test_minMaxInEx08(): Unit = { runner.runOneTest("minMaxInEx08") }
+  @Test def test_minMaxInEx09(): Unit = { runner.runOneTest("minMaxInEx09") }
+  @Test def test_minMaxInEx10(): Unit = { runner.runOneTest("minMaxInEx10") }
+  @Test def test_minMaxInEx11(): Unit = { runner.runOneTest("minMaxInEx11") }
+  @Test def test_minMaxInEx12(): Unit = { runner.runOneTest("minMaxInEx12") }
+  @Test def test_minMaxInEx13(): Unit = { runner.runOneTest("minMaxInEx13") }
+  @Test def test_minMaxInEx14(): Unit = { runner.runOneTest("minMaxInEx14") }
 
-  @Test def test_correctNumCells0() { runner.runOneTest("correctNumCells0") }
-  @Test def test_extraCellsParsed() { runner.runOneTest("extraCellsParsed") }
-  @Test def test_scalarElements() { runner.runOneTest("scalarElements") }
-  @Test def test_scalarElementsExtra() { runner.runOneTest("scalarElementsExtra") }
-  @Test def test_lessThanMinBasic() { runner.runOneTest("lessThanMinBasic") }
-  @Test def test_moreThanMaxBasic() { runner.runOneTest("moreThanMaxBasic") }
+  @Test def test_correctNumCells0(): Unit = { runner.runOneTest("correctNumCells0") }
+  @Test def test_extraCellsParsed(): Unit = { runner.runOneTest("extraCellsParsed") }
+  @Test def test_scalarElements(): Unit = { runner.runOneTest("scalarElements") }
+  @Test def test_scalarElementsExtra(): Unit = { runner.runOneTest("scalarElementsExtra") }
+  @Test def test_lessThanMinBasic(): Unit = { runner.runOneTest("lessThanMinBasic") }
+  @Test def test_moreThanMaxBasic(): Unit = { runner.runOneTest("moreThanMaxBasic") }
   @Test def test_arrayElements() = { runner.runOneTest("arrayElements") }
-  @Test def test_upToMaxParsed() { runner.runOneTest("upToMaxParsed") }
-  @Test def test_lessThanMinCells() { runner.runOneTest("lessThanMinCells") }
-  @Test def test_moreThanMinCells() { runner.runOneTest("moreThanMinCells") }
-  @Test def test_lessThanMinCellsAfterLargeRow() { runner.runOneTest("lessThanMinCellsAfterLargeRow") }
-  @Test def test_largeNumRows() { runner.runOneTest("largeNumRows") }
-  @Test def test_lessThanMinCellsAfterLargeRow_Neg() { runner.runOneTest("lessThanMinCellsAfterLargeRow_Neg") }
-  @Test def test_fixedUnboundedMax() { runner.runOneTest("fixedUnboundedMax") }
-  @Test def test_minMaxDoNotMatch() { runner.runOneTest("minMaxDoNotMatch") }
+  @Test def test_upToMaxParsed(): Unit = { runner.runOneTest("upToMaxParsed") }
+  @Test def test_lessThanMinCells(): Unit = { runner.runOneTest("lessThanMinCells") }
+  @Test def test_moreThanMinCells(): Unit = { runner.runOneTest("moreThanMinCells") }
+  @Test def test_lessThanMinCellsAfterLargeRow(): Unit = { runner.runOneTest("lessThanMinCellsAfterLargeRow") }
+  @Test def test_largeNumRows(): Unit = { runner.runOneTest("largeNumRows") }
+  @Test def test_lessThanMinCellsAfterLargeRow_Neg(): Unit = { runner.runOneTest("lessThanMinCellsAfterLargeRow_Neg") }
+  @Test def test_fixedUnboundedMax(): Unit = { runner.runOneTest("fixedUnboundedMax") }
+  @Test def test_minMaxDoNotMatch(): Unit = { runner.runOneTest("minMaxDoNotMatch") }
 
-  @Test def test_maxOccursPass() { runner.runOneTest("checkMaxOccurs_Pass") }
-  @Test def test_maxOccursFail() { runner.runOneTest("checkMaxOccurs_Fail") }
-  @Test def test_maxOccursUnboundedPass() { runner.runOneTest("checkMaxOccursUnbounded_Pass") }
+  @Test def test_maxOccursPass(): Unit = { runner.runOneTest("checkMaxOccurs_Pass") }
+  @Test def test_maxOccursFail(): Unit = { runner.runOneTest("checkMaxOccurs_Fail") }
+  @Test def test_maxOccursUnboundedPass(): Unit = { runner.runOneTest("checkMaxOccursUnbounded_Pass") }
 
-  @Test def test_testBinary() { runner.runOneTest("testBinary") }
-  @Test def test_totalDigits_Pass_Decimal { runner.runOneTest("checkTotalDigits_Pass_Decimal") }
-  @Test def test_totalDigits_Fail_Decimal { runner.runOneTest("checkTotalDigits_Fail_Decimal") }
-  @Test def test_fractionDigits_Pass { runner.runOneTest("checkFractionDigits_Pass") }
-  @Test def test_fractionDigits_Fail { runner.runOneTest("checkFractionDigits_Fail") }
-  @Test def test_fractionDigits_Pass_LessDigits { runner.runOneTest("checkFractionDigits_Pass_LessDigits") }
-  @Test def test_totalDigitsAndFractionDigits_Pass { runner.runOneTest("checkTotalDigitsFractionDigits_Pass") }
-  @Test def test_totalDigitsAndFractionDigits_Pass2 { runner.runOneTest("checkTotalDigitsFractionDigits_Pass2") }
+  @Test def test_testBinary(): Unit = { runner.runOneTest("testBinary") }
+  @Test def test_totalDigits_Pass_Decimal: Unit = { runner.runOneTest("checkTotalDigits_Pass_Decimal") }
+  @Test def test_totalDigits_Fail_Decimal: Unit = { runner.runOneTest("checkTotalDigits_Fail_Decimal") }
+  @Test def test_fractionDigits_Pass: Unit = { runner.runOneTest("checkFractionDigits_Pass") }
+  @Test def test_fractionDigits_Fail: Unit = { runner.runOneTest("checkFractionDigits_Fail") }
+  @Test def test_fractionDigits_Pass_LessDigits: Unit = { runner.runOneTest("checkFractionDigits_Pass_LessDigits") }
+  @Test def test_totalDigitsAndFractionDigits_Pass: Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass") }
+  @Test def test_totalDigitsAndFractionDigits_Pass2: Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass2") }
 
-  @Test def test_fractionDigitsPass() { runner.runOneTest("fractionDigitsPass") }
-  @Test def test_fractionDigitsFail() { runner.runOneTest("fractionDigitsFail") }
-  @Test def test_fractionTotalDigitsPass() { runner.runOneTest("fractionTotalDigitsPass") }
-  @Test def test_fractionTotalDigitsFail2() { runner.runOneTest("fractionTotalDigitsFail2") }
-  @Test def test_fractionTotalDigitsPass2() { runner.runOneTest("fractionTotalDigitsPass2") }
-  @Test def test_fractionTotalDigitsFail3() { runner.runOneTest("fractionTotalDigitsFail3") }
+  @Test def test_fractionDigitsPass(): Unit = { runner.runOneTest("fractionDigitsPass") }
+  @Test def test_fractionDigitsFail(): Unit = { runner.runOneTest("fractionDigitsFail") }
+  @Test def test_fractionTotalDigitsPass(): Unit = { runner.runOneTest("fractionTotalDigitsPass") }
+  @Test def test_fractionTotalDigitsFail2(): Unit = { runner.runOneTest("fractionTotalDigitsFail2") }
+  @Test def test_fractionTotalDigitsPass2(): Unit = { runner.runOneTest("fractionTotalDigitsPass2") }
+  @Test def test_fractionTotalDigitsFail3(): Unit = { runner.runOneTest("fractionTotalDigitsFail3") }
 
-  @Test def test_totalDigits01() { runner.runOneTest("totalDigits01") }
-  @Test def test_totalDigits02() { runner.runOneTest("totalDigits02") }
+  @Test def test_totalDigits01(): Unit = { runner.runOneTest("totalDigits01") }
+  @Test def test_totalDigits02(): Unit = { runner.runOneTest("totalDigits02") }
 
-  @Test def test_totalDigits05b() { runner.runOneTest("totalDigits05b") }
-  @Test def test_totalDigits09() { runnerV.runOneTest("totalDigits09") }
+  @Test def test_totalDigits05b(): Unit = { runner.runOneTest("totalDigits05b") }
+  @Test def test_totalDigits09(): Unit = { runnerV.runOneTest("totalDigits09") }
 
-  @Test def test_patternRegexDFDL708_01() { runner.runOneTest("patternRegexDFDL708_01") }
-  @Test def test_patternRegexDFDL708_02() { runner.runOneTest("patternRegexDFDL708_02") }
-  @Test def test_patternRegexDFDL708_03() { runner.runOneTest("patternRegexDFDL708_03") }
-  @Test def test_patternRegexDFDL708_04() { runner.runOneTest("patternRegexDFDL708_04") }
+  @Test def test_patternRegexDFDL708_01(): Unit = { runner.runOneTest("patternRegexDFDL708_01") }
+  @Test def test_patternRegexDFDL708_02(): Unit = { runner.runOneTest("patternRegexDFDL708_02") }
+  @Test def test_patternRegexDFDL708_03(): Unit = { runner.runOneTest("patternRegexDFDL708_03") }
+  @Test def test_patternRegexDFDL708_04(): Unit = { runner.runOneTest("patternRegexDFDL708_04") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
@@ -27,7 +27,7 @@ object TestBlobs {
 
   val runner = Runner(testDir, "Blobs.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -35,24 +35,24 @@ object TestBlobs {
 class TestBlobs {
   import TestBlobs._
 
-  @Test def test_blob_01() { runner.runOneTest("blob_01") }
-  @Test def test_blob_02() { runner.runOneTest("blob_02") }
-  @Test def test_blob_03() { runner.runOneTest("blob_03") }
-  @Test def test_blob_04() { runner.runOneTest("blob_04") }
-  @Test def test_blob_05() { runner.runOneTest("blob_05") }
-  @Test def test_blob_06() { runner.runOneTest("blob_06") }
-  @Test def test_blob_07() { runner.runOneTest("blob_07") }
-  @Test def test_blob_08() { runner.runOneTest("blob_08") }
-  @Test def test_blob_09() { runner.runOneTest("blob_09") }
-  @Test def test_blob_10() { runner.runOneTest("blob_10") }
-  @Test def test_blob_11() { runner.runOneTest("blob_11") }
-  @Test def test_blob_12() { runner.runOneTest("blob_12") }
-  @Test def test_blob_13() { runner.runOneTest("blob_13") }
-  @Test def test_blob_14() { runner.runOneTest("blob_14") }
-  @Test def test_blob_15() { runner.runOneTest("blob_15") }
+  @Test def test_blob_01(): Unit = { runner.runOneTest("blob_01") }
+  @Test def test_blob_02(): Unit = { runner.runOneTest("blob_02") }
+  @Test def test_blob_03(): Unit = { runner.runOneTest("blob_03") }
+  @Test def test_blob_04(): Unit = { runner.runOneTest("blob_04") }
+  @Test def test_blob_05(): Unit = { runner.runOneTest("blob_05") }
+  @Test def test_blob_06(): Unit = { runner.runOneTest("blob_06") }
+  @Test def test_blob_07(): Unit = { runner.runOneTest("blob_07") }
+  @Test def test_blob_08(): Unit = { runner.runOneTest("blob_08") }
+  @Test def test_blob_09(): Unit = { runner.runOneTest("blob_09") }
+  @Test def test_blob_10(): Unit = { runner.runOneTest("blob_10") }
+  @Test def test_blob_11(): Unit = { runner.runOneTest("blob_11") }
+  @Test def test_blob_12(): Unit = { runner.runOneTest("blob_12") }
+  @Test def test_blob_13(): Unit = { runner.runOneTest("blob_13") }
+  @Test def test_blob_14(): Unit = { runner.runOneTest("blob_14") }
+  @Test def test_blob_15(): Unit = { runner.runOneTest("blob_15") }
 
-  @Test def test_blob_unparseError() { runner.runOneTest("blob_unparseError") }
+  @Test def test_blob_unparseError(): Unit = { runner.runOneTest("blob_unparseError") }
 
-  @Test def test_clob_01() { runner.runOneTest("clob_01") }
+  @Test def test_clob_01(): Unit = { runner.runOneTest("clob_01") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
@@ -26,7 +26,7 @@ object TestBoolean2 {
 
   val runner = Runner(testDir, "Boolean.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
   }
 }
@@ -34,30 +34,30 @@ object TestBoolean2 {
 class TestBoolean2 {
   import TestBoolean2._
 
-  @Test def test_binaryBoolean_0() { runner.runOneTest("binaryBoolean_0") }
-  @Test def test_binaryBoolean_unparse_0() { runner.runOneTest("binaryBoolean_unparse_0") }
-  @Test def test_binaryBoolean_1() { runner.runOneTest("binaryBoolean_1") }
-  @Test def test_binaryBoolean_unparse_1() { runner.runOneTest("binaryBoolean_unparse_1") }
-  @Test def test_binaryBoolean_unparse_2() { runner.runOneTest("binaryBoolean_unparse_2") }
-  @Test def test_binaryBoolean_2() { runner.runOneTest("binaryBoolean_2") }
-  @Test def test_binaryBoolean_pe_0() { runner.runOneTest("binaryBoolean_pe_0") }
-  @Test def test_binaryBoolean_sde_0() { runner.runOneTest("binaryBoolean_sde_0") }
-  @Test def test_binaryBoolean_sde_1() { runner.runOneTest("binaryBoolean_sde_1") }
-  @Test def test_textBoolean_0() { runner.runOneTest("textBoolean_0") }
-  @Test def test_textBoolean_0a() { runner.runOneTest("textBoolean_0a") }
-  @Test def test_textBoolean_unparse_0() { runner.runOneTest("textBoolean_unparse_0") }
-  @Test def test_textBoolean_1() { runner.runOneTest("textBoolean_1") }
-  @Test def test_textBoolean_2() { runner.runOneTest("textBoolean_2") }
-  @Test def test_textBoolean_3() { runner.runOneTest("textBoolean_3") }
-  @Test def test_textBoolean_sde_0() { runner.runOneTest("textBoolean_sde_0") }
-  @Test def test_textBoolean_sde_1() { runner.runOneTest("textBoolean_sde_1") }
-  @Test def test_textBoolean_sde_2() { runner.runOneTest("textBoolean_sde_2") }
-  @Test def test_textBoolean_unparse_sde_0() { runner.runOneTest("textBoolean_unparse_sde_0") }
-  @Test def test_textBoolean_sde_3() { runner.runOneTest("textBoolean_sde_3") }
-  @Test def test_textBoolean_sde_4() { runner.runOneTest("textBoolean_sde_4") }
-  @Test def test_textBoolean_sde_5() { runner.runOneTest("textBoolean_sde_5") }
-  @Test def test_textBoolean_pe_0() { runner.runOneTest("textBoolean_pe_0") }
-  @Test def test_textBoolean_unparseError() { runner.runOneTest("textBoolean_unparseError") }
+  @Test def test_binaryBoolean_0(): Unit = { runner.runOneTest("binaryBoolean_0") }
+  @Test def test_binaryBoolean_unparse_0(): Unit = { runner.runOneTest("binaryBoolean_unparse_0") }
+  @Test def test_binaryBoolean_1(): Unit = { runner.runOneTest("binaryBoolean_1") }
+  @Test def test_binaryBoolean_unparse_1(): Unit = { runner.runOneTest("binaryBoolean_unparse_1") }
+  @Test def test_binaryBoolean_unparse_2(): Unit = { runner.runOneTest("binaryBoolean_unparse_2") }
+  @Test def test_binaryBoolean_2(): Unit = { runner.runOneTest("binaryBoolean_2") }
+  @Test def test_binaryBoolean_pe_0(): Unit = { runner.runOneTest("binaryBoolean_pe_0") }
+  @Test def test_binaryBoolean_sde_0(): Unit = { runner.runOneTest("binaryBoolean_sde_0") }
+  @Test def test_binaryBoolean_sde_1(): Unit = { runner.runOneTest("binaryBoolean_sde_1") }
+  @Test def test_textBoolean_0(): Unit = { runner.runOneTest("textBoolean_0") }
+  @Test def test_textBoolean_0a(): Unit = { runner.runOneTest("textBoolean_0a") }
+  @Test def test_textBoolean_unparse_0(): Unit = { runner.runOneTest("textBoolean_unparse_0") }
+  @Test def test_textBoolean_1(): Unit = { runner.runOneTest("textBoolean_1") }
+  @Test def test_textBoolean_2(): Unit = { runner.runOneTest("textBoolean_2") }
+  @Test def test_textBoolean_3(): Unit = { runner.runOneTest("textBoolean_3") }
+  @Test def test_textBoolean_sde_0(): Unit = { runner.runOneTest("textBoolean_sde_0") }
+  @Test def test_textBoolean_sde_1(): Unit = { runner.runOneTest("textBoolean_sde_1") }
+  @Test def test_textBoolean_sde_2(): Unit = { runner.runOneTest("textBoolean_sde_2") }
+  @Test def test_textBoolean_unparse_sde_0(): Unit = { runner.runOneTest("textBoolean_unparse_sde_0") }
+  @Test def test_textBoolean_sde_3(): Unit = { runner.runOneTest("textBoolean_sde_3") }
+  @Test def test_textBoolean_sde_4(): Unit = { runner.runOneTest("textBoolean_sde_4") }
+  @Test def test_textBoolean_sde_5(): Unit = { runner.runOneTest("textBoolean_sde_5") }
+  @Test def test_textBoolean_pe_0(): Unit = { runner.runOneTest("textBoolean_pe_0") }
+  @Test def test_textBoolean_unparseError(): Unit = { runner.runOneTest("textBoolean_unparseError") }
 
-  @Test def test_textBoolean_IgnoreCase() { runner.runOneTest("textBoolean_IgnoreCase") }
+  @Test def test_textBoolean_IgnoreCase(): Unit = { runner.runOneTest("textBoolean_IgnoreCase") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestEncodings.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestEncodings.scala
@@ -26,7 +26,7 @@ object TestEncodings {
 
   val runner = Runner(testDir, "Encodings.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
   }
 }
@@ -34,21 +34,21 @@ object TestEncodings {
 class TestEncodings {
   import TestEncodings._
 
-  @Test def test_f293u003_01() { runner.runOneTest("f293u003_01") }
-  @Test def test_f293u003_02() { runner.runOneTest("f293u003_02") }
-  @Test def test_f422u001_01() { runner.runOneTest("f422u001_01") }
-  @Test def test_f422u001_02() { runner.runOneTest("f422u001_02") }
-  @Test def test_f422u001_03() { runner.runOneTest("f422u001_03") }
-  @Test def test_f746u002_01() { runner.runOneTest("f746u002_01") }
-  @Test def test_f746u002_02() { runner.runOneTest("f746u002_02") }
-  @Test def test_f746u002_03() { runner.runOneTest("f746u002_03") }
-  @Test def test_f747u001_01() { runner.runOneTest("f747u001_01") }
-  @Test def test_f747u001_02() { runner.runOneTest("f747u001_02") }
-  @Test def test_f747u001_03() { runner.runOneTest("f747u001_03") }
-  @Test def test_f769u002_01() { runner.runOneTest("f769u002_01") }
-  @Test def test_f769u002_02() { runner.runOneTest("f769u002_02") }
-  @Test def test_f769u002_03() { runner.runOneTest("f769u002_03") }
-  @Test def test_f336u002_01() { runner.runOneTest("f336u002_01") }
-  @Test def test_f336u002_02() { runner.runOneTest("f336u002_02") }
-  @Test def test_f336u002_03() { runner.runOneTest("f336u002_03") }
+  def test_f293u003_01(): Unit = { runner.runOneTest("f293u003_01") }
+  @Test def test_f293u003_02(): Unit = { runner.runOneTest("f293u003_02") }
+  @Test def test_f422u001_01(): Unit = { runner.runOneTest("f422u001_01") }
+  @Test def test_f422u001_02(): Unit = { runner.runOneTest("f422u001_02") }
+  @Test def test_f422u001_03(): Unit = { runner.runOneTest("f422u001_03") }
+  @Test def test_f746u002_01(): Unit = { runner.runOneTest("f746u002_01") }
+  @Test def test_f746u002_02(): Unit = { runner.runOneTest("f746u002_02") }
+  @Test def test_f746u002_03(): Unit = { runner.runOneTest("f746u002_03") }
+  @Test def test_f747u001_01(): Unit = { runner.runOneTest("f747u001_01") }
+  @Test def test_f747u001_02(): Unit = { runner.runOneTest("f747u001_02") }
+  @Test def test_f747u001_03(): Unit = { runner.runOneTest("f747u001_03") }
+  @Test def test_f769u002_01(): Unit = { runner.runOneTest("f769u002_01") }
+  @Test def test_f769u002_02(): Unit = { runner.runOneTest("f769u002_02") }
+  @Test def test_f769u002_03(): Unit = { runner.runOneTest("f769u002_03") }
+  @Test def test_f336u002_01(): Unit = { runner.runOneTest("f336u002_01") }
+  @Test def test_f336u002_02(): Unit = { runner.runOneTest("f336u002_02") }
+  @Test def test_f336u002_03(): Unit = { runner.runOneTest("f336u002_03") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguage.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguage.scala
@@ -26,7 +26,7 @@ object TestRuntimeCalendarLanguage {
 
   val runner = Runner(testDir, "RuntimeCalendarLanguage.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
   }
 }
@@ -34,8 +34,8 @@ object TestRuntimeCalendarLanguage {
 class TestRuntimeCalendarLanguage {
   import TestRuntimeCalendarLanguage._
 
-  @Test def test_runtimeCalendarLanguage1() { runner.runOneTest("runtimeCalendarLanguage1") }
-  @Test def test_invalidCalendarLanguage1() { runner.runOneTest("invalidCalendarLanguage1") }
-  @Test def test_unparseRuntimeCalendarLanguageOVC() { runner.runOneTest("unparseRuntimeCalendarLanguageOVC") }
-  @Test def test_unparseRuntimeCalendarLanguageOVCCacheCheck() { runner.runOneTest("unparseRuntimeCalendarLanguageOVCCacheCheck") }
+  @Test def test_runtimeCalendarLanguage1(): Unit = { runner.runOneTest("runtimeCalendarLanguage1") }
+  @Test def test_invalidCalendarLanguage1(): Unit = { runner.runOneTest("invalidCalendarLanguage1") }
+  @Test def test_unparseRuntimeCalendarLanguageOVC(): Unit = { runner.runOneTest("unparseRuntimeCalendarLanguageOVC") }
+  @Test def test_unparseRuntimeCalendarLanguageOVCCacheCheck(): Unit = { runner.runOneTest("unparseRuntimeCalendarLanguageOVCCacheCheck") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguageNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguageNew.scala
@@ -25,7 +25,7 @@ object TestRuntimeCalendarLanguageNew {
 
   val runner = Runner(testDir, "RuntimeCalendarLanguage.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -27,7 +27,7 @@ object TestSimpleTypes {
 
   val runner = Runner(testDir, "SimpleTypes.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -35,233 +35,233 @@ object TestSimpleTypes {
 class TestSimpleTypes {
   import TestSimpleTypes._
 
-  @Test def test_warning_exercise() { runner.runOneTest("warning_exercise") }
+  @Test def test_warning_exercise(): Unit = { runner.runOneTest("warning_exercise") }
 
-  @Test def test_one_octet() { runner.runOneTest("OneOctetBinaryParse") }
-  @Test def test_oneBit2() { runner.runOneTest("OneBit2") }
+  @Test def test_one_octet(): Unit = { runner.runOneTest("OneOctetBinaryParse") }
+  @Test def test_oneBit2(): Unit = { runner.runOneTest("OneBit2") }
 
-  @Test def test_nonNegativeInteger() { runner.runOneTest("NonNegativeInteger") }
-  @Test def test_nonNegativeInteger_Fail() { runner.runOneTest("NonNegativeInteger_Fail") }
+  @Test def test_nonNegativeInteger(): Unit = { runner.runOneTest("NonNegativeInteger") }
+  @Test def test_nonNegativeInteger_Fail(): Unit = { runner.runOneTest("NonNegativeInteger_Fail") }
 
-  @Test def test_hexBinary_rep() { runner.runOneTest("hexBinary_rep") } //roundTrip
-  @Test def test_hexBinary_fromString() { runner.runOneTest("hexBinary_fromString") } //roundTrip
+  @Test def test_hexBinary_rep(): Unit = { runner.runOneTest("hexBinary_rep") } //roundTrip
+  @Test def test_hexBinary_fromString(): Unit = { runner.runOneTest("hexBinary_fromString") } //roundTrip
 
-  @Test def test_hexBinary_01() { runner.runOneTest("hexBinary_01") } //roundTrip
-  @Test def test_hexBinary_Delimited_01() { runner.runOneTest("hexBinary_Delimited_01") } //roundTrip
-  @Test def test_hexBinary_Delimited_01a() { runner.runOneTest("hexBinary_Delimited_01a") } //roundTrip
-  @Test def test_hexBinary_Delimited_02() { runner.runOneTest("hexBinary_Delimited_02") } //roundTrip
-  @Test def test_hexBinary_Delimited_03() { runner.runOneTest("hexBinary_Delimited_03") } //roundTrip
-  @Test def test_hexBinary_Implicit_01() { runner.runOneTest("hexBinary_Implicit_01") } //roundTrip
-  @Test def test_hexBinary_Implicit_02() { runner.runOneTest("hexBinary_Implicit_02") } //roundTrip
-  @Test def test_hexBinary_Implicit_03() { runner.runOneTest("hexBinary_Implicit_03") } //roundTrip
-  @Test def test_hexBinary_Implicit_03b() { runner.runOneTest("hexBinary_Implicit_03b") } //roundTrip
-  @Test def test_hexBinary_Implicit_03c() { runner.runOneTest("hexBinary_Implicit_03c") } //roundTrip
-  @Test def test_hexBinary_Implicit_04() { runner.runOneTest("hexBinary_Implicit_04") } //roundTrip
-  @Test def test_hexBinary_func() { runner.runOneTest("hexBinary_func") }
-  @Test def test_hexBinary_func_neg() { runner.runOneTest("hexBinary_func_neg") }
+  @Test def test_hexBinary_01(): Unit = { runner.runOneTest("hexBinary_01") } //roundTrip
+  @Test def test_hexBinary_Delimited_01(): Unit = { runner.runOneTest("hexBinary_Delimited_01") } //roundTrip
+  @Test def test_hexBinary_Delimited_01a(): Unit = { runner.runOneTest("hexBinary_Delimited_01a") } //roundTrip
+  @Test def test_hexBinary_Delimited_02(): Unit = { runner.runOneTest("hexBinary_Delimited_02") } //roundTrip
+  @Test def test_hexBinary_Delimited_03(): Unit = { runner.runOneTest("hexBinary_Delimited_03") } //roundTrip
+  @Test def test_hexBinary_Implicit_01(): Unit = { runner.runOneTest("hexBinary_Implicit_01") } //roundTrip
+  @Test def test_hexBinary_Implicit_02(): Unit = { runner.runOneTest("hexBinary_Implicit_02") } //roundTrip
+  @Test def test_hexBinary_Implicit_03(): Unit = { runner.runOneTest("hexBinary_Implicit_03") } //roundTrip
+  @Test def test_hexBinary_Implicit_03b(): Unit = { runner.runOneTest("hexBinary_Implicit_03b") } //roundTrip
+  @Test def test_hexBinary_Implicit_03c(): Unit = { runner.runOneTest("hexBinary_Implicit_03c") } //roundTrip
+  @Test def test_hexBinary_Implicit_04(): Unit = { runner.runOneTest("hexBinary_Implicit_04") } //roundTrip
+  @Test def test_hexBinary_func(): Unit = { runner.runOneTest("hexBinary_func") }
+  @Test def test_hexBinary_func_neg(): Unit = { runner.runOneTest("hexBinary_func_neg") }
 
-  @Test def test_hexBinary_bits_be_msbf() { runner.runOneTest("hexBinary_bits_be_msbf") }
-  @Test def test_hexBinary_bits_le_msbf() { runner.runOneTest("hexBinary_bits_le_msbf") }
-  @Test def test_hexBinary_bits_le_lsbf() { runner.runOneTest("hexBinary_bits_le_lsbf") }
+  @Test def test_hexBinary_bits_be_msbf(): Unit = { runner.runOneTest("hexBinary_bits_be_msbf") }
+  @Test def test_hexBinary_bits_le_msbf(): Unit = { runner.runOneTest("hexBinary_bits_le_msbf") }
+  @Test def test_hexBinary_bits_le_lsbf(): Unit = { runner.runOneTest("hexBinary_bits_le_lsbf") }
 
-  @Test def test_hexBinary_bits_be_msbf_2() { runner.runOneTest("hexBinary_bits_be_msbf_2") }
-  @Test def test_hexBinary_bits_le_msbf_2() { runner.runOneTest("hexBinary_bits_le_msbf_2") }
-  @Test def test_hexBinary_bits_le_lsbf_2() { runner.runOneTest("hexBinary_bits_le_lsbf_2") }
+  @Test def test_hexBinary_bits_be_msbf_2(): Unit = { runner.runOneTest("hexBinary_bits_be_msbf_2") }
+  @Test def test_hexBinary_bits_le_msbf_2(): Unit = { runner.runOneTest("hexBinary_bits_le_msbf_2") }
+  @Test def test_hexBinary_bits_le_lsbf_2(): Unit = { runner.runOneTest("hexBinary_bits_le_lsbf_2") }
 
-  @Test def test_dateTextNumberRep() { runner.runOneTest("dateTextNumberRep") }
+  @Test def test_dateTextNumberRep(): Unit = { runner.runOneTest("dateTextNumberRep") }
 
-  @Test def test_datePattern02() { runner.runOneTest("datePattern02") }
-  @Test def test_datePattern02b() { runner.runOneTest("datePattern02b") }
-  @Test def test_timePattern01() { runner.runOneTest("timePattern01") }
-  @Test def test_timePattern01b() { runner.runOneTest("timePattern01b") }
+  @Test def test_datePattern02(): Unit = { runner.runOneTest("datePattern02") }
+  @Test def test_datePattern02b(): Unit = { runner.runOneTest("datePattern02b") }
+  @Test def test_timePattern01(): Unit = { runner.runOneTest("timePattern01") }
+  @Test def test_timePattern01b(): Unit = { runner.runOneTest("timePattern01b") }
 
-  @Test def test_dateCalendarLanguage() { runner.runOneTest("dateCalendarLanguage") }
-  @Test def test_dateCalendarLanguage2() { runner.runOneTest("dateCalendarLanguage2") }
-  @Test def test_dateCalendarLanguage3() { runner.runOneTest("dateCalendarLanguage3") }
-  @Test def test_dateCalendarLanguage4() { runner.runOneTest("dateCalendarLanguage4") }
+  @Test def test_dateCalendarLanguage(): Unit = { runner.runOneTest("dateCalendarLanguage") }
+  @Test def test_dateCalendarLanguage2(): Unit = { runner.runOneTest("dateCalendarLanguage2") }
+  @Test def test_dateCalendarLanguage3(): Unit = { runner.runOneTest("dateCalendarLanguage3") }
+  @Test def test_dateCalendarLanguage4(): Unit = { runner.runOneTest("dateCalendarLanguage4") }
 
-  @Test def test_dateTimeCalendarDaysInFirstWeek() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek") }
-  @Test def test_dateTimeCalendarDaysInFirstWeek2() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek2") }
-  @Test def test_dateTimeCalendarDaysInFirstWeek3() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek3") }
-  @Test def test_dateTimeCalendarDaysInFirstWeek4() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek4") }
-  @Test def test_dateTimeCalendarDaysInFirstWeek5() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek5") }
-  @Test def test_dateTimeCalendarDaysInFirstWeek6() { runner.runOneTest("dateTimeCalendarDaysInFirstWeek6") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek2(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek2") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek3(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek3") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek4(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek4") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek5(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek5") }
+  @Test def test_dateTimeCalendarDaysInFirstWeek6(): Unit = { runner.runOneTest("dateTimeCalendarDaysInFirstWeek6") }
 
-  @Test def test_dateTimeTrim01() { runner.runOneTest("dateTimeTrim01") }
-  @Test def test_dateTimeTrim02() { runner.runOneTest("dateTimeTrim02") }
-  @Test def test_dateTimeTrim03() { runner.runOneTest("dateTimeTrim03") }
-  @Test def test_dateTimeTrim04() { runner.runOneTest("dateTimeTrim04") }
+  @Test def test_dateTimeTrim01(): Unit = { runner.runOneTest("dateTimeTrim01") }
+  @Test def test_dateTimeTrim02(): Unit = { runner.runOneTest("dateTimeTrim02") }
+  @Test def test_dateTimeTrim03(): Unit = { runner.runOneTest("dateTimeTrim03") }
+  @Test def test_dateTimeTrim04(): Unit = { runner.runOneTest("dateTimeTrim04") }
 
-  @Test def test_dateTimePattern01() { runner.runOneTest("dateTimePattern01") }
-  @Test def test_dateTimePattern02() { runner.runOneTest("dateTimePattern02") }
-  @Test def test_dateTimePattern03() { runner.runOneTest("dateTimePattern03") }
+  @Test def test_dateTimePattern01(): Unit = { runner.runOneTest("dateTimePattern01") }
+  @Test def test_dateTimePattern02(): Unit = { runner.runOneTest("dateTimePattern02") }
+  @Test def test_dateTimePattern03(): Unit = { runner.runOneTest("dateTimePattern03") }
 
-  @Test def test_dateEpochFillIn() { runner.runOneTest("dateEpochFillIn") }
-  @Test def test_dateEpochFillIn2() { runner.runOneTest("dateEpochFillIn2") }
-  @Test def test_dateEpochFillIn3() { runner.runOneTest("dateEpochFillIn3") }
-  @Test def test_datePattern08() { runner.runOneTest("datePattern08") }
-  @Test def test_datePattern08b() { runner.runOneTest("datePattern08b") }
+  @Test def test_dateEpochFillIn(): Unit = { runner.runOneTest("dateEpochFillIn") }
+  @Test def test_dateEpochFillIn2(): Unit = { runner.runOneTest("dateEpochFillIn2") }
+  @Test def test_dateEpochFillIn3(): Unit = { runner.runOneTest("dateEpochFillIn3") }
+  @Test def test_datePattern08(): Unit = { runner.runOneTest("datePattern08") }
+  @Test def test_datePattern08b(): Unit = { runner.runOneTest("datePattern08b") }
 
-  @Test def test_datePattern03() { runner.runOneTest("datePattern03") }
-  @Test def test_datePattern04() { runner.runOneTest("datePattern04") }
-  @Test def test_datePattern05() { runner.runOneTest("datePattern05") }
-  @Test def test_datePattern06() { runner.runOneTest("datePattern06") }
-  @Test def test_datePattern07() { runner.runOneTest("datePattern07") }
+  @Test def test_datePattern03(): Unit = { runner.runOneTest("datePattern03") }
+  @Test def test_datePattern04(): Unit = { runner.runOneTest("datePattern04") }
+  @Test def test_datePattern05(): Unit = { runner.runOneTest("datePattern05") }
+  @Test def test_datePattern06(): Unit = { runner.runOneTest("datePattern06") }
+  @Test def test_datePattern07(): Unit = { runner.runOneTest("datePattern07") }
 
-  @Test def test_datePatternChoice() { runner.runOneTest("datePatternChoice") }
+  @Test def test_datePatternChoice(): Unit = { runner.runOneTest("datePatternChoice") }
 
   // DFDL-519
   //@Test def test_dateCalendarCenturyStart() { runner.runOneTest("dateCalendarCenturyStart") }
   //@Test def test_dateCalendarCenturyStart2() { runner.runOneTest("dateCalendarCenturyStart2") }
 
-  @Test def test_dateCalendarDaysInFirstWeek() { runner.runOneTest("dateCalendarDaysInFirstWeek") }
-  @Test def test_dateCalendarDaysInFirstWeek2() { runner.runOneTest("dateCalendarDaysInFirstWeek2") }
+  @Test def test_dateCalendarDaysInFirstWeek(): Unit = { runner.runOneTest("dateCalendarDaysInFirstWeek") }
+  @Test def test_dateCalendarDaysInFirstWeek2(): Unit = { runner.runOneTest("dateCalendarDaysInFirstWeek2") }
   //DAFFODIL-1945 @Test def test_dateCalendarDaysInFirstWeek3() { runner.runOneTest("dateCalendarDaysInFirstWeek3") }
-  @Test def test_dateCalendarDaysInFirstWeek4() { runner.runOneTest("dateCalendarDaysInFirstWeek4") }
+  @Test def test_dateCalendarDaysInFirstWeek4(): Unit = { runner.runOneTest("dateCalendarDaysInFirstWeek4") }
   //DAFFODIL-1945 @Test def test_dateCalendarDaysInFirstWeek5() { runner.runOneTest("dateCalendarDaysInFirstWeek5") }
 
-  @Test def test_timeSymbols() { runner.runOneTest("timeSymbols") }
-  @Test def test_timeSymbols2() { runner.runOneTest("timeSymbols2") }
-  @Test def test_epochFillIn() { runner.runOneTest("epochFillIn") }
-  @Test def test_epochFillIn2() { runner.runOneTest("epochFillIn2") }
-  @Test def test_epochFillIn3() { runner.runOneTest("epochFillIn3") }
+  @Test def test_timeSymbols(): Unit = { runner.runOneTest("timeSymbols") }
+  @Test def test_timeSymbols2(): Unit = { runner.runOneTest("timeSymbols2") }
+  @Test def test_epochFillIn(): Unit = { runner.runOneTest("epochFillIn") }
+  @Test def test_epochFillIn2(): Unit = { runner.runOneTest("epochFillIn2") }
+  @Test def test_epochFillIn3(): Unit = { runner.runOneTest("epochFillIn3") }
 
-  @Test def test_timeTrim01() { runner.runOneTest("timeTrim01") }
-  @Test def test_timeTrim02() { runner.runOneTest("timeTrim02") }
-  @Test def test_millisecondAccuracy() { runner.runOneTest("millisecondAccuracy") }
-  @Test def test_millisecondAccuracy2() { runner.runOneTest("millisecondAccuracy2") }
-  @Test def test_millisecondAccuracy3() { runner.runOneTest("millisecondAccuracy3") }
-  @Test def test_millisecondAccuracy4() { runner.runOneTest("millisecondAccuracy4") }
-  @Test def test_millisecondAccuracy5() { runner.runOneTest("millisecondAccuracy5") }
-  @Test def test_millisecondAccuracy6() { runner.runOneTest("millisecondAccuracy6") }
-  @Test def test_millisecondAccuracy7() { runner.runOneTest("millisecondAccuracy7") }
+  @Test def test_timeTrim01(): Unit = { runner.runOneTest("timeTrim01") }
+  @Test def test_timeTrim02(): Unit = { runner.runOneTest("timeTrim02") }
+  @Test def test_millisecondAccuracy(): Unit = { runner.runOneTest("millisecondAccuracy") }
+  @Test def test_millisecondAccuracy2(): Unit = { runner.runOneTest("millisecondAccuracy2") }
+  @Test def test_millisecondAccuracy3(): Unit = { runner.runOneTest("millisecondAccuracy3") }
+  @Test def test_millisecondAccuracy4(): Unit = { runner.runOneTest("millisecondAccuracy4") }
+  @Test def test_millisecondAccuracy5(): Unit = { runner.runOneTest("millisecondAccuracy5") }
+  @Test def test_millisecondAccuracy6(): Unit = { runner.runOneTest("millisecondAccuracy6") }
+  @Test def test_millisecondAccuracy7(): Unit = { runner.runOneTest("millisecondAccuracy7") }
 
-  @Test def test_timeFormatting() { runner.runOneTest("timeFormatting") }
-  @Test def test_timeFormatting2() { runner.runOneTest("timeFormatting2") }
-  @Test def test_timeFormatting2c() { runner.runOneTest("timeFormatting2c") }
-  @Test def test_timeFormatting2b() { runner.runOneTest("timeFormatting2b") }
-  @Test def test_timeFormatting3() { runner.runOneTest("timeFormatting3") }
-  @Test def test_timeFormatting4() { runner.runOneTest("timeFormatting4") }
-  @Test def test_timeFormatting6() { runner.runOneTest("timeFormatting6") }
-  @Test def test_timeFormatting7() { runner.runOneTest("timeFormatting7") }
+  @Test def test_timeFormatting(): Unit = { runner.runOneTest("timeFormatting") }
+  @Test def test_timeFormatting2(): Unit = { runner.runOneTest("timeFormatting2") }
+  @Test def test_timeFormatting2c(): Unit = { runner.runOneTest("timeFormatting2c") }
+  @Test def test_timeFormatting2b(): Unit = { runner.runOneTest("timeFormatting2b") }
+  @Test def test_timeFormatting3(): Unit = { runner.runOneTest("timeFormatting3") }
+  @Test def test_timeFormatting4(): Unit = { runner.runOneTest("timeFormatting4") }
+  @Test def test_timeFormatting6(): Unit = { runner.runOneTest("timeFormatting6") }
+  @Test def test_timeFormatting7(): Unit = { runner.runOneTest("timeFormatting7") }
 
-  @Test def test_timeCalendarTimeZone() { runner.runOneTest("timeCalendarTimeZone") }
-  @Test def test_timeCalendarTimeZone2() { runner.runOneTest("timeCalendarTimeZone2") }
-  @Test def test_timeCalendarTimeZone3() { runner.runOneTest("timeCalendarTimeZone3") }
+  @Test def test_timeCalendarTimeZone(): Unit = { runner.runOneTest("timeCalendarTimeZone") }
+  @Test def test_timeCalendarTimeZone2(): Unit = { runner.runOneTest("timeCalendarTimeZone2") }
+  @Test def test_timeCalendarTimeZone3(): Unit = { runner.runOneTest("timeCalendarTimeZone3") }
 
-  @Test def test_timeZoneFormats() { runner.runOneTest("timeZoneFormats") }
-  @Test def test_timeZoneFormats2() { runner.runOneTest("timeZoneFormats2") }
-  @Test def test_timeZoneFormats3() { runner.runOneTest("timeZoneFormats3") }
-  @Test def test_timeZoneFormats4() { runner.runOneTest("timeZoneFormats4") }
-  @Test def test_timeZoneFormats5() { runner.runOneTest("timeZoneFormats5") }
-  @Test def test_timeZoneFormats6() { runner.runOneTest("timeZoneFormats6") }
-  @Test def test_timeZoneFormats7() { runner.runOneTest("timeZoneFormats7") }
-  @Test def test_timeZoneFormats8() { runner.runOneTest("timeZoneFormats8") }
-  @Test def test_timeZoneFormats9() { runner.runOneTest("timeZoneFormats9") }
+  @Test def test_timeZoneFormats(): Unit = { runner.runOneTest("timeZoneFormats") }
+  @Test def test_timeZoneFormats2(): Unit = { runner.runOneTest("timeZoneFormats2") }
+  @Test def test_timeZoneFormats3(): Unit = { runner.runOneTest("timeZoneFormats3") }
+  @Test def test_timeZoneFormats4(): Unit = { runner.runOneTest("timeZoneFormats4") }
+  @Test def test_timeZoneFormats5(): Unit = { runner.runOneTest("timeZoneFormats5") }
+  @Test def test_timeZoneFormats6(): Unit = { runner.runOneTest("timeZoneFormats6") }
+  @Test def test_timeZoneFormats7(): Unit = { runner.runOneTest("timeZoneFormats7") }
+  @Test def test_timeZoneFormats8(): Unit = { runner.runOneTest("timeZoneFormats8") }
+  @Test def test_timeZoneFormats9(): Unit = { runner.runOneTest("timeZoneFormats9") }
 
-  @Test def test_dateCountDeterminesFormat() { runner.runOneTest("dateCountDeterminesFormat") }
-  @Test def test_dateNonAlphaChars01() { runner.runOneTest("dateNonAlphaChars01") }
-  @Test def test_dateTrim01() { runner.runOneTest("dateTrim01") }
-  @Test def test_dateTrim02() { runner.runOneTest("dateTrim02") }
-  @Test def test_dateTrim03() { runner.runOneTest("dateTrim03") }
+  @Test def test_dateCountDeterminesFormat(): Unit = { runner.runOneTest("dateCountDeterminesFormat") }
+  @Test def test_dateNonAlphaChars01(): Unit = { runner.runOneTest("dateNonAlphaChars01") }
+  @Test def test_dateTrim01(): Unit = { runner.runOneTest("dateTrim01") }
+  @Test def test_dateTrim02(): Unit = { runner.runOneTest("dateTrim02") }
+  @Test def test_dateTrim03(): Unit = { runner.runOneTest("dateTrim03") }
 
-  @Test def test_dateCalendarFirstDayOfWeek01() { runner.runOneTest("dateCalendarFirstDayOfWeek01") }
-  @Test def test_dateCalendarFirstDayOfWeek02() { runner.runOneTest("dateCalendarFirstDayOfWeek02") }
+  @Test def test_dateCalendarFirstDayOfWeek01(): Unit = { runner.runOneTest("dateCalendarFirstDayOfWeek01") }
+  @Test def test_dateCalendarFirstDayOfWeek02(): Unit = { runner.runOneTest("dateCalendarFirstDayOfWeek02") }
   //DAFFODIL-1945 @Test def test_dateCalendarFirstDayOfWeek03() { runner.runOneTest("dateCalendarFirstDayOfWeek03") }
   //DAFFODIL-1945 @Test def test_dateCalendarFirstDayOfWeek04() { runner.runOneTest("dateCalendarFirstDayOfWeek04") }
-  @Test def test_timeFractionalSeconds01() { runner.runOneTest("timeFractionalSeconds01") }
-  @Test def test_dateText() { runner.runOneTest("dateText") }
-  @Test def test_dateTextInvalid() { runner.runOneTest("dateTextInvalid") }
-  @Test def test_timeText() { runner.runOneTest("timeText") }
-  @Test def test_timeTextInvalid() { runner.runOneTest("timeTextInvalid") }
-  @Test def test_dateTimeText() { runner.runOneTest("dateTimeText") }
-  @Test def test_dateTimeTextInvalid() { runner.runOneTest("dateTimeTextInvalid") }
-  @Test def test_dateImplicitPattern() { runner.runOneTest("dateImplicitPattern") }
-  @Test def test_dateImplicitPatternFail() { runner.runOneTest("dateImplicitPatternFail") }
-  @Test def test_timeImplicitPattern() { runner.runOneTest("timeImplicitPattern") }
-  @Test def test_timeImplicitPatternFail() { runner.runOneTest("timeImplicitPatternFail") }
-  @Test def test_dateTimeBin() { runner.runOneTest("dateTimeBin") }
-  @Test def test_dateTimeBin2() { runner.runOneTest("dateTimeBin2") }
-  @Test def test_dateTimeBin3() { runner.runOneTest("dateTimeBin3") }
-  @Test def test_dateTimeBin4() { runner.runOneTest("dateTimeBin4") }
-  @Test def test_dateTimeBin5() { runner.runOneTest("dateTimeBin5") }
-  @Test def test_dateTimeBin6() { runner.runOneTest("dateTimeBin6") }
-  @Test def test_dateTimeBin7() { runner.runOneTest("dateTimeBin7") }
-  @Test def test_dateTimeBin8() { runner.runOneTest("dateTimeBin8") }
-  @Test def test_dateTimeBin9() { runner.runOneTest("dateTimeBin9") }
-  @Test def test_dateTimeBin10() { runner.runOneTest("dateTimeBin10") }
-  @Test def test_dateTimeBin11() { runner.runOneTest("dateTimeBin11") }
-  @Test def test_dateTimeBin12() { runner.runOneTest("dateTimeBin12") }
-  @Test def test_dateTimeBin13() { runner.runOneTest("dateTimeBin13") }
-  @Test def test_dateTimeBin14() { runner.runOneTest("dateTimeBin14") }
-  @Test def test_dateTimeBin15() { runner.runOneTest("dateTimeBin15") }
-  @Test def test_dateTimeBin16() { runner.runOneTest("dateTimeBin16") }
-  @Test def test_dateTimeBin17() { runner.runOneTest("dateTimeBin17") }
-  @Test def test_dateTimeBin18() { runner.runOneTest("dateTimeBin18") }
-  @Test def test_dateTimeBin19() { runner.runOneTest("dateTimeBin19") }
-  @Test def test_dateTimeBin20() { runner.runOneTest("dateTimeBin20") }
-  @Test def test_dateTimeBin21() { runner.runOneTest("dateTimeBin21") }
-  @Test def test_dateTimeBin22() { runner.runOneTest("dateTimeBin22") }
-  @Test def test_dateBinBCD() { runner.runOneTest("dateBinBCD") }
-  @Test def test_dateBinBCD2() { runner.runOneTest("dateBinBCD2") }
-  @Test def test_dateBinBCD3() { runner.runOneTest("dateBinBCD3") }
-  @Test def test_dateBinBCD4() { runner.runOneTest("dateBinBCD4") }
-  @Test def test_dateBinBCD5() { runner.runOneTest("dateBinBCD5") }
-  @Test def test_dateBinBCD6() { runner.runOneTest("dateBinBCD6") }
-  @Test def test_dateBinBCD7() { runner.runOneTest("dateBinBCD7") }
-  @Test def test_dateBinBCD8() { runner.runOneTest("dateBinBCD8") }
-  @Test def test_dateBinBCD9() { runner.runOneTest("dateBinBCD9") }
-  @Test def test_timeBinBCD() { runner.runOneTest("timeBinBCD") }
-  @Test def test_timeBinBCD2() { runner.runOneTest("timeBinBCD2") }
-  @Test def test_timeBinBCD3() { runner.runOneTest("timeBinBCD3") }
-  @Test def test_timeBinBCD4() { runner.runOneTest("timeBinBCD4") }
-  @Test def test_timeBinBCD5() { runner.runOneTest("timeBinBCD5") }
-  @Test def test_timeBinBCD6() { runner.runOneTest("timeBinBCD6") }
-  @Test def test_dateTimeBinBCD() { runner.runOneTest("dateTimeBinBCD") }
-  @Test def test_dateTimeBinBCD2() { runner.runOneTest("dateTimeBinBCD2") }
-  @Test def test_dateTimeBinBCD3() { runner.runOneTest("dateTimeBinBCD3") }
-  @Test def test_dateTimeBinBCD4() { runner.runOneTest("dateTimeBinBCD4") }
+  @Test def test_timeFractionalSeconds01(): Unit = { runner.runOneTest("timeFractionalSeconds01") }
+  @Test def test_dateText(): Unit = { runner.runOneTest("dateText") }
+  @Test def test_dateTextInvalid(): Unit = { runner.runOneTest("dateTextInvalid") }
+  @Test def test_timeText(): Unit = { runner.runOneTest("timeText") }
+  @Test def test_timeTextInvalid(): Unit = { runner.runOneTest("timeTextInvalid") }
+  @Test def test_dateTimeText(): Unit = { runner.runOneTest("dateTimeText") }
+  @Test def test_dateTimeTextInvalid(): Unit = { runner.runOneTest("dateTimeTextInvalid") }
+  @Test def test_dateImplicitPattern(): Unit = { runner.runOneTest("dateImplicitPattern") }
+  @Test def test_dateImplicitPatternFail(): Unit = { runner.runOneTest("dateImplicitPatternFail") }
+  @Test def test_timeImplicitPattern(): Unit = { runner.runOneTest("timeImplicitPattern") }
+  @Test def test_timeImplicitPatternFail(): Unit = { runner.runOneTest("timeImplicitPatternFail") }
+  @Test def test_dateTimeBin(): Unit = { runner.runOneTest("dateTimeBin") }
+  @Test def test_dateTimeBin2(): Unit = { runner.runOneTest("dateTimeBin2") }
+  @Test def test_dateTimeBin3(): Unit = { runner.runOneTest("dateTimeBin3") }
+  @Test def test_dateTimeBin4(): Unit = { runner.runOneTest("dateTimeBin4") }
+  @Test def test_dateTimeBin5(): Unit = { runner.runOneTest("dateTimeBin5") }
+  @Test def test_dateTimeBin6(): Unit = { runner.runOneTest("dateTimeBin6") }
+  @Test def test_dateTimeBin7(): Unit = { runner.runOneTest("dateTimeBin7") }
+  @Test def test_dateTimeBin8(): Unit = { runner.runOneTest("dateTimeBin8") }
+  @Test def test_dateTimeBin9(): Unit = { runner.runOneTest("dateTimeBin9") }
+  @Test def test_dateTimeBin10(): Unit = { runner.runOneTest("dateTimeBin10") }
+  @Test def test_dateTimeBin11(): Unit = { runner.runOneTest("dateTimeBin11") }
+  @Test def test_dateTimeBin12(): Unit = { runner.runOneTest("dateTimeBin12") }
+  @Test def test_dateTimeBin13(): Unit = { runner.runOneTest("dateTimeBin13") }
+  @Test def test_dateTimeBin14(): Unit = { runner.runOneTest("dateTimeBin14") }
+  @Test def test_dateTimeBin15(): Unit = { runner.runOneTest("dateTimeBin15") }
+  @Test def test_dateTimeBin16(): Unit = { runner.runOneTest("dateTimeBin16") }
+  @Test def test_dateTimeBin17(): Unit = { runner.runOneTest("dateTimeBin17") }
+  @Test def test_dateTimeBin18(): Unit = { runner.runOneTest("dateTimeBin18") }
+  @Test def test_dateTimeBin19(): Unit = { runner.runOneTest("dateTimeBin19") }
+  @Test def test_dateTimeBin20(): Unit = { runner.runOneTest("dateTimeBin20") }
+  @Test def test_dateTimeBin21(): Unit = { runner.runOneTest("dateTimeBin21") }
+  @Test def test_dateTimeBin22(): Unit = { runner.runOneTest("dateTimeBin22") }
+  @Test def test_dateBinBCD(): Unit = { runner.runOneTest("dateBinBCD") }
+  @Test def test_dateBinBCD2(): Unit = { runner.runOneTest("dateBinBCD2") }
+  @Test def test_dateBinBCD3(): Unit = { runner.runOneTest("dateBinBCD3") }
+  @Test def test_dateBinBCD4(): Unit = { runner.runOneTest("dateBinBCD4") }
+  @Test def test_dateBinBCD5(): Unit = { runner.runOneTest("dateBinBCD5") }
+  @Test def test_dateBinBCD6(): Unit = { runner.runOneTest("dateBinBCD6") }
+  @Test def test_dateBinBCD7(): Unit = { runner.runOneTest("dateBinBCD7") }
+  @Test def test_dateBinBCD8(): Unit = { runner.runOneTest("dateBinBCD8") }
+  @Test def test_dateBinBCD9(): Unit = { runner.runOneTest("dateBinBCD9") }
+  @Test def test_timeBinBCD(): Unit = { runner.runOneTest("timeBinBCD") }
+  @Test def test_timeBinBCD2(): Unit = { runner.runOneTest("timeBinBCD2") }
+  @Test def test_timeBinBCD3(): Unit = { runner.runOneTest("timeBinBCD3") }
+  @Test def test_timeBinBCD4(): Unit = { runner.runOneTest("timeBinBCD4") }
+  @Test def test_timeBinBCD5(): Unit = { runner.runOneTest("timeBinBCD5") }
+  @Test def test_timeBinBCD6(): Unit = { runner.runOneTest("timeBinBCD6") }
+  @Test def test_dateTimeBinBCD(): Unit = { runner.runOneTest("dateTimeBinBCD") }
+  @Test def test_dateTimeBinBCD2(): Unit = { runner.runOneTest("dateTimeBinBCD2") }
+  @Test def test_dateTimeBinBCD3(): Unit = { runner.runOneTest("dateTimeBinBCD3") }
+  @Test def test_dateTimeBinBCD4(): Unit = { runner.runOneTest("dateTimeBinBCD4") }
 
-  @Test def test_dateBinIBM4690Packed() { runner.runOneTest("dateBinIBM4690Packed") }
-  @Test def test_dateBinIBM4690Packed2() { runner.runOneTest("dateBinIBM4690Packed2") }
-  @Test def test_dateBinIBM4690Packed3() { runner.runOneTest("dateBinIBM4690Packed3") }
-  @Test def test_dateTimeBinIBM4690Packed() { runner.runOneTest("dateTimeBinIBM4690Packed") }
-  @Test def test_dateTimeBinIBM4690Packed2() { runner.runOneTest("dateTimeBinIBM4690Packed2") }
-  @Test def test_dateTimeBinIBM4690Packed3() { runner.runOneTest("dateTimeBinIBM4690Packed3") }
-  @Test def test_timeBinIBM4690Packed() { runner.runOneTest("timeBinIBM4690Packed") }
-  @Test def test_timeBinIBM4690Packed2() { runner.runOneTest("timeBinIBM4690Packed2") }
+  @Test def test_dateBinIBM4690Packed(): Unit = { runner.runOneTest("dateBinIBM4690Packed") }
+  @Test def test_dateBinIBM4690Packed2(): Unit = { runner.runOneTest("dateBinIBM4690Packed2") }
+  @Test def test_dateBinIBM4690Packed3(): Unit = { runner.runOneTest("dateBinIBM4690Packed3") }
+  @Test def test_dateTimeBinIBM4690Packed(): Unit = { runner.runOneTest("dateTimeBinIBM4690Packed") }
+  @Test def test_dateTimeBinIBM4690Packed2(): Unit = { runner.runOneTest("dateTimeBinIBM4690Packed2") }
+  @Test def test_dateTimeBinIBM4690Packed3(): Unit = { runner.runOneTest("dateTimeBinIBM4690Packed3") }
+  @Test def test_timeBinIBM4690Packed(): Unit = { runner.runOneTest("timeBinIBM4690Packed") }
+  @Test def test_timeBinIBM4690Packed2(): Unit = { runner.runOneTest("timeBinIBM4690Packed2") }
 
-  @Test def test_dateBinPacked() { runner.runOneTest("dateBinPacked") }
-  @Test def test_dateBinPacked2() { runner.runOneTest("dateBinPacked2") }
-  @Test def test_dateBinPacked4() { runner.runOneTest("dateBinPacked4") }
-  @Test def test_timeBinPacked() { runner.runOneTest("timeBinPacked") }
-  @Test def test_timeBinPacked2() { runner.runOneTest("timeBinPacked2") }
-  @Test def test_dateTimeBinPacked() { runner.runOneTest("dateTimeBinPacked") }
-  @Test def test_dateTimeBinPacked2() { runner.runOneTest("dateTimeBinPacked2") }
-  @Test def test_dateTimeBinPacked3() { runner.runOneTest("dateTimeBinPacked3") }
+  @Test def test_dateBinPacked(): Unit = { runner.runOneTest("dateBinPacked") }
+  @Test def test_dateBinPacked2(): Unit = { runner.runOneTest("dateBinPacked2") }
+  @Test def test_dateBinPacked4(): Unit = { runner.runOneTest("dateBinPacked4") }
+  @Test def test_timeBinPacked(): Unit = { runner.runOneTest("timeBinPacked") }
+  @Test def test_timeBinPacked2(): Unit = { runner.runOneTest("timeBinPacked2") }
+  @Test def test_dateTimeBinPacked(): Unit = { runner.runOneTest("dateTimeBinPacked") }
+  @Test def test_dateTimeBinPacked2(): Unit = { runner.runOneTest("dateTimeBinPacked2") }
+  @Test def test_dateTimeBinPacked3(): Unit = { runner.runOneTest("dateTimeBinPacked3") }
 
-  @Test def test_dateBinInvalid() { runner.runOneTest("dateBinInvalid") }
+  @Test def test_dateBinInvalid(): Unit = { runner.runOneTest("dateBinInvalid") }
 
-  @Test def test_dateTimeImplicitPattern() { runner.runOneTest("dateTimeImplicitPattern") }
-  @Test def test_dateTimeImplicitPatternFail() { runner.runOneTest("dateTimeImplicitPatternFail") }
-  @Test def test_dateTimeImplicitPatternFail2() { runner.runOneTest("dateTimeImplicitPatternFail2") }
-  @Test def test_dateTimeImplicitPatternFail3() { runner.runOneTest("dateTimeImplicitPatternFail3") }
-  @Test def test_dateTimeImplicitPatternFail4() { runner.runOneTest("dateTimeImplicitPatternFail4") }
-  @Test def test_dateTimeImplicitPatternFail5() { runner.runOneTest("dateTimeImplicitPatternFail5") }
-  @Test def test_dateTimeImplicitPatternFail6() { runner.runOneTest("dateTimeImplicitPatternFail6") }
+  @Test def test_dateTimeImplicitPattern(): Unit = { runner.runOneTest("dateTimeImplicitPattern") }
+  @Test def test_dateTimeImplicitPatternFail(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail") }
+  @Test def test_dateTimeImplicitPatternFail2(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail2") }
+  @Test def test_dateTimeImplicitPatternFail3(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail3") }
+  @Test def test_dateTimeImplicitPatternFail4(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail4") }
+  @Test def test_dateTimeImplicitPatternFail5(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail5") }
+  @Test def test_dateTimeImplicitPatternFail6(): Unit = { runner.runOneTest("dateTimeImplicitPatternFail6") }
 
-  @Test def test_datePattern01() { runner.runOneTest("datePattern01") }
+  @Test def test_datePattern01(): Unit = { runner.runOneTest("datePattern01") }
   // DAFFODIL-488
   // @Test def test_datePattern01b() { runner.runOneTest("datePattern01b") }
-  @Test def test_timeLaxCheckPolicy01() { runner.runOneTest("timeLaxCheckPolicy01") }
-  @Test def test_timeLaxCheckPolicy02() { runner.runOneTest("timeLaxCheckPolicy02") }
-  @Test def test_timeLaxCheckPolicy03() { runner.runOneTest("timeLaxCheckPolicy03") }
-  @Test def test_dateTimeLaxCheckPolicy01() { runner.runOneTest("dateTimeLaxCheckPolicy01") }
-  @Test def test_dateLaxCheckPolicy01() { runner.runOneTest("dateLaxCheckPolicy01") }
-  @Test def test_dateLaxCheckPolicy02() { runner.runOneTest("dateLaxCheckPolicy02") }
-  @Test def test_dateLaxCheckPolicy03() { runner.runOneTest("dateLaxCheckPolicy03") }
-  @Test def test_dateLaxCheckPolicy04() { runner.runOneTest("dateLaxCheckPolicy04") }
-  @Test def test_dateLaxCheckPolicy05() { runner.runOneTest("dateLaxCheckPolicy05") }
+  @Test def test_timeLaxCheckPolicy01(): Unit = { runner.runOneTest("timeLaxCheckPolicy01") }
+  @Test def test_timeLaxCheckPolicy02(): Unit = { runner.runOneTest("timeLaxCheckPolicy02") }
+  @Test def test_timeLaxCheckPolicy03(): Unit = { runner.runOneTest("timeLaxCheckPolicy03") }
+  @Test def test_dateTimeLaxCheckPolicy01(): Unit = { runner.runOneTest("dateTimeLaxCheckPolicy01") }
+  @Test def test_dateLaxCheckPolicy01(): Unit = { runner.runOneTest("dateLaxCheckPolicy01") }
+  @Test def test_dateLaxCheckPolicy02(): Unit = { runner.runOneTest("dateLaxCheckPolicy02") }
+  @Test def test_dateLaxCheckPolicy03(): Unit = { runner.runOneTest("dateLaxCheckPolicy03") }
+  @Test def test_dateLaxCheckPolicy04(): Unit = { runner.runOneTest("dateLaxCheckPolicy04") }
+  @Test def test_dateLaxCheckPolicy05(): Unit = { runner.runOneTest("dateLaxCheckPolicy05") }
 
   // DFDL-1042 - not very strict
   // @Test def test_dateStrictCheckPolicy01() { runner.runOneTest("dateStrictCheckPolicy01") }
@@ -269,41 +269,41 @@ class TestSimpleTypes {
   // @Test def test_timeStrictCheckPolicy02() { runner.runOneTest("timeStrictCheckPolicy02") }
   // @Test def test_timeFormatting5() { runner.runOneTest("timeFormatting5") }
 
-  @Test def test_Long1() { runner.runOneTest("Long1") }
-  @Test def test_BigInteger1() { runner.runOneTest("BigInteger1") }
-  @Test def test_Integer01() { runner.runOneTest("Integer01") }
-  @Test def test_integer2() { runner.runOneTest("integer2") }
-  @Test def test_integer_fail() { runner.runOneTest("integer_fail") }
-  @Test def test_integer_fail2() { runner.runOneTest("integer_fail2") }
+  @Test def test_Long1(): Unit = { runner.runOneTest("Long1") }
+  @Test def test_BigInteger1(): Unit = { runner.runOneTest("BigInteger1") }
+  @Test def test_Integer01(): Unit = { runner.runOneTest("Integer01") }
+  @Test def test_integer2(): Unit = { runner.runOneTest("integer2") }
+  @Test def test_integer_fail(): Unit = { runner.runOneTest("integer_fail") }
+  @Test def test_integer_fail2(): Unit = { runner.runOneTest("integer_fail2") }
 
-  @Test def test_Int01() { runner.runOneTest("Int01") }
-  @Test def test_int_error() { runner.runOneTest("int_error") }
+  @Test def test_Int01(): Unit = { runner.runOneTest("Int01") }
+  @Test def test_int_error(): Unit = { runner.runOneTest("int_error") }
 
   // Test warning_exercise moved to scala-debug until warnings are implemented.
 
-  @Test def test_UnsignedNumbers1() { runner.runOneTest("UnsignedNumbers1") }
-  @Test def test_unsignedLong_01() { runner.runOneTest("unsignedLong_01") }
-  @Test def test_unsignedLong_02() { runner.runOneTest("unsignedLong_02") }
-  @Test def test_unsignedLong_03() { runner.runOneTest("unsignedLong_03") }
-  @Test def test_Long2() { runner.runOneTest("Long2") }
-  @Test def test_Long3() { runner.runOneTest("Long3") }
-  @Test def test_Long4() { runner.runOneTest("Long4") }
-  @Test def test_int_error_02() { runner.runOneTest("int_error_02") }
-  @Test def test_int_error_03() { runner.runOneTest("int_error_03") }
-  @Test def test_short_01() { runner.runOneTest("short_01") }
-  @Test def test_short_02() { runner.runOneTest("short_02") }
-  @Test def test_unsignedInt_01() { runner.runOneTest("unsignedInt_01") }
-  @Test def test_unsignedInt_02() { runner.runOneTest("unsignedInt_02") }
+  @Test def test_UnsignedNumbers1(): Unit = { runner.runOneTest("UnsignedNumbers1") }
+  @Test def test_unsignedLong_01(): Unit = { runner.runOneTest("unsignedLong_01") }
+  @Test def test_unsignedLong_02(): Unit = { runner.runOneTest("unsignedLong_02") }
+  @Test def test_unsignedLong_03(): Unit = { runner.runOneTest("unsignedLong_03") }
+  @Test def test_Long2(): Unit = { runner.runOneTest("Long2") }
+  @Test def test_Long3(): Unit = { runner.runOneTest("Long3") }
+  @Test def test_Long4(): Unit = { runner.runOneTest("Long4") }
+  @Test def test_int_error_02(): Unit = { runner.runOneTest("int_error_02") }
+  @Test def test_int_error_03(): Unit = { runner.runOneTest("int_error_03") }
+  @Test def test_short_01(): Unit = { runner.runOneTest("short_01") }
+  @Test def test_short_02(): Unit = { runner.runOneTest("short_02") }
+  @Test def test_unsignedInt_01(): Unit = { runner.runOneTest("unsignedInt_01") }
+  @Test def test_unsignedInt_02(): Unit = { runner.runOneTest("unsignedInt_02") }
 
-  @Test def test_whiteSpaceBeforeValidInt() { runner.runOneTest("whiteSpaceBeforeValidInt") }
-  @Test def test_whiteSpaceBeforeValidInteger() { runner.runOneTest("whiteSpaceBeforeValidInteger") }
-  @Test def test_whiteSpaceBeforeValidLong() { runner.runOneTest("whiteSpaceBeforeValidLong") }
-  @Test def test_whiteSpaceBeforeValidShort() { runner.runOneTest("whiteSpaceBeforeValidShort") }
-  @Test def test_whiteSpaceBeforeValidByte() { runner.runOneTest("whiteSpaceBeforeValidByte") }
-  @Test def test_whiteSpaceBeforeValidUnsignedInt() { runner.runOneTest("whiteSpaceBeforeValidUnsignedInt") }
-  @Test def test_whiteSpaceBeforeValidUnsignedByte() { runner.runOneTest("whiteSpaceBeforeValidUnsignedByte") }
-  @Test def test_whiteSpaceBeforeValidUnsignedLong() { runner.runOneTest("whiteSpaceBeforeValidUnsignedLong") }
-  @Test def test_whiteSpaceBeforeValidUnsignedShort() { runner.runOneTest("whiteSpaceBeforeValidUnsignedShort") }
+  @Test def test_whiteSpaceBeforeValidInt(): Unit = { runner.runOneTest("whiteSpaceBeforeValidInt") }
+  @Test def test_whiteSpaceBeforeValidInteger(): Unit = { runner.runOneTest("whiteSpaceBeforeValidInteger") }
+  @Test def test_whiteSpaceBeforeValidLong(): Unit = { runner.runOneTest("whiteSpaceBeforeValidLong") }
+  @Test def test_whiteSpaceBeforeValidShort(): Unit = { runner.runOneTest("whiteSpaceBeforeValidShort") }
+  @Test def test_whiteSpaceBeforeValidByte(): Unit = { runner.runOneTest("whiteSpaceBeforeValidByte") }
+  @Test def test_whiteSpaceBeforeValidUnsignedInt(): Unit = { runner.runOneTest("whiteSpaceBeforeValidUnsignedInt") }
+  @Test def test_whiteSpaceBeforeValidUnsignedByte(): Unit = { runner.runOneTest("whiteSpaceBeforeValidUnsignedByte") }
+  @Test def test_whiteSpaceBeforeValidUnsignedLong(): Unit = { runner.runOneTest("whiteSpaceBeforeValidUnsignedLong") }
+  @Test def test_whiteSpaceBeforeValidUnsignedShort(): Unit = { runner.runOneTest("whiteSpaceBeforeValidUnsignedShort") }
 
   //DFDL-845
   //@Test def test_whiteSpaceDuringValidShort() { runner.runOneTest("whiteSpaceDuringValidShort") }
@@ -316,224 +316,224 @@ class TestSimpleTypes {
   //@Test def test_whiteSpaceDuringValidLong() { runner.runOneTest("whiteSpaceDuringValidLong") }
   //@Test def test_whiteSpaceDuringValidByte() { runner.runOneTest("whiteSpaceDuringValidByte") }
 
-  @Test def test_whiteSpaceAfterValidInt() { runner.runOneTest("whiteSpaceAfterValidInt") }
-  @Test def test_whiteSpaceAfterValidLong() { runner.runOneTest("whiteSpaceAfterValidLong") }
-  @Test def test_whiteSpaceAfterValidShort() { runner.runOneTest("whiteSpaceAfterValidShort") }
-  @Test def test_whiteSpaceAfterValidUnsignedInt() { runner.runOneTest("whiteSpaceAfterValidUnsignedInt") }
-  @Test def test_whiteSpaceAfterValidUnsignedShort() { runner.runOneTest("whiteSpaceAfterValidUnsignedShort") }
-  @Test def test_whiteSpaceAfterValidUnsignedByte() { runner.runOneTest("whiteSpaceAfterValidUnsignedByte") }
-  @Test def test_whiteSpaceAfterValidByte() { runner.runOneTest("whiteSpaceAfterValidByte") }
-  @Test def test_whiteSpaceAfterValidUnsignedLong() { runner.runOneTest("whiteSpaceAfterValidUnsignedLong") }
-  @Test def test_whiteSpaceAfterValidInteger() { runner.runOneTest("whiteSpaceAfterValidInteger") }
+  @Test def test_whiteSpaceAfterValidInt(): Unit = { runner.runOneTest("whiteSpaceAfterValidInt") }
+  @Test def test_whiteSpaceAfterValidLong(): Unit = { runner.runOneTest("whiteSpaceAfterValidLong") }
+  @Test def test_whiteSpaceAfterValidShort(): Unit = { runner.runOneTest("whiteSpaceAfterValidShort") }
+  @Test def test_whiteSpaceAfterValidUnsignedInt(): Unit = { runner.runOneTest("whiteSpaceAfterValidUnsignedInt") }
+  @Test def test_whiteSpaceAfterValidUnsignedShort(): Unit = { runner.runOneTest("whiteSpaceAfterValidUnsignedShort") }
+  @Test def test_whiteSpaceAfterValidUnsignedByte(): Unit = { runner.runOneTest("whiteSpaceAfterValidUnsignedByte") }
+  @Test def test_whiteSpaceAfterValidByte(): Unit = { runner.runOneTest("whiteSpaceAfterValidByte") }
+  @Test def test_whiteSpaceAfterValidUnsignedLong(): Unit = { runner.runOneTest("whiteSpaceAfterValidUnsignedLong") }
+  @Test def test_whiteSpaceAfterValidInteger(): Unit = { runner.runOneTest("whiteSpaceAfterValidInteger") }
 
-  @Test def test_characterDuringValidInt() { runner.runOneTest("characterDuringValidInt") }
-  @Test def test_int_unparseError() { runner.runOneTest("int_unparseError") }
-  @Test def test_whiteSpaceAfterLengthExceededInt() { runner.runOneTest("whiteSpaceAfterLengthExceededInt") }
-  @Test def test_whiteSpaceBeforeLengthExceededInt() { runner.runOneTest("whiteSpaceBeforeLengthExceededInt") }
-  @Test def test_whiteSpaceDuringLengthExceededInt() { runner.runOneTest("whiteSpaceDuringLengthExceededInt") }
-  @Test def test_characterDuringValidInteger() { runner.runOneTest("characterDuringValidInteger") }
-  @Test def test_integer_unparseError() { runner.runOneTest("integer_unparseError") }
-  @Test def test_whiteSpaceAfterLengthExceededInteger() { runner.runOneTest("whiteSpaceAfterLengthExceededInteger") }
-  @Test def test_whiteSpaceBeforeLengthExceededInteger() { runner.runOneTest("whiteSpaceBeforeLengthExceededInteger") }
-  @Test def test_whiteSpaceDuringLengthExceededInteger() { runner.runOneTest("whiteSpaceDuringLengthExceededInteger") }
-  @Test def test_characterDuringValidLong() { runner.runOneTest("characterDuringValidLong") }
-  @Test def test_long_unparseError() { runner.runOneTest("long_unparseError") }
-  @Test def test_whiteSpaceAfterLengthExceededLong() { runner.runOneTest("whiteSpaceAfterLengthExceededLong") }
-  @Test def test_whiteSpaceBeforeLengthExceededLong() { runner.runOneTest("whiteSpaceBeforeLengthExceededLong") }
-  @Test def test_whiteSpaceDuringLengthExceededLong() { runner.runOneTest("whiteSpaceDuringLengthExceededLong") }
+  @Test def test_characterDuringValidInt(): Unit = { runner.runOneTest("characterDuringValidInt") }
+  @Test def test_int_unparseError(): Unit = { runner.runOneTest("int_unparseError") }
+  @Test def test_whiteSpaceAfterLengthExceededInt(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededInt") }
+  @Test def test_whiteSpaceBeforeLengthExceededInt(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededInt") }
+  @Test def test_whiteSpaceDuringLengthExceededInt(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededInt") }
+  @Test def test_characterDuringValidInteger(): Unit = { runner.runOneTest("characterDuringValidInteger") }
+  @Test def test_integer_unparseError(): Unit = { runner.runOneTest("integer_unparseError") }
+  @Test def test_whiteSpaceAfterLengthExceededInteger(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededInteger") }
+  @Test def test_whiteSpaceBeforeLengthExceededInteger(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededInteger") }
+  @Test def test_whiteSpaceDuringLengthExceededInteger(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededInteger") }
+  @Test def test_characterDuringValidLong(): Unit = { runner.runOneTest("characterDuringValidLong") }
+  @Test def test_long_unparseError(): Unit = { runner.runOneTest("long_unparseError") }
+  @Test def test_whiteSpaceAfterLengthExceededLong(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededLong") }
+  @Test def test_whiteSpaceBeforeLengthExceededLong(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededLong") }
+  @Test def test_whiteSpaceDuringLengthExceededLong(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededLong") }
 
-  @Test def test_characterDuringValidShort() { runner.runOneTest("characterDuringValidShort") }
-  @Test def test_short_unparseError() { runner.runOneTest("short_unparseError") }
-  @Test def test_whiteSpaceAfterLengthExceededShort() { runner.runOneTest("whiteSpaceAfterLengthExceededShort") }
-  @Test def test_whiteSpaceBeforeLengthExceededShort() { runner.runOneTest("whiteSpaceBeforeLengthExceededShort") }
-  @Test def test_whiteSpaceDuringLengthExceededShort() { runner.runOneTest("whiteSpaceDuringLengthExceededShort") }
-  @Test def test_characterDuringValidByte() { runner.runOneTest("characterDuringValidByte") }
-  @Test def test_byte_unparseError() { runner.runOneTest("byte_unparseError") }
-  @Test def test_whiteSpaceAfterLengthExceededByte() { runner.runOneTest("whiteSpaceAfterLengthExceededByte") }
-  @Test def test_whiteSpaceBeforeLengthExceededByte() { runner.runOneTest("whiteSpaceBeforeLengthExceededByte") }
-  @Test def test_whiteSpaceDuringLengthExceededByte() { runner.runOneTest("whiteSpaceDuringLengthExceededByte") }
-  @Test def test_characterDuringValidUnsignedInt() { runner.runOneTest("characterDuringValidUnsignedInt") }
-  @Test def test_negativeUnsignedInt() { runner.runOneTest("negativeUnsignedInt") }
-  @Test def test_whiteSpaceAfterLengthExceededUnsignedInt() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedInt") }
-  @Test def test_whiteSpaceBeforeLengthExceededUnsignedInt() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedInt") }
-  @Test def test_whiteSpaceDuringLengthExceededUnsignedInt() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedInt") }
-  @Test def test_characterDuringValidUnsignedByte() { runner.runOneTest("characterDuringValidUnsignedByte") }
-  @Test def test_unsignedByte_unparseError() { runner.runOneTest("unsignedByte_unparseError") }
-  @Test def test_negativeUnsignedByte() { runner.runOneTest("negativeUnsignedByte") }
-  @Test def test_whiteSpaceAfterLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedByte") }
-  @Test def test_whiteSpaceBeforeLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedByte") }
-  @Test def test_whiteSpaceDuringLengthExceededUnsignedByte() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedByte") }
-  @Test def test_characterDuringValidUnsignedLong() { runner.runOneTest("characterDuringValidUnsignedLong") }
-  @Test def test_unsignedLong_unparseError() { runner.runOneTest("unsignedLong_unparseError") }
-  @Test def test_negativeUnsignedLong() { runner.runOneTest("negativeUnsignedLong") }
-  @Test def test_whiteSpaceAfterLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedLong") }
-  @Test def test_whiteSpaceBeforeLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedLong") }
-  @Test def test_whiteSpaceDuringLengthExceededUnsignedLong() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedLong") }
+  @Test def test_characterDuringValidShort(): Unit = { runner.runOneTest("characterDuringValidShort") }
+  @Test def test_short_unparseError(): Unit = { runner.runOneTest("short_unparseError") }
+  @Test def test_whiteSpaceAfterLengthExceededShort(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededShort") }
+  @Test def test_whiteSpaceBeforeLengthExceededShort(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededShort") }
+  @Test def test_whiteSpaceDuringLengthExceededShort(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededShort") }
+  @Test def test_characterDuringValidByte(): Unit = { runner.runOneTest("characterDuringValidByte") }
+  @Test def test_byte_unparseError(): Unit = { runner.runOneTest("byte_unparseError") }
+  @Test def test_whiteSpaceAfterLengthExceededByte(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededByte") }
+  @Test def test_whiteSpaceBeforeLengthExceededByte(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededByte") }
+  @Test def test_whiteSpaceDuringLengthExceededByte(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededByte") }
+  @Test def test_characterDuringValidUnsignedInt(): Unit = { runner.runOneTest("characterDuringValidUnsignedInt") }
+  @Test def test_negativeUnsignedInt(): Unit = { runner.runOneTest("negativeUnsignedInt") }
+  @Test def test_whiteSpaceAfterLengthExceededUnsignedInt(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedInt") }
+  @Test def test_whiteSpaceBeforeLengthExceededUnsignedInt(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedInt") }
+  @Test def test_whiteSpaceDuringLengthExceededUnsignedInt(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedInt") }
+  @Test def test_characterDuringValidUnsignedByte(): Unit = { runner.runOneTest("characterDuringValidUnsignedByte") }
+  @Test def test_unsignedByte_unparseError(): Unit = { runner.runOneTest("unsignedByte_unparseError") }
+  @Test def test_negativeUnsignedByte(): Unit = { runner.runOneTest("negativeUnsignedByte") }
+  @Test def test_whiteSpaceAfterLengthExceededUnsignedByte(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedByte") }
+  @Test def test_whiteSpaceBeforeLengthExceededUnsignedByte(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedByte") }
+  @Test def test_whiteSpaceDuringLengthExceededUnsignedByte(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedByte") }
+  @Test def test_characterDuringValidUnsignedLong(): Unit = { runner.runOneTest("characterDuringValidUnsignedLong") }
+  @Test def test_unsignedLong_unparseError(): Unit = { runner.runOneTest("unsignedLong_unparseError") }
+  @Test def test_negativeUnsignedLong(): Unit = { runner.runOneTest("negativeUnsignedLong") }
+  @Test def test_whiteSpaceAfterLengthExceededUnsignedLong(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedLong") }
+  @Test def test_whiteSpaceBeforeLengthExceededUnsignedLong(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedLong") }
+  @Test def test_whiteSpaceDuringLengthExceededUnsignedLong(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedLong") }
 
-  @Test def test_characterDuringValidUnsignedShort() { runner.runOneTest("characterDuringValidUnsignedShort") }
-  @Test def test_unsignedShort_unparseError() { runner.runOneTest("unsignedShort_unparseError") }
-  @Test def test_negativeUnsignedShort() { runner.runOneTest("negativeUnsignedShort") }
-  @Test def test_whiteSpaceAfterLengthExceededUnsignedShort() { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedShort") }
-  @Test def test_whiteSpaceBeforeLengthExceededUnsignedShort() { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedShort") }
-  @Test def test_whiteSpaceDuringLengthExceededUnsignedShort() { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedShort") }
+  @Test def test_characterDuringValidUnsignedShort(): Unit = { runner.runOneTest("characterDuringValidUnsignedShort") }
+  @Test def test_unsignedShort_unparseError(): Unit = { runner.runOneTest("unsignedShort_unparseError") }
+  @Test def test_negativeUnsignedShort(): Unit = { runner.runOneTest("negativeUnsignedShort") }
+  @Test def test_whiteSpaceAfterLengthExceededUnsignedShort(): Unit = { runner.runOneTest("whiteSpaceAfterLengthExceededUnsignedShort") }
+  @Test def test_whiteSpaceBeforeLengthExceededUnsignedShort(): Unit = { runner.runOneTest("whiteSpaceBeforeLengthExceededUnsignedShort") }
+  @Test def test_whiteSpaceDuringLengthExceededUnsignedShort(): Unit = { runner.runOneTest("whiteSpaceDuringLengthExceededUnsignedShort") }
 
-  @Test def test_unsignedShort_01() { runner.runOneTest("unsignedShort_01") }
-  @Test def test_unsignedByte_01() { runner.runOneTest("unsignedByte_01") }
-  @Test def test_unsignedByte_02() { runner.runOneTest("unsignedByte_02") }
+  @Test def test_unsignedShort_01(): Unit = { runner.runOneTest("unsignedShort_01") }
+  @Test def test_unsignedByte_01(): Unit = { runner.runOneTest("unsignedByte_01") }
+  @Test def test_unsignedByte_02(): Unit = { runner.runOneTest("unsignedByte_02") }
 
   // Test range checking for signed integers too!
-  @Test def test_byte_01() { runner.runOneTest("byte_01") }
-  @Test def test_byte_02() { runner.runOneTest("byte_02") }
+  @Test def test_byte_01(): Unit = { runner.runOneTest("byte_01") }
+  @Test def test_byte_02(): Unit = { runner.runOneTest("byte_02") }
 
-  @Test def test_signedShort_binary() { runner.runOneTest("signedShort_binary") }
-  @Test def test_signedShort_binary2() { runner.runOneTest("signedShort_binary2") }
+  @Test def test_signedShort_binary(): Unit = { runner.runOneTest("signedShort_binary") }
+  @Test def test_signedShort_binary2(): Unit = { runner.runOneTest("signedShort_binary2") }
 
-  @Test def test_unsignedShort_binary() { runner.runOneTest("unsignedShort_binary") }
-  @Test def test_unsignedShort_binary2() { runner.runOneTest("unsignedShort_binary2") }
+  @Test def test_unsignedShort_binary(): Unit = { runner.runOneTest("unsignedShort_binary") }
+  @Test def test_unsignedShort_binary2(): Unit = { runner.runOneTest("unsignedShort_binary2") }
 
-  @Test def test_unsignedLong_binary() { runner.runOneTest("unsignedLong_binary") }
-  @Test def test_unsignedLong_binary2() { runner.runOneTest("unsignedLong_binary2") }
+  @Test def test_unsignedLong_binary(): Unit = { runner.runOneTest("unsignedLong_binary") }
+  @Test def test_unsignedLong_binary2(): Unit = { runner.runOneTest("unsignedLong_binary2") }
 
-  @Test def test_signedLong_binary() { runner.runOneTest("signedLong_binary") }
-  @Test def test_signedLong_binary2() { runner.runOneTest("signedLong_binary2") }
+  @Test def test_signedLong_binary(): Unit = { runner.runOneTest("signedLong_binary") }
+  @Test def test_signedLong_binary2(): Unit = { runner.runOneTest("signedLong_binary2") }
 
-  @Test def test_unsignedInt_binary() { runner.runOneTest("unsignedInt_binary") }
-  @Test def test_unsignedInt_binary2() { runner.runOneTest("unsignedInt_binary2") }
+  @Test def test_unsignedInt_binary(): Unit = { runner.runOneTest("unsignedInt_binary") }
+  @Test def test_unsignedInt_binary2(): Unit = { runner.runOneTest("unsignedInt_binary2") }
 
-  @Test def test_double_binary_01() { runner.runOneTest("double_binary_01") }
-  @Test def test_double_binary_02() { runner.runOneTest("double_binary_02") }
-  @Test def test_double_binary_03() { runner.runOneTest("double_binary_03") }
-  @Test def test_double_binary_04() { runner.runOneTest("double_binary_04") }
-  @Test def test_double_binary_05() { runner.runOneTest("double_binary_05") }
-  @Test def test_double_binary_06() { runner.runOneTest("double_binary_06") }
-  @Test def test_double_binary_07() { runner.runOneTest("double_binary_07") }
+  @Test def test_double_binary_01(): Unit = { runner.runOneTest("double_binary_01") }
+  @Test def test_double_binary_02(): Unit = { runner.runOneTest("double_binary_02") }
+  @Test def test_double_binary_03(): Unit = { runner.runOneTest("double_binary_03") }
+  @Test def test_double_binary_04(): Unit = { runner.runOneTest("double_binary_04") }
+  @Test def test_double_binary_05(): Unit = { runner.runOneTest("double_binary_05") }
+  @Test def test_double_binary_06(): Unit = { runner.runOneTest("double_binary_06") }
+  @Test def test_double_binary_07(): Unit = { runner.runOneTest("double_binary_07") }
 
-  @Test def test_byte_binary_01() { runner.runOneTest("byte_binary_01") }
-  @Test def test_byte_binary_02() { runner.runOneTest("byte_binary_02") }
-  @Test def test_byte_binary_03() { runner.runOneTest("byte_binary_03") }
-  @Test def test_byte_binary_04() { runner.runOneTest("byte_binary_04") }
-  @Test def test_byte_binary_05() { runner.runOneTest("byte_binary_05") }
+  @Test def test_byte_binary_01(): Unit = { runner.runOneTest("byte_binary_01") }
+  @Test def test_byte_binary_02(): Unit = { runner.runOneTest("byte_binary_02") }
+  @Test def test_byte_binary_03(): Unit = { runner.runOneTest("byte_binary_03") }
+  @Test def test_byte_binary_04(): Unit = { runner.runOneTest("byte_binary_04") }
+  @Test def test_byte_binary_05(): Unit = { runner.runOneTest("byte_binary_05") }
 
-  @Test def test_byte_implicit() { runner.runOneTest("byte_implicit") }
+  @Test def test_byte_implicit(): Unit = { runner.runOneTest("byte_implicit") }
 
-  @Test def test_double_07() { runner.runOneTest("double_07") }
+  @Test def test_double_07(): Unit = { runner.runOneTest("double_07") }
 
-  @Test def test_ubyte_binary_01() { runner.runOneTest("ubyte_binary_01") }
-  @Test def test_ubyte_binary_02() { runner.runOneTest("ubyte_binary_02") }
-  @Test def test_ubyte_binary_03() { runner.runOneTest("ubyte_binary_03") }
-  @Test def test_ubyte_binary_04() { runner.runOneTest("ubyte_binary_04") }
-  @Test def test_ubyte_binary_05() { runner.runOneTest("ubyte_binary_05") }
+  @Test def test_ubyte_binary_01(): Unit = { runner.runOneTest("ubyte_binary_01") }
+  @Test def test_ubyte_binary_02(): Unit = { runner.runOneTest("ubyte_binary_02") }
+  @Test def test_ubyte_binary_03(): Unit = { runner.runOneTest("ubyte_binary_03") }
+  @Test def test_ubyte_binary_04(): Unit = { runner.runOneTest("ubyte_binary_04") }
+  @Test def test_ubyte_binary_05(): Unit = { runner.runOneTest("ubyte_binary_05") }
 
-  @Test def test_ubyte_implicit() { runner.runOneTest("ubyte_implicit") }
+  @Test def test_ubyte_implicit(): Unit = { runner.runOneTest("ubyte_implicit") }
 
-  @Test def test_int_binary_01() { runner.runOneTest("int_binary_01") }
-  @Test def test_int_binary_02() { runner.runOneTest("int_binary_02") }
-  @Test def test_int_binary_03() { runner.runOneTest("int_binary_03") }
-  @Test def test_int_binary_04() { runner.runOneTest("int_binary_04") }
-  @Test def test_int_binary_05() { runner.runOneTest("int_binary_05") }
+  @Test def test_int_binary_01(): Unit = { runner.runOneTest("int_binary_01") }
+  @Test def test_int_binary_02(): Unit = { runner.runOneTest("int_binary_02") }
+  @Test def test_int_binary_03(): Unit = { runner.runOneTest("int_binary_03") }
+  @Test def test_int_binary_04(): Unit = { runner.runOneTest("int_binary_04") }
+  @Test def test_int_binary_05(): Unit = { runner.runOneTest("int_binary_05") }
 
-  @Test def test_binaryInt_unparseError() { runner.runOneTest("binaryInt_unparseError") }
-  @Test def test_hexBinary_unparseError() { runner.runOneTest("hexBinary_unparseError") }
-  @Test def test_calendar_unparseError() { runner.runOneTest("calendar_unparseError") }
+  @Test def test_binaryInt_unparseError(): Unit = { runner.runOneTest("binaryInt_unparseError") }
+  @Test def test_hexBinary_unparseError(): Unit = { runner.runOneTest("hexBinary_unparseError") }
+  @Test def test_calendar_unparseError(): Unit = { runner.runOneTest("calendar_unparseError") }
 
-  @Test def test_int_implicit() { runner.runOneTest("int_implicit") }
+  @Test def test_int_implicit(): Unit = { runner.runOneTest("int_implicit") }
 
-  @Test def test_posinteger_binary_01() { runner.runOneTest("nonNegInt_binary_01") }
+  @Test def test_posinteger_binary_01(): Unit = { runner.runOneTest("nonNegInt_binary_01") }
 
-  @Test def test_literalChar_padding() { runner.runOneTest("literalChar_padding") }
-  @Test def test_literalChar_padding2() { runner.runOneTest("literalChar_padding2") }
-  @Test def test_literalChar_padding3() { runner.runOneTest("literalChar_padding3") }
-  @Test def test_literalChar_padding4() { runner.runOneTest("literalChar_padding4") }
-  @Test def test_literalChar_padding5() { runner.runOneTest("literalChar_padding5") }
-  @Test def test_literalChar_padding6() { runner.runOneTest("literalChar_padding6") }
-  @Test def test_charEntity_padding1() { runner.runOneTest("charEntity_padding1") }
-  @Test def test_charEntity_padding2() { runner.runOneTest("charEntity_padding2") }
-  @Test def test_charEntity_padding3() { runner.runOneTest("charEntity_padding3") }
-  @Test def test_number_padding() { runner.runOneTest("number_padding") }
-  @Test def test_number_padding2() { runner.runOneTest("number_padding2") }
-  @Test def test_number_padding3() { runner.runOneTest("number_padding3") }
-  @Test def test_number_padding4() { runner.runOneTest("number_padding4") }
-  @Test def test_number_padding5() { runner.runOneTest("number_padding5") }
-  @Test def test_padding_escape() { runner.runOneTest("padding_escape") }
-  @Test def test_padding_nil() { runner.runOneTest("padding_nil") }
-  @Test def test_padding_nil2() { runner.runOneTest("padding_nil2") }
-  @Test def test_padding_empty() { runner.runOneTest("padding_empty") }
-  @Test def test_justification_1() { runner.runOneTest("justification_1") }
-  @Test def test_percentPadding() { runner.runOneTest("percentPadding") }
+  @Test def test_literalChar_padding(): Unit = { runner.runOneTest("literalChar_padding") }
+  @Test def test_literalChar_padding2(): Unit = { runner.runOneTest("literalChar_padding2") }
+  @Test def test_literalChar_padding3(): Unit = { runner.runOneTest("literalChar_padding3") }
+  @Test def test_literalChar_padding4(): Unit = { runner.runOneTest("literalChar_padding4") }
+  @Test def test_literalChar_padding5(): Unit = { runner.runOneTest("literalChar_padding5") }
+  @Test def test_literalChar_padding6(): Unit = { runner.runOneTest("literalChar_padding6") }
+  @Test def test_charEntity_padding1(): Unit = { runner.runOneTest("charEntity_padding1") }
+  @Test def test_charEntity_padding2(): Unit = { runner.runOneTest("charEntity_padding2") }
+  @Test def test_charEntity_padding3(): Unit = { runner.runOneTest("charEntity_padding3") }
+  @Test def test_number_padding(): Unit = { runner.runOneTest("number_padding") }
+  @Test def test_number_padding2(): Unit = { runner.runOneTest("number_padding2") }
+  @Test def test_number_padding3(): Unit = { runner.runOneTest("number_padding3") }
+  @Test def test_number_padding4(): Unit = { runner.runOneTest("number_padding4") }
+  @Test def test_number_padding5(): Unit = { runner.runOneTest("number_padding5") }
+  @Test def test_padding_escape(): Unit = { runner.runOneTest("padding_escape") }
+  @Test def test_padding_nil(): Unit = { runner.runOneTest("padding_nil") }
+  @Test def test_padding_nil2(): Unit = { runner.runOneTest("padding_nil2") }
+  @Test def test_padding_empty(): Unit = { runner.runOneTest("padding_empty") }
+  @Test def test_justification_1(): Unit = { runner.runOneTest("justification_1") }
+  @Test def test_percentPadding(): Unit = { runner.runOneTest("percentPadding") }
 
   // Verification that user's test works for DFDL-677
-  @Test def test_unsignedInt() { runner.runOneTest("TestUnsignedInt") }
+  @Test def test_unsignedInt(): Unit = { runner.runOneTest("TestUnsignedInt") }
 
-  @Test def test_nonNegativeInteger_text() { runner.runOneTest("nonNegativeInteger_text") }
-  @Test def test_nonNegativeInteger_text2() { runner.runOneTest("nonNegativeInteger_text2") }
-  @Test def test_nonNegativeInteger_text_fail() { runner.runOneTest("nonNegativeInteger_text_fail") }
-  @Test def test_nonNegativeInteger_text_fail2() { runner.runOneTest("nonNegativeInteger_text_fail2") }
-  @Test def test_nonNegativeInteger_text_fail3() { runner.runOneTest("nonNegativeInteger_text_fail3") }
-  @Test def test_nonNegativeInteger_unparseError() { runner.runOneTest("nonNegativeInteger_unparseError") }
+  @Test def test_nonNegativeInteger_text(): Unit = { runner.runOneTest("nonNegativeInteger_text") }
+  @Test def test_nonNegativeInteger_text2(): Unit = { runner.runOneTest("nonNegativeInteger_text2") }
+  @Test def test_nonNegativeInteger_text_fail(): Unit = { runner.runOneTest("nonNegativeInteger_text_fail") }
+  @Test def test_nonNegativeInteger_text_fail2(): Unit = { runner.runOneTest("nonNegativeInteger_text_fail2") }
+  @Test def test_nonNegativeInteger_text_fail3(): Unit = { runner.runOneTest("nonNegativeInteger_text_fail3") }
+  @Test def test_nonNegativeInteger_unparseError(): Unit = { runner.runOneTest("nonNegativeInteger_unparseError") }
 
-  @Test def test_nonNegativeInteger_bin() { runner.runOneTest("nonNegativeInteger_bin") }
-  @Test def test_nonNegativeInteger_bin2() { runner.runOneTest("nonNegativeInteger_bin2") }
-  @Test def test_nonNegativeInteger_bin3() { runner.runOneTest("nonNegativeInteger_bin3") }
-  @Test def test_nonNegativeInteger_bin4() { runner.runOneTest("nonNegativeInteger_bin4") }
-  @Test def test_nonNegativeInteger_bin5() { runner.runOneTest("nonNegativeInteger_bin5") }
-  @Test def test_nonNegativeInteger_bin6() { runner.runOneTest("nonNegativeInteger_bin6") }
+  @Test def test_nonNegativeInteger_bin(): Unit = { runner.runOneTest("nonNegativeInteger_bin") }
+  @Test def test_nonNegativeInteger_bin2(): Unit = { runner.runOneTest("nonNegativeInteger_bin2") }
+  @Test def test_nonNegativeInteger_bin3(): Unit = { runner.runOneTest("nonNegativeInteger_bin3") }
+  @Test def test_nonNegativeInteger_bin4(): Unit = { runner.runOneTest("nonNegativeInteger_bin4") }
+  @Test def test_nonNegativeInteger_bin5(): Unit = { runner.runOneTest("nonNegativeInteger_bin5") }
+  @Test def test_nonNegativeInteger_bin6(): Unit = { runner.runOneTest("nonNegativeInteger_bin6") }
 
-  @Test def test_integer_binary() { runner.runOneTest("integer_binary") }
-  @Test def test_integer_binary_01() { runner.runOneTest("integer_binary_01") }
-  @Test def test_integer_binary_02() { runner.runOneTest("integer_binary_02") }
-  @Test def test_integer_binary_03() { runner.runOneTest("integer_binary_03") }
-  @Test def test_integer_binary_04() { runner.runOneTest("integer_binary_04") }
+  @Test def test_integer_binary(): Unit = { runner.runOneTest("integer_binary") }
+  @Test def test_integer_binary_01(): Unit = { runner.runOneTest("integer_binary_01") }
+  @Test def test_integer_binary_02(): Unit = { runner.runOneTest("integer_binary_02") }
+  @Test def test_integer_binary_03(): Unit = { runner.runOneTest("integer_binary_03") }
+  @Test def test_integer_binary_04(): Unit = { runner.runOneTest("integer_binary_04") }
 
-  @Test def test_decimal_text() { runner.runOneTest("decimal_text") }
-  @Test def test_decimal_text2() { runner.runOneTest("decimal_text2") }
-  @Test def test_decimal_text3() { runner.runOneTest("decimal_text3") }
-  @Test def test_decimal_text_fail() { runner.runOneTest("decimal_text_fail") }
-  @Test def test_characterDuringValidDecimal() { runner.runOneTest("characterDuringValidDecimal") }
-  @Test def test_decimal_unparseError() { runner.runOneTest("decimal_unparseError") }
+  @Test def test_decimal_text(): Unit = { runner.runOneTest("decimal_text") }
+  @Test def test_decimal_text2(): Unit = { runner.runOneTest("decimal_text2") }
+  @Test def test_decimal_text3(): Unit = { runner.runOneTest("decimal_text3") }
+  @Test def test_decimal_text_fail(): Unit = { runner.runOneTest("decimal_text_fail") }
+  @Test def test_characterDuringValidDecimal(): Unit = { runner.runOneTest("characterDuringValidDecimal") }
+  @Test def test_decimal_unparseError(): Unit = { runner.runOneTest("decimal_unparseError") }
 
-  @Test def test_decimal_binary() { runner.runOneTest("decimal_binary") }
-  @Test def test_decimal_binary_01() { runner.runOneTest("decimal_binary_01") }
-  @Test def test_decimal_binary_02() { runner.runOneTest("decimal_binary_02") }
-  @Test def test_decimal_binary_03() { runner.runOneTest("decimal_binary_03") }
-  @Test def test_decimal_binary_04() { runner.runOneTest("decimal_binary_04") }
-  @Test def test_decimal_binary_05() { runner.runOneTest("decimal_binary_05") }
-  @Test def test_decimal_binary_06() { runner.runOneTest("decimal_binary_06") }
-  @Test def test_decimal_binary_fail_01() { runner.runOneTest("decimal_binary_fail_01") }
-  @Test def test_decimal_binary_fail_02() { runner.runOneTest("decimal_binary_fail_02") }
-  @Test def test_decimal_binary_fail_03() { runner.runOneTest("decimal_binary_fail_03") }
-  @Test def test_decimal_binary_fail_04() { runner.runOneTest("decimal_binary_fail_04") }
+  @Test def test_decimal_binary(): Unit = { runner.runOneTest("decimal_binary") }
+  @Test def test_decimal_binary_01(): Unit = { runner.runOneTest("decimal_binary_01") }
+  @Test def test_decimal_binary_02(): Unit = { runner.runOneTest("decimal_binary_02") }
+  @Test def test_decimal_binary_03(): Unit = { runner.runOneTest("decimal_binary_03") }
+  @Test def test_decimal_binary_04(): Unit = { runner.runOneTest("decimal_binary_04") }
+  @Test def test_decimal_binary_05(): Unit = { runner.runOneTest("decimal_binary_05") }
+  @Test def test_decimal_binary_06(): Unit = { runner.runOneTest("decimal_binary_06") }
+  @Test def test_decimal_binary_fail_01(): Unit = { runner.runOneTest("decimal_binary_fail_01") }
+  @Test def test_decimal_binary_fail_02(): Unit = { runner.runOneTest("decimal_binary_fail_02") }
+  @Test def test_decimal_binary_fail_03(): Unit = { runner.runOneTest("decimal_binary_fail_03") }
+  @Test def test_decimal_binary_fail_04(): Unit = { runner.runOneTest("decimal_binary_fail_04") }
 
-  @Test def test_double_text() { runner.runOneTest("double_text") }
-  @Test def test_double_text2_parse_ab() { runner.runOneTest("double_text2_parse_ab") }
-  @Test def test_double_text2_parse_ac() { runner.runOneTest("double_text2_parse_ac") }
-  @Test def test_double_text2_parse_ub() { runner.runOneTest("double_text2_parse_ub") }
-  @Test def test_double_text2_parse_uc() { runner.runOneTest("double_text2_parse_uc") }
-  @Test def test_double_text2_unparse_ab() { runner.runOneTest("double_text2_unparse_ab") }
-  @Test def test_double_text2_unparse_ac() { runner.runOneTest("double_text2_unparse_ac") }
-  @Test def test_double_text2_unparse_ub() { runner.runOneTest("double_text2_unparse_ub") }
-  @Test def test_double_text2_unparse_uc() { runner.runOneTest("double_text2_unparse_uc") }
-  @Test def test_double_text2_unparse_fail_ab() { runner.runOneTest("double_text2_unparse_fail_ab") }
-  @Test def test_double_text2_unparse_fail_ac() { runner.runOneTest("double_text2_unparse_fail_ac") }
-  @Test def test_double_text2_unparse_fail_ub() { runner.runOneTest("double_text2_unparse_fail_ub") }
-  @Test def test_double_text2_unparse_fail_uc() { runner.runOneTest("double_text2_unparse_fail_uc") }
-  @Test def test_double_text3() { runner.runOneTest("double_text3") }
-  @Test def test_double_text4() { runner.runOneTest("double_text4") }
-  @Test def test_characterDuringValidDouble() { runner.runOneTest("characterDuringValidDouble") }
-  @Test def test_double_unparseError() { runner.runOneTest("double_unparseError") }
+  @Test def test_double_text(): Unit = { runner.runOneTest("double_text") }
+  @Test def test_double_text2_parse_ab(): Unit = { runner.runOneTest("double_text2_parse_ab") }
+  @Test def test_double_text2_parse_ac(): Unit = { runner.runOneTest("double_text2_parse_ac") }
+  @Test def test_double_text2_parse_ub(): Unit = { runner.runOneTest("double_text2_parse_ub") }
+  @Test def test_double_text2_parse_uc(): Unit = { runner.runOneTest("double_text2_parse_uc") }
+  @Test def test_double_text2_unparse_ab(): Unit = { runner.runOneTest("double_text2_unparse_ab") }
+  @Test def test_double_text2_unparse_ac(): Unit = { runner.runOneTest("double_text2_unparse_ac") }
+  @Test def test_double_text2_unparse_ub(): Unit = { runner.runOneTest("double_text2_unparse_ub") }
+  @Test def test_double_text2_unparse_uc(): Unit = { runner.runOneTest("double_text2_unparse_uc") }
+  @Test def test_double_text2_unparse_fail_ab(): Unit = { runner.runOneTest("double_text2_unparse_fail_ab") }
+  @Test def test_double_text2_unparse_fail_ac(): Unit = { runner.runOneTest("double_text2_unparse_fail_ac") }
+  @Test def test_double_text2_unparse_fail_ub(): Unit = { runner.runOneTest("double_text2_unparse_fail_ub") }
+  @Test def test_double_text2_unparse_fail_uc(): Unit = { runner.runOneTest("double_text2_unparse_fail_uc") }
+  @Test def test_double_text3(): Unit = { runner.runOneTest("double_text3") }
+  @Test def test_double_text4(): Unit = { runner.runOneTest("double_text4") }
+  @Test def test_characterDuringValidDouble(): Unit = { runner.runOneTest("characterDuringValidDouble") }
+  @Test def test_double_unparseError(): Unit = { runner.runOneTest("double_unparseError") }
 
-  @Test def test_float_text() { runner.runOneTest("float_text") }
-  @Test def test_float_text2() { runner.runOneTest("float_text2") }
-  @Test def test_float_text3() { runner.runOneTest("float_text3") }
-  @Test def test_float_text_fail() { runner.runOneTest("float_text_fail") }
-  @Test def test_characterDuringValidFloat() { runner.runOneTest("characterDuringValidFloat") }
-  @Test def test_float_unparseError() { runner.runOneTest("float_unparseError") }
-  @Test def test_float_binary_01() { runner.runOneTest("float_binary_01") }
-  @Test def test_float_binary_02() { runner.runOneTest("float_binary_02") }
-  @Test def test_float_binary_03() { runner.runOneTest("float_binary_03") }
-  @Test def test_float_binary_04() { runner.runOneTest("float_binary_04") }
-  @Test def test_float_binary_05() { runner.runOneTest("float_binary_05") }
-  @Test def test_float_binary_fail_01() { runner.runOneTest("float_binary_fail_01") }
-  @Test def test_float_binary_fail_02() { runner.runOneTest("float_binary_fail_02") }
-  @Test def test_float_binary_fail_03() { runner.runOneTest("float_binary_fail_03") }
+  @Test def test_float_text(): Unit = { runner.runOneTest("float_text") }
+  @Test def test_float_text2(): Unit = { runner.runOneTest("float_text2") }
+  @Test def test_float_text3(): Unit = { runner.runOneTest("float_text3") }
+  @Test def test_float_text_fail(): Unit = { runner.runOneTest("float_text_fail") }
+  @Test def test_characterDuringValidFloat(): Unit = { runner.runOneTest("characterDuringValidFloat") }
+  @Test def test_float_unparseError(): Unit = { runner.runOneTest("float_unparseError") }
+  @Test def test_float_binary_01(): Unit = { runner.runOneTest("float_binary_01") }
+  @Test def test_float_binary_02(): Unit = { runner.runOneTest("float_binary_02") }
+  @Test def test_float_binary_03(): Unit = { runner.runOneTest("float_binary_03") }
+  @Test def test_float_binary_04(): Unit = { runner.runOneTest("float_binary_04") }
+  @Test def test_float_binary_05(): Unit = { runner.runOneTest("float_binary_05") }
+  @Test def test_float_binary_fail_01(): Unit = { runner.runOneTest("float_binary_fail_01") }
+  @Test def test_float_binary_fail_02(): Unit = { runner.runOneTest("float_binary_fail_02") }
+  @Test def test_float_binary_fail_03(): Unit = { runner.runOneTest("float_binary_fail_03") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes2.scala
@@ -34,7 +34,7 @@ object TestSimpleTypes2 {
 
   val runner = Runner(testDir, "SimpleTypes.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runnerAL.reset
     runner2.reset
     runnerAJ.reset
@@ -48,39 +48,39 @@ object TestSimpleTypes2 {
 class TestSimpleTypes2 {
   import TestSimpleTypes2._
 
-  @Test def test_AL000() { runnerAL.runOneTest("AL000") }
+  @Test def test_AL000(): Unit = { runnerAL.runOneTest("AL000") }
 
-  @Test def test_AJ000() { runnerAJ.runOneTest("AJ000") }
-  @Test def test_AJ001() { runnerAJ.runOneTest("AJ001") }
+  @Test def test_AJ000(): Unit = { runnerAJ.runOneTest("AJ000") }
+  @Test def test_AJ001(): Unit = { runnerAJ.runOneTest("AJ001") }
 
-  @Test def test_AK000() { runnerAK.runOneTest("AK000") }
-  @Test def test_AK001() { runnerAK.runOneTest("AK001") }
+  @Test def test_AK000(): Unit = { runnerAK.runOneTest("AK000") }
+  @Test def test_AK001(): Unit = { runnerAK.runOneTest("AK001") }
 
-  @Test def test_redefinedFormat() { runner2.runOneTest("redefinedFormat") }
-  @Test def test_whiteSpaceBeforeLax() { runner2.runOneTest("whiteSpaceBeforeLax") }
-  @Test def test_whiteSpaceAfterLax() { runner2.runOneTest("whiteSpaceAfterLax") }
-  @Test def test_whiteSpaceDuringLax() { runner2.runOneTest("whiteSpaceDuringLax") }
-  @Test def test_whiteSpaceBeforeStrict() { runner2.runOneTest("whiteSpaceBeforeStrict") }
-  @Test def test_whiteSpaceDuringStrict() { runner2.runOneTest("whiteSpaceDuringStrict") }
-  @Test def test_whiteSpaceAfterStrict() { runner2.runOneTest("whiteSpaceAfterStrict") }
+  @Test def test_redefinedFormat(): Unit = { runner2.runOneTest("redefinedFormat") }
+  @Test def test_whiteSpaceBeforeLax(): Unit = { runner2.runOneTest("whiteSpaceBeforeLax") }
+  @Test def test_whiteSpaceAfterLax(): Unit = { runner2.runOneTest("whiteSpaceAfterLax") }
+  @Test def test_whiteSpaceDuringLax(): Unit = { runner2.runOneTest("whiteSpaceDuringLax") }
+  @Test def test_whiteSpaceBeforeStrict(): Unit = { runner2.runOneTest("whiteSpaceBeforeStrict") }
+  @Test def test_whiteSpaceDuringStrict(): Unit = { runner2.runOneTest("whiteSpaceDuringStrict") }
+  @Test def test_whiteSpaceAfterStrict(): Unit = { runner2.runOneTest("whiteSpaceAfterStrict") }
 
   // THIS TEST won't round trip until encoding for 7-bit ascii is implemented
   // Currently this is set to roundTrip="false"
-  @Test def test_MIL2045_47001D_Page70_TableB_I_with_string() { runner1.runOneTest("TestMIL2045_47001D_Page70_TableB_I_with_string") }
-  @Test def test_MIL2045_47001D_1() { runner1.runOneTest("TestMIL2045_47001D_1") }
-  @Test def test_LSBFirstSpan3Bytes() { runner1.runOneTest("TestLSBFirstSpan3Bytes") }
-  @Test def test_leastSignificantBitFirst() { runner1.runOneTest("leastSignificantBitFirst") }
-  @Test def test_leastSigBitFirstFloat() { runner1.runOneTest("leastSigBitFirstFloat") }
-  @Test def test_leastSigBitFirstDouble() { runner1.runOneTest("leastSigBitFirstDouble") }
-  @Test def test_leastSignificantBitFirstRTL() { runner1.runOneTest("leastSignificantBitFirstRTL") }
-  @Test def test_mostSignificantBitFirst1() { runner1.runOneTest("mostSignificantBitFirst1") }
-  @Test def test_mostSigBitFirstFloat() { runner1.runOneTest("mostSigBitFirstFloat") }
-  @Test def test_mostSigBitFirstDouble() { runner1.runOneTest("mostSigBitFirstDouble") }
-  @Test def test_littleEndianLeastFirstLTR() { runner1.runOneTest("littleEndianLeastFirstLTR") }
-  @Test def test_littleEndianLeastFirstRTL() { runner1.runOneTest("littleEndianLeastFirstRTL") }
-  @Test def test_bitOrderChangeInvalid2() { runner1.runOneTest("bitOrderChangeInvalid2") }
-  @Test def test_bitOrderChangeInvalid2Unparser() { runner1.runOneTest("bitOrderChangeInvalid2Unparser") }
-  @Test def test_noByteOrder() { runner1.runOneTest("noByteOrder") }
+  @Test def test_MIL2045_47001D_Page70_TableB_I_with_string(): Unit = { runner1.runOneTest("TestMIL2045_47001D_Page70_TableB_I_with_string") }
+  @Test def test_MIL2045_47001D_1(): Unit = { runner1.runOneTest("TestMIL2045_47001D_1") }
+  @Test def test_LSBFirstSpan3Bytes(): Unit = { runner1.runOneTest("TestLSBFirstSpan3Bytes") }
+  @Test def test_leastSignificantBitFirst(): Unit = { runner1.runOneTest("leastSignificantBitFirst") }
+  @Test def test_leastSigBitFirstFloat(): Unit = { runner1.runOneTest("leastSigBitFirstFloat") }
+  @Test def test_leastSigBitFirstDouble(): Unit = { runner1.runOneTest("leastSigBitFirstDouble") }
+  @Test def test_leastSignificantBitFirstRTL(): Unit = { runner1.runOneTest("leastSignificantBitFirstRTL") }
+  @Test def test_mostSignificantBitFirst1(): Unit = { runner1.runOneTest("mostSignificantBitFirst1") }
+  @Test def test_mostSigBitFirstFloat(): Unit = { runner1.runOneTest("mostSigBitFirstFloat") }
+  @Test def test_mostSigBitFirstDouble(): Unit = { runner1.runOneTest("mostSigBitFirstDouble") }
+  @Test def test_littleEndianLeastFirstLTR(): Unit = { runner1.runOneTest("littleEndianLeastFirstLTR") }
+  @Test def test_littleEndianLeastFirstRTL(): Unit = { runner1.runOneTest("littleEndianLeastFirstRTL") }
+  @Test def test_bitOrderChangeInvalid2(): Unit = { runner1.runOneTest("bitOrderChangeInvalid2") }
+  @Test def test_bitOrderChangeInvalid2Unparser(): Unit = { runner1.runOneTest("bitOrderChangeInvalid2Unparser") }
+  @Test def test_noByteOrder(): Unit = { runner1.runOneTest("noByteOrder") }
 
   // DAFFODIL-897
   //@Test def test_bitOrderChange() { runner1.runOneTest("bitOrderChange") }
@@ -89,14 +89,14 @@ class TestSimpleTypes2 {
   //@Test def test_bitOrderChangeInvalid3() { runner1.runOneTest("bitOrderChangeInvalid3") }
   //@Test def test_bitOrderChangeInvalid() { runner3.runOneTest("bitOrderChangeInvalid") }
 
-  @Test def test_simpleTypeDerivedFromPrimType() { runnerST.runOneTest("simpleTypeDerivedFromPrimType") }
-  @Test def test_simpleTypeChainedDerivations() { runnerST.runOneTest("simpleTypeChainedDerivations") }
-  @Test def test_simpleTypeOverlapPrimError() { runnerST.runOneTest("simpleTypeOverlapPrimError") }
-  @Test def test_simpleTypeOverlapSimpleTypeError() { runnerST.runOneTest("simpleTypeOverlapSimpleTypeError") }
+  @Test def test_simpleTypeDerivedFromPrimType(): Unit = { runnerST.runOneTest("simpleTypeDerivedFromPrimType") }
+  @Test def test_simpleTypeChainedDerivations(): Unit = { runnerST.runOneTest("simpleTypeChainedDerivations") }
+  @Test def test_simpleTypeOverlapPrimError(): Unit = { runnerST.runOneTest("simpleTypeOverlapPrimError") }
+  @Test def test_simpleTypeOverlapSimpleTypeError(): Unit = { runnerST.runOneTest("simpleTypeOverlapSimpleTypeError") }
 
-  @Test def test_mostSigBitFirstLEFloat() { runner1.runOneTest("mostSigBitFirstLEFloat") }
-  @Test def test_mostSigBitFirstLEDouble() { runner1.runOneTest("mostSigBitFirstLEDouble") }
+  @Test def test_mostSigBitFirstLEFloat(): Unit = { runner1.runOneTest("mostSigBitFirstLEFloat") }
+  @Test def test_mostSigBitFirstLEDouble(): Unit = { runner1.runOneTest("mostSigBitFirstLEDouble") }
 
-  @Test def test_hexBinary_Delimited_04() { runner.runOneTest("hexBinary_Delimited_04") }
+  @Test def test_hexBinary_Delimited_04(): Unit = { runner.runOneTest("hexBinary_Delimited_04") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesNew.scala
@@ -27,7 +27,7 @@ object TestSimpleTypesNew {
   val runner = Runner(testDir, "SimpleTypes.tdml")
   val runner1 = Runner(testDir, "BitOrder.tdml")
   val runner2 = Runner(testDir, "SimpleTypes2.tdml")
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
     runner1.reset
     runner2.reset
@@ -37,18 +37,18 @@ object TestSimpleTypesNew {
 class TestSimpleTypesNew {
   import TestSimpleTypesNew._
 
-  @Test def test_time_calendarTimeZone_EmptyString() { runner.runOneTest("time_calendarTimeZone_EmptyString") }
-  @Test def test_time_calendarTimeZone_EST() { runner.runOneTest("time_calendarTimeZone_EST") }
-  @Test def test_date_calendarTimeZone_EmptyString() { runner.runOneTest("date_calendarTimeZone_EmptyString") }
-  @Test def test_date_calendarTimeZone_EST() { runner.runOneTest("date_calendarTimeZone_EST") }
-  @Test def test_dateTime_calendarTimeZone_EmptyString() { runner.runOneTest("dateTime_calendarTimeZone_EmptyString") }
-  @Test def test_dateTime_calendarTimeZone_EST() { runner.runOneTest("dateTime_calendarTimeZone_EST") }
+  @Test def test_time_calendarTimeZone_EmptyString(): Unit = { runner.runOneTest("time_calendarTimeZone_EmptyString") }
+  @Test def test_time_calendarTimeZone_EST(): Unit = { runner.runOneTest("time_calendarTimeZone_EST") }
+  @Test def test_date_calendarTimeZone_EmptyString(): Unit = { runner.runOneTest("date_calendarTimeZone_EmptyString") }
+  @Test def test_date_calendarTimeZone_EST(): Unit = { runner.runOneTest("date_calendarTimeZone_EST") }
+  @Test def test_dateTime_calendarTimeZone_EmptyString(): Unit = { runner.runOneTest("dateTime_calendarTimeZone_EmptyString") }
+  @Test def test_dateTime_calendarTimeZone_EST(): Unit = { runner.runOneTest("dateTime_calendarTimeZone_EST") }
 
-  @Test def test_hexBinary_specifiedLengthUnaligned() { runner.runOneTest("hexBinary_specifiedLengthUnaligned") }
+  @Test def test_hexBinary_specifiedLengthUnaligned(): Unit = { runner.runOneTest("hexBinary_specifiedLengthUnaligned") }
 
   // DAFFODIL-1001 fixed.
-  @Test def test_bigEndianLeastFirst() { runner1.runOneTest("bigEndianLeastFirst") }
+  @Test def test_bigEndianLeastFirst(): Unit = { runner1.runOneTest("bigEndianLeastFirst") }
 
   // DAFFODIL-2204
-  @Test def test_terminatorErrorMessage() { runner2.runOneTest("terminatorErrorMessage") }
+  @Test def test_terminatorErrorMessage(): Unit = { runner2.runOneTest("terminatorErrorMessage") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesUnparse.scala
@@ -26,7 +26,7 @@ object TestSimpleTypesUnparse {
 
   val runner = Runner(testDir, "SimpleTypesUnparse.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -38,31 +38,31 @@ class TestSimpleTypesUnparse {
   //dfdl:hexBinary not behaving like xs:hexBinary 
   //@Test def test_hexBinary_unparse_13() { runner.runOneTest("hexBinary_unparse_13") }
   
-  @Test def test_hexBinary_unparse_01() { runner.runOneTest("hexBinary_unparse_01") }
-  @Test def test_hexBinary_unparse_02() { runner.runOneTest("hexBinary_unparse_02") }
-  @Test def test_hexBinary_unparse_03() { runner.runOneTest("hexBinary_unparse_03") }
-  @Test def test_hexBinary_unparse_04() { runner.runOneTest("hexBinary_unparse_04") }
-  @Test def test_hexBinary_unparse_05() { runner.runOneTest("hexBinary_unparse_05") }
-  @Test def test_hexBinary_unparse_06() { runner.runOneTest("hexBinary_unparse_06") }
-  @Test def test_hexBinary_unparse_07() { runner.runOneTest("hexBinary_unparse_07") }
-  @Test def test_hexBinary_unparse_08() { runner.runOneTest("hexBinary_unparse_08") }
-  @Test def test_hexBinary_unparse_09() { runner.runOneTest("hexBinary_unparse_09") }
-  @Test def test_hexBinary_unparse_10() { runner.runOneTest("hexBinary_unparse_10") }
-  @Test def test_hexBinary_unparse_11() { runner.runOneTest("hexBinary_unparse_11") }
-  @Test def test_hexBinary_unparse_12() { runner.runOneTest("hexBinary_unparse_12") }
-  @Test def test_hexBinary_unparse_14() { runner.runOneTest("hexBinary_unparse_14") }
-  @Test def test_hexBinary_unparse_15() { runner.runOneTest("hexBinary_unparse_15") }
-  @Test def test_hexBinary_unparse_16() { runner.runOneTest("hexBinary_unparse_16") }
-  @Test def test_hexBinary_unparse_17() { runner.runOneTest("hexBinary_unparse_17") }
-  @Test def test_hexBinary_unparse_18() { runner.runOneTest("hexBinary_unparse_18") }
-  @Test def test_hexBinary_unparse_19() { runner.runOneTest("hexBinary_unparse_19") }
+  @Test def test_hexBinary_unparse_01(): Unit = { runner.runOneTest("hexBinary_unparse_01") }
+  @Test def test_hexBinary_unparse_02(): Unit = { runner.runOneTest("hexBinary_unparse_02") }
+  @Test def test_hexBinary_unparse_03(): Unit = { runner.runOneTest("hexBinary_unparse_03") }
+  @Test def test_hexBinary_unparse_04(): Unit = { runner.runOneTest("hexBinary_unparse_04") }
+  @Test def test_hexBinary_unparse_05(): Unit = { runner.runOneTest("hexBinary_unparse_05") }
+  @Test def test_hexBinary_unparse_06(): Unit = { runner.runOneTest("hexBinary_unparse_06") }
+  @Test def test_hexBinary_unparse_07(): Unit = { runner.runOneTest("hexBinary_unparse_07") }
+  @Test def test_hexBinary_unparse_08(): Unit = { runner.runOneTest("hexBinary_unparse_08") }
+  @Test def test_hexBinary_unparse_09(): Unit = { runner.runOneTest("hexBinary_unparse_09") }
+  @Test def test_hexBinary_unparse_10(): Unit = { runner.runOneTest("hexBinary_unparse_10") }
+  @Test def test_hexBinary_unparse_11(): Unit = { runner.runOneTest("hexBinary_unparse_11") }
+  @Test def test_hexBinary_unparse_12(): Unit = { runner.runOneTest("hexBinary_unparse_12") }
+  @Test def test_hexBinary_unparse_14(): Unit = { runner.runOneTest("hexBinary_unparse_14") }
+  @Test def test_hexBinary_unparse_15(): Unit = { runner.runOneTest("hexBinary_unparse_15") }
+  @Test def test_hexBinary_unparse_16(): Unit = { runner.runOneTest("hexBinary_unparse_16") }
+  @Test def test_hexBinary_unparse_17(): Unit = { runner.runOneTest("hexBinary_unparse_17") }
+  @Test def test_hexBinary_unparse_18(): Unit = { runner.runOneTest("hexBinary_unparse_18") }
+  @Test def test_hexBinary_unparse_19(): Unit = { runner.runOneTest("hexBinary_unparse_19") }
 
-  @Test def test_hexBinary_variable_unparse_01() { runner.runOneTest("hexBinary_variable_unparse_01") }
-  @Test def test_hexBinary_variable_unparse_02() { runner.runOneTest("hexBinary_variable_unparse_02") }
-  @Test def test_hexBinary_variable_unparse_03() { runner.runOneTest("hexBinary_variable_unparse_03") }
-  @Test def test_hexBinary_variable_unparse_04() { runner.runOneTest("hexBinary_variable_unparse_04") }
+  @Test def test_hexBinary_variable_unparse_01(): Unit = { runner.runOneTest("hexBinary_variable_unparse_01") }
+  @Test def test_hexBinary_variable_unparse_02(): Unit = { runner.runOneTest("hexBinary_variable_unparse_02") }
+  @Test def test_hexBinary_variable_unparse_03(): Unit = { runner.runOneTest("hexBinary_variable_unparse_03") }
+  @Test def test_hexBinary_variable_unparse_04(): Unit = { runner.runOneTest("hexBinary_variable_unparse_04") }
 
-  @Test def test_float_binary_unparse_01() { runner.runOneTest("float_binary_unparse_01") }
-  @Test def test_double_binary_unparse_01() { runner.runOneTest("double_binary_unparse_01") }
-  @Test def test_integer_binary_unparse_01() { runner.runOneTest("integer_binary_unparse_01") }
+  @Test def test_float_binary_unparse_01(): Unit = { runner.runOneTest("float_binary_unparse_01") }
+  @Test def test_double_binary_unparse_01(): Unit = { runner.runOneTest("double_binary_unparse_01") }
+  @Test def test_integer_binary_unparse_01(): Unit = { runner.runOneTest("integer_binary_unparse_01") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestUnions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestUnions.scala
@@ -26,7 +26,7 @@ object TestUnions {
 
   val runner = Runner(testDir, "unions.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
   }
 }
@@ -34,12 +34,12 @@ object TestUnions {
 class TestUnions {
   import TestUnions._
 
-  @Test def test_unionOf1() { runner.runOneTest("unionOf1") }
-  @Test def test_unionOf1b() { runner.runOneTest("unionOf1b") }
-  @Test def test_uu1() { runner.runOneTest("uu1") }
-  @Test def test_uu2() { runner.runOneTest("uu2") }
-  @Test def test_uu3() { runner.runOneTest("uu3") }
-  @Test def test_uu1neg() { runner.runOneTest("uu1neg") }
-  @Test def test_uu2neg() { runner.runOneTest("uu2neg") }
+  @Test def test_unionOf1(): Unit = { runner.runOneTest("unionOf1") }
+  @Test def test_unionOf1b(): Unit = { runner.runOneTest("unionOf1b") }
+  @Test def test_uu1(): Unit = { runner.runOneTest("uu1") }
+  @Test def test_uu2(): Unit = { runner.runOneTest("uu2") }
+  @Test def test_uu3(): Unit = { runner.runOneTest("uu3") }
+  @Test def test_uu1neg(): Unit = { runner.runOneTest("uu1neg") }
+  @Test def test_uu2neg(): Unit = { runner.runOneTest("uu2neg") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
@@ -29,7 +29,7 @@ object TestEntities {
   val runnerEntity = Runner(testDir, "entities_01.tdml")
   val runnerInvalid = Runner(testDir, "InvalidEntities.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner_01.reset
     runnerEntity.reset
@@ -39,84 +39,84 @@ object TestEntities {
 class TestEntities {
   import TestEntities._
 
-  @Test def test_doubleNL2() { runner.runOneTest("doubleNL2") }
+  @Test def test_doubleNL2(): Unit = { runner.runOneTest("doubleNL2") }
 
-  @Test def test_entityInError() { runner.runOneTest("entityInError") }
-  @Test def test_LineFeed() { runner.runOneTest("LineFeed") }
-  @Test def test_CarriageReturn() { runner.runOneTest("CarriageReturn") }
-  @Test def test_LineSeparator() { runner.runOneTest("LineSeparator") }
-  @Test def test_NextLine() { runner.runOneTest("NextLine") }
-  @Test def test_LineFeed_byte() { runner.runOneTest("LineFeed_byte") }
-  @Test def test_CarriageReturn_byte() { runner.runOneTest("CarriageReturn_byte") }
-  @Test def test_CRLF_byte() { runner.runOneTest("CRLF_byte") }
-  @Test def test_LineSeparator_byte() { runner.runOneTest("LineSeparator_byte") }
-  @Test def test_NextLine_byte() { runner.runOneTest("NextLine_byte") }
-  @Test def test_FormFeed() { runner.runOneTest("FormFeed") }
-  @Test def test_HexCodePoint() { runner.runOneTest("HexCodePoint") }
+  @Test def test_entityInError(): Unit = { runner.runOneTest("entityInError") }
+  @Test def test_LineFeed(): Unit = { runner.runOneTest("LineFeed") }
+  @Test def test_CarriageReturn(): Unit = { runner.runOneTest("CarriageReturn") }
+  @Test def test_LineSeparator(): Unit = { runner.runOneTest("LineSeparator") }
+  @Test def test_NextLine(): Unit = { runner.runOneTest("NextLine") }
+  @Test def test_LineFeed_byte(): Unit = { runner.runOneTest("LineFeed_byte") }
+  @Test def test_CarriageReturn_byte(): Unit = { runner.runOneTest("CarriageReturn_byte") }
+  @Test def test_CRLF_byte(): Unit = { runner.runOneTest("CRLF_byte") }
+  @Test def test_LineSeparator_byte(): Unit = { runner.runOneTest("LineSeparator_byte") }
+  @Test def test_NextLine_byte(): Unit = { runner.runOneTest("NextLine_byte") }
+  @Test def test_FormFeed(): Unit = { runner.runOneTest("FormFeed") }
+  @Test def test_HexCodePoint(): Unit = { runner.runOneTest("HexCodePoint") }
 
-  @Test def test_entityAndNonMix_01() { runner_01.runOneTest("entityAndNonMix_01") }
-  @Test def test_entityAndNonMix_02() { runner_01.runOneTest("entityAndNonMix_02") }
-  @Test def test_entityAndNonMix_03() { runner_01.runOneTest("entityAndNonMix_03") }
-  @Test def test_entityAndNonMix_04() { runner_01.runOneTest("entityAndNonMix_04") }
+  @Test def test_entityAndNonMix_01(): Unit = { runner_01.runOneTest("entityAndNonMix_01") }
+  @Test def test_entityAndNonMix_02(): Unit = { runner_01.runOneTest("entityAndNonMix_02") }
+  @Test def test_entityAndNonMix_03(): Unit = { runner_01.runOneTest("entityAndNonMix_03") }
+  @Test def test_entityAndNonMix_04(): Unit = { runner_01.runOneTest("entityAndNonMix_04") }
 
   // DFDL-378
   //  @Test def test_dataDumpEncoding() { runner_01.runOneTest("dataDumpEncoding") }
-  @Test def test_errorEncoding() { runner_01.runOneTest("errorEncoding") }
+  @Test def test_errorEncoding(): Unit = { runner_01.runOneTest("errorEncoding") }
 
-  @Test def test_doubleNLterminator() { runner_01.runOneTest("doubleNLterminator") }
-  @Test def test_doubleNLseparator() { runner_01.runOneTest("doubleNLseparator") }
+  @Test def test_doubleNLterminator(): Unit = { runner_01.runOneTest("doubleNLterminator") }
+  @Test def test_doubleNLseparator(): Unit = { runner_01.runOneTest("doubleNLseparator") }
 
-  @Test def test_text_entities_6_02() { runner_01.runOneTest("text_entities_6_02") }
-  @Test def test_text_entities_6_03() { runner_01.runOneTest("text_entities_6_03") }
-  @Test def test_text_entities_6_03b() { runner_01.runOneTest("text_entities_6_03b") }
-  @Test def test_text_entities_6_04() { runner_01.runOneTest("text_entities_6_04") }
-  @Test def test_byte_entities_6_01() { runner_01.runOneTest("byte_entities_6_01") }
-  @Test def test_byte_entities_6_02() { runner_01.runOneTest("byte_entities_6_02") }
-  @Test def test_byte_entities_6_03() { runner_01.runOneTest("byte_entities_6_03") }
-  @Test def test_byte_entities_6_04() { runner_01.runOneTest("byte_entities_6_04") }
-  @Test def test_byte_entities_6_05() { runner_01.runOneTest("byte_entities_6_05") }
-  @Test def test_byte_entities_6_06() { runner_01.runOneTest("byte_entities_6_06") }
-  @Test def test_byte_entities_6_07() { runner_01.runOneTest("byte_entities_6_07") }
-  @Test def test_byte_entities_6_08() { runner_01.runOneTest("byte_entities_6_08") }
+  @Test def test_text_entities_6_02(): Unit = { runner_01.runOneTest("text_entities_6_02") }
+  @Test def test_text_entities_6_03(): Unit = { runner_01.runOneTest("text_entities_6_03") }
+  @Test def test_text_entities_6_03b(): Unit = { runner_01.runOneTest("text_entities_6_03b") }
+  @Test def test_text_entities_6_04(): Unit = { runner_01.runOneTest("text_entities_6_04") }
+  @Test def test_byte_entities_6_01(): Unit = { runner_01.runOneTest("byte_entities_6_01") }
+  @Test def test_byte_entities_6_02(): Unit = { runner_01.runOneTest("byte_entities_6_02") }
+  @Test def test_byte_entities_6_03(): Unit = { runner_01.runOneTest("byte_entities_6_03") }
+  @Test def test_byte_entities_6_04(): Unit = { runner_01.runOneTest("byte_entities_6_04") }
+  @Test def test_byte_entities_6_05(): Unit = { runner_01.runOneTest("byte_entities_6_05") }
+  @Test def test_byte_entities_6_06(): Unit = { runner_01.runOneTest("byte_entities_6_06") }
+  @Test def test_byte_entities_6_07(): Unit = { runner_01.runOneTest("byte_entities_6_07") }
+  @Test def test_byte_entities_6_08(): Unit = { runner_01.runOneTest("byte_entities_6_08") }
   // DAFFODIL-2102
   //  @Test def test_byte_entities_6_10() { runner_01.runOneTest("byte_entities_6_10") }
 
-  @Test def test_whitespace_01() { runner_01.runOneTest("whitespace_01") }
-  @Test def test_whitespace_02() { runner_01.runOneTest("whitespace_02") }
-  @Test def test_whitespace_03() { runner_01.runOneTest("whitespace_03") }
-  @Test def test_whitespace_04() { runner_01.runOneTest("whitespace_04") }
-  @Test def test_whitespace_05() { runner_01.runOneTest("whitespace_05") }
-  @Test def test_whitespace_06() { runner_01.runOneTest("whitespace_06") }
-  @Test def test_whitespace_07() { runner_01.runOneTest("whitespace_07") }
-  @Test def test_whitespace_08() { runner_01.runOneTest("whitespace_08") }
-  @Test def test_whitespace_09() { runner_01.runOneTest("whitespace_09") }
-  @Test def test_whitespace_10() { runner_01.runOneTest("whitespace_10") }
+  @Test def test_whitespace_01(): Unit = { runner_01.runOneTest("whitespace_01") }
+  @Test def test_whitespace_02(): Unit = { runner_01.runOneTest("whitespace_02") }
+  @Test def test_whitespace_03(): Unit = { runner_01.runOneTest("whitespace_03") }
+  @Test def test_whitespace_04(): Unit = { runner_01.runOneTest("whitespace_04") }
+  @Test def test_whitespace_05(): Unit = { runner_01.runOneTest("whitespace_05") }
+  @Test def test_whitespace_06(): Unit = { runner_01.runOneTest("whitespace_06") }
+  @Test def test_whitespace_07(): Unit = { runner_01.runOneTest("whitespace_07") }
+  @Test def test_whitespace_08(): Unit = { runner_01.runOneTest("whitespace_08") }
+  @Test def test_whitespace_09(): Unit = { runner_01.runOneTest("whitespace_09") }
+  @Test def test_whitespace_10(): Unit = { runner_01.runOneTest("whitespace_10") }
 
   // DAFFODIL-1475
-  @Test def test_emptyStringEntityTermInExpression_01() { runner_01.runOneTest("emptyStringEntityTermInExpression_01") }
-  @Test def test_emptyStringEntityTermInExpression_02() { runner_01.runOneTest("emptyStringEntityTermInExpression_02") }
-  @Test def test_emptyStringEntityTermInExpressionDelimited_01() { runner_01.runOneTest("emptyStringEntityTermInExpressionDelimited_01") }
-  @Test def test_emptyStringEntityTermInComplex_01() { runner_01.runOneTest("emptyStringEntityTermInComplex_01") }
-  @Test def test_emptyStringEntityTermInComplex_02() { runner_01.runOneTest("emptyStringEntityTermInComplex_02") }
+  @Test def test_emptyStringEntityTermInExpression_01(): Unit = { runner_01.runOneTest("emptyStringEntityTermInExpression_01") }
+  @Test def test_emptyStringEntityTermInExpression_02(): Unit = { runner_01.runOneTest("emptyStringEntityTermInExpression_02") }
+  @Test def test_emptyStringEntityTermInExpressionDelimited_01(): Unit = { runner_01.runOneTest("emptyStringEntityTermInExpressionDelimited_01") }
+  @Test def test_emptyStringEntityTermInComplex_01(): Unit = { runner_01.runOneTest("emptyStringEntityTermInComplex_01") }
+  @Test def test_emptyStringEntityTermInComplex_02(): Unit = { runner_01.runOneTest("emptyStringEntityTermInComplex_02") }
 
-  @Test def test_emptyStringEntityInitiator_01() { runner_01.runOneTest("emptyStringEntityInitiator_01") }
-  @Test def test_emptyStringEntityInitiator_02() { runner_01.runOneTest("emptyStringEntityInitiator_02") }
-  @Test def test_emptyStringEntityInitiator_03() { runner_01.runOneTest("emptyStringEntityInitiator_03") }
+  @Test def test_emptyStringEntityInitiator_01(): Unit = { runner_01.runOneTest("emptyStringEntityInitiator_01") }
+  @Test def test_emptyStringEntityInitiator_02(): Unit = { runner_01.runOneTest("emptyStringEntityInitiator_02") }
+  @Test def test_emptyStringEntityInitiator_03(): Unit = { runner_01.runOneTest("emptyStringEntityInitiator_03") }
 
-  @Test def test_entity_fail_01() { runnerEntity.runOneTest("entity_fail_01") }
-  @Test def test_entity_fail_02() { runnerEntity.runOneTest("entity_fail_02") }
+  @Test def test_entity_fail_01(): Unit = { runnerEntity.runOneTest("entity_fail_01") }
+  @Test def test_entity_fail_02(): Unit = { runnerEntity.runOneTest("entity_fail_02") }
 
   // DAFFODIL-1477
-  @Test def test_entity_fail_03a() { runnerEntity.runOneTest("entity_fail_03a") }
-  @Test def test_entity_fail_03b() { runnerEntity.runOneTest("entity_fail_03b") }
-  @Test def test_entity_fail_04() { runnerEntity.runOneTest("entity_fail_04") }
+  @Test def test_entity_fail_03a(): Unit = { runnerEntity.runOneTest("entity_fail_03a") }
+  @Test def test_entity_fail_03b(): Unit = { runnerEntity.runOneTest("entity_fail_03b") }
+  @Test def test_entity_fail_04(): Unit = { runnerEntity.runOneTest("entity_fail_04") }
 
-  @Test def test_invalid_entity_01() { runnerInvalid.runOneTest("text_invalid_entity_name") }
-  @Test def test_invalid_entity_02() { runnerInvalid.runOneTest("text_invalid_entity_decimalCodePoint") }
-  @Test def test_invalid_entity_03() { runnerInvalid.runOneTest("text_invalid_entity_hexaDecimalCodePoint") }
-  @Test def test_invalid_entity_04() { runnerInvalid.runOneTest("text_invalid_entity_rawBytes") }
-  @Test def test_invalid_entity_05() { runnerInvalid.runOneTest("text_invalid_entity_among_multiple_valid") }
-  @Test def test_invalid_entity_06() { runnerInvalid.runOneTest("text_invalid_entity_among_multiple_valid_combined") }
-  @Test def test_invalid_entity_07() { runnerInvalid.runOneTest("text_invalid_entity_escaped") }
+  @Test def test_invalid_entity_01(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_name") }
+  @Test def test_invalid_entity_02(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_decimalCodePoint") }
+  @Test def test_invalid_entity_03(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_hexaDecimalCodePoint") }
+  @Test def test_invalid_entity_04(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_rawBytes") }
+  @Test def test_invalid_entity_05(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_among_multiple_valid") }
+  @Test def test_invalid_entity_06(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_among_multiple_valid_combined") }
+  @Test def test_invalid_entity_07(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_escaped") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
@@ -33,7 +33,7 @@ object TestNamespaces {
   val runner3 = Runner(testDir, "includeImport.tdml")
   val runnerWithSchemaValidation = Runner(testDir, "multiFile.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runnerV.reset
     runner2.reset
@@ -45,21 +45,21 @@ class TestNamespaces {
 
   import TestNamespaces._
 
-  @Test def test_schemaNoGlobalElems_01() { runner.runOneTest("schemaNoGlobalElems_01") }
-  @Test def test_schemaNoGlobalElems_02() { runner.runOneTest("schemaNoGlobalElems_02") }
+  @Test def test_schemaNoGlobalElems_01(): Unit = { runner.runOneTest("schemaNoGlobalElems_01") }
+  @Test def test_schemaNoGlobalElems_02(): Unit = { runner.runOneTest("schemaNoGlobalElems_02") }
 
-  @Test def test_schemaSameDir_01() { runner.runOneTest("schemaSameDir_01") }
-  @Test def test_schemaSameDir_02() { runner.runOneTest("schemaSameDir_02") }
-  @Test def test_schemaSameDir_03() { runner.runOneTest("schemaSameDir_03") }
+  @Test def test_schemaSameDir_01(): Unit = { runner.runOneTest("schemaSameDir_01") }
+  @Test def test_schemaSameDir_02(): Unit = { runner.runOneTest("schemaSameDir_02") }
+  @Test def test_schemaSameDir_03(): Unit = { runner.runOneTest("schemaSameDir_03") }
 
-  @Test def test_schemaSameDirClasspath_01() { runner.runOneTest("schemaSameDirClasspath_01") }
+  @Test def test_schemaSameDirClasspath_01(): Unit = { runner.runOneTest("schemaSameDirClasspath_01") }
 
   // See comments in related bug. JIRA-549
   // This test is looking for a specific file to be mentioned in an error message
   // which is the file with the content responsible for the error, not the file
   // of the object where the error was detected.
 
-  @Test def test_combinations_02() {
+  @Test def test_combinations_02(): Unit = {
     try {
       // Must turn off the Info logging messages, because those will have the filename in them
       // which would create a false positive in this test.
@@ -70,7 +70,7 @@ class TestNamespaces {
     }
   }
 
-  @Test def test_errorLocations_01() {
+  @Test def test_errorLocations_01(): Unit = {
     try {
       // Must turn off the Info logging messages, because those will have the filename in them
       // which would create a false positive in this test.
@@ -81,12 +81,12 @@ class TestNamespaces {
     }
   }
 
-  @Test def test_defaultNamespaceInExpression() { runner.runOneTest("defaultNamespaceInExpression") }
-  @Test def test_defaultNamespaceInExpression2() { runner.runOneTest("defaultNamespaceInExpression2") }
+  @Test def test_defaultNamespaceInExpression(): Unit = { runner.runOneTest("defaultNamespaceInExpression") }
+  @Test def test_defaultNamespaceInExpression2(): Unit = { runner.runOneTest("defaultNamespaceInExpression2") }
 
-  @Test def test_namespaces_qnames() { runner.runOneTest("namespaces_qnames") }
-  @Test def test_namespaces_qnames2() { runner.runOneTest("namespaces_qnames2") }
-  @Test def test_namespaces_qnames3() { runner.runOneTest("namespaces_qnames3") }
+  @Test def test_namespaces_qnames(): Unit = { runner.runOneTest("namespaces_qnames") }
+  @Test def test_namespaces_qnames2(): Unit = { runner.runOneTest("namespaces_qnames2") }
+  @Test def test_namespaces_qnames3(): Unit = { runner.runOneTest("namespaces_qnames3") }
 
   // DFDL-1663
   // @Test def test_namespaceLimitParse() { runner.runOneTest("namespaceLimitParse")  }
@@ -95,115 +95,115 @@ class TestNamespaces {
   // DFDL-1204 - this test no longer works. New loader won't accept character U+00B7 as a character
   // in a prefix name.
   // @Test def test_namespaceSpecialChars() { runner.runOneTest("namespaceSpecialChars") }
-  @Test def test_namespaceSpecialChars2() { runnerV.runOneTest("namespaceSpecialChars2") }
-  @Test def test_namespaceRules1() { runner.runOneTest("namespaceRules1") }
-  @Test def test_namespaceRules2() { runnerV.runOneTest("namespaceRules2") }
+  @Test def test_namespaceSpecialChars2(): Unit = { runnerV.runOneTest("namespaceSpecialChars2") }
+  @Test def test_namespaceRules1(): Unit = { runner.runOneTest("namespaceRules1") }
+  @Test def test_namespaceRules2(): Unit = { runnerV.runOneTest("namespaceRules2") }
 
-  @Test def testSimpleIncludeOfFormat() { runner2.runOneTest("simpleInclude") }
-  @Test def testSimpleImportOfFormat() { runner2.runOneTest("simpleImport") }
-  @Test def testIncludeNoNamespace() { runner2.runOneTest("includeNoNamespace") }
-  @Test def testImportWithOverlappingNSPrefixes1() { runner2.runOneTest("importWithOverlappingNSPrefixes1") }
+  @Test def testSimpleIncludeOfFormat(): Unit = { runner2.runOneTest("simpleInclude") }
+  @Test def testSimpleImportOfFormat(): Unit = { runner2.runOneTest("simpleImport") }
+  @Test def testIncludeNoNamespace(): Unit = { runner2.runOneTest("includeNoNamespace") }
+  @Test def testImportWithOverlappingNSPrefixes1(): Unit = { runner2.runOneTest("importWithOverlappingNSPrefixes1") }
 
-  @Test def test_tdml_schema_import() { runner.runOneTest("tdml_schema_import") }
-  @Test def test_tdml_schema_include() { runner.runOneTest("tdml_schema_include") }
-  @Test def test_multifile_choice_embed() { runner.runOneTest("multifile_choice_embed") }
+  @Test def test_tdml_schema_import(): Unit = { runner.runOneTest("tdml_schema_import") }
+  @Test def test_tdml_schema_include(): Unit = { runner.runOneTest("tdml_schema_include") }
+  @Test def test_multifile_choice_embed(): Unit = { runner.runOneTest("multifile_choice_embed") }
 
-  @Test def test_Lesson2_no_namespace() { runner.runOneTest("Lesson2_no_namespace") }
-  @Test def test_Lesson2_include_schema() { runner.runOneTest("Lesson2_include_schema") }
-  @Test def test_Lesson2_import_schema() { runner.runOneTest("Lesson2_import_schema") }
+  @Test def test_Lesson2_no_namespace(): Unit = { runner.runOneTest("Lesson2_no_namespace") }
+  @Test def test_Lesson2_include_schema(): Unit = { runner.runOneTest("Lesson2_include_schema") }
+  @Test def test_Lesson2_import_schema(): Unit = { runner.runOneTest("Lesson2_import_schema") }
 
-  @Test def test_multifile_cyclical() { runner.runOneTest("multifile_cyclical") }
-  @Test def test_multifile_choice_01() { runner.runOneTest("multifile_choice_01") }
-  @Test def test_multifile_choice_02() { runner.runOneTest("multifile_choice_02") }
+  @Test def test_multifile_cyclical(): Unit = { runner.runOneTest("multifile_cyclical") }
+  @Test def test_multifile_choice_01(): Unit = { runner.runOneTest("multifile_choice_01") }
+  @Test def test_multifile_choice_02(): Unit = { runner.runOneTest("multifile_choice_02") }
   // DAFFODIL-553
   //  @Test def test_multifile_choice_02b() { runner.runOneTest("multifile_choice_02b") }
-  @Test def test_multifile_choice_03() { runner.runOneTest("multifile_choice_03") }
+  @Test def test_multifile_choice_03(): Unit = { runner.runOneTest("multifile_choice_03") }
 
-  @Test def test_multifile_facets_01() { runner.runOneTest("multifile_facets_01") }
-  @Test def test_multifile_facets_02() { runner.runOneTest("multifile_facets_02") }
-  @Test def test_multifile_facets_03() { runner.runOneTest("multifile_facets_03") }
-  @Test def test_multifile_facets_04() { runner.runOneTest("multifile_facets_04") }
+  @Test def test_multifile_facets_01(): Unit = { runner.runOneTest("multifile_facets_01") }
+  @Test def test_multifile_facets_02(): Unit = { runner.runOneTest("multifile_facets_02") }
+  @Test def test_multifile_facets_03(): Unit = { runner.runOneTest("multifile_facets_03") }
+  @Test def test_multifile_facets_04(): Unit = { runner.runOneTest("multifile_facets_04") }
 
-  @Test def test_double_nesting_01() { runner.runOneTest("double_nesting_01") }
+  @Test def test_double_nesting_01(): Unit = { runner.runOneTest("double_nesting_01") }
 
-  @Test def test_scope_01() { runner.runOneTest("scope_01") }
-  @Test def test_scope_02() { runner.runOneTest("scope_02") }
+  @Test def test_scope_01(): Unit = { runner.runOneTest("scope_01") }
+  @Test def test_scope_02(): Unit = { runner.runOneTest("scope_02") }
 
-  @Test def test_long_chain_01() { runner.runOneTest("long_chain_01") }
-  @Test def test_long_chain_02() { runner.runOneTest("long_chain_02") }
-  @Test def test_long_chain_03() { runner.runOneTest("long_chain_03") }
-  @Test def test_long_chain_04() { runner.runOneTest("long_chain_04") }
-  @Test def test_long_chain_05() { runner.runOneTest("long_chain_05") }
-  @Test def test_long_chain_06() { runner.runOneTest("long_chain_06") }
-  @Test def test_long_chain_06b() { runner.runOneTest("long_chain_06b") }
-  @Test def test_long_chain_07() { runner.runOneTest("long_chain_07") }
+  @Test def test_long_chain_01(): Unit = { runner.runOneTest("long_chain_01") }
+  @Test def test_long_chain_02(): Unit = { runner.runOneTest("long_chain_02") }
+  @Test def test_long_chain_03(): Unit = { runner.runOneTest("long_chain_03") }
+  @Test def test_long_chain_04(): Unit = { runner.runOneTest("long_chain_04") }
+  @Test def test_long_chain_05(): Unit = { runner.runOneTest("long_chain_05") }
+  @Test def test_long_chain_06(): Unit = { runner.runOneTest("long_chain_06") }
+  @Test def test_long_chain_06b(): Unit = { runner.runOneTest("long_chain_06b") }
+  @Test def test_long_chain_07(): Unit = { runner.runOneTest("long_chain_07") }
 
-  @Test def test_no_namespace_01() { runner.runOneTest("no_namespace_01") }
+  @Test def test_no_namespace_01(): Unit = { runner.runOneTest("no_namespace_01") }
 
-  @Test def test_no_namespace_02() { runner.runOneTest("no_namespace_02") }
-  @Test def test_no_namespace_03() { runner.runOneTest("no_namespace_03") }
-  @Test def test_no_namespace_04() { runner.runOneTest("no_namespace_04") }
+  @Test def test_no_namespace_02(): Unit = { runner.runOneTest("no_namespace_02") }
+  @Test def test_no_namespace_03(): Unit = { runner.runOneTest("no_namespace_03") }
+  @Test def test_no_namespace_04(): Unit = { runner.runOneTest("no_namespace_04") }
 
-  @Test def test_namespace_conflict_01() { runner.runOneTest("namespace_conflict_01") }
+  @Test def test_namespace_conflict_01(): Unit = { runner.runOneTest("namespace_conflict_01") }
 
-  @Test def test_combinations_03() { runner.runOneTest("combinations_03") }
-  @Test def test_combinations_04() { runner.runOneTest("combinations_04") }
+  @Test def test_combinations_03(): Unit = { runner.runOneTest("combinations_03") }
+  @Test def test_combinations_04(): Unit = { runner.runOneTest("combinations_04") }
 
-  @Test def test_negative_import_01() { runner.runOneTest("negative_import_01") }
+  @Test def test_negative_import_01(): Unit = { runner.runOneTest("negative_import_01") }
 
-  @Test def test_multi_encoding_01() { runner.runOneTest("multi_encoding_01") }
-  @Test def test_multi_encoding_02() { runner.runOneTest("multi_encoding_02") }
-  @Test def test_multi_encoding_03() { runner.runOneTest("multi_encoding_03") }
+  @Test def test_multi_encoding_01(): Unit = { runner.runOneTest("multi_encoding_01") }
+  @Test def test_multi_encoding_02(): Unit = { runner.runOneTest("multi_encoding_02") }
+  @Test def test_multi_encoding_03(): Unit = { runner.runOneTest("multi_encoding_03") }
   //  @Test def test_multi_encoding_04() { runner.runOneTest("multi_encoding_04") } //DAFFODIL-716
   //  @Test def test_multi_encoding_05() { runner.runOneTest("multi_encoding_05") } //DAFFODIL-715
   //  @Test def test_indexOutOfBounds_01() { runner.runOneTest("indexOutOfBounds_01") } // DAFFODIL-717
 
   // Preliminary tests for import format schemas
-  @Test def test_import_format_01() { runner.runOneTest("import_format_01") }
-  @Test def test_import_format_02() { runner.runOneTest("import_format_02") }
+  @Test def test_import_format_01(): Unit = { runner.runOneTest("import_format_01") }
+  @Test def test_import_format_02(): Unit = { runner.runOneTest("import_format_02") }
 
-  @Test def test_multifile_facets_05() { runner.runOneTest("multifile_facets_05") }
+  @Test def test_multifile_facets_05(): Unit = { runner.runOneTest("multifile_facets_05") }
 
-  @Test def test_element_conflict_01() { runner.runOneTest("element_conflict_01") }
-  @Test def test_element_conflict_02() { runner.runOneTest("element_conflict_02") }
+  @Test def test_element_conflict_01(): Unit = { runner.runOneTest("element_conflict_01") }
+  @Test def test_element_conflict_02(): Unit = { runner.runOneTest("element_conflict_02") }
 
-  @Test def test_no_namespace_temp() { runnerV.runOneTest("no_namespace_temp") }
+  @Test def test_no_namespace_temp(): Unit = { runnerV.runOneTest("no_namespace_temp") }
 
-  @Test def test_lion_eater_ambiguity_01() { runner.runOneTest("lion_eater_ambiguity_01") }
-  @Test def test_lion_eater_ambiguity_01b() { runnerV.runOneTest("lion_eater_ambiguity_01b") }
-  @Test def test_lion_eater_ambiguity_02() { runner.runOneTest("lion_eater_ambiguity_02") }
-  @Test def test_lion_eater_ambiguity_03() { runner.runOneTest("lion_eater_ambiguity_03") }
-  @Test def test_lion_eater_ambiguity_04() { runner.runOneTest("lion_eater_ambiguity_04") }
-  @Test def test_lion_eater_ambiguity_05() { runner.runOneTest("lion_eater_ambiguity_05") }
+  @Test def test_lion_eater_ambiguity_01(): Unit = { runner.runOneTest("lion_eater_ambiguity_01") }
+  @Test def test_lion_eater_ambiguity_01b(): Unit = { runnerV.runOneTest("lion_eater_ambiguity_01b") }
+  @Test def test_lion_eater_ambiguity_02(): Unit = { runner.runOneTest("lion_eater_ambiguity_02") }
+  @Test def test_lion_eater_ambiguity_03(): Unit = { runner.runOneTest("lion_eater_ambiguity_03") }
+  @Test def test_lion_eater_ambiguity_04(): Unit = { runner.runOneTest("lion_eater_ambiguity_04") }
+  @Test def test_lion_eater_ambiguity_05(): Unit = { runner.runOneTest("lion_eater_ambiguity_05") }
 
-  @Test def test_namespace_ultra_uniqueness_01() { runner.runOneTest("namespace_ultra_uniqueness_01") }
-  @Test def test_namespace_ultra_uniqueness_02() { runner.runOneTest("namespace_ultra_uniqueness_02") }
-  @Test def test_namespace_ultra_uniqueness_03() { runner.runOneTest("namespace_ultra_uniqueness_03") }
-  @Test def test_namespace_ultra_uniqueness_04() { runner.runOneTest("namespace_ultra_uniqueness_04") }
+  @Test def test_namespace_ultra_uniqueness_01(): Unit = { runner.runOneTest("namespace_ultra_uniqueness_01") }
+  @Test def test_namespace_ultra_uniqueness_02(): Unit = { runner.runOneTest("namespace_ultra_uniqueness_02") }
+  @Test def test_namespace_ultra_uniqueness_03(): Unit = { runner.runOneTest("namespace_ultra_uniqueness_03") }
+  @Test def test_namespace_ultra_uniqueness_04(): Unit = { runner.runOneTest("namespace_ultra_uniqueness_04") }
 
-  @Test def test_primTypesPrefixes01() { runner.runOneTest("primTypesPrefixes01") }
-  @Test def test_typeNameOverlap_01() { runner.runOneTest("typeNameOverlap_01") }
-  @Test def test_typeNameOverlap_02() { runner.runOneTest("typeNameOverlap_02") }
+  @Test def test_primTypesPrefixes01(): Unit = { runner.runOneTest("primTypesPrefixes01") }
+  @Test def test_typeNameOverlap_01(): Unit = { runner.runOneTest("typeNameOverlap_01") }
+  @Test def test_typeNameOverlap_02(): Unit = { runner.runOneTest("typeNameOverlap_02") }
 
-  @Test def test_namespace_scope_01() { runner.runOneTest("namespace_scope_01") }
-  @Test def test_namespace_scope_02() { runner.runOneTest("namespace_scope_02") }
+  @Test def test_namespace_scope_01(): Unit = { runner.runOneTest("namespace_scope_01") }
+  @Test def test_namespace_scope_02(): Unit = { runner.runOneTest("namespace_scope_02") }
 
-  @Test def test_error_messages_01() { runnerV.runOneTest("error_messages_01") }
+  @Test def test_error_messages_01(): Unit = { runnerV.runOneTest("error_messages_01") }
 
-  @Test def test_ibm_format_compat_01() { runner.runOneTest("ibm_format_compat_01") }
-  @Test def test_ibm_format_compat_02() { runner.runOneTest("ibm_format_compat_02") }
-  @Test def test_ibm_format_compat_03() { runner.runOneTest("ibm_format_compat_03") }
-  @Test def test_nonsense_namespace_01() { runner.runOneTest("nonsense_namespace_01") }
-  @Test def test_nonsense_namespace_02() { runner.runOneTest("nonsense_namespace_02") }
-  @Test def test_nonsense_namespace_03() { runner.runOneTest("nonsense_namespace_03") }
-  @Test def test_nonsense_namespace_04() { runnerV.runOneTest("nonsense_namespace_04") }
+  @Test def test_ibm_format_compat_01(): Unit = { runner.runOneTest("ibm_format_compat_01") }
+  @Test def test_ibm_format_compat_02(): Unit = { runner.runOneTest("ibm_format_compat_02") }
+  @Test def test_ibm_format_compat_03(): Unit = { runner.runOneTest("ibm_format_compat_03") }
+  @Test def test_nonsense_namespace_01(): Unit = { runner.runOneTest("nonsense_namespace_01") }
+  @Test def test_nonsense_namespace_02(): Unit = { runner.runOneTest("nonsense_namespace_02") }
+  @Test def test_nonsense_namespace_03(): Unit = { runner.runOneTest("nonsense_namespace_03") }
+  @Test def test_nonsense_namespace_04(): Unit = { runnerV.runOneTest("nonsense_namespace_04") }
 
-  @Test def test_junkAnnotation01() { runner.runOneTest("junkAnnotation01") }
+  @Test def test_junkAnnotation01(): Unit = { runner.runOneTest("junkAnnotation01") }
 
-  @Test def test_include01() { runner3.runOneTest("include01") }
-  @Test def test_include02() { runner3.runOneTest("include02") }
-  @Test def test_toplevel_annotation_invalid_01() { runner.runOneTest("toplevel_annotation_invalid_01") }
-  @Test def test_toplevel_annotation_invalid_02() { runner.runOneTest("toplevel_annotation_invalid_02") }
+  @Test def test_include01(): Unit = { runner3.runOneTest("include01") }
+  @Test def test_include02(): Unit = { runner3.runOneTest("include02") }
+  @Test def test_toplevel_annotation_invalid_01(): Unit = { runner.runOneTest("toplevel_annotation_invalid_01") }
+  @Test def test_toplevel_annotation_invalid_02(): Unit = { runner.runOneTest("toplevel_annotation_invalid_02") }
 
-  @Test def test_incorrectAppinfoSource() { runner.runOneTest("incorrectAppinfoSource") }
+  @Test def test_incorrectAppinfoSource(): Unit = { runner.runOneTest("incorrectAppinfoSource") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
@@ -25,7 +25,7 @@ object TestAnnotations {
   val testDir = "/org/apache/daffodil/section07/annotations/"
   val runner = Runner(testDir, "annotations.tdml", validateTDMLFile = false)
 
-  @AfterClass def tearDown {
+  @AfterClass def tearDown: Unit = {
     runner.reset
   }
 }
@@ -34,13 +34,13 @@ class TestAnnotations {
 
   import TestAnnotations._
 
-  @Test def test_annotationInElementPass() { runner.runOneTest("annotationInElementPass") }
-  @Test def test_annotationInElementFail() { runner.runOneTest("annotationInElementFail") }
+  @Test def test_annotationInElementPass(): Unit = { runner.runOneTest("annotationInElementPass") }
+  @Test def test_annotationInElementFail(): Unit = { runner.runOneTest("annotationInElementFail") }
 
   //DAFFODIL-2142
-  @Test def test_annotationInComplexTypeWarn() { runner.runOneTest("annotationInComplexTypeWarn") }
-  @Test def test_multipleAppsInfosWarn() { runner.runOneTest("multipleAppsInfosWarn") }
-  @Test def test_noAnnotationsInCTPass() { runner.runOneTest("noAnnotationsInCTPass") }
-  @Test def test_noDFDLAnnotationsInCTPass() { runner.runOneTest("noAnnotationsInCTPass") }
+  @Test def test_annotationInComplexTypeWarn(): Unit = { runner.runOneTest("annotationInComplexTypeWarn") }
+  @Test def test_multipleAppsInfosWarn(): Unit = { runner.runOneTest("multipleAppsInfosWarn") }
+  @Test def test_noAnnotationsInCTPass(): Unit = { runner.runOneTest("noAnnotationsInCTPass") }
+  @Test def test_noDFDLAnnotationsInCTPass(): Unit = { runner.runOneTest("noAnnotationsInCTPass") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
@@ -25,7 +25,7 @@ object TestAssertions {
   val testDir = "/org/apache/daffodil/section07/assertions/"
   val runner = Runner(testDir, "assert.tdml", validateTDMLFile = false)
 
-  @AfterClass def tearDown {
+  @AfterClass def tearDown: Unit = {
     runner.reset
   }
 
@@ -35,69 +35,69 @@ class TestAssertions {
 
   import TestAssertions._
 
-  @Test def test_assertPass() { runner.runOneTest("assertPass") }
-  @Test def test_assertFail1() { runner.runOneTest("assertFail1") }
-  @Test def test_assertFail2() { runner.runOneTest("assertFail2") }
+  @Test def test_assertPass(): Unit = { runner.runOneTest("assertPass") }
+  @Test def test_assertFail1(): Unit = { runner.runOneTest("assertFail1") }
+  @Test def test_assertFail2(): Unit = { runner.runOneTest("assertFail2") }
 
   // DAFFODIL-752
   //@Test def test_assertFailShowsValue() { runner.runOneTest("assertFailShowsValue") }
   // DFDL-1043
   // @Test def test_assertFailShowsValue2() { runner.runOneTest("assertFailShowsValue2") }
-  @Test def test_assertFailShowsDetails() { runner.runOneTest("assertFailShowsDetails") }
-  @Test def test_assertWithWhitespace() { runner.runOneTest("assertWithWhitespace") }
-  @Test def test_assertWithWhitespaceAndCdata() { runner.runOneTest("assertWithWhitespaceAndCdata") }
+  @Test def test_assertFailShowsDetails(): Unit = { runner.runOneTest("assertFailShowsDetails") }
+  @Test def test_assertWithWhitespace(): Unit = { runner.runOneTest("assertWithWhitespace") }
+  @Test def test_assertWithWhitespaceAndCdata(): Unit = { runner.runOneTest("assertWithWhitespaceAndCdata") }
 
-  @Test def test_assertGuidesChoice() { runner.runOneTest("assertGuidesChoice") }
+  @Test def test_assertGuidesChoice(): Unit = { runner.runOneTest("assertGuidesChoice") }
 
   @Test def test_assertPatternLiteralTextMatch() = { runner.runOneTest("assertPatternLiteralTextMatch") }
   @Test def test_assertPatternCombinedTextMatch() = { runner.runOneTest("assertPatternCombinedTextMatch") }
   @Test def test_assertPatternCombinedTextMatch2() = { runner.runOneTest("assertPatternCombinedTextMatch2") }
   @Test def test_assertPatternCombinedTextMatch3() = { runner.runOneTest("assertPatternCombinedTextMatch3") }
 
-  @Test def test_assertPatternPass() { runner.runOneTest("assertPatternPass") }
-  @Test def test_assertPatternFail() { runner.runOneTest("assertPatternFail") }
-  @Test def test_assertPatternPass2() { runner.runOneTest("assertPatternPass2") }
-  @Test def test_assertPatternPass3() { runner.runOneTest("assertPatternPass3") }
-  @Test def test_assertPatternFail2() { runner.runOneTest("assertPatternFail2") }
-  @Test def test_assertPatternInitsTerms() { runner.runOneTest("assertPatternInitsTerms") }
-  @Test def test_assertOnSequence() { runner.runOneTest("assertOnSequence") }
+  @Test def test_assertPatternPass(): Unit = { runner.runOneTest("assertPatternPass") }
+  @Test def test_assertPatternFail(): Unit = { runner.runOneTest("assertPatternFail") }
+  @Test def test_assertPatternPass2(): Unit = { runner.runOneTest("assertPatternPass2") }
+  @Test def test_assertPatternPass3(): Unit = { runner.runOneTest("assertPatternPass3") }
+  @Test def test_assertPatternFail2(): Unit = { runner.runOneTest("assertPatternFail2") }
+  @Test def test_assertPatternInitsTerms(): Unit = { runner.runOneTest("assertPatternInitsTerms") }
+  @Test def test_assertOnSequence(): Unit = { runner.runOneTest("assertOnSequence") }
 
-  @Test def test_assertOnGroupRef() { runner.runOneTest("assertOnGroupRef") }
-  @Test def test_assertOnElemRef() { runner.runOneTest("assertOnElemRef") }
+  @Test def test_assertOnGroupRef(): Unit = { runner.runOneTest("assertOnGroupRef") }
+  @Test def test_assertOnElemRef(): Unit = { runner.runOneTest("assertOnElemRef") }
 
-  @Test def test_assertPatternMatch() { runner.runOneTest("assertPatternMatch") }
-  @Test def test_assertPatternMatch2() { runner.runOneTest("assertPatternMatch2") }
+  @Test def test_assertPatternMatch(): Unit = { runner.runOneTest("assertPatternMatch") }
+  @Test def test_assertPatternMatch2(): Unit = { runner.runOneTest("assertPatternMatch2") }
 
-  @Test def test_assertMultFormsFail() { runner.runOneTest("assertMultFormsFail") }
-  @Test def test_assertMultFormsFail2() { runner.runOneTest("assertMultFormsFail2") }
-  @Test def test_assertPatternAndExp() { runner.runOneTest("assertPatternAndExp") }
-  @Test def test_assertPatternAndExp2() { runner.runOneTest("assertPatternAndExp2") }
-  @Test def test_assertOnSimpleType() { runner.runOneTest("assertOnSimpleType") }
-  @Test def test_assertPass2() { runner.runOneTest("assertPass2") }
-  @Test def test_assertPatternEmpty() { runner.runOneTest("assertPatternEmpty") }
+  @Test def test_assertMultFormsFail(): Unit = { runner.runOneTest("assertMultFormsFail") }
+  @Test def test_assertMultFormsFail2(): Unit = { runner.runOneTest("assertMultFormsFail2") }
+  @Test def test_assertPatternAndExp(): Unit = { runner.runOneTest("assertPatternAndExp") }
+  @Test def test_assertPatternAndExp2(): Unit = { runner.runOneTest("assertPatternAndExp2") }
+  @Test def test_assertOnSimpleType(): Unit = { runner.runOneTest("assertOnSimpleType") }
+  @Test def test_assertPass2(): Unit = { runner.runOneTest("assertPass2") }
+  @Test def test_assertPatternEmpty(): Unit = { runner.runOneTest("assertPatternEmpty") }
 
   // DFDL-474
   //  @Test def test_assertExpressionEmpty() { runner.runOneTest("assertExpressionEmpty") }
 
-  @Test def test_assertExpressionRef() { runner.runOneTest("assertExpressionRef") }
-  @Test def test_assertExpressionRefFail() { runner.runOneTest("assertExpressionRefFail") }
-  @Test def test_assertMessage() { runner.runOneTest("assertMessage") }
-  @Test def test_unparseAssertionIgnored() { runner.runOneTest("unparseAssertionIgnored") }
+  @Test def test_assertExpressionRef(): Unit = { runner.runOneTest("assertExpressionRef") }
+  @Test def test_assertExpressionRefFail(): Unit = { runner.runOneTest("assertExpressionRefFail") }
+  @Test def test_assertMessage(): Unit = { runner.runOneTest("assertMessage") }
+  @Test def test_unparseAssertionIgnored(): Unit = { runner.runOneTest("unparseAssertionIgnored") }
 
   // DFDL-2001
   //@Test def test_testPatternX() { runner.runOneTest("testPatternX") }
   //@Test def test_testPatternUnicode() { runner.runOneTest("testPatternUnicode") }
-  @Test def test_testPatternHex() { runner.runOneTest("testPatternHex") }
-  @Test def test_testPatternFreeFormat() { runner.runOneTest("testPatternFreeFormat") }
-  @Test def test_testPatternUregexUword() { runner.runOneTest("testPatternUregexUword") }
-  @Test def test_testPatternWordChar() { runner.runOneTest("testPatternWordChar") }
+  @Test def test_testPatternHex(): Unit = { runner.runOneTest("testPatternHex") }
+  @Test def test_testPatternFreeFormat(): Unit = { runner.runOneTest("testPatternFreeFormat") }
+  @Test def test_testPatternUregexUword(): Unit = { runner.runOneTest("testPatternUregexUword") }
+  @Test def test_testPatternWordChar(): Unit = { runner.runOneTest("testPatternWordChar") }
 
   // JIRA DFDL-1672
-  @Test def testNumberFormatErrorInExprRuntime() { runner.runOneTest("testNumberFormatErrorInExprRuntime") }
-  @Test def testNumberFormatErrorInExprCompileTime() { runner.runOneTest("testNumberFormatErrorInExprCompileTime") }
+  @Test def testNumberFormatErrorInExprRuntime(): Unit = { runner.runOneTest("testNumberFormatErrorInExprRuntime") }
+  @Test def testNumberFormatErrorInExprCompileTime(): Unit = { runner.runOneTest("testNumberFormatErrorInExprCompileTime") }
 
 
-  @Test def test_assertWithMessageExpression_01() { runner.runOneTest("test_assertWithMessageExpression_01") }
-  @Test def test_assertWithMessageExpression_02() { runner.runOneTest("test_assertWithMessageExpression_02") }
+  @Test def test_assertWithMessageExpression_01(): Unit = { runner.runOneTest("test_assertWithMessageExpression_01") }
+  @Test def test_assertWithMessageExpression_02(): Unit = { runner.runOneTest("test_assertWithMessageExpression_02") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/defineFormat/defineFormatTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/defineFormat/defineFormatTests.scala
@@ -25,7 +25,7 @@ object defineFormatTests {
   val testDir = "/org/apache/daffodil/section07/defineFormat/"
   val runner = Runner(testDir, "defineFormat.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 
@@ -35,16 +35,16 @@ class defineFormatTests {
 
   import defineFormatTests._
 
-  @Test def test_format_with_comment() { runner.runOneTest("format_with_comment") }
+  @Test def test_format_with_comment(): Unit = { runner.runOneTest("format_with_comment") }
 
   //DFDL-478
   //@Test def test_nameCollision() { runner.runOneTest("nameCollision") }
 
-  @Test def test_defineFormat_01() { runner.runOneTest("defineFormat_01") }
-  @Test def test_Lesson3_defineFormat() { runner.runOneTest("Lesson3_defineFormat") }
-  @Test def test_Lesson3_inherit_defineFormat() { runner.runOneTest("Lesson3_inherit_defineFormat") }
-  @Test def test_formatOnlyDefine() { runner.runOneTest("formatOnlyDefine") }
-  @Test def test_circularRef() { runner.runOneTest("circularRef") }
-  @Test def test_noNameFormat() { runner.runOneTest("noNameFormat") }
+  @Test def test_defineFormat_01(): Unit = { runner.runOneTest("defineFormat_01") }
+  @Test def test_Lesson3_defineFormat(): Unit = { runner.runOneTest("Lesson3_defineFormat") }
+  @Test def test_Lesson3_inherit_defineFormat(): Unit = { runner.runOneTest("Lesson3_inherit_defineFormat") }
+  @Test def test_formatOnlyDefine(): Unit = { runner.runOneTest("formatOnlyDefine") }
+  @Test def test_circularRef(): Unit = { runner.runOneTest("circularRef") }
+  @Test def test_noNameFormat(): Unit = { runner.runOneTest("noNameFormat") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators2.scala
@@ -25,7 +25,7 @@ object TestDiscriminators2 {
   val testDir = "/org/apache/daffodil/section07/discriminators/"
   val runner2 = Runner(testDir, "discriminator2.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner2.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators3.scala
@@ -25,7 +25,7 @@ object TestDiscriminators {
   val testDir = "/org/apache/daffodil/section07/discriminators/"
   val runner = Runner(testDir, "discriminator.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 
@@ -35,28 +35,28 @@ class TestDiscriminators {
 
   import TestDiscriminators._
 
-  @Test def test_discriminatorGuidesChoice() { runner.runOneTest("discriminatorGuidesChoice") }
-  @Test def test_discriminatorGuidesChoice2() { runner.runOneTest("discriminatorGuidesChoice2") }
+  @Test def test_discriminatorGuidesChoice(): Unit = { runner.runOneTest("discriminatorGuidesChoice") }
+  @Test def test_discriminatorGuidesChoice2(): Unit = { runner.runOneTest("discriminatorGuidesChoice2") }
   @Test def test_discriminatorGuidesChoice3() = {
     //LoggingDefaults.setLoggingLevel(LogLevel.Debug)
     runner.runOneTest("discriminatorGuidesChoice3")
   }
-  @Test def test_discriminatorGuidesChoice4() { runner.runOneTest("discriminatorGuidesChoice4") }
-  @Test def test_discriminatorGuidesChoice5() { runner.runOneTest("discriminatorGuidesChoice5") }
+  @Test def test_discriminatorGuidesChoice4(): Unit = { runner.runOneTest("discriminatorGuidesChoice4") }
+  @Test def test_discriminatorGuidesChoice5(): Unit = { runner.runOneTest("discriminatorGuidesChoice5") }
 
-  @Test def test_discrimPatternPass() { runner.runOneTest("discrimPatternPass") }
-  @Test def test_discrimPatternFail() { runner.runOneTest("discrimPatternFail") }
+  @Test def test_discrimPatternPass(): Unit = { runner.runOneTest("discrimPatternPass") }
+  @Test def test_discrimPatternFail(): Unit = { runner.runOneTest("discrimPatternFail") }
 
-  @Test def test_discrimPatternFail2() { runner.runOneTest("discrimPatternFail2") }
-  @Test def test_discrimPatternFail3() { runner.runOneTest("discrimPatternFail3") }
-  @Test def test_choiceBranchDiscrim() { runner.runOneTest("choiceBranchDiscrim") }
-  @Test def test_unparseDiscrimIgnored() { runner.runOneTest("unparseDiscrimIgnored") }
+  @Test def test_discrimPatternFail2(): Unit = { runner.runOneTest("discrimPatternFail2") }
+  @Test def test_discrimPatternFail3(): Unit = { runner.runOneTest("discrimPatternFail3") }
+  @Test def test_choiceBranchDiscrim(): Unit = { runner.runOneTest("choiceBranchDiscrim") }
+  @Test def test_unparseDiscrimIgnored(): Unit = { runner.runOneTest("unparseDiscrimIgnored") }
 
-  @Test def test_discrimInvalidSchema() { runner.runOneTest("discrimInvalidSchema") }
-  @Test def test_discrimOnSimpleType() { runner.runOneTest("discrimOnSimpleType") }
-  @Test def test_discrimOnGroupRef() { runner.runOneTest("discrimOnGroupRef") }
-  @Test def test_discrimOnGroupRef2() { runner.runOneTest("discrimOnGroupRef2") }
-  @Test def test_discrimOnElementRef() { runner.runOneTest("discrimOnElementRef") }
+  @Test def test_discrimInvalidSchema(): Unit = { runner.runOneTest("discrimInvalidSchema") }
+  @Test def test_discrimOnSimpleType(): Unit = { runner.runOneTest("discrimOnSimpleType") }
+  @Test def test_discrimOnGroupRef(): Unit = { runner.runOneTest("discrimOnGroupRef") }
+  @Test def test_discrimOnGroupRef2(): Unit = { runner.runOneTest("discrimOnGroupRef2") }
+  @Test def test_discrimOnElementRef(): Unit = { runner.runOneTest("discrimOnElementRef") }
   @Test def test_choiceBranchDiscrimFail() = { runner.runOneTest("choiceBranchDiscrimFail") }
 
   @Test def test_discrimPatternMatch() = { runner.runOneTest("discrimPatternMatch") }
@@ -69,11 +69,11 @@ class TestDiscriminators {
   // DAFFODIL-1971
   // @Test def test_discrimExpression_04() = { runner.runOneTest("discrimExpression_04") }
 
-  @Test def test_discrimFailStopsFollowingAssert1() { runner.runOneTest("discrimFailStopsFollowingAssert1") }
-  @Test def test_discrimPEnotSDE1() { runner.runOneTest("discrimPEnotSDE1") }
-  @Test def test_assertSDENotPE1() { runner.runOneTest("assertSDENotPE1") }
-  @Test def test_occursCountSDENotPE1() { runner.runOneTest("occursCountSDENotPE1") }
-  @Test def test_discrimPEvalueLength1() { runner.runOneTest("discrimPEvalueLength1") }
-  @Test def test_discrimPEvalueLengthEnclosingParent1() { runner.runOneTest("discrimPEvalueLengthEnclosingParent1") }
+  @Test def test_discrimFailStopsFollowingAssert1(): Unit = { runner.runOneTest("discrimFailStopsFollowingAssert1") }
+  @Test def test_discrimPEnotSDE1(): Unit = { runner.runOneTest("discrimPEnotSDE1") }
+  @Test def test_assertSDENotPE1(): Unit = { runner.runOneTest("assertSDENotPE1") }
+  @Test def test_occursCountSDENotPE1(): Unit = { runner.runOneTest("occursCountSDENotPE1") }
+  @Test def test_discrimPEvalueLength1(): Unit = { runner.runOneTest("discrimPEvalueLength1") }
+  @Test def test_discrimPEvalueLengthEnclosingParent1(): Unit = { runner.runOneTest("discrimPEvalueLengthEnclosingParent1") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
@@ -27,7 +27,7 @@ object TestEscapeScheme {
   val runnerNeg = Runner(testDir, "escapeSchemeNeg.tdml", validateTDMLFile = false)
   val runner2 = Runner(testDir, "escapeScenarios.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerNeg.reset
     runner2.reset
@@ -42,110 +42,110 @@ class TestEscapeScheme {
   // runner.runOneTest("test_name")
   // }
 
-  @Test def test_escapeSchemeSimple() { runner.runOneTest("escapeSchemeSimple") }
-  @Test def test_escapeSchemeEmpty() { runner.runOneTest("escapeSchemeEmpty") }
-  @Test def test_escapeSchemeUnused() { runner.runOneTest("escapeSchemeUnused") }
-  @Test def test_escapeSchemeFail() { runner.runOneTest("escapeSchemeFail") }
-  @Test def test_escapeSchemeFail2() { runner.runOneTest("escapeSchemeFail2") }
-  @Test def test_escapeSchemeFail3() { runner.runOneTest("escapeSchemeFail3") }
-  @Test def test_escapeSchemeNonEmpty() { runner.runOneTest("escapeSchemeNonEmpty") }
+  @Test def test_escapeSchemeSimple(): Unit = { runner.runOneTest("escapeSchemeSimple") }
+  @Test def test_escapeSchemeEmpty(): Unit = { runner.runOneTest("escapeSchemeEmpty") }
+  @Test def test_escapeSchemeUnused(): Unit = { runner.runOneTest("escapeSchemeUnused") }
+  @Test def test_escapeSchemeFail(): Unit = { runner.runOneTest("escapeSchemeFail") }
+  @Test def test_escapeSchemeFail2(): Unit = { runner.runOneTest("escapeSchemeFail2") }
+  @Test def test_escapeSchemeFail3(): Unit = { runner.runOneTest("escapeSchemeFail3") }
+  @Test def test_escapeSchemeNonEmpty(): Unit = { runner.runOneTest("escapeSchemeNonEmpty") }
   // DAFFODIL-844
   //@Test def test_escapeSchemeNonUnique() { runner.runOneTest("escapeSchemeNonUnique") }
 
-  @Test def test_escapeExpressions_01() { runner.runOneTest("escapeExpressions_01") }
-  @Test def test_escapeExpressions_01b() { runner.runOneTest("escapeExpressions_01b") }
-  @Test def test_escapeExpressions_02() { runner.runOneTest("escapeExpressions_02") }
-  @Test def test_escapeExpressions_03() { runner.runOneTest("escapeExpressions_03") }
-  @Test def test_escapeExpressions_04() { runner.runOneTest("escapeExpressions_04") }
-  @Test def test_escapeExpressions_05() { runner.runOneTest("escapeExpressions_05") }
-  @Test def test_escapeExpressions_06() { runner.runOneTest("escapeExpressions_06") }
+  @Test def test_escapeExpressions_01(): Unit = { runner.runOneTest("escapeExpressions_01") }
+  @Test def test_escapeExpressions_01b(): Unit = { runner.runOneTest("escapeExpressions_01b") }
+  @Test def test_escapeExpressions_02(): Unit = { runner.runOneTest("escapeExpressions_02") }
+  @Test def test_escapeExpressions_03(): Unit = { runner.runOneTest("escapeExpressions_03") }
+  @Test def test_escapeExpressions_04(): Unit = { runner.runOneTest("escapeExpressions_04") }
+  @Test def test_escapeExpressions_05(): Unit = { runner.runOneTest("escapeExpressions_05") }
+  @Test def test_escapeExpressions_06(): Unit = { runner.runOneTest("escapeExpressions_06") }
 
-  @Test def test_escapeSchemeNeg() { runnerNeg.runOneTest("escapeSchemeNeg") }
+  @Test def test_escapeSchemeNeg(): Unit = { runnerNeg.runOneTest("escapeSchemeNeg") }
 
-  @Test def test_scenario1_1() { runner2.runOneTest("scenario1_1") }
-  @Test def test_scenario1_2() { runner2.runOneTest("scenario1_2") }
-  @Test def test_scenario1_3() { runner2.runOneTest("scenario1_3") }
-  @Test def test_scenario1_4() { runner2.runOneTest("scenario1_4") }
-  @Test def test_scenario1_5() { runner2.runOneTest("scenario1_5") }
-  @Test def test_scenario1_6() { runner2.runOneTest("scenario1_6") }
-  @Test def test_scenario1_7() { runner2.runOneTest("scenario1_7") }
-  @Test def test_scenario1_7_postfix() { runner2.runOneTest("scenario1_7_postfix") }
-  @Test def test_scenario1_8() { runner2.runOneTest("scenario1_8") }
-  @Test def test_scenario1_8_req_term() { runner2.runOneTest("scenario1_8_req_term") }
-  @Test def test_scenario1_9() { runner2.runOneTest("scenario1_9") }
-  @Test def test_scenario1_9_postfix() { runner2.runOneTest("scenario1_9_postfix") }
-  @Test def test_scenario1_10() { runner2.runOneTest("scenario1_10") }
-  @Test def test_scenario1_10_postfix() { runner2.runOneTest("scenario1_10_postfix") }
-  @Test def test_scenario1_11() { runner2.runOneTest("scenario1_11") }
-  @Test def test_scenario1_11_postfix() { runner2.runOneTest("scenario1_11_postfix") }
-  @Test def test_scenario1_12() { runner2.runOneTest("scenario1_12") }
-  @Test def test_scenario1_12_postfix() { runner2.runOneTest("scenario1_12_postfix") }
-  @Test def test_scenario1_13() { runner2.runOneTest("scenario1_13") }
-  @Test def test_scenario1_13_postfix() { runner2.runOneTest("scenario1_13_postfix") }
+  @Test def test_scenario1_1(): Unit = { runner2.runOneTest("scenario1_1") }
+  @Test def test_scenario1_2(): Unit = { runner2.runOneTest("scenario1_2") }
+  @Test def test_scenario1_3(): Unit = { runner2.runOneTest("scenario1_3") }
+  @Test def test_scenario1_4(): Unit = { runner2.runOneTest("scenario1_4") }
+  @Test def test_scenario1_5(): Unit = { runner2.runOneTest("scenario1_5") }
+  @Test def test_scenario1_6(): Unit = { runner2.runOneTest("scenario1_6") }
+  @Test def test_scenario1_7(): Unit = { runner2.runOneTest("scenario1_7") }
+  @Test def test_scenario1_7_postfix(): Unit = { runner2.runOneTest("scenario1_7_postfix") }
+  @Test def test_scenario1_8(): Unit = { runner2.runOneTest("scenario1_8") }
+  @Test def test_scenario1_8_req_term(): Unit = { runner2.runOneTest("scenario1_8_req_term") }
+  @Test def test_scenario1_9(): Unit = { runner2.runOneTest("scenario1_9") }
+  @Test def test_scenario1_9_postfix(): Unit = { runner2.runOneTest("scenario1_9_postfix") }
+  @Test def test_scenario1_10(): Unit = { runner2.runOneTest("scenario1_10") }
+  @Test def test_scenario1_10_postfix(): Unit = { runner2.runOneTest("scenario1_10_postfix") }
+  @Test def test_scenario1_11(): Unit = { runner2.runOneTest("scenario1_11") }
+  @Test def test_scenario1_11_postfix(): Unit = { runner2.runOneTest("scenario1_11_postfix") }
+  @Test def test_scenario1_12(): Unit = { runner2.runOneTest("scenario1_12") }
+  @Test def test_scenario1_12_postfix(): Unit = { runner2.runOneTest("scenario1_12_postfix") }
+  @Test def test_scenario1_13(): Unit = { runner2.runOneTest("scenario1_13") }
+  @Test def test_scenario1_13_postfix(): Unit = { runner2.runOneTest("scenario1_13_postfix") }
 
-  @Test def test_scenario2_1() { runner2.runOneTest("scenario2_1") }
-  @Test def test_scenario2_2() { runner2.runOneTest("scenario2_2") }
-  @Test def test_scenario2_3() { runner2.runOneTest("scenario2_3") }
-  @Test def test_scenario2_4() { runner2.runOneTest("scenario2_4") }
-  @Test def test_scenario2_5() { runner2.runOneTest("scenario2_5") }
-  @Test def test_scenario2_6() { runner2.runOneTest("scenario2_6") }
-  @Test def test_scenario2_7() { runner2.runOneTest("scenario2_7") }
-  @Test def test_scenario2_8() { runner2.runOneTest("scenario2_8") }
-  @Test def test_scenario2_9() { runner2.runOneTest("scenario2_9") }
-  @Test def test_scenario2_10() { runner2.runOneTest("scenario2_10") }
-  @Test def test_scenario2_10_postfix() { runner2.runOneTest("scenario2_10_postfix") }
-  @Test def test_scenario2_11() { runner2.runOneTest("scenario2_11") }
-  @Test def test_scenario2_11_req_term() { runner2.runOneTest("scenario2_11_req_term") }
-  @Test def test_scenario2_12() { runner2.runOneTest("scenario2_12") }
-  @Test def test_scenario2_12_postfix() { runner2.runOneTest("scenario2_12_postfix") }
-  @Test def test_scenario2_13() { runner2.runOneTest("scenario2_13") }
-  @Test def test_scenario2_13_postfix() { runner2.runOneTest("scenario2_13_postfix") }
-  @Test def test_scenario2_14() { runner2.runOneTest("scenario2_14") }
-  @Test def test_scenario2_14_req_term() { runner2.runOneTest("scenario2_14_req_term") }
+  @Test def test_scenario2_1(): Unit = { runner2.runOneTest("scenario2_1") }
+  @Test def test_scenario2_2(): Unit = { runner2.runOneTest("scenario2_2") }
+  @Test def test_scenario2_3(): Unit = { runner2.runOneTest("scenario2_3") }
+  @Test def test_scenario2_4(): Unit = { runner2.runOneTest("scenario2_4") }
+  @Test def test_scenario2_5(): Unit = { runner2.runOneTest("scenario2_5") }
+  @Test def test_scenario2_6(): Unit = { runner2.runOneTest("scenario2_6") }
+  @Test def test_scenario2_7(): Unit = { runner2.runOneTest("scenario2_7") }
+  @Test def test_scenario2_8(): Unit = { runner2.runOneTest("scenario2_8") }
+  @Test def test_scenario2_9(): Unit = { runner2.runOneTest("scenario2_9") }
+  @Test def test_scenario2_10(): Unit = { runner2.runOneTest("scenario2_10") }
+  @Test def test_scenario2_10_postfix(): Unit = { runner2.runOneTest("scenario2_10_postfix") }
+  @Test def test_scenario2_11(): Unit = { runner2.runOneTest("scenario2_11") }
+  @Test def test_scenario2_11_req_term(): Unit = { runner2.runOneTest("scenario2_11_req_term") }
+  @Test def test_scenario2_12(): Unit = { runner2.runOneTest("scenario2_12") }
+  @Test def test_scenario2_12_postfix(): Unit = { runner2.runOneTest("scenario2_12_postfix") }
+  @Test def test_scenario2_13(): Unit = { runner2.runOneTest("scenario2_13") }
+  @Test def test_scenario2_13_postfix(): Unit = { runner2.runOneTest("scenario2_13_postfix") }
+  @Test def test_scenario2_14(): Unit = { runner2.runOneTest("scenario2_14") }
+  @Test def test_scenario2_14_req_term(): Unit = { runner2.runOneTest("scenario2_14_req_term") }
 
-  @Test def test_scenario3_1() { runner2.runOneTest("scenario3_1") }
-  @Test def test_scenario3_2() { runner2.runOneTest("scenario3_2") }
-  @Test def test_scenario3_3() { runner2.runOneTest("scenario3_3") }
-  @Test def test_scenario3_4() { runner2.runOneTest("scenario3_4") }
-  @Test def test_scenario3_5() { runner2.runOneTest("scenario3_5") }
-  @Test def test_scenario3_6() { runner2.runOneTest("scenario3_6") }
-  @Test def test_scenario3_7() { runner2.runOneTest("scenario3_7") }
-  @Test def test_scenario3_8() { runner2.runOneTest("scenario3_8") }
-  @Test def test_scenario3_9() { runner2.runOneTest("scenario3_9") }
-  @Test def test_scenario3_10() { runner2.runOneTest("scenario3_10") }
-  @Test def test_scenario3_10_postfix() { runner2.runOneTest("scenario3_10_postfix") }
-  @Test def test_scenario3_11() { runner2.runOneTest("scenario3_11") }
+  @Test def test_scenario3_1(): Unit = { runner2.runOneTest("scenario3_1") }
+  @Test def test_scenario3_2(): Unit = { runner2.runOneTest("scenario3_2") }
+  @Test def test_scenario3_3(): Unit = { runner2.runOneTest("scenario3_3") }
+  @Test def test_scenario3_4(): Unit = { runner2.runOneTest("scenario3_4") }
+  @Test def test_scenario3_5(): Unit = { runner2.runOneTest("scenario3_5") }
+  @Test def test_scenario3_6(): Unit = { runner2.runOneTest("scenario3_6") }
+  @Test def test_scenario3_7(): Unit = { runner2.runOneTest("scenario3_7") }
+  @Test def test_scenario3_8(): Unit = { runner2.runOneTest("scenario3_8") }
+  @Test def test_scenario3_9(): Unit = { runner2.runOneTest("scenario3_9") }
+  @Test def test_scenario3_10(): Unit = { runner2.runOneTest("scenario3_10") }
+  @Test def test_scenario3_10_postfix(): Unit = { runner2.runOneTest("scenario3_10_postfix") }
+  @Test def test_scenario3_11(): Unit = { runner2.runOneTest("scenario3_11") }
   //DFDL-961
   //@Test def test_scenario3_11_postfix() { runner2.runOneTest("scenario3_11_postfix") }
-  @Test def test_scenario3_12() { runner2.runOneTest("scenario3_12") }
-  @Test def test_scenario3_12_req_term() { runner2.runOneTest("scenario3_12_req_term") }
-  @Test def test_scenario3_13() { runner2.runOneTest("scenario3_13") }
-  @Test def test_scenario3_13_postfix() { runner2.runOneTest("scenario3_13_postfix") }
-  @Test def test_scenario3_14() { runner2.runOneTest("scenario3_14") }
-  @Test def test_scenario3_14_req_term() { runner2.runOneTest("scenario3_14_req_term") }
+  @Test def test_scenario3_12(): Unit = { runner2.runOneTest("scenario3_12") }
+  @Test def test_scenario3_12_req_term(): Unit = { runner2.runOneTest("scenario3_12_req_term") }
+  @Test def test_scenario3_13(): Unit = { runner2.runOneTest("scenario3_13") }
+  @Test def test_scenario3_13_postfix(): Unit = { runner2.runOneTest("scenario3_13_postfix") }
+  @Test def test_scenario3_14(): Unit = { runner2.runOneTest("scenario3_14") }
+  @Test def test_scenario3_14_req_term(): Unit = { runner2.runOneTest("scenario3_14_req_term") }
 
-  @Test def test_scenario4_1() { runner2.runOneTest("scenario4_1") }
-  @Test def test_scenario4_2() { runner2.runOneTest("scenario4_2") }
-  @Test def test_scenario4_3() { runner2.runOneTest("scenario4_3") }
-  @Test def test_scenario4_4() { runner2.runOneTest("scenario4_4") }
-  @Test def test_scenario4_5() { runner2.runOneTest("scenario4_5") }
-  @Test def test_scenario4_6() { runner2.runOneTest("scenario4_6") }
-  @Test def test_scenario4_7() { runner2.runOneTest("scenario4_7") }
-  @Test def test_scenario4_7_req_term() { runner2.runOneTest("scenario4_7_req_term") }
-  @Test def test_scenario4_8() { runner2.runOneTest("scenario4_8") }
-  @Test def test_scenario4_8_postfix() { runner2.runOneTest("scenario4_8_postfix") }
-  @Test def test_scenario4_9() { runner2.runOneTest("scenario4_9") }
-  @Test def test_scenario4_9_req_term() { runner2.runOneTest("scenario4_9_req_term") }
-  @Test def test_scenario4_10() { runner2.runOneTest("scenario4_10") }
-  @Test def test_scenario4_10_req_term() { runner2.runOneTest("scenario4_10_req_term") }
-  @Test def test_scenario4_11() { runner2.runOneTest("scenario4_11") }
-  @Test def test_scenario4_11_postfix() { runner2.runOneTest("scenario4_11_postfix") }
-  @Test def test_scenario4_12() { runner2.runOneTest("scenario4_12") }
-  @Test def test_scenario4_12_req_term() { runner2.runOneTest("scenario4_12_req_term") }
+  @Test def test_scenario4_1(): Unit = { runner2.runOneTest("scenario4_1") }
+  @Test def test_scenario4_2(): Unit = { runner2.runOneTest("scenario4_2") }
+  @Test def test_scenario4_3(): Unit = { runner2.runOneTest("scenario4_3") }
+  @Test def test_scenario4_4(): Unit = { runner2.runOneTest("scenario4_4") }
+  @Test def test_scenario4_5(): Unit = { runner2.runOneTest("scenario4_5") }
+  @Test def test_scenario4_6(): Unit = { runner2.runOneTest("scenario4_6") }
+  @Test def test_scenario4_7(): Unit = { runner2.runOneTest("scenario4_7") }
+  @Test def test_scenario4_7_req_term(): Unit = { runner2.runOneTest("scenario4_7_req_term") }
+  @Test def test_scenario4_8(): Unit = { runner2.runOneTest("scenario4_8") }
+  @Test def test_scenario4_8_postfix(): Unit = { runner2.runOneTest("scenario4_8_postfix") }
+  @Test def test_scenario4_9(): Unit = { runner2.runOneTest("scenario4_9") }
+  @Test def test_scenario4_9_req_term(): Unit = { runner2.runOneTest("scenario4_9_req_term") }
+  @Test def test_scenario4_10(): Unit = { runner2.runOneTest("scenario4_10") }
+  @Test def test_scenario4_10_req_term(): Unit = { runner2.runOneTest("scenario4_10_req_term") }
+  @Test def test_scenario4_11(): Unit = { runner2.runOneTest("scenario4_11") }
+  @Test def test_scenario4_11_postfix(): Unit = { runner2.runOneTest("scenario4_11_postfix") }
+  @Test def test_scenario4_12(): Unit = { runner2.runOneTest("scenario4_12") }
+  @Test def test_scenario4_12_req_term(): Unit = { runner2.runOneTest("scenario4_12_req_term") }
 
-  @Test def test_scenario5_1() { runner2.runOneTest("scenario5_1") }
+  @Test def test_scenario5_1(): Unit = { runner2.runOneTest("scenario5_1") }
 
-  @Test def test_escBlkAllQuotes() { runner.runOneTest("escBlkAllQuotes") }
-  @Test def test_escBlkEndSame() { runner.runOneTest("escBlkEndSame") }
+  @Test def test_escBlkAllQuotes(): Unit = { runner.runOneTest("escBlkAllQuotes") }
+  @Test def test_escBlkEndSame(): Unit = { runner.runOneTest("escBlkEndSame") }
   //@Test def test_escBlkMultipleEEC() { runner.runOneTest("escBlkMultipleEEC") } // DAFFODIL-1972
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparse.scala
@@ -25,7 +25,7 @@ object TestEscapeSchemeUnparse {
   val testDir = "/org/apache/daffodil/section07/escapeScheme/"
   val runner = Runner(testDir, "escapeSchemeUnparse.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 }
@@ -34,20 +34,20 @@ class TestEscapeSchemeUnparse {
 
   import TestEscapeSchemeUnparse._
 
-  @Test def test_unparseDelimitedEscapedString01() { runner.runOneTest("unparseDelimitedEscapedString01") }
-  @Test def test_unparseDelimitedEscapedString02() { runner.runOneTest("unparseDelimitedEscapedString02") }
-  @Test def test_unparseDelimitedEscapedString03() { runner.runOneTest("unparseDelimitedEscapedString03") }
-  @Test def test_unparseDelimitedEscapedString04() { runner.runOneTest("unparseDelimitedEscapedString04") }
-  @Test def test_unparseDelimitedEscapedString05() { runner.runOneTest("unparseDelimitedEscapedString05") }
-  @Test def test_unparseDelimitedEscapedString06() { runner.runOneTest("unparseDelimitedEscapedString06") }
-  @Test def test_unparseDelimitedEscapedString07() { runner.runOneTest("unparseDelimitedEscapedString07") }
-  @Test def test_unparseDelimitedEscapedString08() { runner.runOneTest("unparseDelimitedEscapedString08") }
-  @Test def test_unparseDelimitedEscapedString09() { runner.runOneTest("unparseDelimitedEscapedString09") }
-  @Test def test_unparseDelimitedEscapedString10() { runner.runOneTest("unparseDelimitedEscapedString10") }
-  @Test def test_unparseDelimitedEscapedString11() { runner.runOneTest("unparseDelimitedEscapedString11") }
-  @Test def test_unparseDelimitedEscapedString12() { runner.runOneTest("unparseDelimitedEscapedString12") }
-  @Test def test_unparseDelimitedEscapedString13() { runner.runOneTest("unparseDelimitedEscapedString13") }
-  @Test def test_unparseDelimitedEscapedString14() { runner.runOneTest("unparseDelimitedEscapedString14") }
+  @Test def test_unparseDelimitedEscapedString01(): Unit = { runner.runOneTest("unparseDelimitedEscapedString01") }
+  @Test def test_unparseDelimitedEscapedString02(): Unit = { runner.runOneTest("unparseDelimitedEscapedString02") }
+  @Test def test_unparseDelimitedEscapedString03(): Unit = { runner.runOneTest("unparseDelimitedEscapedString03") }
+  @Test def test_unparseDelimitedEscapedString04(): Unit = { runner.runOneTest("unparseDelimitedEscapedString04") }
+  @Test def test_unparseDelimitedEscapedString05(): Unit = { runner.runOneTest("unparseDelimitedEscapedString05") }
+  @Test def test_unparseDelimitedEscapedString06(): Unit = { runner.runOneTest("unparseDelimitedEscapedString06") }
+  @Test def test_unparseDelimitedEscapedString07(): Unit = { runner.runOneTest("unparseDelimitedEscapedString07") }
+  @Test def test_unparseDelimitedEscapedString08(): Unit = { runner.runOneTest("unparseDelimitedEscapedString08") }
+  @Test def test_unparseDelimitedEscapedString09(): Unit = { runner.runOneTest("unparseDelimitedEscapedString09") }
+  @Test def test_unparseDelimitedEscapedString10(): Unit = { runner.runOneTest("unparseDelimitedEscapedString10") }
+  @Test def test_unparseDelimitedEscapedString11(): Unit = { runner.runOneTest("unparseDelimitedEscapedString11") }
+  @Test def test_unparseDelimitedEscapedString12(): Unit = { runner.runOneTest("unparseDelimitedEscapedString12") }
+  @Test def test_unparseDelimitedEscapedString13(): Unit = { runner.runOneTest("unparseDelimitedEscapedString13") }
+  @Test def test_unparseDelimitedEscapedString14(): Unit = { runner.runOneTest("unparseDelimitedEscapedString14") }
 
   /* 
    * The following tests demonstrate that for extraEscapedCharacters during Unparsing that:
@@ -59,18 +59,18 @@ class TestEscapeSchemeUnparse {
    * 5. DFDL decimal entities are allowed
    * 6. When an extra escaped character is not present, the text is not escaped.
    * */
-  @Test def test_unparseDelimitedEscapedString15() { runner.runOneTest("unparseDelimitedEscapedString15") }
-  @Test def test_unparseDelimitedEscapedString16() { runner.runOneTest("unparseDelimitedEscapedString16") }
-  @Test def test_unparseDelimitedEscapedString17() { runner.runOneTest("unparseDelimitedEscapedString17") }
-  @Test def test_unparseDelimitedEscapedString18() { runner.runOneTest("unparseDelimitedEscapedString18") }
-  @Test def test_unparseDelimitedEscapedString19() { runner.runOneTest("unparseDelimitedEscapedString19") }
-  @Test def test_unparseDelimitedEscapedString20() { runner.runOneTest("unparseDelimitedEscapedString20") }
-  @Test def test_unparseDelimitedEscapedString21() { runner.runOneTest("unparseDelimitedEscapedString21") }
-  @Test def test_unparseDelimitedEscapedString22() { runner.runOneTest("unparseDelimitedEscapedString22") }
+  @Test def test_unparseDelimitedEscapedString15(): Unit = { runner.runOneTest("unparseDelimitedEscapedString15") }
+  @Test def test_unparseDelimitedEscapedString16(): Unit = { runner.runOneTest("unparseDelimitedEscapedString16") }
+  @Test def test_unparseDelimitedEscapedString17(): Unit = { runner.runOneTest("unparseDelimitedEscapedString17") }
+  @Test def test_unparseDelimitedEscapedString18(): Unit = { runner.runOneTest("unparseDelimitedEscapedString18") }
+  @Test def test_unparseDelimitedEscapedString19(): Unit = { runner.runOneTest("unparseDelimitedEscapedString19") }
+  @Test def test_unparseDelimitedEscapedString20(): Unit = { runner.runOneTest("unparseDelimitedEscapedString20") }
+  @Test def test_unparseDelimitedEscapedString21(): Unit = { runner.runOneTest("unparseDelimitedEscapedString21") }
+  @Test def test_unparseDelimitedEscapedString22(): Unit = { runner.runOneTest("unparseDelimitedEscapedString22") }
 
-  @Test def test_parseDelimitedEscapedString01() { runner.runOneTest("parseDelimitedEscapedString01") }
-  @Test def test_parseDelimitedEscapedString03() { runner.runOneTest("parseDelimitedEscapedString03") }
-  @Test def test_parseDelimitedEscapedString04() { runner.runOneTest("parseDelimitedEscapedString04") }
-  @Test def test_parseDelimitedEscapedString05() { runner.runOneTest("parseDelimitedEscapedString05") }
+  @Test def test_parseDelimitedEscapedString01(): Unit = { runner.runOneTest("parseDelimitedEscapedString01") }
+  @Test def test_parseDelimitedEscapedString03(): Unit = { runner.runOneTest("parseDelimitedEscapedString03") }
+  @Test def test_parseDelimitedEscapedString04(): Unit = { runner.runOneTest("parseDelimitedEscapedString04") }
+  @Test def test_parseDelimitedEscapedString05(): Unit = { runner.runOneTest("parseDelimitedEscapedString05") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparseNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparseNew.scala
@@ -25,7 +25,7 @@ object TestEscapeSchemeUnparseNew {
   val testDir = "/org/apache/daffodil/section07/escapeScheme/"
   val runner = Runner(testDir, "escapeSchemeUnparse.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 }
@@ -33,5 +33,5 @@ class TestEscapeSchemeUnparseNew {
 
   import TestEscapeSchemeUnparse._
 
-  @Test def test_unparseInvalidExtraEscapedCharacters() { runner.runOneTest("unparseInvalidExtraEscapedCharacters") }
+  @Test def test_unparseInvalidExtraEscapedCharacters(): Unit = { runner.runOneTest("unparseInvalidExtraEscapedCharacters") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
@@ -26,7 +26,7 @@ object TestExternalVariables {
   val testDir = "/org/apache/daffodil/section07/external_variables/"
   val runner = Runner(testDir, "external_variables.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 
@@ -36,31 +36,31 @@ class TestExternalVariables {
 
   import TestExternalVariables._
 
-  @Test def test_override_define_vars_01() {
+  @Test def test_override_define_vars_01(): Unit = {
     runner.runOneTest("override_define_vars_01")
   }
 
-  @Test def test_override_define_vars_02() {
+  @Test def test_override_define_vars_02(): Unit = {
     runner.runOneTest("override_define_vars_02")
   }
 
-  @Test def test_override_define_vars_03() {
+  @Test def test_override_define_vars_03(): Unit = {
     runner.runOneTest("override_define_vars_03")
   }
 
-  @Test def test_override_define_vars_04() {
+  @Test def test_override_define_vars_04(): Unit = {
     runner.runOneTest("override_define_vars_04")
   }
 
-  @Test def test_override_define_vars_05() {
+  @Test def test_override_define_vars_05(): Unit = {
     runner.runOneTest("override_define_vars_05")
   }
 
-  @Test def test_access_default_predefined_vars() {
+  @Test def test_access_default_predefined_vars(): Unit = {
     runner.runOneTest("access_default_predefined_vars")
   }
 
-  @Test def test_set_predefined_var() {
+  @Test def test_set_predefined_var(): Unit = {
     runner.runOneTest("set_predefined_var")
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariablesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariablesNew.scala
@@ -34,7 +34,7 @@ class TestExternalVariablesNew {
 
   // Tests that we can specify a file in the parser
   // test case.
-  @Test def test_read_config_from_file() {
+  @Test def test_read_config_from_file(): Unit = {
     runner.runOneTest("read_config_from_file")
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
@@ -26,7 +26,7 @@ object TestPropertySyntax {
   val runner1 = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
   val runner1V = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner1.reset
     runner1V.reset
   }
@@ -37,19 +37,19 @@ class TestPropertySyntax {
 
   import TestPropertySyntax._
 
-  @Test def test_ShortAndLongForm() { runner1.runOneTest("ShortAndLongForm") }
-  @Test def test_ShortAnnotationAndElementForm() { runner1.runOneTest("ShortAnnotationAndElementForm") }
-  @Test def test_AnnotationAndElementForm() { runner1.runOneTest("AnnotationAndElementForm") }
-  @Test def test_ShortAndElementForm() { runner1.runOneTest("ShortAndElementForm") }
-  @Test def test_Lesson3_attribute_form() { runner1.runOneTest("Lesson3_attribute_form") }
-  @Test def test_Lesson3_element_form() { runner1.runOneTest("Lesson3_element_form") }
-  @Test def test_Lesson3_short_form() { runner1.runOneTest("Lesson3_short_form") }
-  @Test def test_encodingEmptyFail() { runner1V.runOneTest("encodingEmptyFail") }
+  @Test def test_ShortAndLongForm(): Unit = { runner1.runOneTest("ShortAndLongForm") }
+  @Test def test_ShortAnnotationAndElementForm(): Unit = { runner1.runOneTest("ShortAnnotationAndElementForm") }
+  @Test def test_AnnotationAndElementForm(): Unit = { runner1.runOneTest("AnnotationAndElementForm") }
+  @Test def test_ShortAndElementForm(): Unit = { runner1.runOneTest("ShortAndElementForm") }
+  @Test def test_Lesson3_attribute_form(): Unit = { runner1.runOneTest("Lesson3_attribute_form") }
+  @Test def test_Lesson3_element_form(): Unit = { runner1.runOneTest("Lesson3_element_form") }
+  @Test def test_Lesson3_short_form(): Unit = { runner1.runOneTest("Lesson3_short_form") }
+  @Test def test_encodingEmptyFail(): Unit = { runner1V.runOneTest("encodingEmptyFail") }
 
-  @Test def test_dafProperty1() { runner1.runOneTest("dafProperty1") }
-  @Test def test_dafProperty2() { runner1.runOneTest("dafProperty2") }
-  @Test def test_dfdlxProperty1() { runner1.runOneTest("dfdlxProperty1") }
-  @Test def test_dfdlxProperty2() { runner1.runOneTest("dfdlxProperty2") }
+  @Test def test_dafProperty1(): Unit = { runner1.runOneTest("dafProperty1") }
+  @Test def test_dafProperty2(): Unit = { runner1.runOneTest("dafProperty2") }
+  @Test def test_dfdlxProperty1(): Unit = { runner1.runOneTest("dfdlxProperty1") }
+  @Test def test_dfdlxProperty2(): Unit = { runner1.runOneTest("dfdlxProperty2") }
 
-  @Test def test_ignoredPropertiesWarning() { runner1.runOneTest("ignoredPropertiesWarning") }
+  @Test def test_ignoredPropertiesWarning(): Unit = { runner1.runOneTest("ignoredPropertiesWarning") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
@@ -26,7 +26,7 @@ object TestPropertySyntax2 {
   val testDir1 = "/org/apache/daffodil/section07/property_syntax/"
   val runner = Runner(testDir1, "PropertySyntax.tdml", false, false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -37,9 +37,9 @@ class TestPropertySyntax2 {
   import TestPropertySyntax2._
 
   // JIRA DFDL-1722
-  @Test def test_badElementFormProperty() { runner.runOneTest("badElementFormProperty") }
+  @Test def test_badElementFormProperty(): Unit = { runner.runOneTest("badElementFormProperty") }
 
   // DAFFODIL-2202
-  @Test def test_badElementFormProperty2() { runner.runOneTest("badElementFormProperty2") }
+  @Test def test_badElementFormProperty2(): Unit = { runner.runOneTest("badElementFormProperty2") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -30,7 +30,7 @@ object TestVariables {
   val runner = Runner(testDir, "variables.tdml")
   val runner_01 = Runner(testDir, "variables_01.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner_01.reset
   }
@@ -40,65 +40,65 @@ object TestVariables {
 class TestVariables {
   import TestVariables._
 
-  @Test def test_setVarAbsolutePath() { runner.runOneTest("setVarAbsolutePath") }
-  @Test def test_varAsSeparator() { runner.runOneTest("varAsSeparator") }
+  @Test def test_setVarAbsolutePath(): Unit = { runner.runOneTest("setVarAbsolutePath") }
+  @Test def test_varAsSeparator(): Unit = { runner.runOneTest("varAsSeparator") }
 
-  @Test def test_setVar1() { runner.runOneTest("setVar1") }
-  @Test def test_doubleSetErr() { runner.runOneTest("doubleSetErr") }
-  @Test def test_multiSetErr() { runner.runOneTest("multiSetErr") }
+  @Test def test_setVar1(): Unit = { runner.runOneTest("setVar1") }
+  @Test def test_doubleSetErr(): Unit = { runner.runOneTest("doubleSetErr") }
+  @Test def test_multiSetErr(): Unit = { runner.runOneTest("multiSetErr") }
   // DFDL-1443 & DFDL-1448
   // @Test def test_setAfterReadErr() { runner.runOneTest("setAfterReadErr") }
-  @Test def test_varInstance_01() { runner.runOneTest("varInstance_01") }
-  @Test def test_varInstance_02() { runner.runOneTest("varInstance_02") }
-  @Test def test_varInstance_03() { runner.runOneTest("varInstance_03") }
-  @Test def test_varInstance_04() { runner.runOneTest("varInstance_04") }
-  @Test def test_varInstance_05() { runner.runOneTest("varInstance_05") }
-  @Test def test_varInstance_06() { runner.runOneTest("varInstance_06") }
-  @Test def test_varInstance_07() { runner.runOneTest("varInstance_07") }
-  @Test def test_varInstance_08() { runner.runOneTest("varInstance_08") }
-  @Test def test_varInstance_09() { runner.runOneTest("varInstance_09") }
-  @Test def test_varInstance_10() { runner.runOneTest("varInstance_10") }
-  @Test def test_varInstance_11() { runner.runOneTest("varInstance_11") }
-  @Test def test_setVarChoice() { runner.runOneTest("setVarChoice") }
-  @Test def test_unparse_setVarChoice() { runner.runOneTest("unparse_setVarChoice") }
-  @Test def test_setVarOnSeqAndElemRef() { runner.runOneTest("setVarOnSeqAndElemRef") }
-  @Test def test_unparse_setVarOnSeq() { runner.runOneTest("unparse_setVarOnSeq") }
-  @Test def test_setVarOnGroupRef() { runner.runOneTest("setVarOnGroupRef") }
-  @Test def test_unparse_setVarOnGroupRef() { runner.runOneTest("unparse_setVarOnGroupRef") }
-  @Test def test_setVarSimpleType() { runner.runOneTest("setVarSimpleType") }
+  @Test def test_varInstance_01(): Unit = { runner.runOneTest("varInstance_01") }
+  @Test def test_varInstance_02(): Unit = { runner.runOneTest("varInstance_02") }
+  @Test def test_varInstance_03(): Unit = { runner.runOneTest("varInstance_03") }
+  @Test def test_varInstance_04(): Unit = { runner.runOneTest("varInstance_04") }
+  @Test def test_varInstance_05(): Unit = { runner.runOneTest("varInstance_05") }
+  @Test def test_varInstance_06(): Unit = { runner.runOneTest("varInstance_06") }
+  @Test def test_varInstance_07(): Unit = { runner.runOneTest("varInstance_07") }
+  @Test def test_varInstance_08(): Unit = { runner.runOneTest("varInstance_08") }
+  @Test def test_varInstance_09(): Unit = { runner.runOneTest("varInstance_09") }
+  @Test def test_varInstance_10(): Unit = { runner.runOneTest("varInstance_10") }
+  @Test def test_varInstance_11(): Unit = { runner.runOneTest("varInstance_11") }
+  @Test def test_setVarChoice(): Unit = { runner.runOneTest("setVarChoice") }
+  @Test def test_unparse_setVarChoice(): Unit = { runner.runOneTest("unparse_setVarChoice") }
+  @Test def test_setVarOnSeqAndElemRef(): Unit = { runner.runOneTest("setVarOnSeqAndElemRef") }
+  @Test def test_unparse_setVarOnSeq(): Unit = { runner.runOneTest("unparse_setVarOnSeq") }
+  @Test def test_setVarOnGroupRef(): Unit = { runner.runOneTest("setVarOnGroupRef") }
+  @Test def test_unparse_setVarOnGroupRef(): Unit = { runner.runOneTest("unparse_setVarOnGroupRef") }
+  @Test def test_setVarSimpleType(): Unit = { runner.runOneTest("setVarSimpleType") }
 
-  @Test def test_setVarValAttribute() { runner.runOneTest("setVarValAttribute") }
-  @Test def test_setVarValAttribute2() { runner.runOneTest("setVarValAttribute2") }
-  @Test def test_setVarTypeMismatch() { runner.runOneTest("setVarTypeMismatch") }
-  @Test def test_setVarCurrVal() { runner.runOneTest("setVarCurrVal") }
-  @Test def test_setVarMismatchRelative() { runner.runOneTest("setVarMismatchRelative") }
-  @Test def test_setVarExpression() { runner.runOneTest("setVarExpression") }
-  @Test def test_setVarExpression2() { runner.runOneTest("setVarExpression2") }
-  @Test def test_setVarBadScope() { runner.runOneTest("setVarBadScope") }
-  @Test def test_varAsSeparator2() { runner.runOneTest("varAsSeparator2") }
-  @Test def test_setVarBadScope2() { runner.runOneTest("setVarBadScope2") }
+  @Test def test_setVarValAttribute(): Unit = { runner.runOneTest("setVarValAttribute") }
+  @Test def test_setVarValAttribute2(): Unit = { runner.runOneTest("setVarValAttribute2") }
+  @Test def test_setVarTypeMismatch(): Unit = { runner.runOneTest("setVarTypeMismatch") }
+  @Test def test_setVarCurrVal(): Unit = { runner.runOneTest("setVarCurrVal") }
+  @Test def test_setVarMismatchRelative(): Unit = { runner.runOneTest("setVarMismatchRelative") }
+  @Test def test_setVarExpression(): Unit = { runner.runOneTest("setVarExpression") }
+  @Test def test_setVarExpression2(): Unit = { runner.runOneTest("setVarExpression2") }
+  @Test def test_setVarBadScope(): Unit = { runner.runOneTest("setVarBadScope") }
+  @Test def test_varAsSeparator2(): Unit = { runner.runOneTest("varAsSeparator2") }
+  @Test def test_setVarBadScope2(): Unit = { runner.runOneTest("setVarBadScope2") }
 
-  @Test def test_resetVar_01() { runner.runOneTest("resetVar_01") }
-  @Test def test_resetVar_02() { runner.runOneTest("resetVar_02") }
+  @Test def test_resetVar_01(): Unit = { runner.runOneTest("resetVar_01") }
+  @Test def test_resetVar_02(): Unit = { runner.runOneTest("resetVar_02") }
 
-  @Test def test_doubleEmptyDefault() { runner.runOneTest("doubleEmptyDefault") }
-  @Test def test_emptyDefault() { runner.runOneTest("emptyDefault") }
-  @Test def test_emptyDefault2() { runner.runOneTest("emptyDefault2") }
+  @Test def test_doubleEmptyDefault(): Unit = { runner.runOneTest("doubleEmptyDefault") }
+  @Test def test_emptyDefault(): Unit = { runner.runOneTest("emptyDefault") }
+  @Test def test_emptyDefault2(): Unit = { runner.runOneTest("emptyDefault2") }
 
-  @Test def test_var_end_path() { runner.runOneTest("var_end_path") }
-  @Test def test_var_in_path() { runner.runOneTest("var_in_path") }
+  @Test def test_var_end_path(): Unit = { runner.runOneTest("var_end_path") }
+  @Test def test_var_in_path(): Unit = { runner.runOneTest("var_in_path") }
 
-  @Test def test_logical_default_values() { runner.runOneTest("logical_default_values") }
-  @Test def test_logical_default_values_err() { runner.runOneTest("logical_default_values_err") }
+  @Test def test_logical_default_values(): Unit = { runner.runOneTest("logical_default_values") }
+  @Test def test_logical_default_values_err(): Unit = { runner.runOneTest("logical_default_values_err") }
 
-  @Test def test_unsignedIntVarCast() { runner.runOneTest("unsignedIntVarCast") }
+  @Test def test_unsignedIntVarCast(): Unit = { runner.runOneTest("unsignedIntVarCast") }
 
-  @Test def test_doubleSetErr_d() { runner_01.runOneTest("doubleSetErr_d") }
-  @Test def test_setVar1_d() { runner_01.runOneTest("setVar1_d") }
+  @Test def test_doubleSetErr_d(): Unit = { runner_01.runOneTest("doubleSetErr_d") }
+  @Test def test_setVar1_d(): Unit = { runner_01.runOneTest("setVar1_d") }
   // DFDL-1443 & DFDL-1448
   // @Test def test_setAfterReadErr_d() { runner_01.runOneTest("setAfterReadErr_d") }
-  @Test def test_setVar1_d_parse() { runner_01.runOneTest("setVar1_d_parse") }
-  @Test def test_setVar1_d_unparse() { runner_01.runOneTest("setVar1_d_unparse") }
+  @Test def test_setVar1_d_parse(): Unit = { runner_01.runOneTest("setVar1_d_parse") }
+  @Test def test_setVar1_d_unparse(): Unit = { runner_01.runOneTest("setVar1_d_unparse") }
 
 /*****************************************************************/
   val tdmlVal = XMLUtils.TDML_NAMESPACE
@@ -126,7 +126,7 @@ class TestVariables {
       </tdml:parserTestCase>
     </tdml:testSuite>
 
-  @Test def test_variables2() {
+  @Test def test_variables2(): Unit = {
     val testSuite = variables2
     lazy val ts = new DFDLTestSuite(testSuite)
     ts.runOneTest("variables2")
@@ -163,7 +163,7 @@ class TestVariables {
       </tdml:parserTestCase>
     </tdml:testSuite>
 
-  @Test def test_variables3() {
+  @Test def test_variables3(): Unit = {
     // Debugger.setDebugging(true)
     val testSuite = variables3
     lazy val ts = new DFDLTestSuite(testSuite)

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
@@ -26,7 +26,7 @@ object TestPropertyScoping {
   val runner = Runner(testDir, "PropertyScoping.tdml")
   val runner_01 = Runner(testDir, "PropertyScoping_01.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner_01.reset
   }
@@ -36,51 +36,51 @@ class TestPropertyScoping {
 
   import TestPropertyScoping._
 
-  @Test def test_defaultForm_01() { runner.runOneTest("defaultForm_01") }
-  @Test def test_defaultForm_02() { runner.runOneTest("defaultForm_02") }
-  @Test def test_defaultForm_03() { runner.runOneTest("defaultForm_03") }
-  @Test def test_defaultForm_04() { runner.runOneTest("defaultForm_04") }
+  @Test def test_defaultForm_01(): Unit = { runner.runOneTest("defaultForm_01") }
+  @Test def test_defaultForm_02(): Unit = { runner.runOneTest("defaultForm_02") }
+  @Test def test_defaultForm_03(): Unit = { runner.runOneTest("defaultForm_03") }
+  @Test def test_defaultForm_04(): Unit = { runner.runOneTest("defaultForm_04") }
 
-  @Test def test_localAnnotation_01() { runner.runOneTest("localAnnotation_01") }
-  @Test def test_localAnnotation_02() { runner.runOneTest("localAnnotation_02") }
-  @Test def test_localAnnotation_03() { runner.runOneTest("localAnnotation_03") }
-  @Test def test_localAnnotation_04() { runner.runOneTest("localAnnotation_04") }
+  @Test def test_localAnnotation_01(): Unit = { runner.runOneTest("localAnnotation_01") }
+  @Test def test_localAnnotation_02(): Unit = { runner.runOneTest("localAnnotation_02") }
+  @Test def test_localAnnotation_03(): Unit = { runner.runOneTest("localAnnotation_03") }
+  @Test def test_localAnnotation_04(): Unit = { runner.runOneTest("localAnnotation_04") }
 
   //DFDL-1036 (was fixed) now DFDL-1159
   //@Test def test_localAnnotation_05() { runner.runOneTest("localAnnotation_05") }
 
-  @Test def test_property_scoping_01() { runner.runOneTest("property_scoping_01") }
-  @Test def test_unparse_property_scoping_01() { runner.runOneTest("unparse_property_scoping_01") }
-  @Test def test_property_scoping_06() { runner.runOneTest("property_scoping_06") }
-  @Test def test_unparse_property_scoping_06() { runner.runOneTest("unparse_property_scoping_06") }
-  @Test def test_group_ref() { runner.runOneTest("group_ref") }
-  @Test def test_multipleDefinition() { runner.runOneTest("multipleDefinition") }
-  @Test def test_multipleDefinition2() { runner.runOneTest("multipleDefinition2") }
-  @Test def test_multipleDefinition3() { runner.runOneTest("multipleDefinition3") }
+  @Test def test_property_scoping_01(): Unit = { runner.runOneTest("property_scoping_01") }
+  @Test def test_unparse_property_scoping_01(): Unit = { runner.runOneTest("unparse_property_scoping_01") }
+  @Test def test_property_scoping_06(): Unit = { runner.runOneTest("property_scoping_06") }
+  @Test def test_unparse_property_scoping_06(): Unit = { runner.runOneTest("unparse_property_scoping_06") }
+  @Test def test_group_ref(): Unit = { runner.runOneTest("group_ref") }
+  @Test def test_multipleDefinition(): Unit = { runner.runOneTest("multipleDefinition") }
+  @Test def test_multipleDefinition2(): Unit = { runner.runOneTest("multipleDefinition2") }
+  @Test def test_multipleDefinition3(): Unit = { runner.runOneTest("multipleDefinition3") }
 
-  @Test def test_format_nesting_01() { runner.runOneTest("format_nesting_01") }
+  @Test def test_format_nesting_01(): Unit = { runner.runOneTest("format_nesting_01") }
 
-  @Test def test_property_scoping_02() { runner_01.runOneTest("property_scoping_02") }
+  @Test def test_property_scoping_02(): Unit = { runner_01.runOneTest("property_scoping_02") }
   // DAFFODIL-2103
   // @Test def test_unparse_property_scoping_02() { runner_01.runOneTest("unparse_property_scoping_02") }
   @Test def test_property_scoping_03() = { runner_01.runOneTest("property_scoping_03") }
   @Test def test_unparse_property_scoping_03() = { runner_01.runOneTest("unparse_property_scoping_03") }
-  @Test def test_property_scoping_04() { runner_01.runOneTest("property_scoping_04") }
-  @Test def test_property_scoping_05() { runner_01.runOneTest("property_scoping_05") }
-  @Test def test_unparse_property_scoping_04() { runner_01.runOneTest("unparse_property_scoping_04") }
-  @Test def test_unparse_property_scoping_05() { runner_01.runOneTest("unparse_property_scoping_05") }
-  @Test def test_property_scoping_07() { runner_01.runOneTest("property_scoping_07") }
-  @Test def test_unparse_property_scoping_07() { runner_01.runOneTest("unparse_property_scoping_07") }
-  @Test def test_property_scoping_08() { runner_01.runOneTest("property_scoping_08") }
-  @Test def test_unparse_property_scoping_08() { runner_01.runOneTest("unparse_property_scoping_08") }
-  @Test def test_property_scoping_09() { runner_01.runOneTest("property_scoping_09") }
-  @Test def test_unparse_property_scoping_09() { runner_01.runOneTest("unparse_property_scoping_09") }
-  @Test def test_property_scoping_10() { runner_01.runOneTest("property_scoping_10") }
-  @Test def test_unparse_property_scoping_10() { runner_01.runOneTest("unparse_property_scoping_10") }
-  @Test def test_property_scoping_11() { runner_01.runOneTest("property_scoping_11") }
-  @Test def test_unparse_property_scoping_11() { runner_01.runOneTest("unparse_property_scoping_11") }
-  @Test def test_unparse_property_scoping_12() { runner_01.runOneTest("unparse_property_scoping_12") }
-  @Test def test_NearestEnclosingSequenceElementRef() { runner_01.runOneTest("NearestEnclosingSequenceElementRef") }
+  @Test def test_property_scoping_04(): Unit = { runner_01.runOneTest("property_scoping_04") }
+  @Test def test_property_scoping_05(): Unit = { runner_01.runOneTest("property_scoping_05") }
+  @Test def test_unparse_property_scoping_04(): Unit = { runner_01.runOneTest("unparse_property_scoping_04") }
+  @Test def test_unparse_property_scoping_05(): Unit = { runner_01.runOneTest("unparse_property_scoping_05") }
+  @Test def test_property_scoping_07(): Unit = { runner_01.runOneTest("property_scoping_07") }
+  @Test def test_unparse_property_scoping_07(): Unit = { runner_01.runOneTest("unparse_property_scoping_07") }
+  @Test def test_property_scoping_08(): Unit = { runner_01.runOneTest("property_scoping_08") }
+  @Test def test_unparse_property_scoping_08(): Unit = { runner_01.runOneTest("unparse_property_scoping_08") }
+  @Test def test_property_scoping_09(): Unit = { runner_01.runOneTest("property_scoping_09") }
+  @Test def test_unparse_property_scoping_09(): Unit = { runner_01.runOneTest("unparse_property_scoping_09") }
+  @Test def test_property_scoping_10(): Unit = { runner_01.runOneTest("property_scoping_10") }
+  @Test def test_unparse_property_scoping_10(): Unit = { runner_01.runOneTest("unparse_property_scoping_10") }
+  @Test def test_property_scoping_11(): Unit = { runner_01.runOneTest("property_scoping_11") }
+  @Test def test_unparse_property_scoping_11(): Unit = { runner_01.runOneTest("unparse_property_scoping_11") }
+  @Test def test_unparse_property_scoping_12(): Unit = { runner_01.runOneTest("unparse_property_scoping_12") }
+  @Test def test_NearestEnclosingSequenceElementRef(): Unit = { runner_01.runOneTest("NearestEnclosingSequenceElementRef") }
 
   @Test def test_property_refElementFormFail() = { runner_01.runOneTest("refElementFormFail") }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
@@ -25,7 +25,7 @@ object TestRepProps {
   val testDir = "/org/apache/daffodil/section10/representation_properties/"
   val runner = Runner(testDir, "RepProps.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -35,14 +35,14 @@ class TestRepProps {
 
   import TestRepProps._
 
-  @Test def test_repPropMissing() { runner.runOneTest("repPropMissing") }
-  @Test def test_repPropMissing2() { runner.runOneTest("repPropMissing2") }
-  @Test def test_repPropMissing3() { runner.runOneTest("repPropMissing3") }
+  @Test def test_repPropMissing(): Unit = { runner.runOneTest("repPropMissing") }
+  @Test def test_repPropMissing2(): Unit = { runner.runOneTest("repPropMissing2") }
+  @Test def test_repPropMissing3(): Unit = { runner.runOneTest("repPropMissing3") }
 
-  @Test def test_hexBinary_01() { runner.runOneTest("hexBinary_01") }
+  @Test def test_hexBinary_01(): Unit = { runner.runOneTest("hexBinary_01") }
 
   //These tests are temporary - see DFDL-994
-  @Test def test_temporaryDefaultProps_01() { runner.runOneTest("temporaryDefaultProps_01") }
-  @Test def test_temporaryDefaultProps_02() { runner.runOneTest("temporaryDefaultProps_02") }
+  @Test def test_temporaryDefaultProps_01(): Unit = { runner.runOneTest("temporaryDefaultProps_01") }
+  @Test def test_temporaryDefaultProps_02(): Unit = { runner.runOneTest("temporaryDefaultProps_02") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps2.scala
@@ -25,7 +25,7 @@ object TestRepProps2 {
   val testDir = "/org/apache/daffodil/section10/representation_properties/"
   val runner = Runner(testDir, "encodings.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section11/content_framing_properties/TestContentFramingProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section11/content_framing_properties/TestContentFramingProperties.scala
@@ -26,7 +26,7 @@ object TestContentFramingProperties {
   private val testDir_02 = "/org/apache/daffodil/section11/content_framing_properties/"
   lazy val runner2 = Runner(testDir_02, "ContentFramingProps.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner2.reset
   }
 }
@@ -38,21 +38,21 @@ class TestContentFramingProperties {
   // @Test def test_xml_utf8_4byte_chars_01() { runner2.runOneTest("xml_utf8_4byte_chars_01") }
   // @Test def test_xml_utf8_4byte_chars() { runner2.runOneTest("xml_utf8_4byte_chars") }
 
-  @Test def test_UTF_16_01() { runner2.runOneTest("UTF_16_01") }
-  @Test def test_xml_illegal_chars_01() { runner2.runOneTest("xml_illegal_chars_01") }
-  @Test def test_xml_illegal_chars_02() { runner2.runOneTest("xml_illegal_chars_02") }
-  @Test def test_xml_illegal_chars() { runner2.runOneTest("xml_illegal_chars") }
+  @Test def test_UTF_16_01(): Unit = { runner2.runOneTest("UTF_16_01") }
+  @Test def test_xml_illegal_chars_01(): Unit = { runner2.runOneTest("xml_illegal_chars_01") }
+  @Test def test_xml_illegal_chars_02(): Unit = { runner2.runOneTest("xml_illegal_chars_02") }
+  @Test def test_xml_illegal_chars(): Unit = { runner2.runOneTest("xml_illegal_chars") }
 
-  @Test def test_alignmentPacked7BitASCII() { runner2.runOneTest("alignmentPacked7BitASCII") }
-  @Test def test_alignmentPacked7BitASCII_03() { runner2.runOneTest("alignmentPacked7BitASCII_03") }
-  @Test def test_alignmentPacked7BitASCII_04() { runner2.runOneTest("alignmentPacked7BitASCII_04") }
+  @Test def test_alignmentPacked7BitASCII(): Unit = { runner2.runOneTest("alignmentPacked7BitASCII") }
+  @Test def test_alignmentPacked7BitASCII_03(): Unit = { runner2.runOneTest("alignmentPacked7BitASCII_03") }
+  @Test def test_alignmentPacked7BitASCII_04(): Unit = { runner2.runOneTest("alignmentPacked7BitASCII_04") }
   //  DFDL-751 - 7-bit ASCII alignment should be 1 bit, complains that it needs to be 8 bits
   //  @Test def test_alignmentPacked7BitASCII_02() { runner2.runOneTest("alignmentPacked7BitASCII_02") }
   //  @Test def test_alignmentPacked7BitASCII_05() { runner2.runOneTest("alignmentPacked7BitASCII_05") }
 
 /*** DFDL-379 X-DFDL-US-ASCII-7-BIT-PACKED text ***/
-  @Test def test_packed7BitASCII1() { runner2.runOneTest("packed7BitASCII1") }
-  @Test def test_packed7BitASCII2() { runner2.runOneTest("packed7BitASCII2") }
+  @Test def test_packed7BitASCII1(): Unit = { runner2.runOneTest("packed7BitASCII1") }
+  @Test def test_packed7BitASCII2(): Unit = { runner2.runOneTest("packed7BitASCII2") }
   @Test def test_packed7BitASCII3() = { runner2.runOneTest("packed7BitASCII3") }
   @Test def test_packed7BitASCII4() = { runner2.runOneTest("packed7BitASCII4") }
   @Test def test_packed7BitASCII5() = { runner2.runOneTest("packed7BitASCII5") }
@@ -61,58 +61,58 @@ class TestContentFramingProperties {
   @Test def test_packed7BitASCII7() = { runner2.runOneTest("packed7BitASCII7") }
   @Test def test_packed7BitASCII8() = { runner2.runOneTest("packed7BitASCII8") }
   @Test def test_packed7BitASCII9() = { runner2.runOneTest("packed7BitASCII9") }
-  @Test def test_packed7BitASCII10() { runner2.runOneTest("packed7BitASCII10") }
-  @Test def test_packed7BitASCII_unparse() { runner2.runOneTest("packed7BitASCII_unparse") }
-  @Test def test_packed7BitASCII_unparse2() { runner2.runOneTest("packed7BitASCII_unparse2") }
+  @Test def test_packed7BitASCII10(): Unit = { runner2.runOneTest("packed7BitASCII10") }
+  @Test def test_packed7BitASCII_unparse(): Unit = { runner2.runOneTest("packed7BitASCII_unparse") }
+  @Test def test_packed7BitASCII_unparse2(): Unit = { runner2.runOneTest("packed7BitASCII_unparse2") }
 
   // DFDL-935 to re-enable, needs encodingErrorPolicy="error"
   //@Test def test_packed7BitASCII_unparse3() { runner2.runOneTest("packed7BitASCII_unparse3") }
 
   @Test def test_encoding_iso_8859_1() = { runner2.runOneTest("encoding_iso-8859-1") }
 
-  @Test def test_encodingErrorReplace() { runner2.runOneTest("encodingErrorReplace") }
+  @Test def test_encodingErrorReplace(): Unit = { runner2.runOneTest("encodingErrorReplace") }
   // JIRA Ticket DFDL-1386 - 4-byte utf-8 characters/surrogate-pair issue.
-  @Test def test_encodingNoError() { runner2.runOneTest("encodingNoError") }
-  @Test def test_encodingErrorReplace2() { runner2.runOneTest("encodingErrorReplace2") }
-  @Test def test_encodingErrorReplace3() { runner2.runOneTest("encodingErrorReplace3") }
-  @Test def test_encodingErrorReplace4() { runner2.runOneTest("encodingErrorReplace4") }
-  @Test def test_encoding_property_expression() { runner2.runOneTest("encoding_property_expression") }
+  @Test def test_encodingNoError(): Unit = { runner2.runOneTest("encodingNoError") }
+  @Test def test_encodingErrorReplace2(): Unit = { runner2.runOneTest("encodingErrorReplace2") }
+  @Test def test_encodingErrorReplace3(): Unit = { runner2.runOneTest("encodingErrorReplace3") }
+  @Test def test_encodingErrorReplace4(): Unit = { runner2.runOneTest("encodingErrorReplace4") }
+  @Test def test_encoding_property_expression(): Unit = { runner2.runOneTest("encoding_property_expression") }
 
-  @Test def test_mixedEncoding1() { runner2.runOneTest("mixedEncoding1") }
-  @Test def test_mixedEncoding2() { runner2.runOneTest("mixedEncoding2") }
+  @Test def test_mixedEncoding1(): Unit = { runner2.runOneTest("mixedEncoding1") }
+  @Test def test_mixedEncoding2(): Unit = { runner2.runOneTest("mixedEncoding2") }
 
   // Added for JIRA Ticket DFDL-1288
-  @Test def test_encodingErrorReplace_unparse() { runner2.runOneTest("encodingErrorReplace_unparse") }
-  @Test def test_packed7BitASCII11() { runner2.runOneTest("packed7BitASCII11") }
-  @Test def test_packed7BitASCII12() { runner2.runOneTest("packed7BitASCII12") }
-  @Test def test_packed6BitASCII1() { runner2.runOneTest("packed6BitASCII1") }
-  @Test def test_encoding_property_expression2() { runner2.runOneTest("encoding_property_expression2") }
-  @Test def test_encoding_property_expression3() { runner2.runOneTest("encoding_property_expression3") }
-  @Test def test_encoding_property_expression4() { runner2.runOneTest("encoding_property_expression4") }
-  @Test def test_encoding_property_expression2_unparse() { runner2.runOneTest("encoding_property_expression2_unparse") }
-  @Test def test_alignmentPacked6BitASCII() { runner2.runOneTest("alignmentPacked6BitASCII") }
-  @Test def test_packed6BitASCII_unparse1() { runner2.runOneTest("packed6BitASCII_unparse1") }
-  @Test def test_packed6BitASCII_unparse2() { runner2.runOneTest("packed6BitASCII_unparse2") }
-  @Test def test_packed6BitASCII3() { runner2.runOneTest("packed6BitASCII3") }
-  @Test def test_packed6BitASCII4() { runner2.runOneTest("packed6BitASCII4") }
-  @Test def test_packed6BitASCII5() { runner2.runOneTest("packed6BitASCII5") }
-  @Test def test_packed5Bit1() { runner2.runOneTest("packed5Bit1") }
-  @Test def test_packed5Bit2() { runner2.runOneTest("packed5Bit2") }
-  @Test def test_packed5Bit3() { runner2.runOneTest("packed5Bit3") }
-  @Test def test_packed5Bit4() { runner2.runOneTest("packed5Bit4") }
-  @Test def test_packed5Bit5() { runner2.runOneTest("packed5Bit5") }
-  @Test def test_packed5Bit6() { runner2.runOneTest("packed5Bit6") }
-  @Test def test_packed5Bit_unparse1() { runner2.runOneTest("packed5Bit_unparse1") }
-  @Test def test_packed5Bit_unparse2() { runner2.runOneTest("packed5Bit_unparse2") }
-  @Test def test_packed5Bit_unparse3() { runner2.runOneTest("packed5Bit_unparse3") }
-  @Test def test_octalLSBF1() { runner2.runOneTest("octalLSBF1") }
-  @Test def test_octalLSBF2() { runner2.runOneTest("octalLSBF2") }
-  @Test def test_octalLSBF_unparse1() { runner2.runOneTest("octalLSBF_unparse1") }
+  @Test def test_encodingErrorReplace_unparse(): Unit = { runner2.runOneTest("encodingErrorReplace_unparse") }
+  @Test def test_packed7BitASCII11(): Unit = { runner2.runOneTest("packed7BitASCII11") }
+  @Test def test_packed7BitASCII12(): Unit = { runner2.runOneTest("packed7BitASCII12") }
+  @Test def test_packed6BitASCII1(): Unit = { runner2.runOneTest("packed6BitASCII1") }
+  @Test def test_encoding_property_expression2(): Unit = { runner2.runOneTest("encoding_property_expression2") }
+  @Test def test_encoding_property_expression3(): Unit = { runner2.runOneTest("encoding_property_expression3") }
+  @Test def test_encoding_property_expression4(): Unit = { runner2.runOneTest("encoding_property_expression4") }
+  @Test def test_encoding_property_expression2_unparse(): Unit = { runner2.runOneTest("encoding_property_expression2_unparse") }
+  @Test def test_alignmentPacked6BitASCII(): Unit = { runner2.runOneTest("alignmentPacked6BitASCII") }
+  @Test def test_packed6BitASCII_unparse1(): Unit = { runner2.runOneTest("packed6BitASCII_unparse1") }
+  @Test def test_packed6BitASCII_unparse2(): Unit = { runner2.runOneTest("packed6BitASCII_unparse2") }
+  @Test def test_packed6BitASCII3(): Unit = { runner2.runOneTest("packed6BitASCII3") }
+  @Test def test_packed6BitASCII4(): Unit = { runner2.runOneTest("packed6BitASCII4") }
+  @Test def test_packed6BitASCII5(): Unit = { runner2.runOneTest("packed6BitASCII5") }
+  @Test def test_packed5Bit1(): Unit = { runner2.runOneTest("packed5Bit1") }
+  @Test def test_packed5Bit2(): Unit = { runner2.runOneTest("packed5Bit2") }
+  @Test def test_packed5Bit3(): Unit = { runner2.runOneTest("packed5Bit3") }
+  @Test def test_packed5Bit4(): Unit = { runner2.runOneTest("packed5Bit4") }
+  @Test def test_packed5Bit5(): Unit = { runner2.runOneTest("packed5Bit5") }
+  @Test def test_packed5Bit6(): Unit = { runner2.runOneTest("packed5Bit6") }
+  @Test def test_packed5Bit_unparse1(): Unit = { runner2.runOneTest("packed5Bit_unparse1") }
+  @Test def test_packed5Bit_unparse2(): Unit = { runner2.runOneTest("packed5Bit_unparse2") }
+  @Test def test_packed5Bit_unparse3(): Unit = { runner2.runOneTest("packed5Bit_unparse3") }
+  @Test def test_octalLSBF1(): Unit = { runner2.runOneTest("octalLSBF1") }
+  @Test def test_octalLSBF2(): Unit = { runner2.runOneTest("octalLSBF2") }
+  @Test def test_octalLSBF_unparse1(): Unit = { runner2.runOneTest("octalLSBF_unparse1") }
   // DFDL-935 to re-enable, needs encodingErrorPolicy="error"
   //@Test def test_octalLSBF_unparse_error() { runner2.runOneTest("octalLSBF_unparse_error") }
-  @Test def test_octalLSBF3() { runner2.runOneTest("octalLSBF3") }
-  @Test def test_hexLSBF1() { runner2.runOneTest("hexLSBF1") }
-  @Test def test_hexLSBF2() { runner2.runOneTest("hexLSBF2") }
-  @Test def test_hexLSBF_unparse1() { runner2.runOneTest("hexLSBF_unparse1") }
+  @Test def test_octalLSBF3(): Unit = { runner2.runOneTest("octalLSBF3") }
+  @Test def test_hexLSBF1(): Unit = { runner2.runOneTest("hexLSBF1") }
+  @Test def test_hexLSBF2(): Unit = { runner2.runOneTest("hexLSBF2") }
+  @Test def test_hexLSBF_unparse1(): Unit = { runner2.runOneTest("hexLSBF_unparse1") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
@@ -26,7 +26,7 @@ object TestAlignedData {
   val runner1 = Runner(testDir_01, "Aligned_Data.tdml")
   val runner2 = Runner(testDir_01, "BinaryInput_01.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner1.reset
     runner2.reset
   }
@@ -174,14 +174,14 @@ class TestAlignedData {
   @Test def test_alignmentLSBFirst() = { runner1.runOneTest("alignmentLSBFirst") }
   @Test def test_alignmentMSBFirst() = { runner1.runOneTest("alignmentMSBFirst") }
 
-  @Test def test_LeadingSkipBytes() { runner2.runOneTest("LeadingSkipBytes") }
-  @Test def test_LeadingSkipBits() { runner2.runOneTest("LeadingSkipBits") }
-  @Test def test_TrailingSkipBytes() { runner2.runOneTest("TrailingSkipBytes") }
-  @Test def test_TrailingSkipBits() { runner2.runOneTest("TrailingSkipBits") }
-  @Test def test_AligningSkipBytes() { runner2.runOneTest("AligningSkipBytes") }
-  @Test def test_AligningSkipBytes2() { runner2.runOneTest("AligningSkipBytes2") }
-  @Test def test_AligningSkipBits() { runner2.runOneTest("AligningSkipBits") }
-  @Test def test_AligningSkipBits2() { runner2.runOneTest("AligningSkipBits2") }
+  @Test def test_LeadingSkipBytes(): Unit = { runner2.runOneTest("LeadingSkipBytes") }
+  @Test def test_LeadingSkipBits(): Unit = { runner2.runOneTest("LeadingSkipBits") }
+  @Test def test_TrailingSkipBytes(): Unit = { runner2.runOneTest("TrailingSkipBytes") }
+  @Test def test_TrailingSkipBits(): Unit = { runner2.runOneTest("TrailingSkipBits") }
+  @Test def test_AligningSkipBytes(): Unit = { runner2.runOneTest("AligningSkipBytes") }
+  @Test def test_AligningSkipBytes2(): Unit = { runner2.runOneTest("AligningSkipBytes2") }
+  @Test def test_AligningSkipBits(): Unit = { runner2.runOneTest("AligningSkipBits") }
+  @Test def test_AligningSkipBits2(): Unit = { runner2.runOneTest("AligningSkipBits2") }
 
   @Test def test_alignmentArray() = { runner1.runOneTest("alignmentArray") }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
@@ -26,7 +26,7 @@ object TestDelimiterProperties {
   val testDir_02 = "/org/apache/daffodil/section12/delimiter_properties/"
   val runner_02 = Runner(testDir_02, "DelimiterProperties.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_02.reset
   }
 
@@ -37,16 +37,16 @@ class TestDelimiterProperties {
   import TestDelimiterProperties._
 
   @Test def test_DelimProp_01() = { runner_02.runOneTest("DelimProp_01") }
-  @Test def test_ParseSequence4() { runner_02.runOneTest("ParseSequence4") }
-  @Test def test_ParseSequence5() { runner_02.runOneTest("ParseSequence5") }
-  @Test def test_DelimProp_02() { runner_02.runOneTest("DelimProp_02") }
-  @Test def test_DelimProp_03() { runner_02.runOneTest("DelimProp_03") }
-  @Test def test_DelimProp_04() { runner_02.runOneTest("DelimProp_04") }
-  @Test def test_DelimProp_05() { runner_02.runOneTest("DelimProp_05") }
-  @Test def test_DelimProp_06() { runner_02.runOneTest("DelimProp_06") }
-  @Test def test_DelimProp_07() { runner_02.runOneTest("DelimProp_07") }
-  @Test def test_initiatedContentSimple1() { runner_02.runOneTest("initiatedContentSimple1") }
-  @Test def test_Lesson4_initiators_terminators() { runner_02.runOneTest("Lesson4_initiators_terminators") }
+  @Test def test_ParseSequence4(): Unit = { runner_02.runOneTest("ParseSequence4") }
+  @Test def test_ParseSequence5(): Unit = { runner_02.runOneTest("ParseSequence5") }
+  @Test def test_DelimProp_02(): Unit = { runner_02.runOneTest("DelimProp_02") }
+  @Test def test_DelimProp_03(): Unit = { runner_02.runOneTest("DelimProp_03") }
+  @Test def test_DelimProp_04(): Unit = { runner_02.runOneTest("DelimProp_04") }
+  @Test def test_DelimProp_05(): Unit = { runner_02.runOneTest("DelimProp_05") }
+  @Test def test_DelimProp_06(): Unit = { runner_02.runOneTest("DelimProp_06") }
+  @Test def test_DelimProp_07(): Unit = { runner_02.runOneTest("DelimProp_07") }
+  @Test def test_initiatedContentSimple1(): Unit = { runner_02.runOneTest("initiatedContentSimple1") }
+  @Test def test_Lesson4_initiators_terminators(): Unit = { runner_02.runOneTest("Lesson4_initiators_terminators") }
 
   @Test def test_DelimProp_10() = { runner_02.runOneTest("DelimProp_10") }
   @Test def test_DelimProp_10_01() = { runner_02.runOneTest("DelimProp_10_01") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterPropertiesUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterPropertiesUnparse.scala
@@ -26,7 +26,7 @@ object TestDelimiterPropertiesUnparse {
   val testDir_02 = "/org/apache/daffodil/section12/delimiter_properties/"
   val runner = Runner(testDir_02, "DelimiterPropertiesUnparse.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -36,27 +36,27 @@ class TestDelimiterPropertiesUnparse {
 
   import TestDelimiterPropertiesUnparse._
 
-  @Test def test_unparseSeparatorLeadingSpace() { runner.runOneTest("unparseSeparatorLeadingSpace") }
+  @Test def test_unparseSeparatorLeadingSpace(): Unit = { runner.runOneTest("unparseSeparatorLeadingSpace") }
 
   //DFDL-1493, DFDL-1477
   //@Test def test_unparseMultipleInitiators04() { runner.runOneTest("unparseMultipleInitiators04") }
   //@Test def test_unparseMultipleInitiators06() { runner.runOneTest("unparseMultipleInitiators06") }
 
-  @Test def test_unparseMultipleInitiators05() { runner.runOneTest("unparseMultipleInitiators05") }
-  @Test def test_unparseMultipleTerminators03() { runner.runOneTest("unparseMultipleTerminators03") }
+  @Test def test_unparseMultipleInitiators05(): Unit = { runner.runOneTest("unparseMultipleInitiators05") }
+  @Test def test_unparseMultipleTerminators03(): Unit = { runner.runOneTest("unparseMultipleTerminators03") }
 
-  @Test def test_unparseMultipleInitiators01() { runner.runOneTest("unparseMultipleInitiators01") }
-  @Test def test_unparseMultipleInitiators02() { runner.runOneTest("unparseMultipleInitiators02") }
-  @Test def test_unparseMultipleInitiators03() { runner.runOneTest("unparseMultipleInitiators03") }
-  @Test def test_unparseMultipleInitiators07() { runner.runOneTest("unparseMultipleInitiators07") }
+  @Test def test_unparseMultipleInitiators01(): Unit = { runner.runOneTest("unparseMultipleInitiators01") }
+  @Test def test_unparseMultipleInitiators02(): Unit = { runner.runOneTest("unparseMultipleInitiators02") }
+  @Test def test_unparseMultipleInitiators03(): Unit = { runner.runOneTest("unparseMultipleInitiators03") }
+  @Test def test_unparseMultipleInitiators07(): Unit = { runner.runOneTest("unparseMultipleInitiators07") }
 
-  @Test def test_unparseMultipleTerminators01() { runner.runOneTest("unparseMultipleTerminators01") }
-  @Test def test_unparseMultipleTerminators02() { runner.runOneTest("unparseMultipleTerminators02") }
-  @Test def test_unparseMultipleTerminators04() { runner.runOneTest("unparseMultipleTerminators04") }
-  @Test def test_unparseMultipleTerminators05() { runner.runOneTest("unparseMultipleTerminators05") }
+  @Test def test_unparseMultipleTerminators01(): Unit = { runner.runOneTest("unparseMultipleTerminators01") }
+  @Test def test_unparseMultipleTerminators02(): Unit = { runner.runOneTest("unparseMultipleTerminators02") }
+  @Test def test_unparseMultipleTerminators04(): Unit = { runner.runOneTest("unparseMultipleTerminators04") }
+  @Test def test_unparseMultipleTerminators05(): Unit = { runner.runOneTest("unparseMultipleTerminators05") }
 
-  @Test def test_unparseMultipleSeparators01() { runner.runOneTest("unparseMultipleSeparators01") }
-  @Test def test_unparseMultipleSeparators02() { runner.runOneTest("unparseMultipleSeparators02") }
-  @Test def test_unparseMultipleSeparators03() { runner.runOneTest("unparseMultipleSeparators03") }
+  @Test def test_unparseMultipleSeparators01(): Unit = { runner.runOneTest("unparseMultipleSeparators01") }
+  @Test def test_unparseMultipleSeparators02(): Unit = { runner.runOneTest("unparseMultipleSeparators02") }
+  @Test def test_unparseMultipleSeparators03(): Unit = { runner.runOneTest("unparseMultipleSeparators03") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindDelimited.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindDelimited.scala
@@ -28,7 +28,7 @@ object TestLengthKindDelimited {
   val runnerAB = Runner(testDir, "AB.tdml")
   val runnerAN = Runner(testDir, "AN.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runnerAB.reset
     runnerAN.reset
@@ -50,46 +50,46 @@ class TestLengthKindDelimited {
   @Test def test_NumSeq_00nl() = { runner.runOneTest("NumSeq_00nl") }
   @Test def test_NumSeq_01() = { runner.runOneTest("NumSeq_01") }
   @Test def test_nested_NumSeq_01() = { runner.runOneTest("nested_NumSeq_01") }
-  @Test def test_eofTest1() { runner.runOneTest("eofTest1") }
-  @Test def test_NumSeq_03() { runner.runOneTest("NumSeq_03") }
-  @Test def test_NumSeq_04() { runner.runOneTest("NumSeq_04") }
-  @Test def test_NumSeq_05() { runner.runOneTest("NumSeq_05") }
-  @Test def test_NumSeq_06() { runner.runOneTest("NumSeq_06") }
-  @Test def test_NumSeq_07() { runner.runOneTest("NumSeq_07") }
-  @Test def test_NumSeq_08() { runner.runOneTest("NumSeq_08") }
-  @Test def test_NumSeq_09() { runner.runOneTest("NumSeq_09") }
+  @Test def test_eofTest1(): Unit = { runner.runOneTest("eofTest1") }
+  @Test def test_NumSeq_03(): Unit = { runner.runOneTest("NumSeq_03") }
+  @Test def test_NumSeq_04(): Unit = { runner.runOneTest("NumSeq_04") }
+  @Test def test_NumSeq_05(): Unit = { runner.runOneTest("NumSeq_05") }
+  @Test def test_NumSeq_06(): Unit = { runner.runOneTest("NumSeq_06") }
+  @Test def test_NumSeq_07(): Unit = { runner.runOneTest("NumSeq_07") }
+  @Test def test_NumSeq_08(): Unit = { runner.runOneTest("NumSeq_08") }
+  @Test def test_NumSeq_09(): Unit = { runner.runOneTest("NumSeq_09") }
   // DAFFODIL-230 dfdl:documentFinalTerminatorCanBeMissing
   //  @Test def test_NumSeq_10() { runner.runOneTest("NumSeq_10") }
-  @Test def test_delimsCheck() { runner.runOneTest("delimsCheck") }
-  @Test def test_lengthKindDelimited_01() { runner.runOneTest("lengthKindDelimited_01") }
-  @Test def test_lengthKindDelimited_02() { runner.runOneTest("lengthKindDelimited_02") }
-  @Test def test_lengthKindDelimited_03() { runner.runOneTest("lengthKindDelimited_03") }
-  @Test def test_lengthKindDelimited_04() { runner.runOneTest("lengthKindDelimited_04") }
-  @Test def test_NumSeq_11() { runner.runOneTest("NumSeq_11") }
-  @Test def test_NumSeq_12() { runner.runOneTest("NumSeq_12") }
-  @Test def test_NumSeq_13() { runner.runOneTest("NumSeq_13") }
+  @Test def test_delimsCheck(): Unit = { runner.runOneTest("delimsCheck") }
+  @Test def test_lengthKindDelimited_01(): Unit = { runner.runOneTest("lengthKindDelimited_01") }
+  @Test def test_lengthKindDelimited_02(): Unit = { runner.runOneTest("lengthKindDelimited_02") }
+  @Test def test_lengthKindDelimited_03(): Unit = { runner.runOneTest("lengthKindDelimited_03") }
+  @Test def test_lengthKindDelimited_04(): Unit = { runner.runOneTest("lengthKindDelimited_04") }
+  @Test def test_NumSeq_11(): Unit = { runner.runOneTest("NumSeq_11") }
+  @Test def test_NumSeq_12(): Unit = { runner.runOneTest("NumSeq_12") }
+  @Test def test_NumSeq_13(): Unit = { runner.runOneTest("NumSeq_13") }
   // DAFFODIL-1975
   // @Test def test_NumSeq_13a() { runner.runOneTest("NumSeq_13a") }
-  @Test def test_NumSeq_13Fail() { runner.runOneTest("NumSeq_13Fail") }
-  @Test def test_NumSeq_14() { runner.runOneTest("NumSeq_14") }
+  @Test def test_NumSeq_13Fail(): Unit = { runner.runOneTest("NumSeq_13Fail") }
+  @Test def test_NumSeq_14(): Unit = { runner.runOneTest("NumSeq_14") }
   // Tests that initiator is found when on ElementRef
-  @Test def test_refInitiator() { runner.runOneTest("refInitiator") }
+  @Test def test_refInitiator(): Unit = { runner.runOneTest("refInitiator") }
   // Tests that initiator is found when on GlobalElmentDecl
-  @Test def test_refInitiator2() { runner.runOneTest("refInitiator2") }
-  @Test def test_binary_delimited_fail() { runner.runOneTest("binary_delimited_fail") }
-  @Test def test_Lesson1_lengthKind_delimited() { runner.runOneTest("Lesson1_lengthKind_delimited") }
-  @Test def test_Lesson4_delimited_fixed_length() { runner.runOneTest("Lesson4_delimited_fixed_length") }
-  @Test def test_delimited_construct() { runner.runOneTest("delimited_construct") }
+  @Test def test_refInitiator2(): Unit = { runner.runOneTest("refInitiator2") }
+  @Test def test_binary_delimited_fail(): Unit = { runner.runOneTest("binary_delimited_fail") }
+  @Test def test_Lesson1_lengthKind_delimited(): Unit = { runner.runOneTest("Lesson1_lengthKind_delimited") }
+  @Test def test_Lesson4_delimited_fixed_length(): Unit = { runner.runOneTest("Lesson4_delimited_fixed_length") }
+  @Test def test_delimited_construct(): Unit = { runner.runOneTest("delimited_construct") }
 
-  @Test def test_AB000() { runnerAB.runOneTest("AB000") }
-  @Test def test_AB001() { runnerAB.runOneTest("AB001") }
-  @Test def test_AB002() { runnerAB.runOneTest("AB002") }
-  @Test def test_AB003() { runnerAB.runOneTest("AB003") }
-  @Test def test_AB004() { runnerAB.runOneTest("AB004") }
-  @Test def test_AB005_parse() { runnerAB.runOneTest("AB005_parse") }
-  @Test def test_AB005_unparse() { runnerAB.runOneTest("AB005_unparse") }
+  @Test def test_AB000(): Unit = { runnerAB.runOneTest("AB000") }
+  @Test def test_AB001(): Unit = { runnerAB.runOneTest("AB001") }
+  @Test def test_AB002(): Unit = { runnerAB.runOneTest("AB002") }
+  @Test def test_AB003(): Unit = { runnerAB.runOneTest("AB003") }
+  @Test def test_AB004(): Unit = { runnerAB.runOneTest("AB004") }
+  @Test def test_AB005_parse(): Unit = { runnerAB.runOneTest("AB005_parse") }
+  @Test def test_AB005_unparse(): Unit = { runnerAB.runOneTest("AB005_unparse") }
 
-  @Test def test_AN000() { runnerAN.runOneTest("AN000") }
-  @Test def test_AN001() { runnerAN.runOneTest("AN001") }
+  @Test def test_AN000(): Unit = { runnerAN.runOneTest("AN000") }
+  @Test def test_AN001(): Unit = { runnerAN.runOneTest("AN001") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindEndOfParent2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindEndOfParent2.scala
@@ -25,7 +25,7 @@ object TestLengthKindEndOfParent2 {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner = Runner(testDir, "EndOfParentTests.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -25,7 +25,7 @@ object TestLengthKindExplicit {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner = Runner(testDir, "ExplicitTests.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -35,7 +35,7 @@ class TestLengthKindExplicit {
 
   import TestLengthKindExplicit._
 
-  @Test def test_Lesson1_lengthKind_explicit() { runner.runOneTest("Lesson1_lengthKind_explicit") }
+  @Test def test_Lesson1_lengthKind_explicit(): Unit = { runner.runOneTest("Lesson1_lengthKind_explicit") }
   @Test def test_ExplicitLengthBytesNotFixed() = { runner.runOneTest("test_ExplicitLengthBytesNotFixed") }
   @Test def test_ExplicitLengthBitsFixed() = { runner.runOneTest("ExplicitLengthBitsFixed") }
   @Test def test_ExplicitLengthBytesFixed() = { runner.runOneTest("test_ExplicitLengthBytesFixed") }
@@ -61,7 +61,7 @@ class TestLengthKindExplicit {
   @Test def test_explicitBytes_int_02() = { runner.runOneTest("explicitBytes_int_02") }
 
   // Added for issue related to DFDL-1674
-  @Test def test_denseBit_lengthKind_explicit() { runner.runOneTest("denseBit_lengthKind_explicit") }
+  @Test def test_denseBit_lengthKind_explicit(): Unit = { runner.runOneTest("denseBit_lengthKind_explicit") }
 
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindImplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindImplicit.scala
@@ -25,7 +25,7 @@ object TestLengthKindImplicit {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner_01 = Runner(testDir, "implicit.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_01.reset
   }
 
@@ -41,10 +41,10 @@ class TestLengthKindImplicit {
   // runner.runOneTest("test_name")
   // }
 
-  @Test def test_nested_seq() { runner_01.runOneTest("nested_seq") }
-  @Test def test_nested_seq_01() { runner_01.runOneTest("nested_seq_01") }
+  @Test def test_nested_seq(): Unit = { runner_01.runOneTest("nested_seq") }
+  @Test def test_nested_seq_01(): Unit = { runner_01.runOneTest("nested_seq_01") }
 
-  @Test def test_implicit_with_len() { runner_01.runOneTest("implicit_with_len") }
-  @Test def test_implicitLenTime() { runner_01.runOneTest("implicitLenTime") }
+  @Test def test_implicit_with_len(): Unit = { runner_01.runOneTest("implicit_with_len") }
+  @Test def test_implicitLenTime(): Unit = { runner_01.runOneTest("implicitLenTime") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern.scala
@@ -29,7 +29,7 @@ object TestLengthKindPattern {
 
   val runnerAI = Runner(testDir, "AI.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runnerAI.reset
   }
@@ -39,49 +39,49 @@ class TestLengthKindPattern {
 
   import TestLengthKindPattern._
 
-  @Test def test_unmatchedPattern01() { runner.runOneTest("unmatchedPattern01") }
-  @Test def test_unmatchedPattern02() { runner.runOneTest("unmatchedPattern02") }
-  @Test def test_unmatchedPattern03() { runner.runOneTest("unmatchedPattern03") }
+  @Test def test_unmatchedPattern01(): Unit = { runner.runOneTest("unmatchedPattern01") }
+  @Test def test_unmatchedPattern02(): Unit = { runner.runOneTest("unmatchedPattern02") }
+  @Test def test_unmatchedPattern03(): Unit = { runner.runOneTest("unmatchedPattern03") }
 
-  @Test def test_invalid_pattern() { runner.runOneTest("invalid_pattern") }
-  @Test def test_invalid_pattern2() { runner.runOneTest("invalid_pattern2") }
-  @Test def test_invalid_pattern3() { runner.runOneTest("invalid_pattern3") }
+  @Test def test_invalid_pattern(): Unit = { runner.runOneTest("invalid_pattern") }
+  @Test def test_invalid_pattern2(): Unit = { runner.runOneTest("invalid_pattern2") }
+  @Test def test_invalid_pattern3(): Unit = { runner.runOneTest("invalid_pattern3") }
 
-  @Test def test_AI000_rev() { runner.runOneTest("AI000_rev") } // round trip
-  @Test def test_LengthKindPattern() { runner.runOneTest("LengthKindPattern") } // round trip
-  @Test def test_LengthKindPatternCompound() { runner.runOneTest("LengthKindPatternCompound") }
-  @Test def test_LengthKindPatternCompound2() { runner.runOneTest("LengthKindPatternCompound2") } // round trip
-  @Test def test_lengthKindPattern_01() { runner.runOneTest("lengthKindPattern_01") } // round trip
-  @Test def test_lengthKindPattern_02() { runner.runOneTest("lengthKindPattern_02") } // round trip
-  @Test def test_lengthKindPattern_03() { runner.runOneTest("lengthKindPattern_03") } // round trip
-  @Test def test_lengthKindPattern_04() { runner.runOneTest("lengthKindPattern_04") } // round trip
+  @Test def test_AI000_rev(): Unit = { runner.runOneTest("AI000_rev") } // round trip
+  @Test def test_LengthKindPattern(): Unit = { runner.runOneTest("LengthKindPattern") } // round trip
+  @Test def test_LengthKindPatternCompound(): Unit = { runner.runOneTest("LengthKindPatternCompound") }
+  @Test def test_LengthKindPatternCompound2(): Unit = { runner.runOneTest("LengthKindPatternCompound2") } // round trip
+  @Test def test_lengthKindPattern_01(): Unit = { runner.runOneTest("lengthKindPattern_01") } // round trip
+  @Test def test_lengthKindPattern_02(): Unit = { runner.runOneTest("lengthKindPattern_02") } // round trip
+  @Test def test_lengthKindPattern_03(): Unit = { runner.runOneTest("lengthKindPattern_03") } // round trip
+  @Test def test_lengthKindPattern_04(): Unit = { runner.runOneTest("lengthKindPattern_04") } // round trip
 
-  @Test def test_LengthPatternIllegalBits_01() { runner.runOneTest("LengthPatternIllegalBits_01") }
-  @Test def test_LengthPatternLegalBits_01() { runner.runOneTest("LengthPatternLegalBits_01") }
+  @Test def test_LengthPatternIllegalBits_01(): Unit = { runner.runOneTest("LengthPatternIllegalBits_01") }
+  @Test def test_LengthPatternLegalBits_01(): Unit = { runner.runOneTest("LengthPatternLegalBits_01") }
 
   // DFDL-309
-  @Test def test_LengthPatternIllegalBits_02_EncodingErrorPolicy_Replace() { runner.runOneTest("LengthPatternIllegalBits_02_EncodingErrorPolicy_Replace") }
+  @Test def test_LengthPatternIllegalBits_02_EncodingErrorPolicy_Replace(): Unit = { runner.runOneTest("LengthPatternIllegalBits_02_EncodingErrorPolicy_Replace") }
   // DFDL-935 dfdl:encodingErrorPolicy='error'
   //@Test def test_LengthPatternIllegalBits_02_EncodingErrorPolicy_Error() { runner.runOneTest("LengthPatternIllegalBits_02_EncodingErrorPolicy_Error") }
 
-  @Test def test_LengthPatternLegalBits_02() { runner.runOneTest("LengthPatternLegalBits_02") } // round trip
-  @Test def test_lengthKindPatternFail() { runner.runOneTest("lengthKindPatternFail") }
+  @Test def test_LengthPatternLegalBits_02(): Unit = { runner.runOneTest("LengthPatternLegalBits_02") } // round trip
+  @Test def test_lengthKindPatternFail(): Unit = { runner.runOneTest("lengthKindPatternFail") }
 
-  @Test def test_ComplexWithBinaryChild() { runner.runOneTest("ComplexWithBinaryChild") }
+  @Test def test_ComplexWithBinaryChild(): Unit = { runner.runOneTest("ComplexWithBinaryChild") }
 
-  @Test def test_AI000() { runnerAI.runOneTest("AI000") }
+  @Test def test_AI000(): Unit = { runnerAI.runOneTest("AI000") }
 
-  @Test def test_LengthPatternNil_NoNil() { runner.runOneTest("LengthPatternNil_NoNil") } // round trip
-  @Test def test_LengthPatternNil_FindsNil() { runner.runOneTest("LengthPatternNil_FindsNil") } // round trip
-  @Test def test_LengthPatternNil_EmptyStringAllowed() { runner.runOneTest("LengthPatternNil_EmptyStringAllowed") }
-  @Test def test_nested_patterns() { runner.runOneTest("nested_patterns") }
-  @Test def test_nested_patterns_01() { runner.runOneTest("nested_patterns_01") }
-  @Test def test_nested_patterns_02() { runner.runOneTest("nested_patterns_02") }
-  @Test def test_nested_patterns_03() { runner.runOneTest("nested_patterns_03") }
+  @Test def test_LengthPatternNil_NoNil(): Unit = { runner.runOneTest("LengthPatternNil_NoNil") } // round trip
+  @Test def test_LengthPatternNil_FindsNil(): Unit = { runner.runOneTest("LengthPatternNil_FindsNil") } // round trip
+  @Test def test_LengthPatternNil_EmptyStringAllowed(): Unit = { runner.runOneTest("LengthPatternNil_EmptyStringAllowed") }
+  @Test def test_nested_patterns(): Unit = { runner.runOneTest("nested_patterns") }
+  @Test def test_nested_patterns_01(): Unit = { runner.runOneTest("nested_patterns_01") }
+  @Test def test_nested_patterns_02(): Unit = { runner.runOneTest("nested_patterns_02") }
+  @Test def test_nested_patterns_03(): Unit = { runner.runOneTest("nested_patterns_03") }
 
-  @Test def test_hexBinaryLengthKindPattern01() { runner.runOneTest("hexBinaryLengthKindPattern01") }
+  @Test def test_hexBinaryLengthKindPattern01(): Unit = { runner.runOneTest("hexBinaryLengthKindPattern01") }
 
-  @Test def test_lengthPatternEncodingErrorReplace() { runner.runOneTest("lengthPatternEncodingErrorReplace") }
+  @Test def test_lengthPatternEncodingErrorReplace(): Unit = { runner.runOneTest("lengthPatternEncodingErrorReplace") }
 
-  @Test def test_lengthPatternBinaryPatternLimit() { runner.runOneTest("lengthPatternBinaryPatternLimit") }
+  @Test def test_lengthPatternBinaryPatternLimit(): Unit = { runner.runOneTest("lengthPatternBinaryPatternLimit") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -26,7 +26,7 @@ object TestLengthKindPrefixed {
 
   val runner = Runner(testDir, "PrefixedTests.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
@@ -27,7 +27,7 @@ object TestLengthProperties {
 
   val runner_02 = Runner(testDir_02, "LengthProperties.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_02.reset
   }
 
@@ -37,52 +37,52 @@ class TestLengthProperties {
 
   import TestLengthProperties._
 
-  @Test def test_LengthProp_02() { runner_02.runOneTest("LengthProp_02") }
-  @Test def test_LengthProp_charVsBytes() { runner_02.runOneTest("LengthProp_charVsBytes") }
-  @Test def test_LengthProp_charVsBytes2() { runner_02.runOneTest("LengthProp_charVsBytes2") }
-  @Test def test_LengthProp_longByteLength() { runner_02.runOneTest("LengthProp_longByteLength") }
+  @Test def test_LengthProp_02(): Unit = { runner_02.runOneTest("LengthProp_02") }
+  @Test def test_LengthProp_charVsBytes(): Unit = { runner_02.runOneTest("LengthProp_charVsBytes") }
+  @Test def test_LengthProp_charVsBytes2(): Unit = { runner_02.runOneTest("LengthProp_charVsBytes2") }
+  @Test def test_LengthProp_longByteLength(): Unit = { runner_02.runOneTest("LengthProp_longByteLength") }
 
-  @Test def test_LengthProp_04() { runner_02.runOneTest("LengthProp_04") }
-  @Test def test_LengthProp_05() { runner_02.runOneTest("LengthProp_05") }
-  @Test def test_LengthProp_06() { runner_02.runOneTest("LengthProp_06") }
+  @Test def test_LengthProp_04(): Unit = { runner_02.runOneTest("LengthProp_04") }
+  @Test def test_LengthProp_05(): Unit = { runner_02.runOneTest("LengthProp_05") }
+  @Test def test_LengthProp_06(): Unit = { runner_02.runOneTest("LengthProp_06") }
 
-  @Test def test_LengthProp_sequenceByLength() { runner_02.runOneTest("LengthProp_sequenceByLength") }
+  @Test def test_LengthProp_sequenceByLength(): Unit = { runner_02.runOneTest("LengthProp_sequenceByLength") }
 
-  @Test def test_LengthProp_tooShortFailure() { runner_02.runOneTest("LengthProp_tooShortFailure") }
-  @Test def test_LengthProp_tooLongFailure() { runner_02.runOneTest("LengthProp_tooLongFailure") }
+  @Test def test_LengthProp_tooShortFailure(): Unit = { runner_02.runOneTest("LengthProp_tooShortFailure") }
+  @Test def test_LengthProp_tooLongFailure(): Unit = { runner_02.runOneTest("LengthProp_tooLongFailure") }
 
-  @Test def test_LengthProp_zeroLength() { runner_02.runOneTest("LengthProp_zeroLength") }
-  @Test def test_LengthProp_byteLength() { runner_02.runOneTest("LengthProp_byteLength") }
-  @Test def test_LengthProp_byteLength_UTF16() { runner_02.runOneTest("LengthProp_byteLength_UTF16") }
-  @Test def test_LengthProp_byteLength_UTF16fail() { runner_02.runOneTest("LengthProp_byteLength_UTF16fail") }
+  @Test def test_LengthProp_zeroLength(): Unit = { runner_02.runOneTest("LengthProp_zeroLength") }
+  @Test def test_LengthProp_byteLength(): Unit = { runner_02.runOneTest("LengthProp_byteLength") }
+  @Test def test_LengthProp_byteLength_UTF16(): Unit = { runner_02.runOneTest("LengthProp_byteLength_UTF16") }
+  @Test def test_LengthProp_byteLength_UTF16fail(): Unit = { runner_02.runOneTest("LengthProp_byteLength_UTF16fail") }
 
-  @Test def test_LengthProp_longTextLength() { runner_02.runOneTest("LengthProp_longTextLength") }
-  @Test def test_LengthProp_lengthExpression1() { runner_02.runOneTest("LengthProp_lengthExpression1") }
+  @Test def test_LengthProp_longTextLength(): Unit = { runner_02.runOneTest("LengthProp_longTextLength") }
+  @Test def test_LengthProp_lengthExpression1(): Unit = { runner_02.runOneTest("LengthProp_lengthExpression1") }
 
-  @Test def test_LengthProp_bits_01() { runner_02.runOneTest("LengthProp_bits_01") }
-  @Test def test_LengthProp_bits_02() { runner_02.runOneTest("LengthProp_bits_02") }
+  @Test def test_LengthProp_bits_01(): Unit = { runner_02.runOneTest("LengthProp_bits_01") }
+  @Test def test_LengthProp_bits_02(): Unit = { runner_02.runOneTest("LengthProp_bits_02") }
 
-  @Test def test_OneBitLeftOver() { runner_02.runOneTest("OneBitLeftOver") }
-  @Test def test_OneBit1() { runner_02.runOneTest("OneBit1") }
-  @Test def test_ThreeBit1() { runner_02.runOneTest("ThreeBit1") }
-  @Test def test_seqBit1() { runner_02.runOneTest("seqBit1") }
-  @Test def test_seqBitLeftOver() { runner_02.runOneTest("seqBitLeftOver") }
+  @Test def test_OneBitLeftOver(): Unit = { runner_02.runOneTest("OneBitLeftOver") }
+  @Test def test_OneBit1(): Unit = { runner_02.runOneTest("OneBit1") }
+  @Test def test_ThreeBit1(): Unit = { runner_02.runOneTest("ThreeBit1") }
+  @Test def test_seqBit1(): Unit = { runner_02.runOneTest("seqBit1") }
+  @Test def test_seqBitLeftOver(): Unit = { runner_02.runOneTest("seqBitLeftOver") }
 
-  @Test def test_twoByteLittleEndian() { runner_02.runOneTest("twoByteLittleEndian") }
-  @Test def test_twoByteBigEndian() { runner_02.runOneTest("twoByteBigEndian") }
+  @Test def test_twoByteLittleEndian(): Unit = { runner_02.runOneTest("twoByteLittleEndian") }
+  @Test def test_twoByteBigEndian(): Unit = { runner_02.runOneTest("twoByteBigEndian") }
 
-  @Test def test_bit1() { runner_02.runOneTest("bit1") }
-  @Test def test_bit2() { runner_02.runOneTest("bit2") }
-  @Test def test_bit3() { runner_02.runOneTest("bit3") }
+  @Test def test_bit1(): Unit = { runner_02.runOneTest("bit1") }
+  @Test def test_bit2(): Unit = { runner_02.runOneTest("bit2") }
+  @Test def test_bit3(): Unit = { runner_02.runOneTest("bit3") }
 
-  @Test def test_bitsRepresentedAsText1() { runner_02.runOneTest("bitsRepresentedAsText1") }
-  @Test def test_bitsRepresentedAsText2() { runner_02.runOneTest("bitsRepresentedAsText2") }
+  @Test def test_bitsRepresentedAsText1(): Unit = { runner_02.runOneTest("bitsRepresentedAsText1") }
+  @Test def test_bitsRepresentedAsText2(): Unit = { runner_02.runOneTest("bitsRepresentedAsText2") }
 
-  @Test def test_lengthGreaterThanEight1() { runner_02.runOneTest("lengthGreaterThanEight1") }
-  @Test def test_lengthGreaterThanEight2() { runner_02.runOneTest("lengthGreaterThanEight2") }
-  @Test def test_lengthGreaterThanEight3() { runner_02.runOneTest("lengthGreaterThanEight3") }
-  @Test def test_lengthGreaterThanEight4() { runner_02.runOneTest("lengthGreaterThanEight4") }
-  @Test def test_lengthGreaterThanEight5() { runner_02.runOneTest("lengthGreaterThanEight5") }
+  @Test def test_lengthGreaterThanEight1(): Unit = { runner_02.runOneTest("lengthGreaterThanEight1") }
+  @Test def test_lengthGreaterThanEight2(): Unit = { runner_02.runOneTest("lengthGreaterThanEight2") }
+  @Test def test_lengthGreaterThanEight3(): Unit = { runner_02.runOneTest("lengthGreaterThanEight3") }
+  @Test def test_lengthGreaterThanEight4(): Unit = { runner_02.runOneTest("lengthGreaterThanEight4") }
+  @Test def test_lengthGreaterThanEight5(): Unit = { runner_02.runOneTest("lengthGreaterThanEight5") }
 
   @Test def test_littleEndianBits1() = {
     import org.apache.daffodil.util._
@@ -92,34 +92,34 @@ class TestLengthProperties {
     assertEquals(384, res)
   }
 
-  @Test def test_bitUnsignedLong() { runner_02.runOneTest("bitUnsignedLong") }
-  @Test def test_bitUnsignedLong2() { runner_02.runOneTest("bitUnsignedLong2") }
-  @Test def test_bitUnsignedLong3() { runner_02.runOneTest("bitUnsignedLong3") }
-  @Test def test_bitUnsignedLong4() { runner_02.runOneTest("bitUnsignedLong4") }
-  @Test def test_bitUnsignedLong5() { runner_02.runOneTest("bitUnsignedLong5") }
-  @Test def test_bitUCombo() { runner_02.runOneTest("bitUCombo") }
-  @Test def test_bitUCombo2() { runner_02.runOneTest("bitUCombo2") }
+  @Test def test_bitUnsignedLong(): Unit = { runner_02.runOneTest("bitUnsignedLong") }
+  @Test def test_bitUnsignedLong2(): Unit = { runner_02.runOneTest("bitUnsignedLong2") }
+  @Test def test_bitUnsignedLong3(): Unit = { runner_02.runOneTest("bitUnsignedLong3") }
+  @Test def test_bitUnsignedLong4(): Unit = { runner_02.runOneTest("bitUnsignedLong4") }
+  @Test def test_bitUnsignedLong5(): Unit = { runner_02.runOneTest("bitUnsignedLong5") }
+  @Test def test_bitUCombo(): Unit = { runner_02.runOneTest("bitUCombo") }
+  @Test def test_bitUCombo2(): Unit = { runner_02.runOneTest("bitUCombo2") }
 
-  @Test def test_LengthProp_bits_bool() { runner_02.runOneTest("LengthProp_bits_bool") }
-  @Test def test_LengthProp_bits_bool_false() { runner_02.runOneTest("LengthProp_bits_bool_false") }
+  @Test def test_LengthProp_bits_bool(): Unit = { runner_02.runOneTest("LengthProp_bits_bool") }
+  @Test def test_LengthProp_bits_bool_false(): Unit = { runner_02.runOneTest("LengthProp_bits_bool_false") }
 
-  @Test def test_LengthProp_leftover1() { runner_02.runOneTest("LengthProp_leftover1") }
-  @Test def test_LengthProp_leftover2() { runner_02.runOneTest("LengthProp_leftover2") }
-  @Test def test_LengthProp_leftover3() { runner_02.runOneTest("LengthProp_leftover3") }
-  @Test def test_LengthProp_leftover4() { runner_02.runOneTest("LengthProp_leftover4") }
+  @Test def test_LengthProp_leftover1(): Unit = { runner_02.runOneTest("LengthProp_leftover1") }
+  @Test def test_LengthProp_leftover2(): Unit = { runner_02.runOneTest("LengthProp_leftover2") }
+  @Test def test_LengthProp_leftover3(): Unit = { runner_02.runOneTest("LengthProp_leftover3") }
+  @Test def test_LengthProp_leftover4(): Unit = { runner_02.runOneTest("LengthProp_leftover4") }
 
   //DFDL-460
-  @Test def test_LengthProp_floatBits() { runner_02.runOneTest("LengthProp_floatBits") }
+  @Test def test_LengthProp_floatBits(): Unit = { runner_02.runOneTest("LengthProp_floatBits") }
 
-  @Test def test_bitShort() { runner_02.runOneTest("bitShort") }
-  @Test def test_bitShort2() { runner_02.runOneTest("bitShort2") }
-  @Test def test_bitShort3() { runner_02.runOneTest("bitShort3") }
-  @Test def test_bitShortImplicit() { runner_02.runOneTest("bitShortImplicit") }
-  @Test def test_bitInt() { runner_02.runOneTest("bitInt") }
-  @Test def test_bitIntImplicit() { runner_02.runOneTest("bitIntImplicit") }
-  @Test def test_bitInteger() { runner_02.runOneTest("bitInteger") }
-  @Test def test_bitLong() { runner_02.runOneTest("bitLong") }
-  @Test def test_bitByte() { runner_02.runOneTest("bitByte") }
-  @Test def test_bitSignedCombo() { runner_02.runOneTest("bitSignedCombo") }
+  @Test def test_bitShort(): Unit = { runner_02.runOneTest("bitShort") }
+  @Test def test_bitShort2(): Unit = { runner_02.runOneTest("bitShort2") }
+  @Test def test_bitShort3(): Unit = { runner_02.runOneTest("bitShort3") }
+  @Test def test_bitShortImplicit(): Unit = { runner_02.runOneTest("bitShortImplicit") }
+  @Test def test_bitInt(): Unit = { runner_02.runOneTest("bitInt") }
+  @Test def test_bitIntImplicit(): Unit = { runner_02.runOneTest("bitIntImplicit") }
+  @Test def test_bitInteger(): Unit = { runner_02.runOneTest("bitInteger") }
+  @Test def test_bitLong(): Unit = { runner_02.runOneTest("bitLong") }
+  @Test def test_bitByte(): Unit = { runner_02.runOneTest("bitByte") }
+  @Test def test_bitSignedCombo(): Unit = { runner_02.runOneTest("bitSignedCombo") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthPropertiesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthPropertiesNew.scala
@@ -26,7 +26,7 @@ object TestLengthPropertiesNew {
 
   val runner_02 = Runner(testDir_02, "LengthProperties.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_02.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
@@ -30,7 +30,7 @@ object TestNillable {
   val runnerLC = Runner(testDir, "literal-character-nils.tdml")
   val runnerEntity = Runner(testDir_01, "entities_01.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runnerAA.reset
     runnerLN.reset
     runnerEntity.reset
@@ -43,26 +43,26 @@ class TestNillable {
 
   import TestNillable._
 
-  @Test def test_complex_nil() { runnerLN.runOneTest("test_complex_nil") }
+  @Test def test_complex_nil(): Unit = { runnerLN.runOneTest("test_complex_nil") }
 
-  @Test def test_litNil1() { runnerAA.runOneTest("litNil1") }
-  @Test def test_litNil2() { runnerAA.runOneTest("litNil2") }
-  @Test def test_litNil3() { runnerAA.runOneTest("litNil3") }
-  @Test def test_litNil4() { runnerAA.runOneTest("litNil4") }
-  @Test def test_litNil4b() { runnerAA.runOneTest("litNil4b") }
-  @Test def test_litNil5() { runnerAA.runOneTest("litNil5") }
-  @Test def test_litNil6() { runnerAA.runOneTest("litNil6") }
-  @Test def test_litNil7() { runnerAA.runOneTest("litNil7") }
-  @Test def test_missing_scalar() { runnerAA.runOneTest("missing_scalar") }
-  @Test def test_nillable1() { runnerAA.runOneTest("nillable1") }
-  @Test def test_edifact1a() { runnerAA.runOneTest("edifact1a") }
+  @Test def test_litNil1(): Unit = { runnerAA.runOneTest("litNil1") }
+  @Test def test_litNil2(): Unit = { runnerAA.runOneTest("litNil2") }
+  @Test def test_litNil3(): Unit = { runnerAA.runOneTest("litNil3") }
+  @Test def test_litNil4(): Unit = { runnerAA.runOneTest("litNil4") }
+  @Test def test_litNil4b(): Unit = { runnerAA.runOneTest("litNil4b") }
+  @Test def test_litNil5(): Unit = { runnerAA.runOneTest("litNil5") }
+  @Test def test_litNil6(): Unit = { runnerAA.runOneTest("litNil6") }
+  @Test def test_litNil7(): Unit = { runnerAA.runOneTest("litNil7") }
+  @Test def test_missing_scalar(): Unit = { runnerAA.runOneTest("missing_scalar") }
+  @Test def test_nillable1(): Unit = { runnerAA.runOneTest("nillable1") }
+  @Test def test_edifact1a(): Unit = { runnerAA.runOneTest("edifact1a") }
 
   @Test def test_text_nil_characterClass_04_parse() = { runnerLN.runOneTest("text_nil_characterClass_04_parse") }
 
-  @Test def test_text_03() { runnerLN.runOneTest("text_03") }
-  @Test def test_text_03ic() { runnerLN.runOneTest("text_03ic") }
-  @Test def test_text_04() { runnerLN.runOneTest("text_04") }
-  @Test def test_text_05() { runnerLN.runOneTest("text_05") }
+  @Test def test_text_03(): Unit = { runnerLN.runOneTest("text_03") }
+  @Test def test_text_03ic(): Unit = { runnerLN.runOneTest("text_03ic") }
+  @Test def test_text_04(): Unit = { runnerLN.runOneTest("text_04") }
+  @Test def test_text_05(): Unit = { runnerLN.runOneTest("text_05") }
   @Test def test_text_06() = { runnerLN.runOneTest("text_06") }
   @Test def test_binary_01() = { runnerLN.runOneTest("binary_01") }
   @Test def test_padded_nils() = { runnerLN.runOneTest("test_padded_nils") }
@@ -78,16 +78,16 @@ class TestNillable {
    *  According to analysis doc, should also work for numeric
    *  and hex entities.
    * */
-  @Test def test_text_lit_char_01() { runnerLC.runOneTest("text_01") }
-  @Test def test_text_lit_char_01ic() { runnerLC.runOneTest("text_01ic") }
-  @Test def test_text_lit_char_02() { runnerLC.runOneTest("text_02") }
-  @Test def test_text_lit_char_03() { runnerLC.runOneTest("text_03") }
-  @Test def test_text_lit_char_04() { runnerLC.runOneTest("text_04") }
-  @Test def test_binary_lit_char_01() { runnerLC.runOneTest("binary_01") }
+  @Test def test_text_lit_char_01(): Unit = { runnerLC.runOneTest("text_01") }
+  @Test def test_text_lit_char_01ic(): Unit = { runnerLC.runOneTest("text_01ic") }
+  @Test def test_text_lit_char_02(): Unit = { runnerLC.runOneTest("text_02") }
+  @Test def test_text_lit_char_03(): Unit = { runnerLC.runOneTest("text_03") }
+  @Test def test_text_lit_char_04(): Unit = { runnerLC.runOneTest("text_04") }
+  @Test def test_binary_lit_char_01(): Unit = { runnerLC.runOneTest("binary_01") }
 
-  @Test def test_entity_fail_05() { runnerEntity.runOneTest("entity_fail_05") }
-  @Test def test_entity_fail_06() { runnerEntity.runOneTest("entity_fail_06") }
-  @Test def test_entity_success_05() { runnerEntity.runOneTest("entity_success_05") }
-  @Test def test_entity_success_06() { runnerEntity.runOneTest("entity_success_06") }
+  @Test def test_entity_fail_05(): Unit = { runnerEntity.runOneTest("entity_fail_05") }
+  @Test def test_entity_fail_06(): Unit = { runnerEntity.runOneTest("entity_fail_06") }
+  @Test def test_entity_success_05(): Unit = { runnerEntity.runOneTest("entity_success_05") }
+  @Test def test_entity_success_06(): Unit = { runnerEntity.runOneTest("entity_success_06") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillableUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillableUnparse.scala
@@ -26,7 +26,7 @@ object TestNillableUnparse {
   val runnerLN = Runner(testDir, "literal-value-nils-unparse.tdml")
   val runnerLC = Runner(testDir, "literal-character-nils-unparse.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runnerLN.reset
     runnerLC.reset
   }
@@ -36,40 +36,40 @@ class TestNillableUnparse {
 
   import TestNillableUnparse._
 
-  @Test def test_scalar_nonDefaultable_nillable() { runnerLN.runOneTest("scalar_nonDefaultable_nillable") }
-  @Test def test_scalar_nonDefaultable_nillable_02() { runnerLN.runOneTest("scalar_nonDefaultable_nillable_02") }
-  @Test def test_scalar_nonDefaultable_nillable_03() { runnerLN.runOneTest("scalar_nonDefaultable_nillable_03") }
+  @Test def test_scalar_nonDefaultable_nillable(): Unit = { runnerLN.runOneTest("scalar_nonDefaultable_nillable") }
+  @Test def test_scalar_nonDefaultable_nillable_02(): Unit = { runnerLN.runOneTest("scalar_nonDefaultable_nillable_02") }
+  @Test def test_scalar_nonDefaultable_nillable_03(): Unit = { runnerLN.runOneTest("scalar_nonDefaultable_nillable_03") }
 
-  @Test def test_text_complex_nil() { runnerLN.runOneTest("text_complex_nil") }
-  @Test def test_text_complex_nil2() { runnerLN.runOneTest("text_complex_nil2") }
-  @Test def test_text_complex_nil3() { runnerLN.runOneTest("text_complex_nil3") }
+  @Test def test_text_complex_nil(): Unit = { runnerLN.runOneTest("text_complex_nil") }
+  @Test def test_text_complex_nil2(): Unit = { runnerLN.runOneTest("text_complex_nil2") }
+  @Test def test_text_complex_nil3(): Unit = { runnerLN.runOneTest("text_complex_nil3") }
 
-  @Test def test_text_nil_only1() { runnerLN.runOneTest("text_nil_only1") }
-  @Test def test_text_nil_only2() { runnerLN.runOneTest("text_nil_only2") }
-  @Test def test_text_nil_only3() { runnerLN.runOneTest("text_nil_only3") }
-  @Test def test_text_nil_only4() { runnerLN.runOneTest("text_nil_only4") }
-  @Test def test_text_nil_only5() { runnerLN.runOneTest("text_nil_only5") }
-  @Test def test_text_nil_only6() { runnerLN.runOneTest("text_nil_only6") }
-  @Test def test_text_nil_only7() { runnerLN.runOneTest("text_nil_only7") }
-  @Test def test_text_nil_only8() { runnerLN.runOneTest("text_nil_only8") }
-  @Test def test_text_nil_only9() { runnerLN.runOneTest("text_nil_only9") }
-  @Test def test_text_nil_only10() { runnerLN.runOneTest("text_nil_only10") }
-  @Test def test_text_nil_only11() { runnerLN.runOneTest("text_nil_only11") }
-  @Test def test_text_nil_only12() { runnerLN.runOneTest("text_nil_only12") }
-  @Test def test_text_nil_only13() { runnerLN.runOneTest("text_nil_only13") }
-  @Test def test_text_nil_only14() { runnerLN.runOneTest("text_nil_only14") }
-  @Test def test_text_nil_only15() { runnerLN.runOneTest("text_nil_only15") }
-  @Test def test_text_nil_only16() { runnerLN.runOneTest("text_nil_only16") }
-  @Test def test_text_nil_only17() { runnerLN.runOneTest("text_nil_only17") }
+  @Test def test_text_nil_only1(): Unit = { runnerLN.runOneTest("text_nil_only1") }
+  @Test def test_text_nil_only2(): Unit = { runnerLN.runOneTest("text_nil_only2") }
+  @Test def test_text_nil_only3(): Unit = { runnerLN.runOneTest("text_nil_only3") }
+  @Test def test_text_nil_only4(): Unit = { runnerLN.runOneTest("text_nil_only4") }
+  @Test def test_text_nil_only5(): Unit = { runnerLN.runOneTest("text_nil_only5") }
+  @Test def test_text_nil_only6(): Unit = { runnerLN.runOneTest("text_nil_only6") }
+  @Test def test_text_nil_only7(): Unit = { runnerLN.runOneTest("text_nil_only7") }
+  @Test def test_text_nil_only8(): Unit = { runnerLN.runOneTest("text_nil_only8") }
+  @Test def test_text_nil_only9(): Unit = { runnerLN.runOneTest("text_nil_only9") }
+  @Test def test_text_nil_only10(): Unit = { runnerLN.runOneTest("text_nil_only10") }
+  @Test def test_text_nil_only11(): Unit = { runnerLN.runOneTest("text_nil_only11") }
+  @Test def test_text_nil_only12(): Unit = { runnerLN.runOneTest("text_nil_only12") }
+  @Test def test_text_nil_only13(): Unit = { runnerLN.runOneTest("text_nil_only13") }
+  @Test def test_text_nil_only14(): Unit = { runnerLN.runOneTest("text_nil_only14") }
+  @Test def test_text_nil_only15(): Unit = { runnerLN.runOneTest("text_nil_only15") }
+  @Test def test_text_nil_only16(): Unit = { runnerLN.runOneTest("text_nil_only16") }
+  @Test def test_text_nil_only17(): Unit = { runnerLN.runOneTest("text_nil_only17") }
 
-  @Test def test_text_nil_characterClass_01() { runnerLN.runOneTest("text_nil_characterClass_01") }
-  @Test def test_text_nil_characterClass_02() { runnerLN.runOneTest("text_nil_characterClass_02") }
-  @Test def test_text_nil_characterClass_03() { runnerLN.runOneTest("text_nil_characterClass_03") }
-  @Test def test_text_nil_characterClass_04() { runnerLN.runOneTest("text_nil_characterClass_04") }
-  @Test def test_text_nil_characterClass_05() { runnerLN.runOneTest("text_nil_characterClass_05") }
-  @Test def test_text_nil_characterClass_06() { runnerLN.runOneTest("text_nil_characterClass_06") }
+  @Test def test_text_nil_characterClass_01(): Unit = { runnerLN.runOneTest("text_nil_characterClass_01") }
+  @Test def test_text_nil_characterClass_02(): Unit = { runnerLN.runOneTest("text_nil_characterClass_02") }
+  @Test def test_text_nil_characterClass_03(): Unit = { runnerLN.runOneTest("text_nil_characterClass_03") }
+  @Test def test_text_nil_characterClass_04(): Unit = { runnerLN.runOneTest("text_nil_characterClass_04") }
+  @Test def test_text_nil_characterClass_05(): Unit = { runnerLN.runOneTest("text_nil_characterClass_05") }
+  @Test def test_text_nil_characterClass_06(): Unit = { runnerLN.runOneTest("text_nil_characterClass_06") }
 
-  @Test def test_text_lit_char_01() { runnerLC.runOneTest("text_01") }
-  @Test def test_text_lit_char_01a() { runnerLC.runOneTest("text_01a") }
+  @Test def test_text_lit_char_01(): Unit = { runnerLC.runOneTest("text_01") }
+  @Test def test_text_lit_char_01a(): Unit = { runnerLC.runOneTest("text_01a") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropertiesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropertiesNew.scala
@@ -28,5 +28,5 @@ class TestTextNumberPropsNew {
   lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
 
   // DFDL-861
-  @Test def test_standardZeroRep03() { runner.runOneTest("standardZeroRep03") }
+  @Test def test_standardZeroRep03(): Unit = { runner.runOneTest("standardZeroRep03") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -25,218 +25,218 @@ object TestTextNumberProps {
   val testDir = "/org/apache/daffodil/section13/text_number_props/"
   val runner = Runner(testDir, "TextNumberProps.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
 class TestTextNumberProps {
   import TestTextNumberProps._
 
-  @Test def test_textNumberPattern_baseConflict() { runner.runOneTest("textNumberPattern_baseConflict") }
+  @Test def test_textNumberPattern_baseConflict(): Unit = { runner.runOneTest("textNumberPattern_baseConflict") }
 
-  @Test def test_textNumberPattern_positiveMandatory() { runner.runOneTest("textNumberPattern_positiveMandatory") }
-  @Test def test_textNumberPattern_negativeOptional() { runner.runOneTest("textNumberPattern_negativeOptional") }
+  @Test def test_textNumberPattern_positiveMandatory(): Unit = { runner.runOneTest("textNumberPattern_positiveMandatory") }
+  @Test def test_textNumberPattern_negativeOptional(): Unit = { runner.runOneTest("textNumberPattern_negativeOptional") }
 
-  @Test def test_textNumberPattern_negativeIgnored01() { runner.runOneTest("textNumberPattern_negativeIgnored01") }
-  @Test def test_textNumberPattern_negativeIgnored02() { runner.runOneTest("textNumberPattern_negativeIgnored02") }
-  @Test def test_textNumberPattern_negativeIgnored03() { runner.runOneTest("textNumberPattern_negativeIgnored03") }
-  @Test def test_textNumberPattern_negativeIgnored04() { runner.runOneTest("textNumberPattern_negativeIgnored04") }
-  @Test def test_textNumberPattern_negativeIgnored05() { runner.runOneTest("textNumberPattern_negativeIgnored05") }
-  @Test def test_textNumberPattern_negativeIgnored06() { runner.runOneTest("textNumberPattern_negativeIgnored06") }
+  @Test def test_textNumberPattern_negativeIgnored01(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored01") }
+  @Test def test_textNumberPattern_negativeIgnored02(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored02") }
+  @Test def test_textNumberPattern_negativeIgnored03(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored03") }
+  @Test def test_textNumberPattern_negativeIgnored04(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored04") }
+  @Test def test_textNumberPattern_negativeIgnored05(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored05") }
+  @Test def test_textNumberPattern_negativeIgnored06(): Unit = { runner.runOneTest("textNumberPattern_negativeIgnored06") }
 
-  @Test def test_textNumberPattern_exponent01() { runner.runOneTest("textNumberPattern_exponent01") }
-  @Test def test_textNumberPattern_specialChar01() { runner.runOneTest("textNumberPattern_specialChar01") }
-  @Test def test_textNumberPattern_specialChar02() { runner.runOneTest("textNumberPattern_specialChar02") }
-  @Test def test_textNumberPattern_specialChar03() { runner.runOneTest("textNumberPattern_specialChar03") }
-  @Test def test_textNumberPattern_specialChar04() { runner.runOneTest("textNumberPattern_specialChar04") }
-  @Test def test_textNumberPattern_specialChar05() { runner.runOneTest("textNumberPattern_specialChar05") }
-  @Test def test_textNumberPattern_specialChar06() { runner.runOneTest("textNumberPattern_specialChar06") }
-  @Test def test_textNumberPattern_specialChar07() { runner.runOneTest("textNumberPattern_specialChar07") }
-  @Test def test_textNumberPattern_specialChar08() { runner.runOneTest("textNumberPattern_specialChar08") }
+  @Test def test_textNumberPattern_exponent01(): Unit = { runner.runOneTest("textNumberPattern_exponent01") }
+  @Test def test_textNumberPattern_specialChar01(): Unit = { runner.runOneTest("textNumberPattern_specialChar01") }
+  @Test def test_textNumberPattern_specialChar02(): Unit = { runner.runOneTest("textNumberPattern_specialChar02") }
+  @Test def test_textNumberPattern_specialChar03(): Unit = { runner.runOneTest("textNumberPattern_specialChar03") }
+  @Test def test_textNumberPattern_specialChar04(): Unit = { runner.runOneTest("textNumberPattern_specialChar04") }
+  @Test def test_textNumberPattern_specialChar05(): Unit = { runner.runOneTest("textNumberPattern_specialChar05") }
+  @Test def test_textNumberPattern_specialChar06(): Unit = { runner.runOneTest("textNumberPattern_specialChar06") }
+  @Test def test_textNumberPattern_specialChar07(): Unit = { runner.runOneTest("textNumberPattern_specialChar07") }
+  @Test def test_textNumberPattern_specialChar08(): Unit = { runner.runOneTest("textNumberPattern_specialChar08") }
 
-  @Test def test_textNumberPattern_inputValueCalc() { runner.runOneTest("textNumberPattern_inputValueCalc") }
+  @Test def test_textNumberPattern_inputValueCalc(): Unit = { runner.runOneTest("textNumberPattern_inputValueCalc") }
 
-  @Test def test_patternDeterminesChoice01() { runner.runOneTest("patternDeterminesChoice01") }
-  @Test def test_patternDeterminesChoice02() { runner.runOneTest("patternDeterminesChoice02") }
-  @Test def test_patternDeterminesChoice03() { runner.runOneTest("patternDeterminesChoice03") }
+  @Test def test_patternDeterminesChoice01(): Unit = { runner.runOneTest("patternDeterminesChoice01") }
+  @Test def test_patternDeterminesChoice02(): Unit = { runner.runOneTest("patternDeterminesChoice02") }
+  @Test def test_patternDeterminesChoice03(): Unit = { runner.runOneTest("patternDeterminesChoice03") }
 
-  @Test def test_textNumberPattern_facets01() { runner.runOneTest("textNumberPattern_facets01") }
-  @Test def test_textNumberPattern_facets02() { runner.runOneTest("textNumberPattern_facets02") }
+  @Test def test_textNumberPattern_facets01(): Unit = { runner.runOneTest("textNumberPattern_facets01") }
+  @Test def test_textNumberPattern_facets02(): Unit = { runner.runOneTest("textNumberPattern_facets02") }
 
-  @Test def test_standardZeroRep01() { runner.runOneTest("standardZeroRep01") }
-  @Test def test_standardZeroRep02() { runner.runOneTest("standardZeroRep02") }
-  @Test def test_standardZeroRep03() { runner.runOneTest("standardZeroRep03") }
-  @Test def test_standardZeroRep04() { runner.runOneTest("standardZeroRep04") }
-  @Test def test_standardZeroRep04b() { runner.runOneTest("standardZeroRep04b") }
-  @Test def test_standardZeroRep05() { runner.runOneTest("standardZeroRep05") }
-  @Test def test_standardZeroRep06() { runner.runOneTest("standardZeroRep06") }
-  @Test def test_standardZeroRep07() { runner.runOneTest("standardZeroRep07") }
-  @Test def test_standardZeroRep08() { runner.runOneTest("standardZeroRep08") }
-  @Test def test_standardZeroRep09() { runner.runOneTest("standardZeroRep09") }
-  @Test def test_standardZeroRep10() { runner.runOneTest("standardZeroRep10") }
-  @Test def test_standardZeroRep11() { runner.runOneTest("standardZeroRep11") }
+  @Test def test_standardZeroRep01(): Unit = { runner.runOneTest("standardZeroRep01") }
+  @Test def test_standardZeroRep02(): Unit = { runner.runOneTest("standardZeroRep02") }
+  @Test def test_standardZeroRep03(): Unit = { runner.runOneTest("standardZeroRep03") }
+  @Test def test_standardZeroRep04(): Unit = { runner.runOneTest("standardZeroRep04") }
+  @Test def test_standardZeroRep04b(): Unit = { runner.runOneTest("standardZeroRep04b") }
+  @Test def test_standardZeroRep05(): Unit = { runner.runOneTest("standardZeroRep05") }
+  @Test def test_standardZeroRep06(): Unit = { runner.runOneTest("standardZeroRep06") }
+  @Test def test_standardZeroRep07(): Unit = { runner.runOneTest("standardZeroRep07") }
+  @Test def test_standardZeroRep08(): Unit = { runner.runOneTest("standardZeroRep08") }
+  @Test def test_standardZeroRep09(): Unit = { runner.runOneTest("standardZeroRep09") }
+  @Test def test_standardZeroRep10(): Unit = { runner.runOneTest("standardZeroRep10") }
+  @Test def test_standardZeroRep11(): Unit = { runner.runOneTest("standardZeroRep11") }
 
-  @Test def test_textNumberPattern_noNegative() { runner.runOneTest("textNumberPattern_noNegative") }
+  @Test def test_textNumberPattern_noNegative(): Unit = { runner.runOneTest("textNumberPattern_noNegative") }
 
-  @Test def test_lengthDeterminedFirst01() { runner.runOneTest("lengthDeterminedFirst01") }
-  @Test def test_lengthDeterminedFirst02() { runner.runOneTest("lengthDeterminedFirst02") }
+  @Test def test_lengthDeterminedFirst01(): Unit = { runner.runOneTest("lengthDeterminedFirst01") }
+  @Test def test_lengthDeterminedFirst02(): Unit = { runner.runOneTest("lengthDeterminedFirst02") }
 
-  @Test def test_textNumberPattern_unsignedType01() { runner.runOneTest("textNumberPattern_unsignedType01") }
-  @Test def test_textNumberPattern_unsignedType02() { runner.runOneTest("textNumberPattern_unsignedType02") }
+  @Test def test_textNumberPattern_unsignedType01(): Unit = { runner.runOneTest("textNumberPattern_unsignedType01") }
+  @Test def test_textNumberPattern_unsignedType02(): Unit = { runner.runOneTest("textNumberPattern_unsignedType02") }
 
-  @Test def test_dynamicExp() { runner.runOneTest("dynamicExp") }
-  @Test def test_dynamicExp2() { runner.runOneTest("dynamicExp2") }
-  @Test def test_dynamicExp_neg() { runner.runOneTest("dynamicExpNeg") }
-  @Test def test_dynamicExpInvalid() { runner.runOneTest("dynamicExpInvalid") }
-  @Test def test_expCaseInsensitive() { runner.runOneTest("expCaseInsensitive") }
+  @Test def test_dynamicExp(): Unit = { runner.runOneTest("dynamicExp") }
+  @Test def test_dynamicExp2(): Unit = { runner.runOneTest("dynamicExp2") }
+  @Test def test_dynamicExp_neg(): Unit = { runner.runOneTest("dynamicExpNeg") }
+  @Test def test_dynamicExpInvalid(): Unit = { runner.runOneTest("dynamicExpInvalid") }
+  @Test def test_expCaseInsensitive(): Unit = { runner.runOneTest("expCaseInsensitive") }
   // DAFFODIL-861
   //@Test def test_expCaseSensitive() { runner.runOneTest("expCaseSensitive") }
-  @Test def test_expRawByteInvalid() { runner.runOneTest("expRawByteInvalid") }
-  @Test def test_expRawByteNotAllowed() { runner.runOneTest("expRawByteNotAllowed") }
-  @Test def test_expCharClasses() { runner.runOneTest("expCharClasses") }
-  @Test def test_expCharEntities() { runner.runOneTest("expCharEntities") }
-  @Test def test_expCharEntities2() { runner.runOneTest("expCharEntities2") }
-  @Test def test_noStandardExpRep() { runner.runOneTest("noStandardExpRep") }
-  @Test def test_noStandardExpRep2() { runner.runOneTest("noStandardExpRep2") }
+  @Test def test_expRawByteInvalid(): Unit = { runner.runOneTest("expRawByteInvalid") }
+  @Test def test_expRawByteNotAllowed(): Unit = { runner.runOneTest("expRawByteNotAllowed") }
+  @Test def test_expCharClasses(): Unit = { runner.runOneTest("expCharClasses") }
+  @Test def test_expCharEntities(): Unit = { runner.runOneTest("expCharEntities") }
+  @Test def test_expCharEntities2(): Unit = { runner.runOneTest("expCharEntities2") }
+  @Test def test_noStandardExpRep(): Unit = { runner.runOneTest("noStandardExpRep") }
+  @Test def test_noStandardExpRep2(): Unit = { runner.runOneTest("noStandardExpRep2") }
   // DAFFODIL-1981
   //@Test def test_expEmptyString() { runner.runOneTest("expEmptyString") }
   //@Test def test_expEmptyString2() { runner.runOneTest("expEmptyString2") }
 
-  @Test def test_zero() { runner.runOneTest("zero") }
-  @Test def test_pattern_neg1() { runner.runOneTest("pattern_neg1") }
+  @Test def test_zero(): Unit = { runner.runOneTest("zero") }
+  @Test def test_pattern_neg1(): Unit = { runner.runOneTest("pattern_neg1") }
 
-  @Test def test_infnanDouble() { runner.runOneTest("infnanDouble") }
-  @Test def test_nanFloat() { runner.runOneTest("nanFloat") }
-  @Test def test_infFloat() { runner.runOneTest("infFloat") }
-  @Test def test_infnan2() { runner.runOneTest("infnan2") }
-  @Test def test_nanInvalidType() { runner.runOneTest("nanInvalidType") }
-  @Test def test_infInvalidType() { runner.runOneTest("infInvalidType") }
-  @Test def test_infInvalid() { runner.runOneTest("infInvalid") }
-  @Test def test_nanInvalid() { runner.runOneTest("nanInvalid") }
-  @Test def test_nanCharClasses() { runner.runOneTest("nanCharClasses") }
-  @Test def test_nanCharEntities() { runner.runOneTest("nanCharEntities") }
-  @Test def test_infCharClasses() { runner.runOneTest("infCharClasses") }
-  @Test def test_infCharEntities() { runner.runOneTest("infCharEntities") }
+  @Test def test_infnanDouble(): Unit = { runner.runOneTest("infnanDouble") }
+  @Test def test_nanFloat(): Unit = { runner.runOneTest("nanFloat") }
+  @Test def test_infFloat(): Unit = { runner.runOneTest("infFloat") }
+  @Test def test_infnan2(): Unit = { runner.runOneTest("infnan2") }
+  @Test def test_nanInvalidType(): Unit = { runner.runOneTest("nanInvalidType") }
+  @Test def test_infInvalidType(): Unit = { runner.runOneTest("infInvalidType") }
+  @Test def test_infInvalid(): Unit = { runner.runOneTest("infInvalid") }
+  @Test def test_nanInvalid(): Unit = { runner.runOneTest("nanInvalid") }
+  @Test def test_nanCharClasses(): Unit = { runner.runOneTest("nanCharClasses") }
+  @Test def test_nanCharEntities(): Unit = { runner.runOneTest("nanCharEntities") }
+  @Test def test_infCharClasses(): Unit = { runner.runOneTest("infCharClasses") }
+  @Test def test_infCharEntities(): Unit = { runner.runOneTest("infCharEntities") }
   // DAFFODIL-861
   //@Test def test_infnanCaseInsensitive() { runner.runOneTest("infnanCaseInsensitive") }
 
-  @Test def test_textNumberCheckPolicy_lax01() { runner.runOneTest("textNumberCheckPolicy_lax01") }
-  @Test def test_textNumberCheckPolicy_lax02() { runner.runOneTest("textNumberCheckPolicy_lax02") }
-  @Test def test_textNumberCheckPolicy_lax03() { runner.runOneTest("textNumberCheckPolicy_lax03") }
-  @Test def test_textNumberCheckPolicy_lax04() { runner.runOneTest("textNumberCheckPolicy_lax04") }
-  @Test def test_textNumberCheckPolicy_lax05() { runner.runOneTest("textNumberCheckPolicy_lax05") }
-  @Test def test_textNumberCheckPolicy_lax06() { runner.runOneTest("textNumberCheckPolicy_lax06") }
-  @Test def test_textNumberCheckPolicy_lax07() { runner.runOneTest("textNumberCheckPolicy_lax07") }
-  @Test def test_textNumberCheckPolicy_lax08() { runner.runOneTest("textNumberCheckPolicy_lax08") }
-  @Test def test_textNumberCheckPolicy_lax09() { runner.runOneTest("textNumberCheckPolicy_lax09") }
-  @Test def test_textNumberCheckPolicy_lax10() { runner.runOneTest("textNumberCheckPolicy_lax10") }
-  @Test def test_textNumberCheckPolicy_lax11() { runner.runOneTest("textNumberCheckPolicy_lax11") }
-  @Test def test_textNumberCheckPolicy_lax12() { runner.runOneTest("textNumberCheckPolicy_lax12") }
-  @Test def test_textNumberCheckPolicy_lax13() { runner.runOneTest("textNumberCheckPolicy_lax13") }
-  @Test def test_textNumberCheckPolicy_lax14() { runner.runOneTest("textNumberCheckPolicy_lax14") }
-  @Test def test_textNumberCheckPolicy_lax15() { runner.runOneTest("textNumberCheckPolicy_lax15") }
-  @Test def test_textNumberCheckPolicy_lax16() { runner.runOneTest("textNumberCheckPolicy_lax16") }
-  @Test def test_textNumberCheckPolicy_lax17() { runner.runOneTest("textNumberCheckPolicy_lax17") }
+  @Test def test_textNumberCheckPolicy_lax01(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax01") }
+  @Test def test_textNumberCheckPolicy_lax02(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax02") }
+  @Test def test_textNumberCheckPolicy_lax03(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax03") }
+  @Test def test_textNumberCheckPolicy_lax04(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax04") }
+  @Test def test_textNumberCheckPolicy_lax05(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax05") }
+  @Test def test_textNumberCheckPolicy_lax06(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax06") }
+  @Test def test_textNumberCheckPolicy_lax07(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax07") }
+  @Test def test_textNumberCheckPolicy_lax08(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax08") }
+  @Test def test_textNumberCheckPolicy_lax09(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax09") }
+  @Test def test_textNumberCheckPolicy_lax10(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax10") }
+  @Test def test_textNumberCheckPolicy_lax11(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax11") }
+  @Test def test_textNumberCheckPolicy_lax12(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax12") }
+  @Test def test_textNumberCheckPolicy_lax13(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax13") }
+  @Test def test_textNumberCheckPolicy_lax14(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax14") }
+  @Test def test_textNumberCheckPolicy_lax15(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax15") }
+  @Test def test_textNumberCheckPolicy_lax16(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax16") }
+  @Test def test_textNumberCheckPolicy_lax17(): Unit = { runner.runOneTest("textNumberCheckPolicy_lax17") }
 
-  @Test def test_textNumberCheckPolicy_strict01() { runner.runOneTest("textNumberCheckPolicy_strict01") }
-  @Test def test_textNumberCheckPolicy_strict02() { runner.runOneTest("textNumberCheckPolicy_strict02") }
-  @Test def test_textNumberCheckPolicy_strict03() { runner.runOneTest("textNumberCheckPolicy_strict03") }
-  @Test def test_textNumberCheckPolicy_strict04() { runner.runOneTest("textNumberCheckPolicy_strict04") }
-  @Test def test_textNumberCheckPolicy_strict05() { runner.runOneTest("textNumberCheckPolicy_strict05") }
-  @Test def test_textNumberCheckPolicy_strict06() { runner.runOneTest("textNumberCheckPolicy_strict06") }
-  @Test def test_textNumberCheckPolicy_strict07() { runner.runOneTest("textNumberCheckPolicy_strict07") }
+  @Test def test_textNumberCheckPolicy_strict01(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict01") }
+  @Test def test_textNumberCheckPolicy_strict02(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict02") }
+  @Test def test_textNumberCheckPolicy_strict03(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict03") }
+  @Test def test_textNumberCheckPolicy_strict04(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict04") }
+  @Test def test_textNumberCheckPolicy_strict05(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict05") }
+  @Test def test_textNumberCheckPolicy_strict06(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict06") }
+  @Test def test_textNumberCheckPolicy_strict07(): Unit = { runner.runOneTest("textNumberCheckPolicy_strict07") }
 
-  @Test def test_textStandardDecimalSeparator01() { runner.runOneTest("textStandardDecimalSeparator01") }
-  @Test def test_textStandardDecimalSeparator02() { runner.runOneTest("textStandardDecimalSeparator02") }
-  @Test def test_textStandardDecimalSeparator03() { runner.runOneTest("textStandardDecimalSeparator03") }
-  @Test def test_textStandardDecimalSeparator04() { runner.runOneTest("textStandardDecimalSeparator04") }
-  @Test def test_textStandardDecimalSeparator05() { runner.runOneTest("textStandardDecimalSeparator05") }
-  @Test def test_textStandardDecimalSeparator06() { runner.runOneTest("textStandardDecimalSeparator06") }
-  @Test def test_textStandardDecimalSeparator07() { runner.runOneTest("textStandardDecimalSeparator07") }
-  @Test def test_textStandardDecimalSeparator08() { runner.runOneTest("textStandardDecimalSeparator08") }
-  @Test def test_textStandardDecimalSeparator09() { runner.runOneTest("textStandardDecimalSeparator09") }
-  @Test def test_textStandardDecimalSeparator12() { runner.runOneTest("textStandardDecimalSeparator12") }
-  @Test def test_textStandardDecimalSeparator13() { runner.runOneTest("textStandardDecimalSeparator13") }
-  @Test def test_textStandardDecimalSeparator14() { runner.runOneTest("textStandardDecimalSeparator14") }
-  @Test def test_textStandardDecimalSeparator15() { runner.runOneTest("textStandardDecimalSeparator15") }
-  @Test def test_textStandardDecimalSeparator16() { runner.runOneTest("textStandardDecimalSeparator16") }
-  @Test def test_textStandardDecimalSeparator17() { runner.runOneTest("textStandardDecimalSeparator17") }
+  @Test def test_textStandardDecimalSeparator01(): Unit = { runner.runOneTest("textStandardDecimalSeparator01") }
+  @Test def test_textStandardDecimalSeparator02(): Unit = { runner.runOneTest("textStandardDecimalSeparator02") }
+  @Test def test_textStandardDecimalSeparator03(): Unit = { runner.runOneTest("textStandardDecimalSeparator03") }
+  @Test def test_textStandardDecimalSeparator04(): Unit = { runner.runOneTest("textStandardDecimalSeparator04") }
+  @Test def test_textStandardDecimalSeparator05(): Unit = { runner.runOneTest("textStandardDecimalSeparator05") }
+  @Test def test_textStandardDecimalSeparator06(): Unit = { runner.runOneTest("textStandardDecimalSeparator06") }
+  @Test def test_textStandardDecimalSeparator07(): Unit = { runner.runOneTest("textStandardDecimalSeparator07") }
+  @Test def test_textStandardDecimalSeparator08(): Unit = { runner.runOneTest("textStandardDecimalSeparator08") }
+  @Test def test_textStandardDecimalSeparator09(): Unit = { runner.runOneTest("textStandardDecimalSeparator09") }
+  @Test def test_textStandardDecimalSeparator12(): Unit = { runner.runOneTest("textStandardDecimalSeparator12") }
+  @Test def test_textStandardDecimalSeparator13(): Unit = { runner.runOneTest("textStandardDecimalSeparator13") }
+  @Test def test_textStandardDecimalSeparator14(): Unit = { runner.runOneTest("textStandardDecimalSeparator14") }
+  @Test def test_textStandardDecimalSeparator15(): Unit = { runner.runOneTest("textStandardDecimalSeparator15") }
+  @Test def test_textStandardDecimalSeparator16(): Unit = { runner.runOneTest("textStandardDecimalSeparator16") }
+  @Test def test_textStandardDecimalSeparator17(): Unit = { runner.runOneTest("textStandardDecimalSeparator17") }
 
   // DFDL-847
   //  @Test def test_textStandardDecimalSeparator10() { runner.runOneTest("textStandardDecimalSeparator10") }
   //  @Test def test_textStandardDecimalSeparator11() { runner.runOneTest("textStandardDecimalSeparator11") }
 
-  @Test def test_textStandardGroupingSeparator01() { runner.runOneTest("textStandardGroupingSeparator01") }
-  @Test def test_textStandardGroupingSeparator02() { runner.runOneTest("textStandardGroupingSeparator02") }
-  @Test def test_textStandardGroupingSeparator03() { runner.runOneTest("textStandardGroupingSeparator03") }
-  @Test def test_textStandardGroupingSeparator04() { runner.runOneTest("textStandardGroupingSeparator04") }
-  @Test def test_textStandardGroupingSeparator05() { runner.runOneTest("textStandardGroupingSeparator05") }
-  @Test def test_textStandardGroupingSeparator06() { runner.runOneTest("textStandardGroupingSeparator06") }
-  @Test def test_textStandardGroupingSeparator07() { runner.runOneTest("textStandardGroupingSeparator07") }
-  @Test def test_textStandardGroupingSeparator08() { runner.runOneTest("textStandardGroupingSeparator08") }
-  @Test def test_textStandardGroupingSeparator09() { runner.runOneTest("textStandardGroupingSeparator09") }
-  @Test def test_textStandardGroupingSeparator10() { runner.runOneTest("textStandardGroupingSeparator10") }
-  @Test def test_textStandardGroupingSeparator11() { runner.runOneTest("textStandardGroupingSeparator11") }
-  @Test def test_textStandardGroupingSeparator12() { runner.runOneTest("textStandardGroupingSeparator12") }
-  @Test def test_textStandardGroupingSeparator13() { runner.runOneTest("textStandardGroupingSeparator13") }
-  @Test def test_textStandardGroupingSeparator14() { runner.runOneTest("textStandardGroupingSeparator14") }
-  @Test def test_textStandardGroupingSeparator15() { runner.runOneTest("textStandardGroupingSeparator15") }
-  @Test def test_textStandardGroupingSeparator16() { runner.runOneTest("textStandardGroupingSeparator16") }
-  @Test def test_textStandardGroupingSeparator17() { runner.runOneTest("textStandardGroupingSeparator17") }
+  @Test def test_textStandardGroupingSeparator01(): Unit = { runner.runOneTest("textStandardGroupingSeparator01") }
+  @Test def test_textStandardGroupingSeparator02(): Unit = { runner.runOneTest("textStandardGroupingSeparator02") }
+  @Test def test_textStandardGroupingSeparator03(): Unit = { runner.runOneTest("textStandardGroupingSeparator03") }
+  @Test def test_textStandardGroupingSeparator04(): Unit = { runner.runOneTest("textStandardGroupingSeparator04") }
+  @Test def test_textStandardGroupingSeparator05(): Unit = { runner.runOneTest("textStandardGroupingSeparator05") }
+  @Test def test_textStandardGroupingSeparator06(): Unit = { runner.runOneTest("textStandardGroupingSeparator06") }
+  @Test def test_textStandardGroupingSeparator07(): Unit = { runner.runOneTest("textStandardGroupingSeparator07") }
+  @Test def test_textStandardGroupingSeparator08(): Unit = { runner.runOneTest("textStandardGroupingSeparator08") }
+  @Test def test_textStandardGroupingSeparator09(): Unit = { runner.runOneTest("textStandardGroupingSeparator09") }
+  @Test def test_textStandardGroupingSeparator10(): Unit = { runner.runOneTest("textStandardGroupingSeparator10") }
+  @Test def test_textStandardGroupingSeparator11(): Unit = { runner.runOneTest("textStandardGroupingSeparator11") }
+  @Test def test_textStandardGroupingSeparator12(): Unit = { runner.runOneTest("textStandardGroupingSeparator12") }
+  @Test def test_textStandardGroupingSeparator13(): Unit = { runner.runOneTest("textStandardGroupingSeparator13") }
+  @Test def test_textStandardGroupingSeparator14(): Unit = { runner.runOneTest("textStandardGroupingSeparator14") }
+  @Test def test_textStandardGroupingSeparator15(): Unit = { runner.runOneTest("textStandardGroupingSeparator15") }
+  @Test def test_textStandardGroupingSeparator16(): Unit = { runner.runOneTest("textStandardGroupingSeparator16") }
+  @Test def test_textStandardGroupingSeparator17(): Unit = { runner.runOneTest("textStandardGroupingSeparator17") }
 
   // DFDL-853
   //  @Test def test_textNumberPattern_pSymbol01() { runner.runOneTest("textNumberPattern_pSymbol01") }
   //  @Test def test_textNumberPattern_pSymbol02() { runner.runOneTest("textNumberPattern_pSymbol02") }
 
-  @Test def test_textNumberPattern_scientificNotation01() { runner.runOneTest("textNumberPattern_scientificNotation01") }
-  @Test def test_textNumberPattern_scientificNotation02() { runner.runOneTest("textNumberPattern_scientificNotation02") }
-  @Test def test_textNumberPattern_scientificNotation03() { runner.runOneTest("textNumberPattern_scientificNotation03") }
-  @Test def test_textNumberPattern_scientificNotation04() { runner.runOneTest("textNumberPattern_scientificNotation04") }
-  @Test def test_textNumberPattern_scientificNotation05() { runner.runOneTest("textNumberPattern_scientificNotation05") }
-  @Test def test_textNumberPattern_scientificNotation06() { runner.runOneTest("textNumberPattern_scientificNotation06") }
-  @Test def test_textNumberPattern_scientificNotation07() { runner.runOneTest("textNumberPattern_scientificNotation07") }
+  @Test def test_textNumberPattern_scientificNotation01(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation01") }
+  @Test def test_textNumberPattern_scientificNotation02(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation02") }
+  @Test def test_textNumberPattern_scientificNotation03(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation03") }
+  @Test def test_textNumberPattern_scientificNotation04(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation04") }
+  @Test def test_textNumberPattern_scientificNotation05(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation05") }
+  @Test def test_textNumberPattern_scientificNotation06(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation06") }
+  @Test def test_textNumberPattern_scientificNotation07(): Unit = { runner.runOneTest("textNumberPattern_scientificNotation07") }
 
-  @Test def test_textNumberPattern_padding01() { runner.runOneTest("textNumberPattern_padding01") }
-  @Test def test_textNumberPattern_padding02() { runner.runOneTest("textNumberPattern_padding02") }
-  @Test def test_textNumberPattern_padding03() { runner.runOneTest("textNumberPattern_padding03") }
-  @Test def test_textNumberPattern_padding04() { runner.runOneTest("textNumberPattern_padding04") }
-  @Test def test_textNumberPattern_padding05() { runner.runOneTest("textNumberPattern_padding05") }
-  @Test def test_textNumberPattern_padding06() { runner.runOneTest("textNumberPattern_padding06") }
-  @Test def test_textNumberPattern_padding07() { runner.runOneTest("textNumberPattern_padding07") }
-  @Test def test_textNumberPattern_padding08() { runner.runOneTest("textNumberPattern_padding08") }
-  @Test def test_textNumberPattern_padding09() { runner.runOneTest("textNumberPattern_padding09") }
-  @Test def test_textNumberPattern_padding10() { runner.runOneTest("textNumberPattern_padding10") }
-  @Test def test_textNumberPattern_padding11() { runner.runOneTest("textNumberPattern_padding11") }
-  @Test def test_textNumberPattern_padding12() { runner.runOneTest("textNumberPattern_padding12") }
-  @Test def test_textNumberPattern_padding13() { runner.runOneTest("textNumberPattern_padding13") }
+  @Test def test_textNumberPattern_padding01(): Unit = { runner.runOneTest("textNumberPattern_padding01") }
+  @Test def test_textNumberPattern_padding02(): Unit = { runner.runOneTest("textNumberPattern_padding02") }
+  @Test def test_textNumberPattern_padding03(): Unit = { runner.runOneTest("textNumberPattern_padding03") }
+  @Test def test_textNumberPattern_padding04(): Unit = { runner.runOneTest("textNumberPattern_padding04") }
+  @Test def test_textNumberPattern_padding05(): Unit = { runner.runOneTest("textNumberPattern_padding05") }
+  @Test def test_textNumberPattern_padding06(): Unit = { runner.runOneTest("textNumberPattern_padding06") }
+  @Test def test_textNumberPattern_padding07(): Unit = { runner.runOneTest("textNumberPattern_padding07") }
+  @Test def test_textNumberPattern_padding08(): Unit = { runner.runOneTest("textNumberPattern_padding08") }
+  @Test def test_textNumberPattern_padding09(): Unit = { runner.runOneTest("textNumberPattern_padding09") }
+  @Test def test_textNumberPattern_padding10(): Unit = { runner.runOneTest("textNumberPattern_padding10") }
+  @Test def test_textNumberPattern_padding11(): Unit = { runner.runOneTest("textNumberPattern_padding11") }
+  @Test def test_textNumberPattern_padding12(): Unit = { runner.runOneTest("textNumberPattern_padding12") }
+  @Test def test_textNumberPattern_padding13(): Unit = { runner.runOneTest("textNumberPattern_padding13") }
 
-  @Test def test_textNumberPattern_paddingCombo01() { runner.runOneTest("textNumberPattern_paddingCombo01") }
-  @Test def test_textNumberPattern_paddingCombo02() { runner.runOneTest("textNumberPattern_paddingCombo02") }
-  @Test def test_textNumberPattern_paddingCombo03() { runner.runOneTest("textNumberPattern_paddingCombo03") }
-  @Test def test_textNumberPattern_paddingCombo04() { runner.runOneTest("textNumberPattern_paddingCombo04") }
-  @Test def test_textNumberPattern_paddingCombo05() { runner.runOneTest("textNumberPattern_paddingCombo05") }
-  @Test def test_textNumberPattern_paddingCombo06() { runner.runOneTest("textNumberPattern_paddingCombo06") }
+  @Test def test_textNumberPattern_paddingCombo01(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo01") }
+  @Test def test_textNumberPattern_paddingCombo02(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo02") }
+  @Test def test_textNumberPattern_paddingCombo03(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo03") }
+  @Test def test_textNumberPattern_paddingCombo04(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo04") }
+  @Test def test_textNumberPattern_paddingCombo05(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo05") }
+  @Test def test_textNumberPattern_paddingCombo06(): Unit = { runner.runOneTest("textNumberPattern_paddingCombo06") }
 
-  @Test def test_decimalPadding01() { runner.runOneTest("decimalPadding01") }
-  @Test def test_decimalPadding02() { runner.runOneTest("decimalPadding02") }
-  @Test def test_decimalPadding03() { runner.runOneTest("decimalPadding03") }
-  @Test def test_decimalPadding04() { runner.runOneTest("decimalPadding04") }
-  @Test def test_decimalPadding05() { runner.runOneTest("decimalPadding05") }
+  @Test def test_decimalPadding01(): Unit = { runner.runOneTest("decimalPadding01") }
+  @Test def test_decimalPadding02(): Unit = { runner.runOneTest("decimalPadding02") }
+  @Test def test_decimalPadding03(): Unit = { runner.runOneTest("decimalPadding03") }
+  @Test def test_decimalPadding04(): Unit = { runner.runOneTest("decimalPadding04") }
+  @Test def test_decimalPadding05(): Unit = { runner.runOneTest("decimalPadding05") }
 
-  @Test def test_nonNegIntPadding01() { runner.runOneTest("nonNegIntPadding01") }
-  @Test def test_nonNegIntPadding02() { runner.runOneTest("nonNegIntPadding02") }
-  @Test def test_nonNegIntPadding03() { runner.runOneTest("nonNegIntPadding03") }
-  @Test def test_nonNegIntPadding04() { runner.runOneTest("nonNegIntPadding04") }
+  @Test def test_nonNegIntPadding01(): Unit = { runner.runOneTest("nonNegIntPadding01") }
+  @Test def test_nonNegIntPadding02(): Unit = { runner.runOneTest("nonNegIntPadding02") }
+  @Test def test_nonNegIntPadding03(): Unit = { runner.runOneTest("nonNegIntPadding03") }
+  @Test def test_nonNegIntPadding04(): Unit = { runner.runOneTest("nonNegIntPadding04") }
 
-  @Test def test_hexBinaryPadding01() { runner.runOneTest("hexBinaryPadding01") }
+  @Test def test_hexBinaryPadding01(): Unit = { runner.runOneTest("hexBinaryPadding01") }
 
-  @Test def test_dynamic() { runner.runOneTest("dynamic") }
-  @Test def test_dynamicNeg1() { runner.runOneTest("dynamicNeg1") }
-  @Test def test_dynamicNeg2() { runner.runOneTest("dynamicNeg2") }
+  @Test def test_dynamic(): Unit = { runner.runOneTest("dynamic") }
+  @Test def test_dynamicNeg1(): Unit = { runner.runOneTest("dynamicNeg1") }
+  @Test def test_dynamicNeg2(): Unit = { runner.runOneTest("dynamicNeg2") }
 
-  @Test def test_textStandardDistinctValues() { runner.runOneTest("textStandardDistinctValues") }
-  @Test def test_textStandardDistinctValues2() { runner.runOneTest("textStandardDistinctValues2") }
-  @Test def test_textStandardDistinctValues3() { runner.runOneTest("textStandardDistinctValues3") }
+  @Test def test_textStandardDistinctValues(): Unit = { runner.runOneTest("textStandardDistinctValues") }
+  @Test def test_textStandardDistinctValues2(): Unit = { runner.runOneTest("textStandardDistinctValues2") }
+  @Test def test_textStandardDistinctValues3(): Unit = { runner.runOneTest("textStandardDistinctValues3") }
 
-  @Test def test_textStandardFloatPatternNoSeparators1() { runner.runOneTest("textStandardFloatPatternNoSeparators1") }
+  @Test def test_textStandardFloatPatternNoSeparators1(): Unit = { runner.runOneTest("textStandardFloatPatternNoSeparators1") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
@@ -26,7 +26,7 @@ object TestTextNumberPropsUnparse {
 
   val runner = Runner(testDir, "TextNumberPropsUnparse.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }
@@ -34,38 +34,38 @@ class TestTextNumberPropsUnparse {
 
   import TestTextNumberPropsUnparse._
 
-  @Test def test_unparseDelimitedPaddedString01() { runner.runOneTest("unparseDelimitedPaddedString01") }
-  @Test def test_unparseDelimitedPaddedString02() { runner.runOneTest("unparseDelimitedPaddedString02") }
-  @Test def test_unparseDelimitedPaddedString03() { runner.runOneTest("unparseDelimitedPaddedString03") }
-  @Test def test_unparseDelimitedPaddedString04() { runner.runOneTest("unparseDelimitedPaddedString04") }
-  @Test def test_unparseDelimitedPaddedString05() { runner.runOneTest("unparseDelimitedPaddedString05") }
-  @Test def test_unparseDelimitedPaddedString06() { runner.runOneTest("unparseDelimitedPaddedString06") }
-  @Test def test_unparseDelimitedPaddedString07() { runner.runOneTest("unparseDelimitedPaddedString07") }
-  @Test def test_unparseDelimitedPaddedString08() { runner.runOneTest("unparseDelimitedPaddedString08") }
-  @Test def test_unparseDelimitedPaddedString09() { runner.runOneTest("unparseDelimitedPaddedString09") }
-  @Test def test_unparseDelimitedPaddedString11() { runner.runOneTest("unparseDelimitedPaddedString11") }
-  @Test def test_unparseDelimitedPaddedString12() { runner.runOneTest("unparseDelimitedPaddedString12") }
-  @Test def test_unparseDelimitedPaddedString13() { runner.runOneTest("unparseDelimitedPaddedString13") }
-  @Test def test_unparseDelimitedPaddedString14() { runner.runOneTest("unparseDelimitedPaddedString14") }
+  @Test def test_unparseDelimitedPaddedString01(): Unit = { runner.runOneTest("unparseDelimitedPaddedString01") }
+  @Test def test_unparseDelimitedPaddedString02(): Unit = { runner.runOneTest("unparseDelimitedPaddedString02") }
+  @Test def test_unparseDelimitedPaddedString03(): Unit = { runner.runOneTest("unparseDelimitedPaddedString03") }
+  @Test def test_unparseDelimitedPaddedString04(): Unit = { runner.runOneTest("unparseDelimitedPaddedString04") }
+  @Test def test_unparseDelimitedPaddedString05(): Unit = { runner.runOneTest("unparseDelimitedPaddedString05") }
+  @Test def test_unparseDelimitedPaddedString06(): Unit = { runner.runOneTest("unparseDelimitedPaddedString06") }
+  @Test def test_unparseDelimitedPaddedString07(): Unit = { runner.runOneTest("unparseDelimitedPaddedString07") }
+  @Test def test_unparseDelimitedPaddedString08(): Unit = { runner.runOneTest("unparseDelimitedPaddedString08") }
+  @Test def test_unparseDelimitedPaddedString09(): Unit = { runner.runOneTest("unparseDelimitedPaddedString09") }
+  @Test def test_unparseDelimitedPaddedString11(): Unit = { runner.runOneTest("unparseDelimitedPaddedString11") }
+  @Test def test_unparseDelimitedPaddedString12(): Unit = { runner.runOneTest("unparseDelimitedPaddedString12") }
+  @Test def test_unparseDelimitedPaddedString13(): Unit = { runner.runOneTest("unparseDelimitedPaddedString13") }
+  @Test def test_unparseDelimitedPaddedString14(): Unit = { runner.runOneTest("unparseDelimitedPaddedString14") }
 
-  @Test def test_unparsePaddedString10() { runner.runOneTest("unparsePaddedString10") }
+  @Test def test_unparsePaddedString10(): Unit = { runner.runOneTest("unparsePaddedString10") }
 
-  @Test def test_unparsePaddedStringTruncate01() { runner.runOneTest("unparsePaddedStringTruncate01") }
-  @Test def test_unparsePaddedStringTruncate02() { runner.runOneTest("unparsePaddedStringTruncate02") }
-  @Test def test_unparsePaddedStringTruncate03() { runner.runOneTest("unparsePaddedStringTruncate03") }
-  @Test def test_unparsePaddedStringTruncate04() { runner.runOneTest("unparsePaddedStringTruncate04") }
-  @Test def test_unparsePaddedStringTruncate05() { runner.runOneTest("unparsePaddedStringTruncate05") }
-  @Test def test_unparsePaddedStringTruncate06() { runner.runOneTest("unparsePaddedStringTruncate06") }
+  @Test def test_unparsePaddedStringTruncate01(): Unit = { runner.runOneTest("unparsePaddedStringTruncate01") }
+  @Test def test_unparsePaddedStringTruncate02(): Unit = { runner.runOneTest("unparsePaddedStringTruncate02") }
+  @Test def test_unparsePaddedStringTruncate03(): Unit = { runner.runOneTest("unparsePaddedStringTruncate03") }
+  @Test def test_unparsePaddedStringTruncate04(): Unit = { runner.runOneTest("unparsePaddedStringTruncate04") }
+  @Test def test_unparsePaddedStringTruncate05(): Unit = { runner.runOneTest("unparsePaddedStringTruncate05") }
+  @Test def test_unparsePaddedStringTruncate06(): Unit = { runner.runOneTest("unparsePaddedStringTruncate06") }
 
-  @Test def test_parseDelimitedPaddedString01() { runner.runOneTest("parseDelimitedPaddedString01") }
+  @Test def test_parseDelimitedPaddedString01(): Unit = { runner.runOneTest("parseDelimitedPaddedString01") }
 
-  @Test def test_unparse_int_01() { runner.runOneTest("unparse_int_01") }
-  @Test def test_parse_int_01() { runner.runOneTest("parse_int_01") }
+  @Test def test_unparse_int_01(): Unit = { runner.runOneTest("unparse_int_01") }
+  @Test def test_parse_int_01(): Unit = { runner.runOneTest("parse_int_01") }
 
-  @Test def test_unparse_tnp_01() { runner.runOneTest("unparse_tnp_01") }
-  @Test def test_unparse_tnp_02() { runner.runOneTest("unparse_tnp_02") }
-  @Test def test_unparse_tnp_03() { runner.runOneTest("unparse_tnp_03") }
-  @Test def test_unparse_tnp_04() { runner.runOneTest("unparse_tnp_04") }
-  @Test def test_unparse_tnp_05a() { runner.runOneTest("unparse_tnp_05a") }
-  @Test def test_unparse_tnp_05b() { runner.runOneTest("unparse_tnp_05b") }
+  @Test def test_unparse_tnp_01(): Unit = { runner.runOneTest("unparse_tnp_01") }
+  @Test def test_unparse_tnp_02(): Unit = { runner.runOneTest("unparse_tnp_02") }
+  @Test def test_unparse_tnp_03(): Unit = { runner.runOneTest("unparse_tnp_03") }
+  @Test def test_unparse_tnp_04(): Unit = { runner.runOneTest("unparse_tnp_04") }
+  @Test def test_unparse_tnp_05a(): Unit = { runner.runOneTest("unparse_tnp_05a") }
+  @Test def test_unparse_tnp_05b(): Unit = { runner.runOneTest("unparse_tnp_05b") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
@@ -25,7 +25,7 @@ object TestTextStandardBase {
   val testDir = "/org/apache/daffodil/section13/text_number_props/"
   val runner = Runner(testDir, "TextStandardBase.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -35,166 +35,166 @@ class TestTextStandardBase {
 
   // Tests of min, max, and 1 + max for each numeric data type in all non-base-10 bases
 
-  @Test def test_base2_integer_min() { runner.runOneTest("base2_integer_min") }
-  @Test def test_base8_integer_min() { runner.runOneTest("base8_integer_min") }
-  @Test def test_base16_integer_min() { runner.runOneTest("base16_integer_min") }
+  @Test def test_base2_integer_min(): Unit = { runner.runOneTest("base2_integer_min") }
+  @Test def test_base8_integer_min(): Unit = { runner.runOneTest("base8_integer_min") }
+  @Test def test_base16_integer_min(): Unit = { runner.runOneTest("base16_integer_min") }
 
-  @Test def test_base2_integer_large() { runner.runOneTest("base2_integer_large") }
-  @Test def test_base8_integer_large() { runner.runOneTest("base8_integer_large") }
-  @Test def test_base16_integer_large() { runner.runOneTest("base16_integer_large") }
+  @Test def test_base2_integer_large(): Unit = { runner.runOneTest("base2_integer_large") }
+  @Test def test_base8_integer_large(): Unit = { runner.runOneTest("base8_integer_large") }
+  @Test def test_base16_integer_large(): Unit = { runner.runOneTest("base16_integer_large") }
 
-  @Test def test_base2_long_min() { runner.runOneTest("base2_long_min") }
-  @Test def test_base8_long_min() { runner.runOneTest("base8_long_min") }
-  @Test def test_base16_long_min() { runner.runOneTest("base16_long_min") }
+  @Test def test_base2_long_min(): Unit = { runner.runOneTest("base2_long_min") }
+  @Test def test_base8_long_min(): Unit = { runner.runOneTest("base8_long_min") }
+  @Test def test_base16_long_min(): Unit = { runner.runOneTest("base16_long_min") }
 
-  @Test def test_base2_long_max() { runner.runOneTest("base2_long_max") }
-  @Test def test_base8_long_max() { runner.runOneTest("base8_long_max") }
-  @Test def test_base16_long_max() { runner.runOneTest("base16_long_max") }
+  @Test def test_base2_long_max(): Unit = { runner.runOneTest("base2_long_max") }
+  @Test def test_base8_long_max(): Unit = { runner.runOneTest("base8_long_max") }
+  @Test def test_base16_long_max(): Unit = { runner.runOneTest("base16_long_max") }
 
-  @Test def test_base2_long_max_plus_one() { runner.runOneTest("base2_long_max_plus_one") }
-  @Test def test_base8_long_max_plus_one() { runner.runOneTest("base8_long_max_plus_one") }
-  @Test def test_base16_long_max_plus_one() { runner.runOneTest("base16_long_max_plus_one") }
+  @Test def test_base2_long_max_plus_one(): Unit = { runner.runOneTest("base2_long_max_plus_one") }
+  @Test def test_base8_long_max_plus_one(): Unit = { runner.runOneTest("base8_long_max_plus_one") }
+  @Test def test_base16_long_max_plus_one(): Unit = { runner.runOneTest("base16_long_max_plus_one") }
 
-  @Test def test_base2_int_min() { runner.runOneTest("base2_int_min") }
-  @Test def test_base8_int_min() { runner.runOneTest("base8_int_min") }
-  @Test def test_base16_int_min() { runner.runOneTest("base16_int_min") }
+  @Test def test_base2_int_min(): Unit = { runner.runOneTest("base2_int_min") }
+  @Test def test_base8_int_min(): Unit = { runner.runOneTest("base8_int_min") }
+  @Test def test_base16_int_min(): Unit = { runner.runOneTest("base16_int_min") }
 
-  @Test def test_base2_int_max() { runner.runOneTest("base2_int_max") }
-  @Test def test_base8_int_max() { runner.runOneTest("base8_int_max") }
-  @Test def test_base16_int_max() { runner.runOneTest("base16_int_max") }
+  @Test def test_base2_int_max(): Unit = { runner.runOneTest("base2_int_max") }
+  @Test def test_base8_int_max(): Unit = { runner.runOneTest("base8_int_max") }
+  @Test def test_base16_int_max(): Unit = { runner.runOneTest("base16_int_max") }
 
-  @Test def test_base2_int_max_plus_one() { runner.runOneTest("base2_int_max_plus_one") }
-  @Test def test_base8_int_max_plus_one() { runner.runOneTest("base8_int_max_plus_one") }
-  @Test def test_base16_int_max_plus_one() { runner.runOneTest("base16_int_max_plus_one") }
+  @Test def test_base2_int_max_plus_one(): Unit = { runner.runOneTest("base2_int_max_plus_one") }
+  @Test def test_base8_int_max_plus_one(): Unit = { runner.runOneTest("base8_int_max_plus_one") }
+  @Test def test_base16_int_max_plus_one(): Unit = { runner.runOneTest("base16_int_max_plus_one") }
 
-  @Test def test_base2_short_min() { runner.runOneTest("base2_short_min") }
-  @Test def test_base8_short_min() { runner.runOneTest("base8_short_min") }
-  @Test def test_base16_short_min() { runner.runOneTest("base16_short_min") }
+  @Test def test_base2_short_min(): Unit = { runner.runOneTest("base2_short_min") }
+  @Test def test_base8_short_min(): Unit = { runner.runOneTest("base8_short_min") }
+  @Test def test_base16_short_min(): Unit = { runner.runOneTest("base16_short_min") }
 
-  @Test def test_base2_short_max() { runner.runOneTest("base2_short_max") }
-  @Test def test_base8_short_max() { runner.runOneTest("base8_short_max") }
-  @Test def test_base16_short_max() { runner.runOneTest("base16_short_max") }
+  @Test def test_base2_short_max(): Unit = { runner.runOneTest("base2_short_max") }
+  @Test def test_base8_short_max(): Unit = { runner.runOneTest("base8_short_max") }
+  @Test def test_base16_short_max(): Unit = { runner.runOneTest("base16_short_max") }
 
-  @Test def test_base2_short_max_plus_one() { runner.runOneTest("base2_short_max_plus_one") }
-  @Test def test_base8_short_max_plus_one() { runner.runOneTest("base8_short_max_plus_one") }
-  @Test def test_base16_short_max_plus_one() { runner.runOneTest("base16_short_max_plus_one") }
+  @Test def test_base2_short_max_plus_one(): Unit = { runner.runOneTest("base2_short_max_plus_one") }
+  @Test def test_base8_short_max_plus_one(): Unit = { runner.runOneTest("base8_short_max_plus_one") }
+  @Test def test_base16_short_max_plus_one(): Unit = { runner.runOneTest("base16_short_max_plus_one") }
 
-  @Test def test_base2_byte_min() { runner.runOneTest("base2_byte_min") }
-  @Test def test_base8_byte_min() { runner.runOneTest("base8_byte_min") }
-  @Test def test_base16_byte_min() { runner.runOneTest("base16_byte_min") }
+  @Test def test_base2_byte_min(): Unit = { runner.runOneTest("base2_byte_min") }
+  @Test def test_base8_byte_min(): Unit = { runner.runOneTest("base8_byte_min") }
+  @Test def test_base16_byte_min(): Unit = { runner.runOneTest("base16_byte_min") }
 
-  @Test def test_base2_byte_max() { runner.runOneTest("base2_byte_max") }
-  @Test def test_base8_byte_max() { runner.runOneTest("base8_byte_max") }
-  @Test def test_base16_byte_max() { runner.runOneTest("base16_byte_max") }
+  @Test def test_base2_byte_max(): Unit = { runner.runOneTest("base2_byte_max") }
+  @Test def test_base8_byte_max(): Unit = { runner.runOneTest("base8_byte_max") }
+  @Test def test_base16_byte_max(): Unit = { runner.runOneTest("base16_byte_max") }
 
-  @Test def test_base2_byte_max_plus_one() { runner.runOneTest("base2_byte_max_plus_one") }
-  @Test def test_base8_byte_max_plus_one() { runner.runOneTest("base8_byte_max_plus_one") }
-  @Test def test_base16_byte_max_plus_one() { runner.runOneTest("base16_byte_max_plus_one") }
+  @Test def test_base2_byte_max_plus_one(): Unit = { runner.runOneTest("base2_byte_max_plus_one") }
+  @Test def test_base8_byte_max_plus_one(): Unit = { runner.runOneTest("base8_byte_max_plus_one") }
+  @Test def test_base16_byte_max_plus_one(): Unit = { runner.runOneTest("base16_byte_max_plus_one") }
 
-  @Test def test_base2_uinteger_min() { runner.runOneTest("base2_uinteger_min") }
-  @Test def test_base8_uinteger_min() { runner.runOneTest("base8_uinteger_min") }
-  @Test def test_base16_uinteger_min() { runner.runOneTest("base16_uinteger_min") }
+  @Test def test_base2_uinteger_min(): Unit = { runner.runOneTest("base2_uinteger_min") }
+  @Test def test_base8_uinteger_min(): Unit = { runner.runOneTest("base8_uinteger_min") }
+  @Test def test_base16_uinteger_min(): Unit = { runner.runOneTest("base16_uinteger_min") }
 
-  @Test def test_base2_uinteger_large() { runner.runOneTest("base2_uinteger_large") }
-  @Test def test_base8_uinteger_large() { runner.runOneTest("base8_uinteger_large") }
-  @Test def test_base16_uinteger_large() { runner.runOneTest("base16_uinteger_large") }
+  @Test def test_base2_uinteger_large(): Unit = { runner.runOneTest("base2_uinteger_large") }
+  @Test def test_base8_uinteger_large(): Unit = { runner.runOneTest("base8_uinteger_large") }
+  @Test def test_base16_uinteger_large(): Unit = { runner.runOneTest("base16_uinteger_large") }
 
-  @Test def test_base2_ulong_min() { runner.runOneTest("base2_ulong_min") }
-  @Test def test_base8_ulong_min() { runner.runOneTest("base8_ulong_min") }
-  @Test def test_base16_ulong_min() { runner.runOneTest("base16_ulong_min") }
+  @Test def test_base2_ulong_min(): Unit = { runner.runOneTest("base2_ulong_min") }
+  @Test def test_base8_ulong_min(): Unit = { runner.runOneTest("base8_ulong_min") }
+  @Test def test_base16_ulong_min(): Unit = { runner.runOneTest("base16_ulong_min") }
 
-  @Test def test_base2_ulong_max() { runner.runOneTest("base2_ulong_max") }
-  @Test def test_base8_ulong_max() { runner.runOneTest("base8_ulong_max") }
-  @Test def test_base16_ulong_max() { runner.runOneTest("base16_ulong_max") }
+  @Test def test_base2_ulong_max(): Unit = { runner.runOneTest("base2_ulong_max") }
+  @Test def test_base8_ulong_max(): Unit = { runner.runOneTest("base8_ulong_max") }
+  @Test def test_base16_ulong_max(): Unit = { runner.runOneTest("base16_ulong_max") }
 
-  @Test def test_base2_ulong_max_plus_one() { runner.runOneTest("base2_ulong_max_plus_one") }
-  @Test def test_base8_ulong_max_plus_one() { runner.runOneTest("base8_ulong_max_plus_one") }
-  @Test def test_base16_ulong_max_plus_one() { runner.runOneTest("base16_ulong_max_plus_one") }
+  @Test def test_base2_ulong_max_plus_one(): Unit = { runner.runOneTest("base2_ulong_max_plus_one") }
+  @Test def test_base8_ulong_max_plus_one(): Unit = { runner.runOneTest("base8_ulong_max_plus_one") }
+  @Test def test_base16_ulong_max_plus_one(): Unit = { runner.runOneTest("base16_ulong_max_plus_one") }
 
-  @Test def test_base2_uint_min() { runner.runOneTest("base2_uint_min") }
-  @Test def test_base8_uint_min() { runner.runOneTest("base8_uint_min") }
-  @Test def test_base16_uint_min() { runner.runOneTest("base16_uint_min") }
+  @Test def test_base2_uint_min(): Unit = { runner.runOneTest("base2_uint_min") }
+  @Test def test_base8_uint_min(): Unit = { runner.runOneTest("base8_uint_min") }
+  @Test def test_base16_uint_min(): Unit = { runner.runOneTest("base16_uint_min") }
 
-  @Test def test_base2_uint_max() { runner.runOneTest("base2_uint_max") }
-  @Test def test_base8_uint_max() { runner.runOneTest("base8_uint_max") }
-  @Test def test_base16_uint_max() { runner.runOneTest("base16_uint_max") }
+  @Test def test_base2_uint_max(): Unit = { runner.runOneTest("base2_uint_max") }
+  @Test def test_base8_uint_max(): Unit = { runner.runOneTest("base8_uint_max") }
+  @Test def test_base16_uint_max(): Unit = { runner.runOneTest("base16_uint_max") }
 
-  @Test def test_base2_uint_max_plus_one() { runner.runOneTest("base2_uint_max_plus_one") }
-  @Test def test_base8_uint_max_plus_one() { runner.runOneTest("base8_uint_max_plus_one") }
-  @Test def test_base16_uint_max_plus_one() { runner.runOneTest("base16_uint_max_plus_one") }
+  @Test def test_base2_uint_max_plus_one(): Unit = { runner.runOneTest("base2_uint_max_plus_one") }
+  @Test def test_base8_uint_max_plus_one(): Unit = { runner.runOneTest("base8_uint_max_plus_one") }
+  @Test def test_base16_uint_max_plus_one(): Unit = { runner.runOneTest("base16_uint_max_plus_one") }
 
-  @Test def test_base2_ushort_min() { runner.runOneTest("base2_ushort_min") }
-  @Test def test_base8_ushort_min() { runner.runOneTest("base8_ushort_min") }
-  @Test def test_base16_ushort_min() { runner.runOneTest("base16_ushort_min") }
+  @Test def test_base2_ushort_min(): Unit = { runner.runOneTest("base2_ushort_min") }
+  @Test def test_base8_ushort_min(): Unit = { runner.runOneTest("base8_ushort_min") }
+  @Test def test_base16_ushort_min(): Unit = { runner.runOneTest("base16_ushort_min") }
 
-  @Test def test_base2_ushort_max() { runner.runOneTest("base2_ushort_max") }
-  @Test def test_base8_ushort_max() { runner.runOneTest("base8_ushort_max") }
-  @Test def test_base16_ushort_max() { runner.runOneTest("base16_ushort_max") }
+  @Test def test_base2_ushort_max(): Unit = { runner.runOneTest("base2_ushort_max") }
+  @Test def test_base8_ushort_max(): Unit = { runner.runOneTest("base8_ushort_max") }
+  @Test def test_base16_ushort_max(): Unit = { runner.runOneTest("base16_ushort_max") }
 
-  @Test def test_base2_ushort_max_plus_one() { runner.runOneTest("base2_ushort_max_plus_one") }
-  @Test def test_base8_ushort_max_plus_one() { runner.runOneTest("base8_ushort_max_plus_one") }
-  @Test def test_base16_ushort_max_plus_one() { runner.runOneTest("base16_ushort_max_plus_one") }
+  @Test def test_base2_ushort_max_plus_one(): Unit = { runner.runOneTest("base2_ushort_max_plus_one") }
+  @Test def test_base8_ushort_max_plus_one(): Unit = { runner.runOneTest("base8_ushort_max_plus_one") }
+  @Test def test_base16_ushort_max_plus_one(): Unit = { runner.runOneTest("base16_ushort_max_plus_one") }
 
-  @Test def test_base2_ubyte_min() { runner.runOneTest("base2_ubyte_min") }
-  @Test def test_base8_ubyte_min() { runner.runOneTest("base8_ubyte_min") }
-  @Test def test_base16_ubyte_min() { runner.runOneTest("base16_ubyte_min") }
+  @Test def test_base2_ubyte_min(): Unit = { runner.runOneTest("base2_ubyte_min") }
+  @Test def test_base8_ubyte_min(): Unit = { runner.runOneTest("base8_ubyte_min") }
+  @Test def test_base16_ubyte_min(): Unit = { runner.runOneTest("base16_ubyte_min") }
 
-  @Test def test_base2_ubyte_max() { runner.runOneTest("base2_ubyte_max") }
-  @Test def test_base8_ubyte_max() { runner.runOneTest("base8_ubyte_max") }
-  @Test def test_base16_ubyte_max() { runner.runOneTest("base16_ubyte_max") }
+  @Test def test_base2_ubyte_max(): Unit = { runner.runOneTest("base2_ubyte_max") }
+  @Test def test_base8_ubyte_max(): Unit = { runner.runOneTest("base8_ubyte_max") }
+  @Test def test_base16_ubyte_max(): Unit = { runner.runOneTest("base16_ubyte_max") }
 
-  @Test def test_base2_ubyte_max_plus_one() { runner.runOneTest("base2_ubyte_max_plus_one") }
-  @Test def test_base8_ubyte_max_plus_one() { runner.runOneTest("base8_ubyte_max_plus_one") }
-  @Test def test_base16_ubyte_max_plus_one() { runner.runOneTest("base16_ubyte_max_plus_one") }
+  @Test def test_base2_ubyte_max_plus_one(): Unit = { runner.runOneTest("base2_ubyte_max_plus_one") }
+  @Test def test_base8_ubyte_max_plus_one(): Unit = { runner.runOneTest("base8_ubyte_max_plus_one") }
+  @Test def test_base16_ubyte_max_plus_one(): Unit = { runner.runOneTest("base16_ubyte_max_plus_one") }
 
   // SDE if type is float, double, or decimal in each non-base-10 base
 
-  @Test def test_base2_float_err() { runner.runOneTest("base2_float_err") }
-  @Test def test_base8_float_err() { runner.runOneTest("base8_float_err") }
-  @Test def test_base16_float_err() { runner.runOneTest("base16_float_err") }
+  @Test def test_base2_float_err(): Unit = { runner.runOneTest("base2_float_err") }
+  @Test def test_base8_float_err(): Unit = { runner.runOneTest("base8_float_err") }
+  @Test def test_base16_float_err(): Unit = { runner.runOneTest("base16_float_err") }
 
-  @Test def test_base2_double_err() { runner.runOneTest("base2_double_err") }
-  @Test def test_base8_double_err() { runner.runOneTest("base8_double_err") }
-  @Test def test_base16_double_err() { runner.runOneTest("base16_double_err") }
+  @Test def test_base2_double_err(): Unit = { runner.runOneTest("base2_double_err") }
+  @Test def test_base8_double_err(): Unit = { runner.runOneTest("base8_double_err") }
+  @Test def test_base16_double_err(): Unit = { runner.runOneTest("base16_double_err") }
 
-  @Test def test_base2_decimal_err() { runner.runOneTest("base2_decimal_err") }
-  @Test def test_base8_decimal_err() { runner.runOneTest("base8_decimal_err") }
-  @Test def test_base16_decimal_err() { runner.runOneTest("base16_decimal_err") }
+  @Test def test_base2_decimal_err(): Unit = { runner.runOneTest("base2_decimal_err") }
+  @Test def test_base8_decimal_err(): Unit = { runner.runOneTest("base8_decimal_err") }
+  @Test def test_base16_decimal_err(): Unit = { runner.runOneTest("base16_decimal_err") }
 
   // PE if text number is the empty string
 
-  @Test def test_non_base_10_empty_string_err() { runner.runOneTest("non_base_10_empty_string_err") }
+  @Test def test_non_base_10_empty_string_err(): Unit = { runner.runOneTest("non_base_10_empty_string_err") }
 
   // PE if leading sign
 
-  @Test def test_non_base_10_leading_sign_negative_err() { runner.runOneTest("non_base_10_leading_sign_negative_err") }
-  @Test def test_non_base_10_leading_sign_positive_err() { runner.runOneTest("non_base_10_leading_sign_positive_err") }
+  @Test def test_non_base_10_leading_sign_negative_err(): Unit = { runner.runOneTest("non_base_10_leading_sign_negative_err") }
+  @Test def test_non_base_10_leading_sign_positive_err(): Unit = { runner.runOneTest("non_base_10_leading_sign_positive_err") }
 
   // PE if text number contains characters not valid in the base
 
-  @Test def test_base2_invalid_char_err() { runner.runOneTest("base2_invalid_char_err") }
-  @Test def test_base8_invalid_char_err() { runner.runOneTest("base8_invalid_char_err") }
-  @Test def test_base16_invalid_char_err() { runner.runOneTest("base16_invalid_char_err") }
+  @Test def test_base2_invalid_char_err(): Unit = { runner.runOneTest("base2_invalid_char_err") }
+  @Test def test_base8_invalid_char_err(): Unit = { runner.runOneTest("base8_invalid_char_err") }
+  @Test def test_base16_invalid_char_err(): Unit = { runner.runOneTest("base16_invalid_char_err") }
 
   // SDE if textStandardBase is not a supported base
 
-  @Test def test_unsupported_base_err() { runner.runOneTest("unsupported_base_err") }
+  @Test def test_unsupported_base_err(): Unit = { runner.runOneTest("unsupported_base_err") }
 
   // Accepts uppercase hex characters, but always unparses to lowercase. Requires two-pass
 
-  @Test def test_base16_uppercase() { runner.runOneTest("base16_uppercase") }
+  @Test def test_base16_uppercase(): Unit = { runner.runOneTest("base16_uppercase") }
 
   // Leading zeros are accepted during parsing. Requires two-pass
 
-  @Test def test_non_base_10_leading_zeros_ignored() { runner.runOneTest("non_base_10_leading_zeros_ignored") }
+  @Test def test_non_base_10_leading_zeros_ignored(): Unit = { runner.runOneTest("non_base_10_leading_zeros_ignored") }
 
   // SDE if unparsing a negative number
 
-  @Test def test_non_base_10_unparse_negative_int_err() { runner.runOneTest("non_base_10_unparse_negative_int_err") }
-  @Test def test_non_base_10_unparse_negative_uinteger_err() { runner.runOneTest("non_base_10_unparse_negative_uinteger_err") }
+  @Test def test_non_base_10_unparse_negative_int_err(): Unit = { runner.runOneTest("non_base_10_unparse_negative_int_err") }
+  @Test def test_non_base_10_unparse_negative_uinteger_err(): Unit = { runner.runOneTest("non_base_10_unparse_negative_uinteger_err") }
 
   // Unparse always goes to lowercase
 
-  @Test def test_non_base_10_unparse_lower_case() { runner.runOneTest("non_base_10_unparse_lower_case") }
+  @Test def test_non_base_10_unparse_lower_case(): Unit = { runner.runOneTest("non_base_10_unparse_lower_case") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/occursCountKind/TestOCKImplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/occursCountKind/TestOCKImplicit.scala
@@ -29,7 +29,7 @@ object TestOCKImplicit {
   val testDir = "/org/apache/daffodil/section14/occursCountKind/"
   val runner = Runner(testDir, "ockImplicit.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -38,31 +38,31 @@ object TestOCKImplicit {
 class TestOCKImplicit {
   import TestOCKImplicit._
 
-  @Test def test_ockImplicit1() { runner.runOneTest("ockImplicit1") }
-  @Test def test_ockImplicit2() { runner.runOneTest("ockImplicit2") }
-  @Test def test_ockImplicit3() { runner.runOneTest("ockImplicit3") }
-  @Test def test_ockImplicit4() { runner.runOneTest("ockImplicit4") }
-  @Test def test_ockImplicit5() { runner.runOneTest("ockImplicit5") }
-  @Test def test_ockImplicit6() { runner.runOneTest("ockImplicit6") }
-  @Test def test_ockImplicit7() { runner.runOneTest("ockImplicit7") }
-  @Test def test_ockImplicit8() { runner.runOneTest("ockImplicit8") }
-  @Test def test_ockImplicit9() { runner.runOneTest("ockImplicit9") }
-  @Test def test_ockImplicit10() { runner.runOneTest("ockImplicit10") }
-  @Test def test_ockImplicit11() { runner.runOneTest("ockImplicit11") }
-  @Test def test_ockImplicit12() { runner.runOneTest("ockImplicit12") }
-  @Test def test_ockImplicit13() { runner.runOneTest("ockImplicit13") }
-  @Test def test_ockImplicit14() { runner.runOneTest("ockImplicit14") }
-  @Test def test_ockImplicit15() { runner.runOneTest("ockImplicit15") }
+  @Test def test_ockImplicit1(): Unit = { runner.runOneTest("ockImplicit1") }
+  @Test def test_ockImplicit2(): Unit = { runner.runOneTest("ockImplicit2") }
+  @Test def test_ockImplicit3(): Unit = { runner.runOneTest("ockImplicit3") }
+  @Test def test_ockImplicit4(): Unit = { runner.runOneTest("ockImplicit4") }
+  @Test def test_ockImplicit5(): Unit = { runner.runOneTest("ockImplicit5") }
+  @Test def test_ockImplicit6(): Unit = { runner.runOneTest("ockImplicit6") }
+  @Test def test_ockImplicit7(): Unit = { runner.runOneTest("ockImplicit7") }
+  @Test def test_ockImplicit8(): Unit = { runner.runOneTest("ockImplicit8") }
+  @Test def test_ockImplicit9(): Unit = { runner.runOneTest("ockImplicit9") }
+  @Test def test_ockImplicit10(): Unit = { runner.runOneTest("ockImplicit10") }
+  @Test def test_ockImplicit11(): Unit = { runner.runOneTest("ockImplicit11") }
+  @Test def test_ockImplicit12(): Unit = { runner.runOneTest("ockImplicit12") }
+  @Test def test_ockImplicit13(): Unit = { runner.runOneTest("ockImplicit13") }
+  @Test def test_ockImplicit14(): Unit = { runner.runOneTest("ockImplicit14") }
+  @Test def test_ockImplicit15(): Unit = { runner.runOneTest("ockImplicit15") }
 
-  @Test def test_ockImplicit16() { runner.runOneTest("ockImplicit16") }
-  @Test def test_ockImplicit17() { runner.runOneTest("ockImplicit17") }
-  @Test def test_ockImplicit18() { runner.runOneTest("ockImplicit18") }
-  @Test def test_ockImplicit19() { runner.runOneTest("ockImplicit19") }
+  @Test def test_ockImplicit16(): Unit = { runner.runOneTest("ockImplicit16") }
+  @Test def test_ockImplicit17(): Unit = { runner.runOneTest("ockImplicit17") }
+  @Test def test_ockImplicit18(): Unit = { runner.runOneTest("ockImplicit18") }
+  @Test def test_ockImplicit19(): Unit = { runner.runOneTest("ockImplicit19") }
 
-  @Test def test_ockImplicit20() { runner.runOneTest("ockImplicit20") }
-  @Test def test_ockImplicit21() { runner.runOneTest("ockImplicit21") }
-  @Test def test_ockImplicit22() { runner.runOneTest("ockImplicit22") }
-  @Test def test_ockImplicit23() { runner.runOneTest("ockImplicit23") }
+  @Test def test_ockImplicit20(): Unit = { runner.runOneTest("ockImplicit20") }
+  @Test def test_ockImplicit21(): Unit = { runner.runOneTest("ockImplicit21") }
+  @Test def test_ockImplicit22(): Unit = { runner.runOneTest("ockImplicit22") }
+  @Test def test_ockImplicit23(): Unit = { runner.runOneTest("ockImplicit23") }
   //DFDL-1662
-  @Test def test_ockImplicit24() { runner.runOneTest("ockImplicit24") }
+  @Test def test_ockImplicit24(): Unit = { runner.runOneTest("ockImplicit24") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
@@ -27,7 +27,7 @@ object TestHiddenSequences {
 
   val runner = Runner(testDir, "HiddenSequences.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -38,21 +38,21 @@ class TestHiddenSequences {
   import TestHiddenSequences._
 
 
-  @Test def test_parseHiddenGroupRef() { runner.runOneTest("parseHiddenGroupRef") }
-  @Test def test_parseRegularGroupRef() { runner.runOneTest("parseRegularGroupRef") }
-  @Test def test_parseSeqOfHiddenAndRegularRef() { runner.runOneTest("parseSeqOfHiddenAndRegularRef") }
-  @Test def test_parseNestedHiddenAndRegularRef() { runner.runOneTest("parseNestedHiddenAndRegularRef") }
-  @Test def test_parseNestedRegularAndHiddenRef() { runner.runOneTest("parseNestedRegularAndHiddenRef") }
-  @Test def test_parseNestedHiddenGroupRefs() { runner.runOneTest("parseNestedHiddenGroupRefs") }
+  @Test def test_parseHiddenGroupRef(): Unit = { runner.runOneTest("parseHiddenGroupRef") }
+  @Test def test_parseRegularGroupRef(): Unit = { runner.runOneTest("parseRegularGroupRef") }
+  @Test def test_parseSeqOfHiddenAndRegularRef(): Unit = { runner.runOneTest("parseSeqOfHiddenAndRegularRef") }
+  @Test def test_parseNestedHiddenAndRegularRef(): Unit = { runner.runOneTest("parseNestedHiddenAndRegularRef") }
+  @Test def test_parseNestedRegularAndHiddenRef(): Unit = { runner.runOneTest("parseNestedRegularAndHiddenRef") }
+  @Test def test_parseNestedHiddenGroupRefs(): Unit = { runner.runOneTest("parseNestedHiddenGroupRefs") }
 
-  @Test def test_unparseHiddenGroupRef() { runner.runOneTest("unparseHiddenGroupRef") }
-  @Test def test_unparseRegularGroupRef() { runner.runOneTest("unparseRegularGroupRef") }
-  @Test def test_unparseSeqOfHiddenAndRegularRef() { runner.runOneTest("unparseSeqOfHiddenAndRegularRef") }
-  @Test def test_unparseNestedHiddenAndRegularRef() { runner.runOneTest("unparseNestedHiddenAndRegularRef") }
-  @Test def test_unparseNestedRegularAndHiddenRef() { runner.runOneTest("unparseNestedRegularAndHiddenRef") }
-  @Test def test_unparseNestedHiddenGroupRefs() { runner.runOneTest("unparseNestedHiddenGroupRefs") }
-  @Test def test_noOVCinHiddenContext() { runner.runOneTest("noOVCinHiddenContext") }
-  @Test def test_nestedNoOVCinHiddenContext() { runner.runOneTest("nestedNoOVCinHiddenContext") }
+  @Test def test_unparseHiddenGroupRef(): Unit = { runner.runOneTest("unparseHiddenGroupRef") }
+  @Test def test_unparseRegularGroupRef(): Unit = { runner.runOneTest("unparseRegularGroupRef") }
+  @Test def test_unparseSeqOfHiddenAndRegularRef(): Unit = { runner.runOneTest("unparseSeqOfHiddenAndRegularRef") }
+  @Test def test_unparseNestedHiddenAndRegularRef(): Unit = { runner.runOneTest("unparseNestedHiddenAndRegularRef") }
+  @Test def test_unparseNestedRegularAndHiddenRef(): Unit = { runner.runOneTest("unparseNestedRegularAndHiddenRef") }
+  @Test def test_unparseNestedHiddenGroupRefs(): Unit = { runner.runOneTest("unparseNestedHiddenGroupRefs") }
+  @Test def test_noOVCinHiddenContext(): Unit = { runner.runOneTest("noOVCinHiddenContext") }
+  @Test def test_nestedNoOVCinHiddenContext(): Unit = { runner.runOneTest("nestedNoOVCinHiddenContext") }
 
-  @Test def test_invalidGroupDefWithHiddenSequenceModelGroup() { runner.runOneTest("invalidGroupDefWithHiddenSequenceModelGroup") }
+  @Test def test_invalidGroupDefWithHiddenSequenceModelGroup(): Unit = { runner.runOneTest("invalidGroupDefWithHiddenSequenceModelGroup") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupInitiatedContent.scala
@@ -25,7 +25,7 @@ object TestSequenceGroupInitiatedContent {
   val testDir_01 = "/org/apache/daffodil/section14/sequence_groups/"
   val runner_01 = Runner(testDir_01, "SequenceGroupInitiatedContent.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_01.reset
   }
 
@@ -35,17 +35,17 @@ class TestSequenceGroupInitiatedContent {
 
   import TestSequenceGroupInitiatedContent._
 
-  @Test def test_baseline() { runner_01.runOneTest("initiatedContentSeqBaseline") }
-  @Test def test_1() { runner_01.runOneTest("initiatedContentSeq1") }
-  @Test def test_2() { runner_01.runOneTest("initiatedContentSeq2") }
-  @Test def test_3() { runner_01.runOneTest("initiatedContentSeq3") }
+  @Test def test_baseline(): Unit = { runner_01.runOneTest("initiatedContentSeqBaseline") }
+  @Test def test_1(): Unit = { runner_01.runOneTest("initiatedContentSeq1") }
+  @Test def test_2(): Unit = { runner_01.runOneTest("initiatedContentSeq2") }
+  @Test def test_3(): Unit = { runner_01.runOneTest("initiatedContentSeq3") }
 
   // Tests for DAFFODIL-2143
-  @Test def test_sequenceScalarChildDoesNotDiscriminateAnything1() { runner_01.runOneTest("sequenceScalarChildDoesNotDiscriminateAnything1") }
-  @Test def test_sequenceScalarChildDoesNotDiscriminateAnything2() { runner_01.runOneTest("sequenceScalarChildDoesNotDiscriminateAnything2") }
-  @Test def test_sequenceFixedOccursChildDoesNotDiscriminateAnything1() { runner_01.runOneTest("sequenceFixedOccursChildDoesNotDiscriminateAnything1") }
-  @Test def test_sequenceExpressionOccursChildDoesNotDiscriminateAnything1() { runner_01.runOneTest("sequenceExpressionOccursChildDoesNotDiscriminateAnything1") }
-  @Test def test_sequenceImplicitOccursLessThanMinOccursDoesNotDiscriminateAnything1() { runner_01.runOneTest("sequenceImplicitOccursLessThanMinOccursDoesNotDiscriminateAnything1") }
-  @Test def test_sequenceImplicitOccursZeroOrMoreDiscriminates1() { runner_01.runOneTest("sequenceImplicitOccursZeroOrMoreDiscriminates1") }
+  @Test def test_sequenceScalarChildDoesNotDiscriminateAnything1(): Unit = { runner_01.runOneTest("sequenceScalarChildDoesNotDiscriminateAnything1") }
+  @Test def test_sequenceScalarChildDoesNotDiscriminateAnything2(): Unit = { runner_01.runOneTest("sequenceScalarChildDoesNotDiscriminateAnything2") }
+  @Test def test_sequenceFixedOccursChildDoesNotDiscriminateAnything1(): Unit = { runner_01.runOneTest("sequenceFixedOccursChildDoesNotDiscriminateAnything1") }
+  @Test def test_sequenceExpressionOccursChildDoesNotDiscriminateAnything1(): Unit = { runner_01.runOneTest("sequenceExpressionOccursChildDoesNotDiscriminateAnything1") }
+  @Test def test_sequenceImplicitOccursLessThanMinOccursDoesNotDiscriminateAnything1(): Unit = { runner_01.runOneTest("sequenceImplicitOccursLessThanMinOccursDoesNotDiscriminateAnything1") }
+  @Test def test_sequenceImplicitOccursZeroOrMoreDiscriminates1(): Unit = { runner_01.runOneTest("sequenceImplicitOccursZeroOrMoreDiscriminates1") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
@@ -27,19 +27,19 @@ object TestSequenceGroupUnparse {
   val aa = testDir + "SequenceGroupUnparse.tdml"
   val res = Misc.getRequiredResource(aa)
   var runner = new DFDLTestSuite(res)
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner = null
   }
 }
 class TestSequenceGroupUnparse {
   import TestSequenceGroupUnparse._
 
-  @Test def test_seqWithOptionals1() { runner.runOneTest("seqWithOptionals1") }
-  @Test def test_seqWithOptionals2() { runner.runOneTest("seqWithOptionals2") }
-  @Test def test_seqWithOptionals3() { runner.runOneTest("seqWithOptionals3") }
-  @Test def test_seqWithOptionals4() { runner.runOneTest("seqWithOptionals4") }
-  @Test def test_seqWithOptionals5() { runner.runOneTest("seqWithOptionals5") }
+  @Test def test_seqWithOptionals1(): Unit = { runner.runOneTest("seqWithOptionals1") }
+  @Test def test_seqWithOptionals2(): Unit = { runner.runOneTest("seqWithOptionals2") }
+  @Test def test_seqWithOptionals3(): Unit = { runner.runOneTest("seqWithOptionals3") }
+  @Test def test_seqWithOptionals4(): Unit = { runner.runOneTest("seqWithOptionals4") }
+  @Test def test_seqWithOptionals5(): Unit = { runner.runOneTest("seqWithOptionals5") }
 
-  @Test def test_seqWithHiddenGroupContainingComplex() { runner.runOneTest("seqWithHiddenGroupContainingComplex") }
+  @Test def test_seqWithHiddenGroupContainingComplex(): Unit = { runner.runOneTest("seqWithHiddenGroupContainingComplex") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -28,7 +28,7 @@ object TestSequenceGroups {
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
   var runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_01.reset
     runner_02.reset
   }
@@ -42,58 +42,58 @@ class TestSequenceGroups {
 
 
 
-  @Test def test_SeqGrp_01() { runner_01.runOneTest("SeqGrp_01") }
-  @Test def test_SeqGrp_02() { runner_01.runOneTest("SeqGrp_02") }
-  @Test def test_SeqGrp_03() { runner_01.runOneTest("SeqGrp_03") }
-  @Test def test_SeqGrp_04() { runner_01.runOneTest("SeqGrp_04") }
-  @Test def test_prefix() { runner_01.runOneTest("prefix") }
-  @Test def test_prefix_01() { runner_01.runOneTest("prefix_01") }
-  @Test def test_NumSeq_02() { runner_01.runOneTest("NumSeq_02") }
-  @Test def test_groupRefInheritProps() { runner_01.runOneTest("groupRefInheritProps") }
-  @Test def test_sequenceWithinSequence() { runner_01.runOneTest("sequenceWithinSequence") }
-  @Test def test_delimitedByNextInitFail() { runner_01.runOneTest("delimitedByNextInitFail") }
+  @Test def test_SeqGrp_01(): Unit = { runner_01.runOneTest("SeqGrp_01") }
+  @Test def test_SeqGrp_02(): Unit = { runner_01.runOneTest("SeqGrp_02") }
+  @Test def test_SeqGrp_03(): Unit = { runner_01.runOneTest("SeqGrp_03") }
+  @Test def test_SeqGrp_04(): Unit = { runner_01.runOneTest("SeqGrp_04") }
+  @Test def test_prefix(): Unit = { runner_01.runOneTest("prefix") }
+  @Test def test_prefix_01(): Unit = { runner_01.runOneTest("prefix_01") }
+  @Test def test_NumSeq_02(): Unit = { runner_01.runOneTest("NumSeq_02") }
+  @Test def test_groupRefInheritProps(): Unit = { runner_01.runOneTest("groupRefInheritProps") }
+  @Test def test_sequenceWithinSequence(): Unit = { runner_01.runOneTest("sequenceWithinSequence") }
+  @Test def test_delimitedByNextInitFail(): Unit = { runner_01.runOneTest("delimitedByNextInitFail") }
 
   // DAFFODIL-669
   //  @Test def test_emptySequenceSDE() { runner_02.runOneTest("emptySequenceSDE") }
-  @Test def test_NadaParser() { runner_02.runOneTest("nadaParser") }
-  @Test def test_complexEmptyContent() { runner_02.runOneTest("complexEmptyContent") }
-  @Test def test_noContentComplexSDE() { runner_02.runOneTest("noContentComplexSDE") }
-  @Test def test_noContentAnnotatedComplexSDE() { runner_02.runOneTest("noContentAnnotatedComplexSDE") }
+  @Test def test_NadaParser(): Unit = { runner_02.runOneTest("nadaParser") }
+  @Test def test_complexEmptyContent(): Unit = { runner_02.runOneTest("complexEmptyContent") }
+  @Test def test_noContentComplexSDE(): Unit = { runner_02.runOneTest("noContentComplexSDE") }
+  @Test def test_noContentAnnotatedComplexSDE(): Unit = { runner_02.runOneTest("noContentAnnotatedComplexSDE") }
 
-  @Test def test_SeqGrp546() { runner_02.runOneTest("SeqGrp546") }
+  @Test def test_SeqGrp546(): Unit = { runner_02.runOneTest("SeqGrp546") }
 
-  @Test def test_SeqGrp_05() { runner_02.runOneTest("SeqGrp_05") }
+  @Test def test_SeqGrp_05(): Unit = { runner_02.runOneTest("SeqGrp_05") }
 
-  @Test def test_hiddenGroup1() { runner_02.runOneTest("hiddenGroup1") }
-  @Test def test_hiddenGroupSchemaFail() { runner_02.runOneTest("hiddenGroupSchemaFail") }
-  @Test def test_hiddenGroupWithAssert() { runner_02.runOneTest("hiddenGroupWithAssert") }
-  @Test def test_hiddenGroupWithAssert2() { runner_02.runOneTest("hiddenGroupWithAssert2") }
-  @Test def test_hiddenGroupNested() { runner_02.runOneTest("hiddenGroupNested") }
-  @Test def test_hiddenGroupNested2() { runner_02.runOneTest("hiddenGroupNested2") }
-  @Test def test_nestedGroupRefs() { runner_02.runOneTest("nestedGroupRefs") }
-  @Test def test_nestedGroupRefs2() { runner_02.runOneTest("nestedGroupRefs2") }
-  @Test def test_hiddenGroupChoice() { runner_02.runOneTest("hiddenGroupChoice") }
-  @Test def test_hiddenGroupChoice2() { runner_02.runOneTest("hiddenGroupChoice2") }
-  @Test def test_hiddenGroupIgnoredProps() { runner_02.runOneTest("hiddenGroupIgnoredProps") }
-  @Test def test_hiddenGroupAttributeNotation() { runner_02.runOneTest("hiddenGroupAttributeNotation") }
-  @Test def test_hiddenGroupElementNotation() { runner_02.runOneTest("hiddenGroupElementNotation") }
+  @Test def test_hiddenGroup1(): Unit = { runner_02.runOneTest("hiddenGroup1") }
+  @Test def test_hiddenGroupSchemaFail(): Unit = { runner_02.runOneTest("hiddenGroupSchemaFail") }
+  @Test def test_hiddenGroupWithAssert(): Unit = { runner_02.runOneTest("hiddenGroupWithAssert") }
+  @Test def test_hiddenGroupWithAssert2(): Unit = { runner_02.runOneTest("hiddenGroupWithAssert2") }
+  @Test def test_hiddenGroupNested(): Unit = { runner_02.runOneTest("hiddenGroupNested") }
+  @Test def test_hiddenGroupNested2(): Unit = { runner_02.runOneTest("hiddenGroupNested2") }
+  @Test def test_nestedGroupRefs(): Unit = { runner_02.runOneTest("nestedGroupRefs") }
+  @Test def test_nestedGroupRefs2(): Unit = { runner_02.runOneTest("nestedGroupRefs2") }
+  @Test def test_hiddenGroupChoice(): Unit = { runner_02.runOneTest("hiddenGroupChoice") }
+  @Test def test_hiddenGroupChoice2(): Unit = { runner_02.runOneTest("hiddenGroupChoice2") }
+  @Test def test_hiddenGroupIgnoredProps(): Unit = { runner_02.runOneTest("hiddenGroupIgnoredProps") }
+  @Test def test_hiddenGroupAttributeNotation(): Unit = { runner_02.runOneTest("hiddenGroupAttributeNotation") }
+  @Test def test_hiddenGroupElementNotation(): Unit = { runner_02.runOneTest("hiddenGroupElementNotation") }
 
   //DFDL-284
   // @Test def test_hiddenGroupLoop() { runner_02.runOneTest("hiddenGroupLoop") }
 
   //DFDL-598(related to, but this test does not say this is fixed)
-  @Test def test_hiddenGroupRefEmptyString() { runner_02.runOneTest("hiddenGroupRefEmptyString") }
-  @Test def test_hiddenGroupRefDoesNotExist() { runner_02.runOneTest("hiddenGroupRefDoesNotExist") }
+  @Test def test_hiddenGroupRefEmptyString(): Unit = { runner_02.runOneTest("hiddenGroupRefEmptyString") }
+  @Test def test_hiddenGroupRefDoesNotExist(): Unit = { runner_02.runOneTest("hiddenGroupRefDoesNotExist") }
 
-  @Test def test_AC000() { runner_02.runOneTest("AC000") }
-  @Test def test_AD000() { runner_02.runOneTest("AD000") }
-  @Test def test_AS000() { runner_02.runOneTest("AS000") }
+  @Test def test_AC000(): Unit = { runner_02.runOneTest("AC000") }
+  @Test def test_AD000(): Unit = { runner_02.runOneTest("AD000") }
+  @Test def test_AS000(): Unit = { runner_02.runOneTest("AS000") }
 
-  @Test def test_noDefaultSeqKind() { runner_02.runOneTest("noDefaultSeqKind") }
-  @Test def test_sequenceWithComplexType() { runner_02.runOneTest("sequenceWithComplexType") }
+  @Test def test_noDefaultSeqKind(): Unit = { runner_02.runOneTest("noDefaultSeqKind") }
+  @Test def test_sequenceWithComplexType(): Unit = { runner_02.runOneTest("sequenceWithComplexType") }
 
   // DAFFODIL-2171
-  @Test def test_delimiterScanning_01() { runner_01.runOneTest("delimiterScanning_01") }
-  @Test def test_delimiterScanning_02() { runner_01.runOneTest("delimiterScanning_02") }
+  @Test def test_delimiterScanning_01(): Unit = { runner_01.runOneTest("delimiterScanning_01") }
+  @Test def test_delimiterScanning_02(): Unit = { runner_01.runOneTest("delimiterScanning_02") }
   //@Test def test_delimiterScanning_03() { runner_01.runOneTest("delimiterScanning_03") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
@@ -28,7 +28,7 @@ object TestSequenceGroups3 {
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
   val runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_01.reset
     runner_02.reset
   }
@@ -38,13 +38,13 @@ object TestSequenceGroups3 {
 class TestSequenceGroups3 {
   import TestSequenceGroups3._
 
-  @Test def test_lastElts() { runner_01.runOneTest("lastElts") }
+  @Test def test_lastElts(): Unit = { runner_01.runOneTest("lastElts") }
 
-  @Test def test_hiddenGroupSeqWithRequiredElements() { runner_02.runOneTest("hiddenGroupSeqWithRequiredElements") }
-  @Test def test_hiddenGroupChoiceWithAllRequiredBranches() { runner_02.runOneTest("hiddenGroupChoiceWithAllRequiredBranches") }
+  @Test def test_hiddenGroupSeqWithRequiredElements(): Unit = { runner_02.runOneTest("hiddenGroupSeqWithRequiredElements") }
+  @Test def test_hiddenGroupChoiceWithAllRequiredBranches(): Unit = { runner_02.runOneTest("hiddenGroupChoiceWithAllRequiredBranches") }
 
-  @Test def test_sequence_group_with_annotation_01() { runner_02.runOneTest("sequence_group_with_annotation_01") }
-  @Test def test_choice_group_with_annotation_01() { runner_02.runOneTest("choice_group_with_annotation_01") }
+  @Test def test_sequence_group_with_annotation_01(): Unit = { runner_02.runOneTest("sequence_group_with_annotation_01") }
+  @Test def test_choice_group_with_annotation_01(): Unit = { runner_02.runOneTest("choice_group_with_annotation_01") }
 
-  @Test def test_similar_model_groups_01() { runner_02.runOneTest("similar_model_groups_01") }
+  @Test def test_similar_model_groups_01(): Unit = { runner_02.runOneTest("similar_model_groups_01") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequencesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequencesNew.scala
@@ -26,7 +26,7 @@ object TestUnorderedSequencesNew {
   val runner = Runner(testDir, "UnorderedSequences.tdml")
   val runnerBE = Runner(testDir, "BE.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
@@ -27,7 +27,7 @@ object TestChoice {
   val runnerCH = Runner(testDir, "choice.tdml")
   val runnerCE = Runner(testDir, "ChoiceLengthExplicit.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runnerCH.reset
     runnerCE.reset
   }
@@ -38,107 +38,107 @@ class TestChoice {
 
   import TestChoice._
 
-  @Test def test_optionalChoice01() { runnerCH.runOneTest("optionalChoice01") }
-  @Test def test_optionalChoice02() { runnerCH.runOneTest("optionalChoice02") }
-  @Test def test_optionalChoice03() { runnerCH.runOneTest("optionalChoice03") }
-  @Test def test_optionalChoice04() { runnerCH.runOneTest("optionalChoice04") }
-  @Test def test_optionalChoice05() { runnerCH.runOneTest("optionalChoice05") }
+  @Test def test_optionalChoice01(): Unit = { runnerCH.runOneTest("optionalChoice01") }
+  @Test def test_optionalChoice02(): Unit = { runnerCH.runOneTest("optionalChoice02") }
+  @Test def test_optionalChoice03(): Unit = { runnerCH.runOneTest("optionalChoice03") }
+  @Test def test_optionalChoice04(): Unit = { runnerCH.runOneTest("optionalChoice04") }
+  @Test def test_optionalChoice05(): Unit = { runnerCH.runOneTest("optionalChoice05") }
 
-  @Test def test_choiceOfGroupRefs() { runnerCH.runOneTest("choiceOfGroupRefs") }
+  @Test def test_choiceOfGroupRefs(): Unit = { runnerCH.runOneTest("choiceOfGroupRefs") }
 
-  @Test def test_basic() { runnerCH.runOneTest("basic") }
-  @Test def test_choice2() { runnerCH.runOneTest("choice2") }
-  @Test def test_choice3() { runnerCH.runOneTest("choice3") }
-  @Test def test_choice4() { runnerCH.runOneTest("choice4") }
+  @Test def test_basic(): Unit = { runnerCH.runOneTest("basic") }
+  @Test def test_choice2(): Unit = { runnerCH.runOneTest("choice2") }
+  @Test def test_choice3(): Unit = { runnerCH.runOneTest("choice3") }
+  @Test def test_choice4(): Unit = { runnerCH.runOneTest("choice4") }
 
-  @Test def test_choiceWithInitsAndTermsInt() { runnerCH.runOneTest("choiceWithInitsAndTermsInt") }
-  @Test def test_choiceWithInitsAndTermsStr() { runnerCH.runOneTest("choiceWithInitsAndTermsStr") }
-  @Test def test_choiceWithInitsAndTermsError() { runnerCH.runOneTest("choiceWithInitsAndTermsError") }
-  @Test def test_choiceWithInitsAndTermsSeqInt() { runnerCH.runOneTest("choiceWithInitsAndTermsSeqInt") }
-  @Test def test_choiceWithInitsAndTermsSeqStr() { runnerCH.runOneTest("choiceWithInitsAndTermsSeqStr") }
-  @Test def test_nestedChoiceWithInitsAndTermsNestedInt() { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsNestedInt") }
-  @Test def test_nestedChoiceWithInitsAndTermsNestedStr() { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsNestedStr") }
-  @Test def test_nestedChoiceWithInitsAndTermsInt() { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsInt") }
+  @Test def test_choiceWithInitsAndTermsInt(): Unit = { runnerCH.runOneTest("choiceWithInitsAndTermsInt") }
+  @Test def test_choiceWithInitsAndTermsStr(): Unit = { runnerCH.runOneTest("choiceWithInitsAndTermsStr") }
+  @Test def test_choiceWithInitsAndTermsError(): Unit = { runnerCH.runOneTest("choiceWithInitsAndTermsError") }
+  @Test def test_choiceWithInitsAndTermsSeqInt(): Unit = { runnerCH.runOneTest("choiceWithInitsAndTermsSeqInt") }
+  @Test def test_choiceWithInitsAndTermsSeqStr(): Unit = { runnerCH.runOneTest("choiceWithInitsAndTermsSeqStr") }
+  @Test def test_nestedChoiceWithInitsAndTermsNestedInt(): Unit = { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsNestedInt") }
+  @Test def test_nestedChoiceWithInitsAndTermsNestedStr(): Unit = { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsNestedStr") }
+  @Test def test_nestedChoiceWithInitsAndTermsInt(): Unit = { runnerCH.runOneTest("nestedChoiceWithInitsAndTermsInt") }
 
-  @Test def test_choiceWithSequence1() { runnerCH.runOneTest("choiceWithSequence1") }
-  @Test def test_choiceWithSequence2() { runnerCH.runOneTest("choiceWithSequence2") }
-  @Test def test_choiceWithChoiceInt() { runnerCH.runOneTest("choiceWithChoiceInt") }
-  @Test def test_choiceWithChoiceFloat() { runnerCH.runOneTest("choiceWithChoiceFloat") }
-  @Test def test_choiceWithChoiceString() { runnerCH.runOneTest("choiceWithChoiceString") }
-  @Test def test_choiceWithArrayInts() { runnerCH.runOneTest("choiceWithArrayInts") }
-  @Test def test_choiceWithArrayFloats() { runnerCH.runOneTest("choiceWithArrayFloats") }
-  @Test def test_choiceWithArrayString() { runnerCH.runOneTest("choiceWithChoiceString") }
+  @Test def test_choiceWithSequence1(): Unit = { runnerCH.runOneTest("choiceWithSequence1") }
+  @Test def test_choiceWithSequence2(): Unit = { runnerCH.runOneTest("choiceWithSequence2") }
+  @Test def test_choiceWithChoiceInt(): Unit = { runnerCH.runOneTest("choiceWithChoiceInt") }
+  @Test def test_choiceWithChoiceFloat(): Unit = { runnerCH.runOneTest("choiceWithChoiceFloat") }
+  @Test def test_choiceWithChoiceString(): Unit = { runnerCH.runOneTest("choiceWithChoiceString") }
+  @Test def test_choiceWithArrayInts(): Unit = { runnerCH.runOneTest("choiceWithArrayInts") }
+  @Test def test_choiceWithArrayFloats(): Unit = { runnerCH.runOneTest("choiceWithArrayFloats") }
+  @Test def test_choiceWithArrayString(): Unit = { runnerCH.runOneTest("choiceWithChoiceString") }
 
-  @Test def test_choice5() { runnerCH.runOneTest("choice5") }
-  @Test def test_choice6() { runnerCH.runOneTest("choice6") }
-  @Test def test_choiceFail1() { runnerCH.runOneTest("choiceFail1") }
-  @Test def test_choiceDelim1() {
+  @Test def test_choice5(): Unit = { runnerCH.runOneTest("choice5") }
+  @Test def test_choice6(): Unit = { runnerCH.runOneTest("choice6") }
+  @Test def test_choiceFail1(): Unit = { runnerCH.runOneTest("choiceFail1") }
+  @Test def test_choiceDelim1(): Unit = {
     // Logging@Test defaults.setLoggingLevel(LogLevel.Debug)
     runnerCH.runOneTest("choiceDelim1")
   }
-  @Test def test_choiceDelim2() { runnerCH.runOneTest("choiceDelim2") }
-  @Test def test_choiceDelimFloat() { runnerCH.runOneTest("choiceDelimFloat") }
-  @Test def test_choiceDelimString() { runnerCH.runOneTest("choiceDelimString") }
-  @Test def test_choiceDelimStringwSp() { runnerCH.runOneTest("choiceDelimStringwSp") }
-  @Test def test_choiceDelimInt() { runnerCH.runOneTest("choiceDelimInt") }
+  @Test def test_choiceDelim2(): Unit = { runnerCH.runOneTest("choiceDelim2") }
+  @Test def test_choiceDelimFloat(): Unit = { runnerCH.runOneTest("choiceDelimFloat") }
+  @Test def test_choiceDelimString(): Unit = { runnerCH.runOneTest("choiceDelimString") }
+  @Test def test_choiceDelimStringwSp(): Unit = { runnerCH.runOneTest("choiceDelimStringwSp") }
+  @Test def test_choiceDelimInt(): Unit = { runnerCH.runOneTest("choiceDelimInt") }
 
-  @Test def test_nestedChoice1() {
+  @Test def test_nestedChoice1(): Unit = {
     // Logging@Test defaults.setLoggingLevel(LogLevel.Debug)
     runnerCH.runOneTest("nestedChoice1")
   }
 
-  @Test def test_nestedChoiceAllString() { runnerCH.runOneTest("nestedChoiceAllString") }
-  @Test def test_nestedChoiceAllFloat() { runnerCH.runOneTest("nestedChoiceAllFloat") }
-  @Test def test_nestedChoiceAllInt() { runnerCH.runOneTest("nestedChoiceAllInt") }
+  @Test def test_nestedChoiceAllString(): Unit = { runnerCH.runOneTest("nestedChoiceAllString") }
+  @Test def test_nestedChoiceAllFloat(): Unit = { runnerCH.runOneTest("nestedChoiceAllFloat") }
+  @Test def test_nestedChoiceAllInt(): Unit = { runnerCH.runOneTest("nestedChoiceAllInt") }
 
-  @Test def test_choiceInSequenceWithSeparators1() { runnerCH.runOneTest("choiceInSequenceWithSeparators1") }
-  @Test def test_choiceInSequenceWithSeparators2() { runnerCH.runOneTest("choiceInSequenceWithSeparators2") }
+  @Test def test_choiceInSequenceWithSeparators1(): Unit = { runnerCH.runOneTest("choiceInSequenceWithSeparators1") }
+  @Test def test_choiceInSequenceWithSeparators2(): Unit = { runnerCH.runOneTest("choiceInSequenceWithSeparators2") }
 
-  @Test def test_sequenceInChoiceInSequenceWithSeparators1() { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSeparators1") }
-  @Test def test_sequenceInChoiceInSequenceWithSeparators2() { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSeparators2") }
-  @Test def test_sequenceInChoiceInSequenceWithSameSeparators1() { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSameSeparators1") }
-  @Test def test_sequenceInChoiceInSequenceWithSameSeparators2() { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSameSeparators2") }
+  @Test def test_sequenceInChoiceInSequenceWithSeparators1(): Unit = { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSeparators1") }
+  @Test def test_sequenceInChoiceInSequenceWithSeparators2(): Unit = { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSeparators2") }
+  @Test def test_sequenceInChoiceInSequenceWithSameSeparators1(): Unit = { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSameSeparators1") }
+  @Test def test_sequenceInChoiceInSequenceWithSameSeparators2(): Unit = { runnerCH.runOneTest("sequenceInChoiceInSequenceWithSameSeparators2") }
 
-  @Test def test_choice_minOccurs() { runnerCH.runOneTest("choice_minOccurs") }
-  @Test def test_choice_maxOccurs() { runnerCH.runOneTest("choice_maxOccurs") }
+  @Test def test_choice_minOccurs(): Unit = { runnerCH.runOneTest("choice_minOccurs") }
+  @Test def test_choice_maxOccurs(): Unit = { runnerCH.runOneTest("choice_maxOccurs") }
 
-  @Test def test_choice_with_inputvaluecalc() { runnerCH.runOneTest("choice_with_inputvaluecalc") }
+  @Test def test_choice_with_inputvaluecalc(): Unit = { runnerCH.runOneTest("choice_with_inputvaluecalc") }
 
   // DFDL-641
-  @Test def test_direct_dispatch_01() { runnerCH.runOneTest("direct_dispatch_01") }
-  @Test def test_direct_dispatch_02() { runnerCH.runOneTest("direct_dispatch_02") }
-  @Test def test_direct_dispatch_03() { runnerCH.runOneTest("direct_dispatch_03") }
-  @Test def test_direct_dispatch_04() { runnerCH.runOneTest("direct_dispatch_04") }
-  @Test def test_direct_dispatch_05() { runnerCH.runOneTest("direct_dispatch_05") }
-  @Test def test_direct_dispatch_06() { runnerCH.runOneTest("direct_dispatch_06") }
-  @Test def test_direct_dispatch_07() { runnerCH.runOneTest("direct_dispatch_07") }
-  @Test def test_direct_dispatch_08() { runnerCH.runOneTest("direct_dispatch_08") }
-  @Test def test_direct_dispatch_09() { runnerCH.runOneTest("direct_dispatch_09") }
-  @Test def test_direct_dispatch_10() { runnerCH.runOneTest("direct_dispatch_10") }
-  @Test def test_direct_dispatch_11() { runnerCH.runOneTest("direct_dispatch_11") }
-  @Test def test_direct_dispatch_12() { runnerCH.runOneTest("direct_dispatch_12") }
-  @Test def test_direct_dispatch_13() { runnerCH.runOneTest("direct_dispatch_13") }
-  @Test def test_direct_dispatch_14() { runnerCH.runOneTest("direct_dispatch_14") }
-  @Test def test_direct_dispatch_15() { runnerCH.runOneTest("direct_dispatch_15") }
-  @Test def test_direct_dispatch_16() { runnerCH.runOneTest("direct_dispatch_16") }
-  @Test def test_direct_dispatch_17() { runnerCH.runOneTest("direct_dispatch_17") }
+  @Test def test_direct_dispatch_01(): Unit = { runnerCH.runOneTest("direct_dispatch_01") }
+  @Test def test_direct_dispatch_02(): Unit = { runnerCH.runOneTest("direct_dispatch_02") }
+  @Test def test_direct_dispatch_03(): Unit = { runnerCH.runOneTest("direct_dispatch_03") }
+  @Test def test_direct_dispatch_04(): Unit = { runnerCH.runOneTest("direct_dispatch_04") }
+  @Test def test_direct_dispatch_05(): Unit = { runnerCH.runOneTest("direct_dispatch_05") }
+  @Test def test_direct_dispatch_06(): Unit = { runnerCH.runOneTest("direct_dispatch_06") }
+  @Test def test_direct_dispatch_07(): Unit = { runnerCH.runOneTest("direct_dispatch_07") }
+  @Test def test_direct_dispatch_08(): Unit = { runnerCH.runOneTest("direct_dispatch_08") }
+  @Test def test_direct_dispatch_09(): Unit = { runnerCH.runOneTest("direct_dispatch_09") }
+  @Test def test_direct_dispatch_10(): Unit = { runnerCH.runOneTest("direct_dispatch_10") }
+  @Test def test_direct_dispatch_11(): Unit = { runnerCH.runOneTest("direct_dispatch_11") }
+  @Test def test_direct_dispatch_12(): Unit = { runnerCH.runOneTest("direct_dispatch_12") }
+  @Test def test_direct_dispatch_13(): Unit = { runnerCH.runOneTest("direct_dispatch_13") }
+  @Test def test_direct_dispatch_14(): Unit = { runnerCH.runOneTest("direct_dispatch_14") }
+  @Test def test_direct_dispatch_15(): Unit = { runnerCH.runOneTest("direct_dispatch_15") }
+  @Test def test_direct_dispatch_16(): Unit = { runnerCH.runOneTest("direct_dispatch_16") }
+  @Test def test_direct_dispatch_17(): Unit = { runnerCH.runOneTest("direct_dispatch_17") }
 
   //@Test def test_choice_noBranch() { runnerCH.runOneTest("choice_noBranch") } - Test consumes no data, which causes a TDMLError
 
 
-  @Test def test_explicit_01() { runnerCE.runOneTest("explicit_01") }
-  @Test def test_explicit_02() { runnerCE.runOneTest("explicit_02") }
-  @Test def test_explicit_03() { runnerCE.runOneTest("explicit_03") }
-  @Test def test_explicit_04() { runnerCE.runOneTest("explicit_04") }
-  @Test def test_explicit_05() { runnerCE.runOneTest("explicit_05") }
-  @Test def test_explicit_06() { runnerCE.runOneTest("explicit_06") }
-  @Test def test_explicit_07() { runnerCE.runOneTest("explicit_07") }
-  @Test def test_explicit_08() { runnerCE.runOneTest("explicit_08") }
-  @Test def test_explicit_09() { runnerCE.runOneTest("explicit_09") }
+  @Test def test_explicit_01(): Unit = { runnerCE.runOneTest("explicit_01") }
+  @Test def test_explicit_02(): Unit = { runnerCE.runOneTest("explicit_02") }
+  @Test def test_explicit_03(): Unit = { runnerCE.runOneTest("explicit_03") }
+  @Test def test_explicit_04(): Unit = { runnerCE.runOneTest("explicit_04") }
+  @Test def test_explicit_05(): Unit = { runnerCE.runOneTest("explicit_05") }
+  @Test def test_explicit_06(): Unit = { runnerCE.runOneTest("explicit_06") }
+  @Test def test_explicit_07(): Unit = { runnerCE.runOneTest("explicit_07") }
+  @Test def test_explicit_08(): Unit = { runnerCE.runOneTest("explicit_08") }
+  @Test def test_explicit_09(): Unit = { runnerCE.runOneTest("explicit_09") }
 
-  @Test def test_explicit_multiple_choices() { runnerCE.runOneTest("explicit_multiple_choices") }
+  @Test def test_explicit_multiple_choices(): Unit = { runnerCE.runOneTest("explicit_multiple_choices") }
 
-  @Test def test_explicit_unparse_01() { runnerCE.runOneTest("explicit_unparse_01") }
-  @Test def test_explicit_unparse_02() { runnerCE.runOneTest("explicit_unparse_02") }
+  @Test def test_explicit_unparse_01(): Unit = { runnerCE.runOneTest("explicit_unparse_01") }
+  @Test def test_explicit_unparse_02(): Unit = { runnerCE.runOneTest("explicit_unparse_02") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice2.scala
@@ -28,7 +28,7 @@ object TestChoice2 {
   val runner1773 = Runner(testDir, "choice1773.tdml")
   val runner2162 = Runner(testDir, "choice2162.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner1773.reset
     runner2162.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
@@ -25,7 +25,7 @@ object TestChoiceGroupInitiatedContent {
   val testDir_01 = "/org/apache/daffodil/section15/choice_groups/"
   val runner_01 = Runner(testDir_01, "ChoiceGroupInitiatedContent.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner_01.reset
   }
 
@@ -35,29 +35,29 @@ class TestChoiceGroupInitiatedContent {
 
   import TestChoiceGroupInitiatedContent._
 
-  @Test def test_initiatedContentChoice1() { runner_01.runOneTest("initiatedContentChoice1") }
-  @Test def test_initiatedContentChoice2() { runner_01.runOneTest("initiatedContentChoice2") }
-  @Test def test_initiatedContentChoice3() { runner_01.runOneTest("initiatedContentChoice3") }
-  @Test def test_initiatedContentChoice4() { runner_01.runOneTest("initiatedContentChoice4") }
-  @Test def test_initiatedContentChoice5() { runner_01.runOneTest("initiatedContentChoice5") }
-  @Test def test_initiatedContentChoice6() { runner_01.runOneTest("initiatedContentChoice6") }
-  @Test def test_initiatedContentChoice7() { runner_01.runOneTest("initiatedContentChoice7") }
-  @Test def test_initiatedContentChoice8() { runner_01.runOneTest("initiatedContentChoice8") }
-  @Test def test_initiatedContentChoice9() { runner_01.runOneTest("initiatedContentChoice9") }
-  @Test def test_initiatedContentChoice10() { runner_01.runOneTest("initiatedContentChoice10") }
+  @Test def test_initiatedContentChoice1(): Unit = { runner_01.runOneTest("initiatedContentChoice1") }
+  @Test def test_initiatedContentChoice2(): Unit = { runner_01.runOneTest("initiatedContentChoice2") }
+  @Test def test_initiatedContentChoice3(): Unit = { runner_01.runOneTest("initiatedContentChoice3") }
+  @Test def test_initiatedContentChoice4(): Unit = { runner_01.runOneTest("initiatedContentChoice4") }
+  @Test def test_initiatedContentChoice5(): Unit = { runner_01.runOneTest("initiatedContentChoice5") }
+  @Test def test_initiatedContentChoice6(): Unit = { runner_01.runOneTest("initiatedContentChoice6") }
+  @Test def test_initiatedContentChoice7(): Unit = { runner_01.runOneTest("initiatedContentChoice7") }
+  @Test def test_initiatedContentChoice8(): Unit = { runner_01.runOneTest("initiatedContentChoice8") }
+  @Test def test_initiatedContentChoice9(): Unit = { runner_01.runOneTest("initiatedContentChoice9") }
+  @Test def test_initiatedContentChoice10(): Unit = { runner_01.runOneTest("initiatedContentChoice10") }
 
   // Test for DAFFODIL-2143
-  @Test def test_arrayOptionalChildDiscriminatesElementAndChoice1() { runner_01.runOneTest("arrayOptionalChildDiscriminatesElementAndChoice1") }
+  @Test def test_arrayOptionalChildDiscriminatesElementAndChoice1(): Unit = { runner_01.runOneTest("arrayOptionalChildDiscriminatesElementAndChoice1") }
 
-  @Test def test_arrayOfChoice() { runner_01.runOneTest("arrayOfChoice") }
-  @Test def test_arrayOfChoice2() { runner_01.runOneTest("arrayOfChoice2") }
-  @Test def test_discriminatorNesting1() { runner_01.runOneTest("discriminatorNesting1") }
-  @Test def test_discriminatorNesting2() { runner_01.runOneTest("discriminatorNesting2") }
-  @Test def test_Lesson5_choice_state() { runner_01.runOneTest("Lesson5_choice_state") }
-  @Test def test_Lesson5_choice_county() { runner_01.runOneTest("Lesson5_choice_county") }
-  @Test def test_Lesson5_choice_province() { runner_01.runOneTest("Lesson5_choice_province") }
+  @Test def test_arrayOfChoice(): Unit = { runner_01.runOneTest("arrayOfChoice") }
+  @Test def test_arrayOfChoice2(): Unit = { runner_01.runOneTest("arrayOfChoice2") }
+  @Test def test_discriminatorNesting1(): Unit = { runner_01.runOneTest("discriminatorNesting1") }
+  @Test def test_discriminatorNesting2(): Unit = { runner_01.runOneTest("discriminatorNesting2") }
+  @Test def test_Lesson5_choice_state(): Unit = { runner_01.runOneTest("Lesson5_choice_state") }
+  @Test def test_Lesson5_choice_county(): Unit = { runner_01.runOneTest("Lesson5_choice_county") }
+  @Test def test_Lesson5_choice_province(): Unit = { runner_01.runOneTest("Lesson5_choice_province") }
 
-  @Test def test_unparse_initiatedContentChoice1() { runner_01.runOneTest("unparse_initiatedContentChoice1") }
-  @Test def test_initiatedContentNestedChoices1() { runner_01.runOneTest("initiatedContentNestedChoices1") }
-  @Test def test_initiatedContentNestedChoices2() { runner_01.runOneTest("initiatedContentNestedChoices2") }
+  @Test def test_unparse_initiatedContentChoice1(): Unit = { runner_01.runOneTest("unparse_initiatedContentChoice1") }
+  @Test def test_initiatedContentNestedChoices1(): Unit = { runner_01.runOneTest("initiatedContentNestedChoices1") }
+  @Test def test_initiatedContentNestedChoices2(): Unit = { runner_01.runOneTest("initiatedContentNestedChoices2") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceNest.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceNest.scala
@@ -26,7 +26,7 @@ object TestChoiceNest {
 
   val runner = Runner(testDir, "choiceNests.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -36,10 +36,10 @@ class TestChoiceNest {
 
   import TestChoiceNest._
 
-  @Test def test_choiceNest1() { runner.runOneTest("choiceNest1") }
-  @Test def test_choiceNest2() { runner.runOneTest("choiceNest2") }
-  @Test def test_choiceNest2a() { runner.runOneTest("choiceNest2a") }
-  @Test def test_choiceNest3() { runner.runOneTest("choiceNest3") }
-  @Test def test_choiceNest4() { runner.runOneTest("choiceNest4") }
+  @Test def test_choiceNest1(): Unit = { runner.runOneTest("choiceNest1") }
+  @Test def test_choiceNest2(): Unit = { runner.runOneTest("choiceNest2") }
+  @Test def test_choiceNest2a(): Unit = { runner.runOneTest("choiceNest2a") }
+  @Test def test_choiceNest3(): Unit = { runner.runOneTest("choiceNest3") }
+  @Test def test_choiceNest4(): Unit = { runner.runOneTest("choiceNest4") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
@@ -27,7 +27,7 @@ object TestHiddenChoices {
 
   val runner = Runner(testDir, "HiddenChoices.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -38,19 +38,19 @@ class TestHiddenChoices {
   import TestHiddenChoices._
 
 
-  @Test def test_parseHiddenGroupRef() { runner.runOneTest("parseHiddenGroupRef") }
-  @Test def test_parseRegularGroupRef() { runner.runOneTest("parseRegularGroupRef") }
-  @Test def test_parseSeqOfHiddenAndRegularRef() { runner.runOneTest("parseSeqOfHiddenAndRegularRef") }
-  @Test def test_parseNestedHiddenAndRegularRef() { runner.runOneTest("parseNestedHiddenAndRegularRef") }
-  @Test def test_parseNestedHiddenGroupRefs() { runner.runOneTest("parseNestedHiddenGroupRefs") }
+  @Test def test_parseHiddenGroupRef(): Unit = { runner.runOneTest("parseHiddenGroupRef") }
+  @Test def test_parseRegularGroupRef(): Unit = { runner.runOneTest("parseRegularGroupRef") }
+  @Test def test_parseSeqOfHiddenAndRegularRef(): Unit = { runner.runOneTest("parseSeqOfHiddenAndRegularRef") }
+  @Test def test_parseNestedHiddenAndRegularRef(): Unit = { runner.runOneTest("parseNestedHiddenAndRegularRef") }
+  @Test def test_parseNestedHiddenGroupRefs(): Unit = { runner.runOneTest("parseNestedHiddenGroupRefs") }
 
-  @Test def test_unparseHiddenGroupRef() { runner.runOneTest("unparseHiddenGroupRef") }
-  @Test def test_unparseRegularGroupRef() { runner.runOneTest("unparseRegularGroupRef") }
-  @Test def test_unparseSeqOfHiddenAndRegularRef() { runner.runOneTest("unparseSeqOfHiddenAndRegularRef") }
-  @Test def test_unparseNestedHiddenAndRegularRef() { runner.runOneTest("unparseNestedHiddenAndRegularRef") }
-  @Test def test_unparseNestedRegularAndHiddenRef() { runner.runOneTest("unparseNestedRegularAndHiddenRef") }
-  @Test def test_unparseNestedHiddenGroupRefs() { runner.runOneTest("unparseNestedHiddenGroupRefs") }
-  @Test def test_noOVCinHiddenContext() { runner.runOneTest("noOVCinHiddenContext") }
-  @Test def test_nestedNoOVCinHiddenContext() { runner.runOneTest("nestedNoOVCinHiddenContext") }
+  @Test def test_unparseHiddenGroupRef(): Unit = { runner.runOneTest("unparseHiddenGroupRef") }
+  @Test def test_unparseRegularGroupRef(): Unit = { runner.runOneTest("unparseRegularGroupRef") }
+  @Test def test_unparseSeqOfHiddenAndRegularRef(): Unit = { runner.runOneTest("unparseSeqOfHiddenAndRegularRef") }
+  @Test def test_unparseNestedHiddenAndRegularRef(): Unit = { runner.runOneTest("unparseNestedHiddenAndRegularRef") }
+  @Test def test_unparseNestedRegularAndHiddenRef(): Unit = { runner.runOneTest("unparseNestedRegularAndHiddenRef") }
+  @Test def test_unparseNestedHiddenGroupRefs(): Unit = { runner.runOneTest("unparseNestedHiddenGroupRefs") }
+  @Test def test_noOVCinHiddenContext(): Unit = { runner.runOneTest("noOVCinHiddenContext") }
+  @Test def test_nestedNoOVCinHiddenContext(): Unit = { runner.runOneTest("nestedNoOVCinHiddenContext") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoice.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoice.scala
@@ -25,7 +25,7 @@ object TestUnparseChoice {
   val testDir = "/org/apache/daffodil/section15/choice_groups/"
   val runnerCH = Runner(testDir, "choice-unparse.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runnerCH.reset
   }
 }
@@ -33,10 +33,10 @@ object TestUnparseChoice {
 class TestUnparseChoice {
   import TestUnparseChoice._
 
-  @Test def test_choice1() { runnerCH.runOneTest("choice1") }
-  @Test def test_choice2() { runnerCH.runOneTest("choice2") }
-  @Test def test_choice3() { runnerCH.runOneTest("choice3") }
-  @Test def test_choice4() { runnerCH.runOneTest("choice4") }
-  @Test def test_choice5() { runnerCH.runOneTest("choice5") }
-  @Test def test_choice6() { runnerCH.runOneTest("choice6") }
+  @Test def test_choice1(): Unit = { runnerCH.runOneTest("choice1") }
+  @Test def test_choice2(): Unit = { runnerCH.runOneTest("choice2") }
+  @Test def test_choice3(): Unit = { runnerCH.runOneTest("choice3") }
+  @Test def test_choice4(): Unit = { runnerCH.runOneTest("choice4") }
+  @Test def test_choice5(): Unit = { runnerCH.runOneTest("choice5") }
+  @Test def test_choice6(): Unit = { runnerCH.runOneTest("choice6") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoice2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoice2.scala
@@ -27,7 +27,7 @@ object TestUnparseChoice2 {
 
   val runner = Runner(testDir, "choice-unparse2.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 }
@@ -36,10 +36,10 @@ class TestUnparseChoice2 {
   import TestUnparseChoice2._
 
   // DAFFODIL-2259
-  @Test def test_choice_with_array_branch1() { runner.runOneTest("choice_with_array_branch1") }
-  @Test def test_choice_with_array_branch2() { runner.runOneTest("choice_with_array_branch2") }
-  @Test def test_choice_with_array_branch3() { runner.runOneTest("choice_with_array_branch3") }
-  @Test def test_choice_with_presence_bits_followed_by_array() { runner.runOneTest("choice_with_presence_bits_followed_by_array")}
+  @Test def test_choice_with_array_branch1(): Unit = { runner.runOneTest("choice_with_array_branch1") }
+  @Test def test_choice_with_array_branch2(): Unit = { runner.runOneTest("choice_with_array_branch2") }
+  @Test def test_choice_with_array_branch3(): Unit = { runner.runOneTest("choice_with_array_branch3") }
+  @Test def test_choice_with_presence_bits_followed_by_array(): Unit = { runner.runOneTest("choice_with_presence_bits_followed_by_array")}
 
-  @Test def test_choice_defaultable_branch_is_empty() { runner.runOneTest("choice_default_branch_is_empty")}
+  @Test def test_choice_defaultable_branch_is_empty(): Unit = { runner.runOneTest("choice_default_branch_is_empty")}
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoiceNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoiceNew.scala
@@ -27,7 +27,7 @@ object TestUnparseChoiceNew {
   val aa = testDir + "choice-unparse.tdml"
   var runnerCH = new DFDLTestSuite(Misc.getRequiredResource(aa))
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runnerCH = null
   }
 }
@@ -35,8 +35,8 @@ object TestUnparseChoiceNew {
 class TestUnparseChoiceNew {
   import TestUnparseChoiceNew._
 
-  @Test def test_choice7() { runnerCH.runOneTest("choice7") }
-  @Test def test_choice8() { runnerCH.runOneTest("choice8") }
-  @Test def test_choice9() { runnerCH.runOneTest("choice9") }
-  @Test def test_choice10() { runnerCH.runOneTest("choice10") }
+  @Test def test_choice7(): Unit = { runnerCH.runOneTest("choice7") }
+  @Test def test_choice8(): Unit = { runnerCH.runOneTest("choice8") }
+  @Test def test_choice9(): Unit = { runnerCH.runOneTest("choice9") }
+  @Test def test_choice10(): Unit = { runnerCH.runOneTest("choice10") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
@@ -30,7 +30,7 @@ object TestArrayOptionalElem {
   val rBack = Runner(testDir, "backtracking.tdml")
   val runnerAC = Runner(testDir, "ArrayComb.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner01.reset
     rBack.reset
@@ -47,47 +47,47 @@ class TestArrayOptionalElem {
   @Test def test_arrayComb1() = { runnerAC.runOneTest("arrayComb1") }
   @Test def test_arrayComb2() = { runnerAC.runOneTest("arrayComb2") }
 
-  @Test def test_arrayExpressions01() { runner.runOneTest("arrayExpressions01") }
-  @Test def test_arrayExpressions02() { runner.runOneTest("arrayExpressions02") }
-  @Test def test_arrayExpressions02b() { runner.runOneTest("arrayExpressions02b") }
-  @Test def test_arrayExpressions02c() { runner.runOneTest("arrayExpressions02c") }
-  @Test def test_arrayExpressions02d() { runner.runOneTest("arrayExpressions02d") }
-  @Test def test_arrayExpressions03() { runner.runOneTest("arrayExpressions03") }
-  @Test def test_arrayExpressions04() { runner.runOneTest("arrayExpressions04") }
-  @Test def test_arrayExpressions05() { runner.runOneTest("arrayExpressions05") }
+  @Test def test_arrayExpressions01(): Unit = { runner.runOneTest("arrayExpressions01") }
+  @Test def test_arrayExpressions02(): Unit = { runner.runOneTest("arrayExpressions02") }
+  @Test def test_arrayExpressions02b(): Unit = { runner.runOneTest("arrayExpressions02b") }
+  @Test def test_arrayExpressions02c(): Unit = { runner.runOneTest("arrayExpressions02c") }
+  @Test def test_arrayExpressions02d(): Unit = { runner.runOneTest("arrayExpressions02d") }
+  @Test def test_arrayExpressions03(): Unit = { runner.runOneTest("arrayExpressions03") }
+  @Test def test_arrayExpressions04(): Unit = { runner.runOneTest("arrayExpressions04") }
+  @Test def test_arrayExpressions05(): Unit = { runner.runOneTest("arrayExpressions05") }
 
-  @Test def test_error01() { runner.runOneTest("error01") }
-  @Test def test_postfixNoErr() { runner.runOneTest("postfixNoErr") }
+  @Test def test_error01(): Unit = { runner.runOneTest("error01") }
+  @Test def test_postfixNoErr(): Unit = { runner.runOneTest("postfixNoErr") }
 
-  @Test def test_optionalElem() { runner.runOneTest("optionalElem") }
-  @Test def test_optionalWithSeparators() { runner.runOneTest("optionalWithSeparators") }
-  @Test def test_Lesson6_optional_element() { runner.runOneTest("Lesson6_optional_element") }
-  @Test def test_Lesson6_optional_element_01() { runner.runOneTest("Lesson6_optional_element_01") }
-  @Test def test_Lesson6_fixed_array() { runner.runOneTest("Lesson6_fixed_array") }
-  @Test def test_Lesson6_variable_array() { runner.runOneTest("Lesson6_variable_array") }
-  @Test def test_Lesson6_variable_array_01() { runner.runOneTest("Lesson6_variable_array_01") }
-  @Test def test_Lesson6_variable_array_02() { runner.runOneTest("Lesson6_variable_array_02") }
+  @Test def test_optionalElem(): Unit = { runner.runOneTest("optionalElem") }
+  @Test def test_optionalWithSeparators(): Unit = { runner.runOneTest("optionalWithSeparators") }
+  @Test def test_Lesson6_optional_element(): Unit = { runner.runOneTest("Lesson6_optional_element") }
+  @Test def test_Lesson6_optional_element_01(): Unit = { runner.runOneTest("Lesson6_optional_element_01") }
+  @Test def test_Lesson6_fixed_array(): Unit = { runner.runOneTest("Lesson6_fixed_array") }
+  @Test def test_Lesson6_variable_array(): Unit = { runner.runOneTest("Lesson6_variable_array") }
+  @Test def test_Lesson6_variable_array_01(): Unit = { runner.runOneTest("Lesson6_variable_array_01") }
+  @Test def test_Lesson6_variable_array_02(): Unit = { runner.runOneTest("Lesson6_variable_array_02") }
 
-  @Test def test_leftOverData_Neg() { runner01.runOneTest("leftOverData_Neg") }
+  @Test def test_leftOverData_Neg(): Unit = { runner01.runOneTest("leftOverData_Neg") }
 
   @Test def test_backtrack1Text() = { rBack.runOneTest("backtrack1Text") }
 
-  @Test def test_occursCountKindImplicitSeparators01a() { runner.runOneTest("occursCountKindImplicitSeparators01a") }
-  @Test def test_occursCountKindImplicitSeparators01b() { runner.runOneTest("occursCountKindImplicitSeparators01b") }
-  @Test def test_occursCountKindImplicitSeparators02() { runner.runOneTest("occursCountKindImplicitSeparators02") }
-  @Test def test_occursCountKindImplicitSeparators03() { runner.runOneTest("occursCountKindImplicitSeparators03") }
-  @Test def test_occursCountKindImplicitSeparators04() { runner.runOneTest("occursCountKindImplicitSeparators04") }
-  @Test def test_occursCountKindImplicitSeparators05() { runner.runOneTest("occursCountKindImplicitSeparators05") }
-  @Test def test_occursCountKindImplicitSeparators05Strict() { runner.runOneTest("occursCountKindImplicitSeparators05Strict") }
-  @Test def test_occursCountKindImplicitSeparatorsUnparser() { runner.runOneTest("occursCountKindImplicitSeparatorsUnparser") }
+  @Test def test_occursCountKindImplicitSeparators01a(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators01a") }
+  @Test def test_occursCountKindImplicitSeparators01b(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators01b") }
+  @Test def test_occursCountKindImplicitSeparators02(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators02") }
+  @Test def test_occursCountKindImplicitSeparators03(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators03") }
+  @Test def test_occursCountKindImplicitSeparators04(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators04") }
+  @Test def test_occursCountKindImplicitSeparators05(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators05") }
+  @Test def test_occursCountKindImplicitSeparators05Strict(): Unit = { runner.runOneTest("occursCountKindImplicitSeparators05Strict") }
+  @Test def test_occursCountKindImplicitSeparatorsUnparser(): Unit = { runner.runOneTest("occursCountKindImplicitSeparatorsUnparser") }
 
-  @Test def test_ambigSep1() { runner.runOneTest("ambigSep1") }
-  @Test def test_ambigSep2() { runner.runOneTest("ambigSep2") }
+  @Test def test_ambigSep1(): Unit = { runner.runOneTest("ambigSep1") }
+  @Test def test_ambigSep2(): Unit = { runner.runOneTest("ambigSep2") }
 
   // DAFFODIL-1886
-  @Test def test_manyAdjacentOptionals_01() { runner.runOneTest("manyAdjacentOptionals_01") }
+  @Test def test_manyAdjacentOptionals_01(): Unit = { runner.runOneTest("manyAdjacentOptionals_01") }
 
   // DAFFODIL-2263
-  @Test def test_dfdl2263() { runner.runOneTest("dfdl2263") }
+  @Test def test_dfdl2263(): Unit = { runner.runOneTest("dfdl2263") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayOptionalElem.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayOptionalElem.scala
@@ -31,7 +31,7 @@ object TestUnparseArrayOptionalElem {
   val runner_expr = Runner(testDir, "UnparseArrayExpressionConstant.tdml")
   val runner_delim = Runner(testDir, "UnparseArrayDelimitedOptionalElem.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner_fixed.reset
     runner_imp.reset
     runner_parsed.reset
@@ -45,69 +45,69 @@ class TestUnparseArrayOptionalElem {
 
   import TestUnparseArrayOptionalElem._
 
-  @Test def test_exprOptPresent() { runner_expr.runOneTest("exprOptPresent") }
-  @Test def test_exprOptPresentArray() { runner_expr.runOneTest("exprOptPresentArray") }
-  @Test def test_exprOptAbsentArray() { runner_expr.runOneTest("exprOptAbsentArray") }
-  @Test def test_exprOptTwoArrays() { runner_expr.runOneTest("exprOptTwoArrays") }
-  @Test def test_exprOptScalarThenArray() { runner_expr.runOneTest("exprOptScalarThenArray") }
-  @Test def test_exprOptArrayThenScalar() { runner_expr.runOneTest("exprOptArrayThenScalar") }
+  @Test def test_exprOptPresent(): Unit = { runner_expr.runOneTest("exprOptPresent") }
+  @Test def test_exprOptPresentArray(): Unit = { runner_expr.runOneTest("exprOptPresentArray") }
+  @Test def test_exprOptAbsentArray(): Unit = { runner_expr.runOneTest("exprOptAbsentArray") }
+  @Test def test_exprOptTwoArrays(): Unit = { runner_expr.runOneTest("exprOptTwoArrays") }
+  @Test def test_exprOptScalarThenArray(): Unit = { runner_expr.runOneTest("exprOptScalarThenArray") }
+  @Test def test_exprOptArrayThenScalar(): Unit = { runner_expr.runOneTest("exprOptArrayThenScalar") }
 
-  @Test def test_exprOptParsedData_01() { runner_expr.runOneTest("exprOptParsedData_01") }
-  @Test def test_exprOptParsedData_02() { runner_expr.runOneTest("exprOptParsedData_02") }
-  @Test def test_exprOptParsedData_03() { runner_expr.runOneTest("exprOptParsedData_03") }
-  @Test def test_exprOptParsedData_04() { runner_expr.runOneTest("exprOptParsedData_04") }
+  @Test def test_exprOptParsedData_01(): Unit = { runner_expr.runOneTest("exprOptParsedData_01") }
+  @Test def test_exprOptParsedData_02(): Unit = { runner_expr.runOneTest("exprOptParsedData_02") }
+  @Test def test_exprOptParsedData_03(): Unit = { runner_expr.runOneTest("exprOptParsedData_03") }
+  @Test def test_exprOptParsedData_04(): Unit = { runner_expr.runOneTest("exprOptParsedData_04") }
 
-  @Test def test_fixedUnparseArrayTooManyElements01() { runner_fixed.runOneTest("fixedUnparseArrayTooManyElements01") }
-  @Test def test_fixedUnparseArrayTooFewElements01() { runner_fixed.runOneTest("fixedUnparseArrayTooFewElements01") }
-  @Test def test_impOptScalarThenArray03() { runner_imp.runOneTest("impOptScalarThenArray03") }
-  @Test def test_impOptArrayThenScalar03() { runner_imp.runOneTest("impOptArrayThenScalar03") }
+  @Test def test_fixedUnparseArrayTooManyElements01(): Unit = { runner_fixed.runOneTest("fixedUnparseArrayTooManyElements01") }
+  @Test def test_fixedUnparseArrayTooFewElements01(): Unit = { runner_fixed.runOneTest("fixedUnparseArrayTooFewElements01") }
+  @Test def test_impOptScalarThenArray03(): Unit = { runner_imp.runOneTest("impOptScalarThenArray03") }
+  @Test def test_impOptArrayThenScalar03(): Unit = { runner_imp.runOneTest("impOptArrayThenScalar03") }
 
-  @Test def test_fixedOptPresent() { runner_fixed.runOneTest("fixedOptPresent") }
-  @Test def test_fixedOptPresentArray() { runner_fixed.runOneTest("fixedOptPresentArray") }
-  @Test def test_fixedOptAbsentArray() { runner_fixed.runOneTest("fixedOptAbsentArray") }
-  @Test def test_fixedOptTwoArrays() { runner_fixed.runOneTest("fixedOptTwoArrays") }
-  @Test def test_fixedOptScalarThenArray() { runner_fixed.runOneTest("fixedOptScalarThenArray") }
-  @Test def test_fixedOptArrayThenScalar() { runner_fixed.runOneTest("fixedOptArrayThenScalar") }
+  @Test def test_fixedOptPresent(): Unit = { runner_fixed.runOneTest("fixedOptPresent") }
+  @Test def test_fixedOptPresentArray(): Unit = { runner_fixed.runOneTest("fixedOptPresentArray") }
+  @Test def test_fixedOptAbsentArray(): Unit = { runner_fixed.runOneTest("fixedOptAbsentArray") }
+  @Test def test_fixedOptTwoArrays(): Unit = { runner_fixed.runOneTest("fixedOptTwoArrays") }
+  @Test def test_fixedOptScalarThenArray(): Unit = { runner_fixed.runOneTest("fixedOptScalarThenArray") }
+  @Test def test_fixedOptArrayThenScalar(): Unit = { runner_fixed.runOneTest("fixedOptArrayThenScalar") }
 
-  @Test def test_impOptPresent() { runner_imp.runOneTest("impOptPresent") }
-  @Test def test_impOptPresentArray() { runner_imp.runOneTest("impOptPresentArray") }
-  @Test def test_impOptPresentArrayMax2() { runner_imp.runOneTest("impOptPresentArrayMax2") }
-  @Test def test_impOptAbsentArray() { runner_imp.runOneTest("impOptAbsentArray") }
-  @Test def test_impOptTwoArrays() { runner_imp.runOneTest("impOptTwoArrays") }
+  @Test def test_impOptPresent(): Unit = { runner_imp.runOneTest("impOptPresent") }
+  @Test def test_impOptPresentArray(): Unit = { runner_imp.runOneTest("impOptPresentArray") }
+  @Test def test_impOptPresentArrayMax2(): Unit = { runner_imp.runOneTest("impOptPresentArrayMax2") }
+  @Test def test_impOptAbsentArray(): Unit = { runner_imp.runOneTest("impOptAbsentArray") }
+  @Test def test_impOptTwoArrays(): Unit = { runner_imp.runOneTest("impOptTwoArrays") }
 
-  @Test def test_impOptScalarThenArray() { runner_imp.runOneTest("impOptScalarThenArray") }
-  @Test def test_impOptScalarThenArray02() { runner_imp.runOneTest("impOptScalarThenArray02") }
+  @Test def test_impOptScalarThenArray(): Unit = { runner_imp.runOneTest("impOptScalarThenArray") }
+  @Test def test_impOptScalarThenArray02(): Unit = { runner_imp.runOneTest("impOptScalarThenArray02") }
 
-  @Test def test_impOptArrayThenScalar() { runner_imp.runOneTest("impOptArrayThenScalar") }
-  @Test def test_impOptArrayThenScalar02() { runner_imp.runOneTest("impOptArrayThenScalar02") }
-  @Test def test_impOptArrayThenScalar02parse() { runner_imp.runOneTest("impOptArrayThenScalar02parse") }
+  @Test def test_impOptArrayThenScalar(): Unit = { runner_imp.runOneTest("impOptArrayThenScalar") }
+  @Test def test_impOptArrayThenScalar02(): Unit = { runner_imp.runOneTest("impOptArrayThenScalar02") }
+  @Test def test_impOptArrayThenScalar02parse(): Unit = { runner_imp.runOneTest("impOptArrayThenScalar02parse") }
 
-  @Test def test_scalarThenImpOptArray01() { runner_imp.runOneTest("scalarThenImpOptArray01") }
-  @Test def test_scalarThenImpOptArray02() { runner_imp.runOneTest("scalarThenImpOptArray02") }
-  @Test def test_scalarThenImpOptArray03() { runner_imp.runOneTest("scalarThenImpOptArray03") }
+  @Test def test_scalarThenImpOptArray01(): Unit = { runner_imp.runOneTest("scalarThenImpOptArray01") }
+  @Test def test_scalarThenImpOptArray02(): Unit = { runner_imp.runOneTest("scalarThenImpOptArray02") }
+  @Test def test_scalarThenImpOptArray03(): Unit = { runner_imp.runOneTest("scalarThenImpOptArray03") }
 
-  @Test def test_parsedOptPresent() { runner_parsed.runOneTest("parsedOptPresent") }
-  @Test def test_parsedOptPresentArray() { runner_parsed.runOneTest("parsedOptPresentArray") }
-  @Test def test_parsedOptAbsentArray() { runner_parsed.runOneTest("parsedOptAbsentArray") }
-  @Test def test_parsedOptTwoArrays() { runner_parsed.runOneTest("parsedOptTwoArrays") }
+  @Test def test_parsedOptPresent(): Unit = { runner_parsed.runOneTest("parsedOptPresent") }
+  @Test def test_parsedOptPresentArray(): Unit = { runner_parsed.runOneTest("parsedOptPresentArray") }
+  @Test def test_parsedOptAbsentArray(): Unit = { runner_parsed.runOneTest("parsedOptAbsentArray") }
+  @Test def test_parsedOptTwoArrays(): Unit = { runner_parsed.runOneTest("parsedOptTwoArrays") }
 
-  @Test def test_parsedOptScalarThenArray() { runner_parsed.runOneTest("parsedOptScalarThenArray") }
-  @Test def test_parsedOptScalarThenArray02() { runner_parsed.runOneTest("parsedOptScalarThenArray02") }
-  @Test def test_parsedOptArrayThenScalar() { runner_parsed.runOneTest("parsedOptArrayThenScalar") }
-  @Test def test_parsedOptArrayThenScalar02() { runner_parsed.runOneTest("parsedOptArrayThenScalar02") }
-  @Test def test_parsedOptArrayThenScalar03() { runner_parsed.runOneTest("parsedOptArrayThenScalar03") }
+  @Test def test_parsedOptScalarThenArray(): Unit = { runner_parsed.runOneTest("parsedOptScalarThenArray") }
+  @Test def test_parsedOptScalarThenArray02(): Unit = { runner_parsed.runOneTest("parsedOptScalarThenArray02") }
+  @Test def test_parsedOptArrayThenScalar(): Unit = { runner_parsed.runOneTest("parsedOptArrayThenScalar") }
+  @Test def test_parsedOptArrayThenScalar02(): Unit = { runner_parsed.runOneTest("parsedOptArrayThenScalar02") }
+  @Test def test_parsedOptArrayThenScalar03(): Unit = { runner_parsed.runOneTest("parsedOptArrayThenScalar03") }
 
-  @Test def test_delimOptPresent() { runner_delim.runOneTest("delimOptPresent") }
-  @Test def test_delimOptPresentArray() { runner_delim.runOneTest("delimOptPresentArray") }
-  @Test def test_delimOptPresentArrayMax2() { runner_delim.runOneTest("delimOptPresentArrayMax2") }
-  @Test def test_delimOptAbsentArray() { runner_delim.runOneTest("delimOptAbsentArray") }
-  @Test def test_delimOptTwoArrays() { runner_delim.runOneTest("delimOptTwoArrays") }
+  @Test def test_delimOptPresent(): Unit = { runner_delim.runOneTest("delimOptPresent") }
+  @Test def test_delimOptPresentArray(): Unit = { runner_delim.runOneTest("delimOptPresentArray") }
+  @Test def test_delimOptPresentArrayMax2(): Unit = { runner_delim.runOneTest("delimOptPresentArrayMax2") }
+  @Test def test_delimOptAbsentArray(): Unit = { runner_delim.runOneTest("delimOptAbsentArray") }
+  @Test def test_delimOptTwoArrays(): Unit = { runner_delim.runOneTest("delimOptTwoArrays") }
 
-  @Test def test_delimOptScalarThenArray() { runner_delim.runOneTest("delimOptScalarThenArray") }
-  @Test def test_delimOptScalarThenArray02() { runner_delim.runOneTest("delimOptScalarThenArray02") }
-  @Test def test_delimOptScalarThenArray03() { runner_delim.runOneTest("delimOptScalarThenArray03") }
-  @Test def test_delimOptArrayThenScalar() { runner_delim.runOneTest("delimOptArrayThenScalar") }
-  @Test def test_delimOptArrayThenScalar02() { runner_delim.runOneTest("delimOptArrayThenScalar02") }
-  @Test def test_delimOptArrayThenScalar03() { runner_delim.runOneTest("delimOptArrayThenScalar03") }
+  @Test def test_delimOptScalarThenArray(): Unit = { runner_delim.runOneTest("delimOptScalarThenArray") }
+  @Test def test_delimOptScalarThenArray02(): Unit = { runner_delim.runOneTest("delimOptScalarThenArray02") }
+  @Test def test_delimOptScalarThenArray03(): Unit = { runner_delim.runOneTest("delimOptScalarThenArray03") }
+  @Test def test_delimOptArrayThenScalar(): Unit = { runner_delim.runOneTest("delimOptArrayThenScalar") }
+  @Test def test_delimOptArrayThenScalar02(): Unit = { runner_delim.runOneTest("delimOptArrayThenScalar02") }
+  @Test def test_delimOptArrayThenScalar03(): Unit = { runner_delim.runOneTest("delimOptArrayThenScalar03") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -29,7 +29,7 @@ object TestInputValueCalc {
   val runnerAQ = Runner(testDir, "AQ.tdml")
   val runnerAA = Runner(testDir, "AA.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runnerAR.reset
     runnerAQ.reset
@@ -42,45 +42,45 @@ class TestInputValueCalc {
 
   import TestInputValueCalc._
 
-  @Test def test_AR000() { runnerAR.runOneTest("AR000") }
+  @Test def test_AR000(): Unit = { runnerAR.runOneTest("AR000") }
 
-  @Test def test_AQ000() { runnerAQ.runOneTest("AQ000") }
+  @Test def test_AQ000(): Unit = { runnerAQ.runOneTest("AQ000") }
 
-  @Test def test_AA000() { runnerAA.runOneTest("AA000") }
-  @Test def test_inputValueCalcErrorDiagnostic1() { runnerAA.runOneTest("inputValueCalcErrorDiagnostic1") }
-  @Test def test_inputValueCalcErrorDiagnostic2() { runnerAA.runOneTest("inputValueCalcErrorDiagnostic2") }
-  @Test def test_inputValueCalcAbsolutePath() { runnerAA.runOneTest("inputValueCalcAbsolutePath") }
+  @Test def test_AA000(): Unit = { runnerAA.runOneTest("AA000") }
+  @Test def test_inputValueCalcErrorDiagnostic1(): Unit = { runnerAA.runOneTest("inputValueCalcErrorDiagnostic1") }
+  @Test def test_inputValueCalcErrorDiagnostic2(): Unit = { runnerAA.runOneTest("inputValueCalcErrorDiagnostic2") }
+  @Test def test_inputValueCalcAbsolutePath(): Unit = { runnerAA.runOneTest("inputValueCalcAbsolutePath") }
 
-  @Test def test_InputValueCalc_01() { runner.runOneTest("InputValueCalc_01") }
-  @Test def test_InputValueCalc_02() { runner.runOneTest("InputValueCalc_02") }
-  @Test def test_InputValueCalc_03() { runner.runOneTest("InputValueCalc_03") }
-  @Test def test_InputValueCalc_04() { runner.runOneTest("InputValueCalc_04") }
-  @Test def test_InputValueCalc_05() { runner.runOneTest("InputValueCalc_05") }
-  @Test def test_InputValueCalc_06() { runner.runOneTest("InputValueCalc_06") }
-  @Test def test_InputValueCalc_08() { runner.runOneTest("InputValueCalc_08") }
-  @Test def test_InputValueCalc_09() { runner.runOneTest("InputValueCalc_09") }
-  @Test def test_InputValueCalc_10() { runner.runOneTest("InputValueCalc_10") }
-  @Test def test_InputValueCalc_11() { runner.runOneTest("InputValueCalc_11") }
+  @Test def test_InputValueCalc_01(): Unit = { runner.runOneTest("InputValueCalc_01") }
+  @Test def test_InputValueCalc_02(): Unit = { runner.runOneTest("InputValueCalc_02") }
+  @Test def test_InputValueCalc_03(): Unit = { runner.runOneTest("InputValueCalc_03") }
+  @Test def test_InputValueCalc_04(): Unit = { runner.runOneTest("InputValueCalc_04") }
+  @Test def test_InputValueCalc_05(): Unit = { runner.runOneTest("InputValueCalc_05") }
+  @Test def test_InputValueCalc_06(): Unit = { runner.runOneTest("InputValueCalc_06") }
+  @Test def test_InputValueCalc_08(): Unit = { runner.runOneTest("InputValueCalc_08") }
+  @Test def test_InputValueCalc_09(): Unit = { runner.runOneTest("InputValueCalc_09") }
+  @Test def test_InputValueCalc_10(): Unit = { runner.runOneTest("InputValueCalc_10") }
+  @Test def test_InputValueCalc_11(): Unit = { runner.runOneTest("InputValueCalc_11") }
 
-  @Test def test_InputValueCalc_Int_Range_Min_Pass() { runner.runOneTest("InputValueCalc_Int_Range_Min_Pass") }
-  @Test def test_InputValueCalc_Int_Range_Max_Pass() { runner.runOneTest("InputValueCalc_Int_Range_Max_Pass") }
+  @Test def test_InputValueCalc_Int_Range_Min_Pass(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Min_Pass") }
+  @Test def test_InputValueCalc_Int_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_Short_Range_Min_Pass() { runner.runOneTest("InputValueCalc_Short_Range_Min_Pass") }
-  @Test def test_InputValueCalc_Short_Range_Max_Pass() { runner.runOneTest("InputValueCalc_Short_Range_Max_Pass") }
+  @Test def test_InputValueCalc_Short_Range_Min_Pass(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Min_Pass") }
+  @Test def test_InputValueCalc_Short_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Pass() { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Pass") }
+  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Pass() { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Pass") }
+  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_Long_Range_Min_Pass() { runner.runOneTest("InputValueCalc_Long_Range_Min_Pass") }
-  @Test def test_InputValueCalc_Long_Range_Max_Pass() { runner.runOneTest("InputValueCalc_Long_Range_Max_Pass") }
+  @Test def test_InputValueCalc_Long_Range_Min_Pass(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Min_Pass") }
+  @Test def test_InputValueCalc_Long_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_Byte_Range_Min_Pass() { runner.runOneTest("InputValueCalc_Byte_Range_Min_Pass") }
-  @Test def test_InputValueCalc_Byte_Range_Max_Pass() { runner.runOneTest("InputValueCalc_Byte_Range_Max_Pass") }
+  @Test def test_InputValueCalc_Byte_Range_Min_Pass(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Min_Pass") }
+  @Test def test_InputValueCalc_Byte_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Pass() { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Pass") }
+  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Pass") }
 
-  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Pass() { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Pass") }
+  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Pass(): Unit = { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Pass") }
 
   // NOTE: These tests were modified to test both the CompileTime and RunTime side of expressions
   // when dealing with InputValueCalc.  Essentially, constant expressions are evaluated at compile time.
@@ -88,49 +88,49 @@ class TestInputValueCalc {
   // Constant: inputValueCalc="{ 3 }"
   // Run Time: inputValueCalc="{ ../ex:num }"
   //
-  @Test def test_InputValueCalc_Short_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Short_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Short_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_Short_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_Short_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Short_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Short_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_Short_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedInt_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedInt_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedShort_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedShort_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_Long_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Long_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Long_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_Long_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_Long_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Long_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Long_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_Long_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedLong_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedLong_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_Byte_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Byte_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Byte_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_Byte_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_Byte_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Byte_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Byte_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_Byte_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedByte_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedByte_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_Int_Range_Min_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Int_Range_Min_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Int_Range_Min_Fail_RunTime() { runner.runOneTest("InputValueCalc_Int_Range_Min_Fail_RunTime") }
-  @Test def test_InputValueCalc_Int_Range_Max_Fail_CompileTime() { runner.runOneTest("InputValueCalc_Int_Range_Max_Fail_CompileTime") }
-  @Test def test_InputValueCalc_Int_Range_Max_Fail_RunTime() { runner.runOneTest("InputValueCalc_Int_Range_Max_Fail_RunTime") }
-  @Test def test_InputValueCalc_nonmatching_types() { runner.runOneTest("InputValueCalc_nonmatching_types") }
-  @Test def test_InputValueCalc_no_representation() { runner.runOneTest("InputValueCalc_no_representation") }
-  @Test def test_InputValueCalc_in_format() { runner.runOneTest("InputValueCalc_in_format") }
-  @Test def test_InputValueCalc_with_outputValueCalc() { runner.runOneTest("InputValueCalc_with_outputValueCalc") }
+  @Test def test_InputValueCalc_Short_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Short_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_Short_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Short_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Short_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedInt_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedInt_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedInt_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedInt_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedShort_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedShort_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedShort_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedShort_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_Long_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Long_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_Long_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Long_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Long_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedLong_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedLong_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedLong_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_Byte_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Byte_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_Byte_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Byte_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Byte_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedByte_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedByte_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_UnsignedByte_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_UnsignedByte_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_Int_Range_Min_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Min_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Int_Range_Min_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Min_Fail_RunTime") }
+  @Test def test_InputValueCalc_Int_Range_Max_Fail_CompileTime(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Max_Fail_CompileTime") }
+  @Test def test_InputValueCalc_Int_Range_Max_Fail_RunTime(): Unit = { runner.runOneTest("InputValueCalc_Int_Range_Max_Fail_RunTime") }
+  @Test def test_InputValueCalc_nonmatching_types(): Unit = { runner.runOneTest("InputValueCalc_nonmatching_types") }
+  @Test def test_InputValueCalc_no_representation(): Unit = { runner.runOneTest("InputValueCalc_no_representation") }
+  @Test def test_InputValueCalc_in_format(): Unit = { runner.runOneTest("InputValueCalc_in_format") }
+  @Test def test_InputValueCalc_with_outputValueCalc(): Unit = { runner.runOneTest("InputValueCalc_with_outputValueCalc") }
 
   //DFDL-1025
   //@Test def test_InputValueCalc_refers_self() { runner.runOneTest("InputValueCalc_refers_self") }
   //@Test def test_InputValueCalc_circular_ref() { runner.runOneTest("InputValueCalc_circular_ref") }
   
   //DFDL-1024
-  @Test def test_InputValueCalc_optional_elem() { runner.runOneTest("InputValueCalc_optional_elem") }
-  @Test def test_InputValueCalc_array_elem() { runner.runOneTest("InputValueCalc_array_elem") }
+  @Test def test_InputValueCalc_optional_elem(): Unit = { runner.runOneTest("InputValueCalc_optional_elem") }
+  @Test def test_InputValueCalc_array_elem(): Unit = { runner.runOneTest("InputValueCalc_array_elem") }
   //@Test def test_InputValueCalc_global_elem() { runner.runOneTest("InputValueCalc_global_elem") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -28,7 +28,7 @@ object TestOutputValueCalc {
   val runner2 = Runner(testDir, "outputValueCalc2.tdml")
   val runner3 = Runner(testDir, "outputValueCalc3.tdml")
 
-  @AfterClass def shutdown {
+  @AfterClass def shutdown: Unit = {
     runner.reset
     runner2.reset
     runner3.reset
@@ -38,56 +38,56 @@ object TestOutputValueCalc {
 class TestOutputValueCalc {
   import TestOutputValueCalc._
 
-  @Test def test_OutputValueCalc_01() { runner.runOneTest("OutputValueCalc_01") }
-  @Test def test_OutputValueCalc_02() { runner.runOneTest("OutputValueCalc_02") }
-  @Test def test_OutputValueCalc_03() { runner.runOneTest("OutputValueCalc_03") }
-  @Test def test_OutputValueCalc_04() { runner.runOneTest("OutputValueCalc_04") }
-  @Test def test_OutputValueCalc_05() { runner.runOneTest("OutputValueCalc_05") }
-  @Test def test_OutputValueCalc_06() { runner.runOneTest("OutputValueCalc_06") }
-  @Test def test_OutputValueCalc_07() { runner.runOneTest("OutputValueCalc_07") }
-  @Test def test_OutputValueCalc_08() { runner.runOneTest("OutputValueCalc_08") }
+  @Test def test_OutputValueCalc_01(): Unit = { runner.runOneTest("OutputValueCalc_01") }
+  @Test def test_OutputValueCalc_02(): Unit = { runner.runOneTest("OutputValueCalc_02") }
+  @Test def test_OutputValueCalc_03(): Unit = { runner.runOneTest("OutputValueCalc_03") }
+  @Test def test_OutputValueCalc_04(): Unit = { runner.runOneTest("OutputValueCalc_04") }
+  @Test def test_OutputValueCalc_05(): Unit = { runner.runOneTest("OutputValueCalc_05") }
+  @Test def test_OutputValueCalc_06(): Unit = { runner.runOneTest("OutputValueCalc_06") }
+  @Test def test_OutputValueCalc_07(): Unit = { runner.runOneTest("OutputValueCalc_07") }
+  @Test def test_OutputValueCalc_08(): Unit = { runner.runOneTest("OutputValueCalc_08") }
 
-  @Test def test_binaryInteger_BigEndian() { runner.runOneTest("binaryIntegerBigEndian") }
-  @Test def test_binaryInteger_LittleEndian() { runner.runOneTest("binaryIntegerLittleEndian") }
+  @Test def test_binaryInteger_BigEndian(): Unit = { runner.runOneTest("binaryIntegerBigEndian") }
+  @Test def test_binaryInteger_LittleEndian(): Unit = { runner.runOneTest("binaryIntegerLittleEndian") }
 
-  @Test def test_ovcHiddenCalculations1() { runner2.runOneTest("ovcHiddenCalculations1") }
-  @Test def test_ovcHiddenCalculations2() { runner2.runOneTest("ovcHiddenCalculations2") }
-  @Test def test_ovcHiddenCalculations3() { runner2.runOneTest("ovcHiddenCalculations3") }
-  @Test def test_hiddenGroupOvcError() { runner2.runOneTest("hiddenGroupOvcError") }
-  @Test def test_hiddenGroupArrayWithOvc() { runner2.runOneTest("hiddenGroupArrayWithOvc") }
-  @Test def test_optionalWithOvc() { runner2.runOneTest("optionalWithOvc") }
+  @Test def test_ovcHiddenCalculations1(): Unit = { runner2.runOneTest("ovcHiddenCalculations1") }
+  @Test def test_ovcHiddenCalculations2(): Unit = { runner2.runOneTest("ovcHiddenCalculations2") }
+  @Test def test_ovcHiddenCalculations3(): Unit = { runner2.runOneTest("ovcHiddenCalculations3") }
+  @Test def test_hiddenGroupOvcError(): Unit = { runner2.runOneTest("hiddenGroupOvcError") }
+  @Test def test_hiddenGroupArrayWithOvc(): Unit = { runner2.runOneTest("hiddenGroupArrayWithOvc") }
+  @Test def test_optionalWithOvc(): Unit = { runner2.runOneTest("optionalWithOvc") }
 
-  @Test def test_ovcAllowMissingOVCElem() { runner2.runOneTest("ovcAllowMissingOVCElem") }
-  @Test def test_ovcIgnoreOVCElem() { runner2.runOneTest("ovcIgnoreOVCElem") }
+  @Test def test_ovcAllowMissingOVCElem(): Unit = { runner2.runOneTest("ovcAllowMissingOVCElem") }
+  @Test def test_ovcIgnoreOVCElem(): Unit = { runner2.runOneTest("ovcIgnoreOVCElem") }
 
-  @Test def test_ovc_w_runtime_initiator() { runner2.runOneTest("ovc_w_runtime_initiator") }
-  @Test def test_ovc_w_runtime_dec_sep() { runner2.runOneTest("ovc_w_runtime_dec_sep") }
-  @Test def test_ovc_w_runtime_group_sep() { runner2.runOneTest("ovc_w_runtime_group_sep") }
-  @Test def test_ovc_w_runtime_exp_rep() { runner2.runOneTest("ovc_w_runtime_exp_rep") }
-  @Test def test_ovc_w_runtime_cal_lang() { runner2.runOneTest("ovc_w_runtime_cal_lang") }
-  @Test def test_ovc_w_runtime_escape_char() { runner2.runOneTest("ovc_w_runtime_escape_char") }
-  @Test def test_ovc_w_runtime_escape_escape_char() { runner2.runOneTest("ovc_w_runtime_escape_escape_char") }
+  @Test def test_ovc_w_runtime_initiator(): Unit = { runner2.runOneTest("ovc_w_runtime_initiator") }
+  @Test def test_ovc_w_runtime_dec_sep(): Unit = { runner2.runOneTest("ovc_w_runtime_dec_sep") }
+  @Test def test_ovc_w_runtime_group_sep(): Unit = { runner2.runOneTest("ovc_w_runtime_group_sep") }
+  @Test def test_ovc_w_runtime_exp_rep(): Unit = { runner2.runOneTest("ovc_w_runtime_exp_rep") }
+  @Test def test_ovc_w_runtime_cal_lang(): Unit = { runner2.runOneTest("ovc_w_runtime_cal_lang") }
+  @Test def test_ovc_w_runtime_escape_char(): Unit = { runner2.runOneTest("ovc_w_runtime_escape_char") }
+  @Test def test_ovc_w_runtime_escape_escape_char(): Unit = { runner2.runOneTest("ovc_w_runtime_escape_escape_char") }
 
-  @Test def test_OutputValueCalc_09() { runner.runOneTest("OutputValueCalc_09") }
-  @Test def test_OutputValueCalc_10() { runner.runOneTest("OutputValueCalc_10") }
+  @Test def test_OutputValueCalc_09(): Unit = { runner.runOneTest("OutputValueCalc_09") }
+  @Test def test_OutputValueCalc_10(): Unit = { runner.runOneTest("OutputValueCalc_10") }
 
-  @Test def test_errorZeroArg() { runner.runOneTest("errorZeroArg") }
-  @Test def test_errorOneArg() { runner.runOneTest("errorOneArg") }
-  @Test def test_errorTwoArg() { runner.runOneTest("errorTwoArg") }
-  @Test def test_errorThreeArg() { runner.runOneTest("errorThreeArg") }
+  @Test def test_errorZeroArg(): Unit = { runner.runOneTest("errorZeroArg") }
+  @Test def test_errorOneArg(): Unit = { runner.runOneTest("errorOneArg") }
+  @Test def test_errorTwoArg(): Unit = { runner.runOneTest("errorTwoArg") }
+  @Test def test_errorThreeArg(): Unit = { runner.runOneTest("errorThreeArg") }
 
   // DAFFODIL-2069
-  @Test def test_ovcHexBinaryLSBF1() { runner3.runOneTest("rHexBinaryLSBF1") }
-  @Test def test_ovcHexBinaryLSBF2() { runner3.runOneTest("rHexBinaryLSBF2") }
-  @Test def test_ovcStringLSBF1() { runner3.runOneTest("rStringLSBF1") }
+  @Test def test_ovcHexBinaryLSBF1(): Unit = { runner3.runOneTest("rHexBinaryLSBF1") }
+  @Test def test_ovcHexBinaryLSBF2(): Unit = { runner3.runOneTest("rHexBinaryLSBF2") }
+  @Test def test_ovcStringLSBF1(): Unit = { runner3.runOneTest("rStringLSBF1") }
 
-  @Test def test_ovcBitOrderChange() { runner3.runOneTest("ovc_bitOrderChange") }
+  @Test def test_ovcBitOrderChange(): Unit = { runner3.runOneTest("ovc_bitOrderChange") }
 
   // DAFFODIL-1701
-  @Test def test_refSimpleTypeElemWithOvc() { runner.runOneTest("refSimpleTypeElemWithOvc") }
-  @Test def test_refComplexTypeElemNoOvc() { runner.runOneTest("refComplexTypeElemNoOvc") }
-  @Test def test_refComplexTypeElemWithOvc() { runner.runOneTest("refComplexTypeElemWithOvc") }
+  @Test def test_refSimpleTypeElemWithOvc(): Unit = { runner.runOneTest("refSimpleTypeElemWithOvc") }
+  @Test def test_refComplexTypeElemNoOvc(): Unit = { runner.runOneTest("refComplexTypeElemNoOvc") }
+  @Test def test_refComplexTypeElemWithOvc(): Unit = { runner.runOneTest("refComplexTypeElemWithOvc") }
 
   // DAFFODIL-2167
-  @Test def test_arrayWithFollowingOVC() { runner.runOneTest("arrayWithFollowingOVC") }
+  @Test def test_arrayWithFollowingOVC(): Unit = { runner.runOneTest("arrayWithFollowingOVC") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -46,7 +46,7 @@ object TestDFDLExpressions {
 
   val runner7 = Runner(testDir, "expressions2.tdml", compileAllTopLevel = true)
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerNV.reset
     runner2.reset
@@ -64,188 +64,188 @@ object TestDFDLExpressions {
 class TestDFDLExpressions {
   import TestDFDLExpressions._
 
-  @Test def test_variableRefError { runner4.runOneTest("variableRefError") }
+  @Test def test_variableRefError: Unit = { runner4.runOneTest("variableRefError") }
 
-  @Test def test_byteOrderExpr1 { runner4.runOneTest("byteOrderExpr1") }
-  @Test def test_byteOrderExpr1b { runner4.runOneTest("byteOrderExpr1b") }
-  @Test def test_byteOrderExpr2 { runner4.runOneTest("byteOrderExpr2") }
-  @Test def test_byteOrderExpr2b { runner4.runOneTest("byteOrderExpr2b") }
-  @Test def test_byteOrderExpr3 { runner4.runOneTest("byteOrderExpr3") }
-  @Test def test_byteOrderExpr4 { runner4.runOneTest("byteOrderExpr4") }
-  @Test def test_byteOrderExpr5 { runner4.runOneTest("byteOrderExpr5") }
-  @Test def test_byteOrderExpr6 { runner4.runOneTest("byteOrderExpr6") }
-  @Test def test_byteOrderExpr7 { runner4.runOneTest("byteOrderExpr7") }
-  @Test def test_byteOrderExpr7b { runner4.runOneTest("byteOrderExpr7b") }
-  @Test def test_byteOrderExpr7c { runner4.runOneTest("byteOrderExpr7c") }
-  @Test def test_byteOrderExpr8 { runner4.runOneTest("byteOrderExpr8") }
-  @Test def test_byteOrderExpr9 { runner4.runOneTest("byteOrderExpr9") }
+  @Test def test_byteOrderExpr1: Unit = { runner4.runOneTest("byteOrderExpr1") }
+  @Test def test_byteOrderExpr1b: Unit = { runner4.runOneTest("byteOrderExpr1b") }
+  @Test def test_byteOrderExpr2: Unit = { runner4.runOneTest("byteOrderExpr2") }
+  @Test def test_byteOrderExpr2b: Unit = { runner4.runOneTest("byteOrderExpr2b") }
+  @Test def test_byteOrderExpr3: Unit = { runner4.runOneTest("byteOrderExpr3") }
+  @Test def test_byteOrderExpr4: Unit = { runner4.runOneTest("byteOrderExpr4") }
+  @Test def test_byteOrderExpr5: Unit = { runner4.runOneTest("byteOrderExpr5") }
+  @Test def test_byteOrderExpr6: Unit = { runner4.runOneTest("byteOrderExpr6") }
+  @Test def test_byteOrderExpr7: Unit = { runner4.runOneTest("byteOrderExpr7") }
+  @Test def test_byteOrderExpr7b: Unit = { runner4.runOneTest("byteOrderExpr7b") }
+  @Test def test_byteOrderExpr7c: Unit = { runner4.runOneTest("byteOrderExpr7c") }
+  @Test def test_byteOrderExpr8: Unit = { runner4.runOneTest("byteOrderExpr8") }
+  @Test def test_byteOrderExpr9: Unit = { runner4.runOneTest("byteOrderExpr9") }
 
   //DFDL-1111
   //@Test def test_diagnostics_01() { runner.runOneTest("diagnostics_01") }
   //@Test def test_diagnostics_02() { runner.runOneTest("diagnostics_02") }
   //@Test def test_diagnostics_03() { runner.runOneTest("diagnostics_03") }
 
-  @Test def test_sequenceReturned_01() { runner.runOneTest("sequenceReturned_01") }
-  @Test def test_sequenceReturned_02() { runner.runOneTest("sequenceReturned_02") }
-  @Test def test_sequenceReturned_03() { runner.runOneTest("sequenceReturned_03") }
-  @Test def test_longPath_01() { runner.runOneTest("longPath_01") }
-  @Test def test_longPath_02() { runner.runOneTest("longPath_02") }
+  @Test def test_sequenceReturned_01(): Unit = { runner.runOneTest("sequenceReturned_01") }
+  @Test def test_sequenceReturned_02(): Unit = { runner.runOneTest("sequenceReturned_02") }
+  @Test def test_sequenceReturned_03(): Unit = { runner.runOneTest("sequenceReturned_03") }
+  @Test def test_longPath_01(): Unit = { runner.runOneTest("longPath_01") }
+  @Test def test_longPath_02(): Unit = { runner.runOneTest("longPath_02") }
 
-  @Test def test_hiddenDataExpression() { runner.runOneTest("hiddenDataExpression") }
-  @Test def test_hiddenDataExpression2() { runner.runOneTest("hiddenDataExpression2") }
+  @Test def test_hiddenDataExpression(): Unit = { runner.runOneTest("hiddenDataExpression") }
+  @Test def test_hiddenDataExpression2(): Unit = { runner.runOneTest("hiddenDataExpression2") }
 
-  @Test def test_arrayIndexOutOfBounds_01() { runner.runOneTest("arrayIndexOutOfBounds_01") }
-  @Test def test_arrayIndexOutOfBounds_02() { runner.runOneTest("arrayIndexOutOfBounds_02") }
-  @Test def test_arrayIndexOutOfBounds_03() { runner.runOneTest("arrayIndexOutOfBounds_03") }
+  @Test def test_arrayIndexOutOfBounds_01(): Unit = { runner.runOneTest("arrayIndexOutOfBounds_01") }
+  @Test def test_arrayIndexOutOfBounds_02(): Unit = { runner.runOneTest("arrayIndexOutOfBounds_02") }
+  @Test def test_arrayIndexOutOfBounds_03(): Unit = { runner.runOneTest("arrayIndexOutOfBounds_03") }
 
   // DFDL-1865
   //@Test def test_arrayIndexOutOfBounds_04() { runner.runOneTest("arrayIndexOutOfBounds_04") }
-  @Test def test_arrayIndexOutOfBounds_05() { runner.runOneTest("arrayIndexOutOfBounds_05") }
+  @Test def test_arrayIndexOutOfBounds_05(): Unit = { runner.runOneTest("arrayIndexOutOfBounds_05") }
 
-  @Test def test_asterisk_01() { runner.runOneTest("asterisk_01") }
-  @Test def test_asterisk_02() { runner.runOneTest("asterisk_02") }
-  @Test def test_asterisk_03() { runner.runOneTest("asterisk_03") }
+  @Test def test_asterisk_01(): Unit = { runner.runOneTest("asterisk_01") }
+  @Test def test_asterisk_02(): Unit = { runner.runOneTest("asterisk_02") }
+  @Test def test_asterisk_03(): Unit = { runner.runOneTest("asterisk_03") }
 
   //DFDL-1146
   //@Test def test_attribute_axis_01() { runner.runOneTest("attribute_axis_01") }
   //@Test def test_attribute_axis_02() { runner.runOneTest("attribute_axis_02") }
   //@Test def test_attribute_axis_03() { runner.runOneTest("attribute_axis_03") }
 
-  @Test def test_comparison_operators_01() { runner.runOneTest("comparison_operators_01") }
-  @Test def test_comparison_operators_02() { runner.runOneTest("comparison_operators_02") }
-  @Test def test_comparison_operators_03() { runner.runOneTest("comparison_operators_03") }
-  @Test def test_comparison_operators_04() { runner.runOneTest("comparison_operators_04") }
-  @Test def test_comparison_operators_05() { runner.runOneTest("comparison_operators_05") }
-  @Test def test_comparison_operators_06() { runner.runOneTest("comparison_operators_06") }
-  @Test def test_comparison_operators_07() { runner.runOneTest("comparison_operators_07") }
-  @Test def test_comparison_operators_08() { runner.runOneTest("comparison_operators_08") }
-  @Test def test_comparison_operators_09() { runner.runOneTest("comparison_operators_09") }
-  @Test def test_comparison_operators_10() { runner.runOneTest("comparison_operators_10") }
-  @Test def test_comparison_operators_11() { runner.runOneTest("comparison_operators_11") }
-  @Test def test_comparison_operators_12() { runner.runOneTest("comparison_operators_12") }
-  @Test def test_comparison_operators_13() { runner.runOneTest("comparison_operators_13") }
-  @Test def test_comparison_operators_14() { runner.runOneTest("comparison_operators_14") }
-  @Test def test_comparison_operators_15() { runner.runOneTest("comparison_operators_15") }
-  @Test def test_comparison_operators_16() { runner.runOneTest("comparison_operators_16") }
-  @Test def test_comparison_operators_17() { runner.runOneTest("comparison_operators_17") }
-  @Test def test_comparison_operators_18() { runner.runOneTest("comparison_operators_18") }
-  @Test def test_comparison_operators_19() { runner.runOneTest("comparison_operators_19") }
-  @Test def test_comparison_operators_20() { runner.runOneTest("comparison_operators_20") }
-  @Test def test_comparison_operators_21() { runner.runOneTest("comparison_operators_21") }
-  @Test def test_comparison_operators_22() { runner.runOneTest("comparison_operators_22") }
-  @Test def test_comparison_operators_23() { runner.runOneTest("comparison_operators_23") }
-  @Test def test_comparison_operators_24() { runner.runOneTest("comparison_operators_24") }
-  @Test def test_comparison_operators_25() { runner.runOneTest("comparison_operators_25") }
-  @Test def test_comparison_operators_26() { runner.runOneTest("comparison_operators_26") }
-  @Test def test_comparison_operators_27() { runner.runOneTest("comparison_operators_27") }
-  @Test def test_comparison_operators_28() { runner.runOneTest("comparison_operators_28") }
+  @Test def test_comparison_operators_01(): Unit = { runner.runOneTest("comparison_operators_01") }
+  @Test def test_comparison_operators_02(): Unit = { runner.runOneTest("comparison_operators_02") }
+  @Test def test_comparison_operators_03(): Unit = { runner.runOneTest("comparison_operators_03") }
+  @Test def test_comparison_operators_04(): Unit = { runner.runOneTest("comparison_operators_04") }
+  @Test def test_comparison_operators_05(): Unit = { runner.runOneTest("comparison_operators_05") }
+  @Test def test_comparison_operators_06(): Unit = { runner.runOneTest("comparison_operators_06") }
+  @Test def test_comparison_operators_07(): Unit = { runner.runOneTest("comparison_operators_07") }
+  @Test def test_comparison_operators_08(): Unit = { runner.runOneTest("comparison_operators_08") }
+  @Test def test_comparison_operators_09(): Unit = { runner.runOneTest("comparison_operators_09") }
+  @Test def test_comparison_operators_10(): Unit = { runner.runOneTest("comparison_operators_10") }
+  @Test def test_comparison_operators_11(): Unit = { runner.runOneTest("comparison_operators_11") }
+  @Test def test_comparison_operators_12(): Unit = { runner.runOneTest("comparison_operators_12") }
+  @Test def test_comparison_operators_13(): Unit = { runner.runOneTest("comparison_operators_13") }
+  @Test def test_comparison_operators_14(): Unit = { runner.runOneTest("comparison_operators_14") }
+  @Test def test_comparison_operators_15(): Unit = { runner.runOneTest("comparison_operators_15") }
+  @Test def test_comparison_operators_16(): Unit = { runner.runOneTest("comparison_operators_16") }
+  @Test def test_comparison_operators_17(): Unit = { runner.runOneTest("comparison_operators_17") }
+  @Test def test_comparison_operators_18(): Unit = { runner.runOneTest("comparison_operators_18") }
+  @Test def test_comparison_operators_19(): Unit = { runner.runOneTest("comparison_operators_19") }
+  @Test def test_comparison_operators_20(): Unit = { runner.runOneTest("comparison_operators_20") }
+  @Test def test_comparison_operators_21(): Unit = { runner.runOneTest("comparison_operators_21") }
+  @Test def test_comparison_operators_22(): Unit = { runner.runOneTest("comparison_operators_22") }
+  @Test def test_comparison_operators_23(): Unit = { runner.runOneTest("comparison_operators_23") }
+  @Test def test_comparison_operators_24(): Unit = { runner.runOneTest("comparison_operators_24") }
+  @Test def test_comparison_operators_25(): Unit = { runner.runOneTest("comparison_operators_25") }
+  @Test def test_comparison_operators_26(): Unit = { runner.runOneTest("comparison_operators_26") }
+  @Test def test_comparison_operators_27(): Unit = { runner.runOneTest("comparison_operators_27") }
+  @Test def test_comparison_operators_28(): Unit = { runner.runOneTest("comparison_operators_28") }
 
-  @Test def test_comparison_operators_29() { runner.runOneTest("comparison_operators_29") }
-  @Test def test_comparison_operators_30() { runner.runOneTest("comparison_operators_30") }
-  @Test def test_comparison_operators_31() { runner.runOneTest("comparison_operators_31") }
-  @Test def test_comparison_operators_32() { runner.runOneTest("comparison_operators_32") }
-  @Test def test_comparison_operators_33() { runner.runOneTest("comparison_operators_33") }
-  @Test def test_comparison_operators_34() { runner.runOneTest("comparison_operators_34") }
-  @Test def test_comparison_operators_35() { runner.runOneTest("comparison_operators_35") }
-  @Test def test_comparison_operators_36() { runner.runOneTest("comparison_operators_36") }
-  @Test def test_comparison_operators_37() { runner.runOneTest("comparison_operators_37") }
-  @Test def test_comparison_operators_38() { runner.runOneTest("comparison_operators_38") }
-  @Test def test_comparison_operators_39() { runner.runOneTest("comparison_operators_39") }
-  @Test def test_comparison_operators_40() { runner.runOneTest("comparison_operators_40") }
-  @Test def test_comparison_operators_41() { runner.runOneTest("comparison_operators_41") }
-  @Test def test_comparison_operators_42() { runner.runOneTest("comparison_operators_42") }
-  @Test def test_comparison_operators_43() { runner.runOneTest("comparison_operators_43") }
-  @Test def test_comparison_operators_44() { runner.runOneTest("comparison_operators_44") }
-  @Test def test_comparison_operators_45() { runner.runOneTest("comparison_operators_45") }
-  @Test def test_comparison_operators_46() { runner.runOneTest("comparison_operators_46") }
-  @Test def test_comparison_operators_46a() { runner.runOneTest("comparison_operators_46a") }
+  @Test def test_comparison_operators_29(): Unit = { runner.runOneTest("comparison_operators_29") }
+  @Test def test_comparison_operators_30(): Unit = { runner.runOneTest("comparison_operators_30") }
+  @Test def test_comparison_operators_31(): Unit = { runner.runOneTest("comparison_operators_31") }
+  @Test def test_comparison_operators_32(): Unit = { runner.runOneTest("comparison_operators_32") }
+  @Test def test_comparison_operators_33(): Unit = { runner.runOneTest("comparison_operators_33") }
+  @Test def test_comparison_operators_34(): Unit = { runner.runOneTest("comparison_operators_34") }
+  @Test def test_comparison_operators_35(): Unit = { runner.runOneTest("comparison_operators_35") }
+  @Test def test_comparison_operators_36(): Unit = { runner.runOneTest("comparison_operators_36") }
+  @Test def test_comparison_operators_37(): Unit = { runner.runOneTest("comparison_operators_37") }
+  @Test def test_comparison_operators_38(): Unit = { runner.runOneTest("comparison_operators_38") }
+  @Test def test_comparison_operators_39(): Unit = { runner.runOneTest("comparison_operators_39") }
+  @Test def test_comparison_operators_40(): Unit = { runner.runOneTest("comparison_operators_40") }
+  @Test def test_comparison_operators_41(): Unit = { runner.runOneTest("comparison_operators_41") }
+  @Test def test_comparison_operators_42(): Unit = { runner.runOneTest("comparison_operators_42") }
+  @Test def test_comparison_operators_43(): Unit = { runner.runOneTest("comparison_operators_43") }
+  @Test def test_comparison_operators_44(): Unit = { runner.runOneTest("comparison_operators_44") }
+  @Test def test_comparison_operators_45(): Unit = { runner.runOneTest("comparison_operators_45") }
+  @Test def test_comparison_operators_46(): Unit = { runner.runOneTest("comparison_operators_46") }
+  @Test def test_comparison_operators_46a(): Unit = { runner.runOneTest("comparison_operators_46a") }
 
   // from XPath Spec Sec 10.4.6.1 Examples
-  @Test def test_comparison_operators_47() { runner.runOneTest("comparison_operators_47") }
-  @Test def test_comparison_operators_48() { runner.runOneTest("comparison_operators_48") }
-  @Test def test_comparison_operators_49() { runner.runOneTest("comparison_operators_49") }
-  @Test def test_comparison_operators_50() { runner.runOneTest("comparison_operators_50") }
-  @Test def test_comparison_operators_51() { runner.runOneTest("comparison_operators_51") }
-  @Test def test_comparison_operators_52() { runner.runOneTest("comparison_operators_52") }
-  @Test def test_comparison_operators_53() { runner.runOneTest("comparison_operators_53") }
+  @Test def test_comparison_operators_47(): Unit = { runner.runOneTest("comparison_operators_47") }
+  @Test def test_comparison_operators_48(): Unit = { runner.runOneTest("comparison_operators_48") }
+  @Test def test_comparison_operators_49(): Unit = { runner.runOneTest("comparison_operators_49") }
+  @Test def test_comparison_operators_50(): Unit = { runner.runOneTest("comparison_operators_50") }
+  @Test def test_comparison_operators_51(): Unit = { runner.runOneTest("comparison_operators_51") }
+  @Test def test_comparison_operators_52(): Unit = { runner.runOneTest("comparison_operators_52") }
+  @Test def test_comparison_operators_53(): Unit = { runner.runOneTest("comparison_operators_53") }
 
-  @Test def test_comparison_operators_54() { runner.runOneTest("comparison_operators_54") }
-  @Test def test_comparison_operators_55() { runner.runOneTest("comparison_operators_55") }
-  @Test def test_comparison_operators_56() { runner.runOneTest("comparison_operators_56") }
-  @Test def test_comparison_operators_57() { runner.runOneTest("comparison_operators_57") }
-  @Test def test_comparison_operators_58() { runner.runOneTest("comparison_operators_58") }
-  @Test def test_comparison_operators_59() { runner.runOneTest("comparison_operators_59") }
-  @Test def test_comparison_operators_60() { runner.runOneTest("comparison_operators_60") }
-  @Test def test_comparison_operators_61() { runner.runOneTest("comparison_operators_61") }
-  @Test def test_comparison_operators_62() { runner.runOneTest("comparison_operators_62") }
-  @Test def test_comparison_operators_63() { runner.runOneTest("comparison_operators_63") }
-  @Test def test_comparison_operators_64() { runner.runOneTest("comparison_operators_64") }
-  @Test def test_comparison_operators_65() { runner.runOneTest("comparison_operators_65") }
-  @Test def test_comparison_operators_66() { runner.runOneTest("comparison_operators_66") }
-  @Test def test_comparison_operators_67() { runner.runOneTest("comparison_operators_67") }
-  @Test def test_comparison_operators_68() { runner.runOneTest("comparison_operators_68") }
-  @Test def test_comparison_operators_69() { runner.runOneTest("comparison_operators_69") }
-  @Test def test_comparison_operators_70() { runner.runOneTest("comparison_operators_70") }
-  @Test def test_comparison_operators_71() { runner.runOneTest("comparison_operators_71") }
-  @Test def test_comparison_operators_72() { runner.runOneTest("comparison_operators_72") }
-  @Test def test_comparison_operators_73() { runner.runOneTest("comparison_operators_73") }
-  @Test def test_comparison_operators_74() { runner.runOneTest("comparison_operators_74") }
-  @Test def test_comparison_operators_75() { runner.runOneTest("comparison_operators_75") }
-  @Test def test_comparison_operators_76() { runner.runOneTest("comparison_operators_76") }
-  @Test def test_comparison_operators_77() { runner.runOneTest("comparison_operators_77") }
-  @Test def test_comparison_operators_78() { runner.runOneTest("comparison_operators_78") }
-  @Test def test_comparison_operators_79() { runner.runOneTest("comparison_operators_79") }
-  @Test def test_comparison_operators_80() { runner.runOneTest("comparison_operators_80") }
-  @Test def test_comparison_operators_81() { runner.runOneTest("comparison_operators_81") }
-  @Test def test_comparison_operators_82() { runner.runOneTest("comparison_operators_82") }
-  @Test def test_comparison_operators_83() { runner.runOneTest("comparison_operators_83") }
+  @Test def test_comparison_operators_54(): Unit = { runner.runOneTest("comparison_operators_54") }
+  @Test def test_comparison_operators_55(): Unit = { runner.runOneTest("comparison_operators_55") }
+  @Test def test_comparison_operators_56(): Unit = { runner.runOneTest("comparison_operators_56") }
+  @Test def test_comparison_operators_57(): Unit = { runner.runOneTest("comparison_operators_57") }
+  @Test def test_comparison_operators_58(): Unit = { runner.runOneTest("comparison_operators_58") }
+  @Test def test_comparison_operators_59(): Unit = { runner.runOneTest("comparison_operators_59") }
+  @Test def test_comparison_operators_60(): Unit = { runner.runOneTest("comparison_operators_60") }
+  @Test def test_comparison_operators_61(): Unit = { runner.runOneTest("comparison_operators_61") }
+  @Test def test_comparison_operators_62(): Unit = { runner.runOneTest("comparison_operators_62") }
+  @Test def test_comparison_operators_63(): Unit = { runner.runOneTest("comparison_operators_63") }
+  @Test def test_comparison_operators_64(): Unit = { runner.runOneTest("comparison_operators_64") }
+  @Test def test_comparison_operators_65(): Unit = { runner.runOneTest("comparison_operators_65") }
+  @Test def test_comparison_operators_66(): Unit = { runner.runOneTest("comparison_operators_66") }
+  @Test def test_comparison_operators_67(): Unit = { runner.runOneTest("comparison_operators_67") }
+  @Test def test_comparison_operators_68(): Unit = { runner.runOneTest("comparison_operators_68") }
+  @Test def test_comparison_operators_69(): Unit = { runner.runOneTest("comparison_operators_69") }
+  @Test def test_comparison_operators_70(): Unit = { runner.runOneTest("comparison_operators_70") }
+  @Test def test_comparison_operators_71(): Unit = { runner.runOneTest("comparison_operators_71") }
+  @Test def test_comparison_operators_72(): Unit = { runner.runOneTest("comparison_operators_72") }
+  @Test def test_comparison_operators_73(): Unit = { runner.runOneTest("comparison_operators_73") }
+  @Test def test_comparison_operators_74(): Unit = { runner.runOneTest("comparison_operators_74") }
+  @Test def test_comparison_operators_75(): Unit = { runner.runOneTest("comparison_operators_75") }
+  @Test def test_comparison_operators_76(): Unit = { runner.runOneTest("comparison_operators_76") }
+  @Test def test_comparison_operators_77(): Unit = { runner.runOneTest("comparison_operators_77") }
+  @Test def test_comparison_operators_78(): Unit = { runner.runOneTest("comparison_operators_78") }
+  @Test def test_comparison_operators_79(): Unit = { runner.runOneTest("comparison_operators_79") }
+  @Test def test_comparison_operators_80(): Unit = { runner.runOneTest("comparison_operators_80") }
+  @Test def test_comparison_operators_81(): Unit = { runner.runOneTest("comparison_operators_81") }
+  @Test def test_comparison_operators_82(): Unit = { runner.runOneTest("comparison_operators_82") }
+  @Test def test_comparison_operators_83(): Unit = { runner.runOneTest("comparison_operators_83") }
 
-  @Test def test_regexLookahead() { runnerNV.runOneTest("regexLookahead") }
-  @Test def test_regexLookaheadFail() { runnerNV.runOneTest("regexLookaheadFail") }
-  @Test def test_regexLookaheadFail2() { runnerNV.runOneTest("regexLookaheadFail2") }
-  @Test def test_regexCompatFail() { runner.runOneTest("regexCompatFail") }
+  @Test def test_regexLookahead(): Unit = { runnerNV.runOneTest("regexLookahead") }
+  @Test def test_regexLookaheadFail(): Unit = { runnerNV.runOneTest("regexLookaheadFail") }
+  @Test def test_regexLookaheadFail2(): Unit = { runnerNV.runOneTest("regexLookaheadFail2") }
+  @Test def test_regexCompatFail(): Unit = { runner.runOneTest("regexCompatFail") }
 
-  @Test def test_expressionRules01() { runner.runOneTest("expressionRules01") }
-  @Test def test_expressionRules02() { runner.runOneTest("expressionRules02") }
-  @Test def test_expressionRules03() { runner.runOneTest("expressionRules03") }
-  @Test def test_expressionRules04() { runner.runOneTest("expressionRules04") }
-  @Test def test_expressionRules05() { runner.runOneTest("expressionRules05") }
-  @Test def test_expressionRules06() { runner.runOneTest("expressionRules06") }
+  @Test def test_expressionRules01(): Unit = { runner.runOneTest("expressionRules01") }
+  @Test def test_expressionRules02(): Unit = { runner.runOneTest("expressionRules02") }
+  @Test def test_expressionRules03(): Unit = { runner.runOneTest("expressionRules03") }
+  @Test def test_expressionRules04(): Unit = { runner.runOneTest("expressionRules04") }
+  @Test def test_expressionRules05(): Unit = { runner.runOneTest("expressionRules05") }
+  @Test def test_expressionRules06(): Unit = { runner.runOneTest("expressionRules06") }
 
   // uses lengthUnits bytes with utf-8 and lengthKind Explicit
-  @Test def test_lke3_rel() { runner.runOneTest("lke3_rel") }
+  @Test def test_lke3_rel(): Unit = { runner.runOneTest("lke3_rel") }
 
-  @Test def test_lke1_rel() { runner.runOneTest("lke1_rel") }
-  @Test def test_lke1_abs() { runner.runOneTest("lke1_abs") }
-  @Test def test_ocke1() { runner.runOneTest("ocke1") }
-  @Test def test_ocke2() { runner.runOneTest("ocke2") }
-  @Test def test_ArrayOptElem_01() { runner.runOneTest("ArrayOptElem_01") }
-  @Test def test_lke2_rel() { runner.runOneTest("lke2_rel") }
-  @Test def test_expression_type_error1() { runner.runOneTest("expression_type_error1") }
-  @Test def test_expression_type_error2() { runner.runOneTest("expression_type_error2") }
-  @Test def test_expression_type_error3() { runner.runOneTest("expression_type_error3") }
-  @Test def test_expression_type_error4() { runner.runOneTest("expression_type_error4") }
-  @Test def test_expression_type_error5() { runner.runOneTest("expression_type_error5") }
-  @Test def test_expression_type_error6() { runner.runOneTest("expression_type_error6") }
-  @Test def test_expression_type_error7() { runner.runOneTest("expression_type_error7") }
-  @Test def test_expression_unknown_prefix() { runner.runOneTest("expression_unknown_prefix") }
-  @Test def test_ocke_rel() { runner.runOneTest("ocke_rel") }
-  @Test def test_ocke_rel2() { runner.runOneTest("ocke_rel2") }
-  @Test def test_ocke_rel3() { runner.runOneTest("ocke_rel3") }
-  @Test def test_ocke_rel4() { runner.runOneTest("ocke_rel4") }
-  @Test def test_internal_space_preserved() { runner.runOneTest("internal_space_preserved") }
-  @Test def test_internal_space_preserved2() { runner.runOneTest("internal_space_preserved2") }
-  @Test def test_internal_space_preserved3a() { runner.runOneTest("internal_space_preserved3a") }
-  @Test def test_internal_space_preserved3b() { runner.runOneTest("internal_space_preserved3b") }
-  @Test def test_internal_space_preserved4() { runner.runOneTest("internal_space_preserved4") }
-  @Test def test_internal_space_not_preserved1() { runner.runOneTest("internal_space_not_preserved1") }
-  @Test def test_internal_space_not_preserved2() { runner.runOneTest("internal_space_not_preserved2") }
+  @Test def test_lke1_rel(): Unit = { runner.runOneTest("lke1_rel") }
+  @Test def test_lke1_abs(): Unit = { runner.runOneTest("lke1_abs") }
+  @Test def test_ocke1(): Unit = { runner.runOneTest("ocke1") }
+  @Test def test_ocke2(): Unit = { runner.runOneTest("ocke2") }
+  @Test def test_ArrayOptElem_01(): Unit = { runner.runOneTest("ArrayOptElem_01") }
+  @Test def test_lke2_rel(): Unit = { runner.runOneTest("lke2_rel") }
+  @Test def test_expression_type_error1(): Unit = { runner.runOneTest("expression_type_error1") }
+  @Test def test_expression_type_error2(): Unit = { runner.runOneTest("expression_type_error2") }
+  @Test def test_expression_type_error3(): Unit = { runner.runOneTest("expression_type_error3") }
+  @Test def test_expression_type_error4(): Unit = { runner.runOneTest("expression_type_error4") }
+  @Test def test_expression_type_error5(): Unit = { runner.runOneTest("expression_type_error5") }
+  @Test def test_expression_type_error6(): Unit = { runner.runOneTest("expression_type_error6") }
+  @Test def test_expression_type_error7(): Unit = { runner.runOneTest("expression_type_error7") }
+  @Test def test_expression_unknown_prefix(): Unit = { runner.runOneTest("expression_unknown_prefix") }
+  @Test def test_ocke_rel(): Unit = { runner.runOneTest("ocke_rel") }
+  @Test def test_ocke_rel2(): Unit = { runner.runOneTest("ocke_rel2") }
+  @Test def test_ocke_rel3(): Unit = { runner.runOneTest("ocke_rel3") }
+  @Test def test_ocke_rel4(): Unit = { runner.runOneTest("ocke_rel4") }
+  @Test def test_internal_space_preserved(): Unit = { runner.runOneTest("internal_space_preserved") }
+  @Test def test_internal_space_preserved2(): Unit = { runner.runOneTest("internal_space_preserved2") }
+  @Test def test_internal_space_preserved3a(): Unit = { runner.runOneTest("internal_space_preserved3a") }
+  @Test def test_internal_space_preserved3b(): Unit = { runner.runOneTest("internal_space_preserved3b") }
+  @Test def test_internal_space_preserved4(): Unit = { runner.runOneTest("internal_space_preserved4") }
+  @Test def test_internal_space_not_preserved1(): Unit = { runner.runOneTest("internal_space_not_preserved1") }
+  @Test def test_internal_space_not_preserved2(): Unit = { runner.runOneTest("internal_space_not_preserved2") }
 
-  @Test def test_whitespace_expression() { runner.runOneTest("whitespace_expression") }
-  @Test def test_whitespace_expression2() { runner.runOneTest("whitespace_expression2") }
+  @Test def test_whitespace_expression(): Unit = { runner.runOneTest("whitespace_expression") }
+  @Test def test_whitespace_expression2(): Unit = { runner.runOneTest("whitespace_expression2") }
 
-  @Test def test_expresion_bad_path_to_element() { runner.runOneTest("expresion_bad_path_to_element") }
-  @Test def test_ArrayOptElem_02() { runner.runOneTest("ArrayOptElem_02") }
+  @Test def test_expresion_bad_path_to_element(): Unit = { runner.runOneTest("expresion_bad_path_to_element") }
+  @Test def test_ArrayOptElem_02(): Unit = { runner.runOneTest("ArrayOptElem_02") }
 
   //DFDL-1035 - tests need better diagnostic
   //@Test def test_dfdlCheckConstraints() { runner.runOneTest("dfdlCheckConstraints") }
@@ -255,701 +255,701 @@ class TestDFDLExpressions {
   // @Test def test_checkConstraintsComplexTypeFails() { runner.runOneTest("checkConstraintsComplexTypeFails") }
 
   @Test def test_nonFunctionIsDetected() = { runnerNV.runOneTest("nonFunctionIsDetected") }
-  @Test def test_constantFunction1() { runnerNV.runOneTest("constantFunction1") }
-  @Test def test_dfdlPosition1() { runnerNV.runOneTest("dfdlPosition1") }
-  @Test def test_dfdlPosition2() { runnerNV.runOneTest("dfdlPosition2") }
-  @Test def test_dfdlPosition3() { runnerNV.runOneTest("dfdlPosition3") }
-  @Test def test_dfdlPosition4() { runnerNV.runOneTest("dfdlPosition4") }
-  @Test def test_dfdlPosition5() { runnerNV.runOneTest("dfdlPosition5") }
+  @Test def test_constantFunction1(): Unit = { runnerNV.runOneTest("constantFunction1") }
+  @Test def test_dfdlPosition1(): Unit = { runnerNV.runOneTest("dfdlPosition1") }
+  @Test def test_dfdlPosition2(): Unit = { runnerNV.runOneTest("dfdlPosition2") }
+  @Test def test_dfdlPosition3(): Unit = { runnerNV.runOneTest("dfdlPosition3") }
+  @Test def test_dfdlPosition4(): Unit = { runnerNV.runOneTest("dfdlPosition4") }
+  @Test def test_dfdlPosition5(): Unit = { runnerNV.runOneTest("dfdlPosition5") }
 
-  @Test def test_repeatFlags1() { runner.runOneTest("repeatFlags1") }
-  @Test def test_repeatFlags2() { runner.runOneTest("repeatFlags2") }
-  @Test def test_repeatFlags3() { runner.runOneTest("repeatFlags3") }
-  @Test def test_repeatFlags4() { runner.runOneTest("repeatFlags4") }
-  @Test def test_repeatFlags5() { runner.runOneTest("repeatFlags5") }
+  @Test def test_repeatFlags1(): Unit = { runner.runOneTest("repeatFlags1") }
+  @Test def test_repeatFlags2(): Unit = { runner.runOneTest("repeatFlags2") }
+  @Test def test_repeatFlags3(): Unit = { runner.runOneTest("repeatFlags3") }
+  @Test def test_repeatFlags4(): Unit = { runner.runOneTest("repeatFlags4") }
+  @Test def test_repeatFlags5(): Unit = { runner.runOneTest("repeatFlags5") }
 
-  @Test def test_repeatBitFlags1() { runner.runOneTest("repeatBitFlags1") }
-  @Test def test_repeatBitFlags2() { runner.runOneTest("repeatBitFlags2") }
-  @Test def test_repeatBitFlags3() { runner.runOneTest("repeatBitFlags3") }
-  @Test def test_repeatBitFlags4() { runner.runOneTest("repeatBitFlags4") }
-  @Test def test_repeatBitFlags5() { runner.runOneTest("repeatBitFlags5") }
-  @Test def test_repeatBitFlags6() { runner.runOneTest("repeatBitFlags6") }
+  @Test def test_repeatBitFlags1(): Unit = { runner.runOneTest("repeatBitFlags1") }
+  @Test def test_repeatBitFlags2(): Unit = { runner.runOneTest("repeatBitFlags2") }
+  @Test def test_repeatBitFlags3(): Unit = { runner.runOneTest("repeatBitFlags3") }
+  @Test def test_repeatBitFlags4(): Unit = { runner.runOneTest("repeatBitFlags4") }
+  @Test def test_repeatBitFlags5(): Unit = { runner.runOneTest("repeatBitFlags5") }
+  @Test def test_repeatBitFlags6(): Unit = { runner.runOneTest("repeatBitFlags6") }
 
-  @Test def test_invalid_enum_1() { runner.runOneTest("invalid_enum_1") }
-  @Test def test_invalid_enum_2() { runner.runOneTest("invalid_enum_2") }
-  @Test def test_invalid_enum_3() { runner.runOneTest("invalid_enum_3") }
+  @Test def test_invalid_enum_1(): Unit = { runner.runOneTest("invalid_enum_1") }
+  @Test def test_invalid_enum_2(): Unit = { runner.runOneTest("invalid_enum_2") }
+  @Test def test_invalid_enum_3(): Unit = { runner.runOneTest("invalid_enum_3") }
 
   // Test removed including TDML for it. DPath no longer will even execution expressions that have
   // type errors, and type errors at runtime cause SDE so you can't if-then-else them into
   // some usable thing.
   // @Test def test_trueFalseTypeError() { runner.runOneTest("trueFalseTypeError") }
-  @Test def test_trueFalseTypeCorrect() { runner.runOneTest("trueFalseTypeCorrect") }
+  @Test def test_trueFalseTypeCorrect(): Unit = { runner.runOneTest("trueFalseTypeCorrect") }
 
-  @Test def test_predicate_01() { runner.runOneTest("predicate_01") }
+  @Test def test_predicate_01(): Unit = { runner.runOneTest("predicate_01") }
   //DFDL-1164
   //@Test def test_predicate_02() { runner.runOneTest("predicate_02") }
   //@Test def test_predicate_03() { runner.runOneTest("predicate_03") }
-  @Test def test_predicate_04() { runner.runOneTest("predicate_04") }
-  @Test def test_predicate_05() { runner.runOneTest("predicate_05") }
+  @Test def test_predicate_04(): Unit = { runner.runOneTest("predicate_04") }
+  @Test def test_predicate_05(): Unit = { runner.runOneTest("predicate_05") }
 
-  @Test def test_sequential_and_01() { runner.runOneTest("sequential_and_01") }
-  @Test def test_sequential_and_02() { runner.runOneTest("sequential_and_02") }
-  @Test def test_sequential_and_03() { runner.runOneTest("sequential_and_03") }
-  @Test def test_sequential_and_04() { runner.runOneTest("sequential_and_04") }
-  @Test def test_sequential_and_05() { runner.runOneTest("sequential_and_05") }
-  @Test def test_sequential_or_01() { runner.runOneTest("sequential_or_01") }
-  @Test def test_sequential_or_02() { runner.runOneTest("sequential_or_02") }
-  @Test def test_sequential_or_03() { runner.runOneTest("sequential_or_03") }
-  @Test def test_sequential_or_04() { runner.runOneTest("sequential_or_04") }
-  @Test def test_sequential_or_05() { runner.runOneTest("sequential_or_05") }
-  @Test def test_sequential_and_or_01() { runner.runOneTest("sequential_and_or_01") }
-  @Test def test_sequential_and_or_02() { runner.runOneTest("sequential_and_or_02") }
-  @Test def test_sequential_and_or_03() { runner.runOneTest("sequential_and_or_03") }
-  @Test def test_sequential_and_or_04() { runner.runOneTest("sequential_and_or_04") }
-  @Test def test_sequential_and_or_05() { runner.runOneTest("sequential_and_or_05") }
-  @Test def test_sequential_and_or_06() { runner.runOneTest("sequential_and_or_06") }
-  @Test def test_sequential_and_or_07() { runner.runOneTest("sequential_and_or_07") }
+  @Test def test_sequential_and_01(): Unit = { runner.runOneTest("sequential_and_01") }
+  @Test def test_sequential_and_02(): Unit = { runner.runOneTest("sequential_and_02") }
+  @Test def test_sequential_and_03(): Unit = { runner.runOneTest("sequential_and_03") }
+  @Test def test_sequential_and_04(): Unit = { runner.runOneTest("sequential_and_04") }
+  @Test def test_sequential_and_05(): Unit = { runner.runOneTest("sequential_and_05") }
+  @Test def test_sequential_or_01(): Unit = { runner.runOneTest("sequential_or_01") }
+  @Test def test_sequential_or_02(): Unit = { runner.runOneTest("sequential_or_02") }
+  @Test def test_sequential_or_03(): Unit = { runner.runOneTest("sequential_or_03") }
+  @Test def test_sequential_or_04(): Unit = { runner.runOneTest("sequential_or_04") }
+  @Test def test_sequential_or_05(): Unit = { runner.runOneTest("sequential_or_05") }
+  @Test def test_sequential_and_or_01(): Unit = { runner.runOneTest("sequential_and_or_01") }
+  @Test def test_sequential_and_or_02(): Unit = { runner.runOneTest("sequential_and_or_02") }
+  @Test def test_sequential_and_or_03(): Unit = { runner.runOneTest("sequential_and_or_03") }
+  @Test def test_sequential_and_or_04(): Unit = { runner.runOneTest("sequential_and_or_04") }
+  @Test def test_sequential_and_or_05(): Unit = { runner.runOneTest("sequential_and_or_05") }
+  @Test def test_sequential_and_or_06(): Unit = { runner.runOneTest("sequential_and_or_06") }
+  @Test def test_sequential_and_or_07(): Unit = { runner.runOneTest("sequential_and_or_07") }
 
   //DFDL-1059
-  @Test def test_parent_axis_01() { runner.runOneTest("parent_axis_01") }
-  @Test def test_child_axis_01() { runner.runOneTest("child_axis_01") }
-  @Test def test_self_axis_01() { runner.runOneTest("self_axis_01") }
+  @Test def test_parent_axis_01(): Unit = { runner.runOneTest("parent_axis_01") }
+  @Test def test_child_axis_01(): Unit = { runner.runOneTest("child_axis_01") }
+  @Test def test_self_axis_01(): Unit = { runner.runOneTest("self_axis_01") }
   //@Test def test_multiple_axis_01() { runner.runOneTest("multiple_axis_01") }
 
-  @Test def test_attribute_axis_04() { runner.runOneTest("attribute_axis_04") }
+  @Test def test_attribute_axis_04(): Unit = { runner.runOneTest("attribute_axis_04") }
 
-  @Test def test_ancestor_axis_01() { runner.runOneTest("ancestor_axis_01") }
-  @Test def test_ancestor_or_self_axis_01() { runner.runOneTest("ancestor_or_self_axis_01") }
-  @Test def test_descendant_axis_01() { runner.runOneTest("descendant_axis_01") }
-  @Test def test_descendant_or_self_axis_01() { runner.runOneTest("descendant_or_self_axis_01") }
-  @Test def test_following_axis_01() { runner.runOneTest("following_axis_01") }
-  @Test def test_following_sibling_axis_01() { runner.runOneTest("following_sibling_axis_01") }
-  @Test def test_namespace_axis_01() { runner.runOneTest("namespace_axis_01") }
-  @Test def test_preceding_axis_01() { runner.runOneTest("preceding_axis_01") }
-  @Test def test_preceding_sibling_axis_01() { runner.runOneTest("preceding_sibling_axis_01") }
+  @Test def test_ancestor_axis_01(): Unit = { runner.runOneTest("ancestor_axis_01") }
+  @Test def test_ancestor_or_self_axis_01(): Unit = { runner.runOneTest("ancestor_or_self_axis_01") }
+  @Test def test_descendant_axis_01(): Unit = { runner.runOneTest("descendant_axis_01") }
+  @Test def test_descendant_or_self_axis_01(): Unit = { runner.runOneTest("descendant_or_self_axis_01") }
+  @Test def test_following_axis_01(): Unit = { runner.runOneTest("following_axis_01") }
+  @Test def test_following_sibling_axis_01(): Unit = { runner.runOneTest("following_sibling_axis_01") }
+  @Test def test_namespace_axis_01(): Unit = { runner.runOneTest("namespace_axis_01") }
+  @Test def test_preceding_axis_01(): Unit = { runner.runOneTest("preceding_axis_01") }
+  @Test def test_preceding_sibling_axis_01(): Unit = { runner.runOneTest("preceding_sibling_axis_01") }
 
   /////////////////////// FUNCTIONS ///////////////////////////
 
-  @Test def test_dateTimeFunctions01() { runner_fun.runOneTest("dateTimeFunctions01") }
-  @Test def test_dateTimeFunctions02() { runner_fun.runOneTest("dateTimeFunctions02") }
-  @Test def test_dateFunctions01() { runner_fun.runOneTest("dateFunctions01") }
-  @Test def test_dateFunctions02() { runner_fun.runOneTest("dateFunctions02") }
-  @Test def test_timeFunctions01() { runner_fun.runOneTest("timeFunctions01") }
-  @Test def test_timeFunctions02() { runner_fun.runOneTest("timeFunctions02") }
-  @Test def test_functionFail01() { runner_fun.runOneTest("functionFail01") }
-  @Test def test_functionFail02() { runner_fun.runOneTest("functionFail02") }
-  @Test def test_functionFail03() { runner_fun.runOneTest("functionFail03") }
+  @Test def test_dateTimeFunctions01(): Unit = { runner_fun.runOneTest("dateTimeFunctions01") }
+  @Test def test_dateTimeFunctions02(): Unit = { runner_fun.runOneTest("dateTimeFunctions02") }
+  @Test def test_dateFunctions01(): Unit = { runner_fun.runOneTest("dateFunctions01") }
+  @Test def test_dateFunctions02(): Unit = { runner_fun.runOneTest("dateFunctions02") }
+  @Test def test_timeFunctions01(): Unit = { runner_fun.runOneTest("timeFunctions01") }
+  @Test def test_timeFunctions02(): Unit = { runner_fun.runOneTest("timeFunctions02") }
+  @Test def test_functionFail01(): Unit = { runner_fun.runOneTest("functionFail01") }
+  @Test def test_functionFail02(): Unit = { runner_fun.runOneTest("functionFail02") }
+  @Test def test_functionFail03(): Unit = { runner_fun.runOneTest("functionFail03") }
 
-  @Test def test_substringFunction01() { runner_fun.runOneTest("substringFunction01") }
-  @Test def test_substringFunction02() { runner_fun.runOneTest("substringFunction02") }
-  @Test def test_substringFunction03() { runner_fun.runOneTest("substringFunction03") }
-  @Test def test_substringFunction04() { runner_fun.runOneTest("substringFunction04") }
-  @Test def test_substringFunction05() { runner_fun.runOneTest("substringFunction05") }
-  @Test def test_substringFunction06() { runner_fun.runOneTest("substringFunction06") }
-  @Test def test_substringFunction07() { runner_fun.runOneTest("substringFunction07") }
-  @Test def test_substringFunction08() { runner_fun.runOneTest("substringFunction08") }
-  @Test def test_substringFunction12() { runner_fun.runOneTest("substringFunction12") }
-  @Test def test_substringFunction13() { runner_fun.runOneTest("substringFunction13") }
-  @Test def test_substringFunction14() { runner_fun.runOneTest("substringFunction14") }
-  @Test def test_substringFunction15() { runner_fun.runOneTest("substringFunction15") }
+  @Test def test_substringFunction01(): Unit = { runner_fun.runOneTest("substringFunction01") }
+  @Test def test_substringFunction02(): Unit = { runner_fun.runOneTest("substringFunction02") }
+  @Test def test_substringFunction03(): Unit = { runner_fun.runOneTest("substringFunction03") }
+  @Test def test_substringFunction04(): Unit = { runner_fun.runOneTest("substringFunction04") }
+  @Test def test_substringFunction05(): Unit = { runner_fun.runOneTest("substringFunction05") }
+  @Test def test_substringFunction06(): Unit = { runner_fun.runOneTest("substringFunction06") }
+  @Test def test_substringFunction07(): Unit = { runner_fun.runOneTest("substringFunction07") }
+  @Test def test_substringFunction08(): Unit = { runner_fun.runOneTest("substringFunction08") }
+  @Test def test_substringFunction12(): Unit = { runner_fun.runOneTest("substringFunction12") }
+  @Test def test_substringFunction13(): Unit = { runner_fun.runOneTest("substringFunction13") }
+  @Test def test_substringFunction14(): Unit = { runner_fun.runOneTest("substringFunction14") }
+  @Test def test_substringFunction15(): Unit = { runner_fun.runOneTest("substringFunction15") }
 
-  @Test def test_boolFunctionChoice_01() { runner2.runOneTest("boolFunctionChoice_01") }
-  @Test def test_boolFunctionChoice_02() { runner2.runOneTest("boolFunctionChoice_02") }
-  @Test def test_boolFunctionChoice_03() { runner2.runOneTest("boolFunctionChoice_03") }
+  @Test def test_boolFunctionChoice_01(): Unit = { runner2.runOneTest("boolFunctionChoice_01") }
+  @Test def test_boolFunctionChoice_02(): Unit = { runner2.runOneTest("boolFunctionChoice_02") }
+  @Test def test_boolFunctionChoice_03(): Unit = { runner2.runOneTest("boolFunctionChoice_03") }
 
-  @Test def test_boolFlags_01() { runner2.runOneTest("boolFlags_01") }
-  @Test def test_boolFlags_02() { runner2.runOneTest("boolFlags_02") }
-  @Test def test_boolFlags_03() { runner2.runOneTest("boolFlags_03") }
-  @Test def test_boolFlags_04() { runner2.runOneTest("boolFlags_04") }
-  @Test def test_boolFlags_05() { runner2.runOneTest("boolFlags_05") }
+  @Test def test_boolFlags_01(): Unit = { runner2.runOneTest("boolFlags_01") }
+  @Test def test_boolFlags_02(): Unit = { runner2.runOneTest("boolFlags_02") }
+  @Test def test_boolFlags_03(): Unit = { runner2.runOneTest("boolFlags_03") }
+  @Test def test_boolFlags_04(): Unit = { runner2.runOneTest("boolFlags_04") }
+  @Test def test_boolFlags_05(): Unit = { runner2.runOneTest("boolFlags_05") }
 
-  @Test def test_not_01() { runner2.runOneTest("not_01") }
-  @Test def test_not_02() { runner2.runOneTest("not_02") }
-  @Test def test_not_03() { runner2.runOneTest("not_03") }
+  @Test def test_not_01(): Unit = { runner2.runOneTest("not_01") }
+  @Test def test_not_02(): Unit = { runner2.runOneTest("not_02") }
+  @Test def test_not_03(): Unit = { runner2.runOneTest("not_03") }
   //DFDL-1076
   //@Test def test_not_04() { runner2.runOneTest("not_04") }
   //DFDL-1075
   //@Test def test_not_05() { runner2.runOneTest("not_05") }
   //@Test def test_not_07() { runner2.runOneTest("not_07") }
-  @Test def test_not_06() { runner2.runOneTest("not_06") }
-  @Test def test_not_08() { runner2.runOneTest("not_08") }
-  @Test def test_not_09() { runner2.runOneTest("not_09") }
-  @Test def test_not_10() { runner2.runOneTest("not_10") }
-  @Test def test_not_11() { runner2.runOneTest("not_11") }
-  @Test def test_not_12() { runner2.runOneTest("not_12") }
-  @Test def test_not_13() { runner2.runOneTest("not_13") }
-  @Test def test_not_14() { runner2.runOneTest("not_14") }
-  @Test def test_not_15() { runner2.runOneTest("not_15") }
-  @Test def test_not_16() { runner2.runOneTest("not_16") }
+  @Test def test_not_06(): Unit = { runner2.runOneTest("not_06") }
+  @Test def test_not_08(): Unit = { runner2.runOneTest("not_08") }
+  @Test def test_not_09(): Unit = { runner2.runOneTest("not_09") }
+  @Test def test_not_10(): Unit = { runner2.runOneTest("not_10") }
+  @Test def test_not_11(): Unit = { runner2.runOneTest("not_11") }
+  @Test def test_not_12(): Unit = { runner2.runOneTest("not_12") }
+  @Test def test_not_13(): Unit = { runner2.runOneTest("not_13") }
+  @Test def test_not_14(): Unit = { runner2.runOneTest("not_14") }
+  @Test def test_not_15(): Unit = { runner2.runOneTest("not_15") }
+  @Test def test_not_16(): Unit = { runner2.runOneTest("not_16") }
 
-  @Test def test_xPathFunc_abs_01() { runner2.runOneTest("xPathFunc_abs_01") }
-  @Test def test_xPathFunc_abs_02() { runner2.runOneTest("xPathFunc_abs_02") }
-  @Test def test_xPathFunc_abs_03() { runner2.runOneTest("xPathFunc_abs_03") }
-  @Test def test_xPathFunc_abs_04() { runner2.runOneTest("xPathFunc_abs_04") }
-  @Test def test_abs_05() { runner2.runOneTest("abs_05") }
-  @Test def test_abs_06() { runner2.runOneTest("abs_06") }
-  @Test def test_abs_07() { runner2.runOneTest("abs_07") }
-  @Test def test_abs_08() { runner2.runOneTest("abs_08") }
-  @Test def test_abs_09() { runner2.runOneTest("abs_09") }
+  @Test def test_xPathFunc_abs_01(): Unit = { runner2.runOneTest("xPathFunc_abs_01") }
+  @Test def test_xPathFunc_abs_02(): Unit = { runner2.runOneTest("xPathFunc_abs_02") }
+  @Test def test_xPathFunc_abs_03(): Unit = { runner2.runOneTest("xPathFunc_abs_03") }
+  @Test def test_xPathFunc_abs_04(): Unit = { runner2.runOneTest("xPathFunc_abs_04") }
+  @Test def test_abs_05(): Unit = { runner2.runOneTest("abs_05") }
+  @Test def test_abs_06(): Unit = { runner2.runOneTest("abs_06") }
+  @Test def test_abs_07(): Unit = { runner2.runOneTest("abs_07") }
+  @Test def test_abs_08(): Unit = { runner2.runOneTest("abs_08") }
+  @Test def test_abs_09(): Unit = { runner2.runOneTest("abs_09") }
 
-  @Test def test_xPathFunc_ceil_01() { runner2.runOneTest("xPathFunc_ceil_01") }
-  @Test def test_xPathFunc_ceil_02() { runner2.runOneTest("xPathFunc_ceil_02") }
-  @Test def test_xPathFunc_ceil_03() { runner2.runOneTest("xPathFunc_ceil_03") }
-  @Test def test_xPathFunc_ceil_04() { runner2.runOneTest("xPathFunc_ceil_04") }
-  @Test def test_xPathFunc_ceil_05() { runner2.runOneTest("xPathFunc_ceil_05") }
-  @Test def test_ceil_06() { runner2.runOneTest("ceil_06") }
-  @Test def test_ceil_07() { runner2.runOneTest("ceil_07") }
-  @Test def test_ceil_08() { runner2.runOneTest("ceil_08") }
-  @Test def test_ceil_09() { runner2.runOneTest("ceil_09") }
+  @Test def test_xPathFunc_ceil_01(): Unit = { runner2.runOneTest("xPathFunc_ceil_01") }
+  @Test def test_xPathFunc_ceil_02(): Unit = { runner2.runOneTest("xPathFunc_ceil_02") }
+  @Test def test_xPathFunc_ceil_03(): Unit = { runner2.runOneTest("xPathFunc_ceil_03") }
+  @Test def test_xPathFunc_ceil_04(): Unit = { runner2.runOneTest("xPathFunc_ceil_04") }
+  @Test def test_xPathFunc_ceil_05(): Unit = { runner2.runOneTest("xPathFunc_ceil_05") }
+  @Test def test_ceil_06(): Unit = { runner2.runOneTest("ceil_06") }
+  @Test def test_ceil_07(): Unit = { runner2.runOneTest("ceil_07") }
+  @Test def test_ceil_08(): Unit = { runner2.runOneTest("ceil_08") }
+  @Test def test_ceil_09(): Unit = { runner2.runOneTest("ceil_09") }
 
-  @Test def test_xPathFunc_floor_01() { runner2.runOneTest("xPathFunc_floor_01") }
-  @Test def test_xPathFunc_floor_02() { runner2.runOneTest("xPathFunc_floor_02") }
-  @Test def test_xPathFunc_floor_03() { runner2.runOneTest("xPathFunc_floor_03") }
-  @Test def test_xPathFunc_floor_04() { runner2.runOneTest("xPathFunc_floor_04") }
-  @Test def test_xPathFunc_floor_05() { runner2.runOneTest("xPathFunc_floor_05") }
-  @Test def test_floor_06() { runner2.runOneTest("floor_06") }
-  @Test def test_floor_07() { runner2.runOneTest("floor_07") }
-  @Test def test_floor_08() { runner2.runOneTest("floor_08") }
-  @Test def test_floor_09() { runner2.runOneTest("floor_09") }
+  @Test def test_xPathFunc_floor_01(): Unit = { runner2.runOneTest("xPathFunc_floor_01") }
+  @Test def test_xPathFunc_floor_02(): Unit = { runner2.runOneTest("xPathFunc_floor_02") }
+  @Test def test_xPathFunc_floor_03(): Unit = { runner2.runOneTest("xPathFunc_floor_03") }
+  @Test def test_xPathFunc_floor_04(): Unit = { runner2.runOneTest("xPathFunc_floor_04") }
+  @Test def test_xPathFunc_floor_05(): Unit = { runner2.runOneTest("xPathFunc_floor_05") }
+  @Test def test_floor_06(): Unit = { runner2.runOneTest("floor_06") }
+  @Test def test_floor_07(): Unit = { runner2.runOneTest("floor_07") }
+  @Test def test_floor_08(): Unit = { runner2.runOneTest("floor_08") }
+  @Test def test_floor_09(): Unit = { runner2.runOneTest("floor_09") }
 
-  @Test def test_xPathFunc_round_01() { runner2.runOneTest("xPathFunc_round_01") }
-  @Test def test_xPathFunc_round_02() { runner2.runOneTest("xPathFunc_round_02") }
-  @Test def test_xPathFunc_round_03() { runner2.runOneTest("xPathFunc_round_03") }
-  @Test def test_xPathFunc_round_04() { runner2.runOneTest("xPathFunc_round_04") }
-  @Test def test_xPathFunc_round_05() { runner2.runOneTest("xPathFunc_round_05") }
-  @Test def test_xPathFunc_round_06() { runner2.runOneTest("xPathFunc_round_06") }
-  @Test def test_round_07() { runner2.runOneTest("round_07") }
-  @Test def test_round_08() { runner2.runOneTest("round_08") }
-  @Test def test_round_09() { runner2.runOneTest("round_09") }
-  @Test def test_round_10() { runner2.runOneTest("round_10") }
-  @Test def test_round_11() { runner2.runOneTest("round_11") }
-  @Test def test_round_12() { runner2.runOneTest("round_12") }
-  @Test def test_round_13() { runner2.runOneTest("round_13") }
-  @Test def test_xPathFunc_round_14() { runner2.runOneTest("xPathFunc_round_14") }
-  @Test def test_xPathFunc_round_15() { runner2.runOneTest("xPathFunc_round_15") }
-  @Test def test_xPathFunc_round_16() { runner2.runOneTest("xPathFunc_round_16") }
-  @Test def test_round_17() { runner2.runOneTest("round_17") }
-  @Test def test_round_18() { runner2.runOneTest("round_18") }
-  @Test def test_round_19() { runner2.runOneTest("round_19") }
+  @Test def test_xPathFunc_round_01(): Unit = { runner2.runOneTest("xPathFunc_round_01") }
+  @Test def test_xPathFunc_round_02(): Unit = { runner2.runOneTest("xPathFunc_round_02") }
+  @Test def test_xPathFunc_round_03(): Unit = { runner2.runOneTest("xPathFunc_round_03") }
+  @Test def test_xPathFunc_round_04(): Unit = { runner2.runOneTest("xPathFunc_round_04") }
+  @Test def test_xPathFunc_round_05(): Unit = { runner2.runOneTest("xPathFunc_round_05") }
+  @Test def test_xPathFunc_round_06(): Unit = { runner2.runOneTest("xPathFunc_round_06") }
+  @Test def test_round_07(): Unit = { runner2.runOneTest("round_07") }
+  @Test def test_round_08(): Unit = { runner2.runOneTest("round_08") }
+  @Test def test_round_09(): Unit = { runner2.runOneTest("round_09") }
+  @Test def test_round_10(): Unit = { runner2.runOneTest("round_10") }
+  @Test def test_round_11(): Unit = { runner2.runOneTest("round_11") }
+  @Test def test_round_12(): Unit = { runner2.runOneTest("round_12") }
+  @Test def test_round_13(): Unit = { runner2.runOneTest("round_13") }
+  @Test def test_xPathFunc_round_14(): Unit = { runner2.runOneTest("xPathFunc_round_14") }
+  @Test def test_xPathFunc_round_15(): Unit = { runner2.runOneTest("xPathFunc_round_15") }
+  @Test def test_xPathFunc_round_16(): Unit = { runner2.runOneTest("xPathFunc_round_16") }
+  @Test def test_round_17(): Unit = { runner2.runOneTest("round_17") }
+  @Test def test_round_18(): Unit = { runner2.runOneTest("round_18") }
+  @Test def test_round_19(): Unit = { runner2.runOneTest("round_19") }
 
-  @Test def test_xPathFunc_round_hte_01() { runner2.runOneTest("xPathFunc_round_hte_01") }
-  @Test def test_xPathFunc_round_hte_02() { runner2.runOneTest("xPathFunc_round_hte_02") }
-  @Test def test_xPathFunc_round_hte_03() { runner2.runOneTest("xPathFunc_round_hte_03") }
-  @Test def test_xPathFunc_round_hte_04() { runner2.runOneTest("xPathFunc_round_hte_04") }
-  @Test def test_xPathFunc_round_hte_05() { runner2.runOneTest("xPathFunc_round_hte_05") }
-  @Test def test_xPathFunc_round_hte_06() { runner2.runOneTest("xPathFunc_round_hte_06") }
-  @Test def test_xPathFunc_round_hte_07() { runner2.runOneTest("xPathFunc_round_hte_07") }
-  @Test def test_xPathFunc_round_hte_08() { runner2.runOneTest("xPathFunc_round_hte_08") }
-  @Test def test_round_hte_09() { runner2.runOneTest("round_hte_09") }
-  @Test def test_round_hte_10() { runner2.runOneTest("round_hte_10") }
-  @Test def test_round_hte_11() { runner2.runOneTest("round_hte_11") }
-  @Test def test_round_hte_12() { runner2.runOneTest("round_hte_12") }
-  @Test def test_round_hte_13() { runner2.runOneTest("round_hte_13") }
-  @Test def test_round_hte_14() { runner2.runOneTest("round_hte_14") }
-  @Test def test_round_hte_15() { runner2.runOneTest("round_hte_15") }
-  @Test def test_round_hte_16() { runner2.runOneTest("round_hte_16") }
-  @Test def test_round_hte_17() { runner2.runOneTest("round_hte_17") }
-  @Test def test_round_hte_18() { runner2.runOneTest("round_hte_18") }
+  @Test def test_xPathFunc_round_hte_01(): Unit = { runner2.runOneTest("xPathFunc_round_hte_01") }
+  @Test def test_xPathFunc_round_hte_02(): Unit = { runner2.runOneTest("xPathFunc_round_hte_02") }
+  @Test def test_xPathFunc_round_hte_03(): Unit = { runner2.runOneTest("xPathFunc_round_hte_03") }
+  @Test def test_xPathFunc_round_hte_04(): Unit = { runner2.runOneTest("xPathFunc_round_hte_04") }
+  @Test def test_xPathFunc_round_hte_05(): Unit = { runner2.runOneTest("xPathFunc_round_hte_05") }
+  @Test def test_xPathFunc_round_hte_06(): Unit = { runner2.runOneTest("xPathFunc_round_hte_06") }
+  @Test def test_xPathFunc_round_hte_07(): Unit = { runner2.runOneTest("xPathFunc_round_hte_07") }
+  @Test def test_xPathFunc_round_hte_08(): Unit = { runner2.runOneTest("xPathFunc_round_hte_08") }
+  @Test def test_round_hte_09(): Unit = { runner2.runOneTest("round_hte_09") }
+  @Test def test_round_hte_10(): Unit = { runner2.runOneTest("round_hte_10") }
+  @Test def test_round_hte_11(): Unit = { runner2.runOneTest("round_hte_11") }
+  @Test def test_round_hte_12(): Unit = { runner2.runOneTest("round_hte_12") }
+  @Test def test_round_hte_13(): Unit = { runner2.runOneTest("round_hte_13") }
+  @Test def test_round_hte_14(): Unit = { runner2.runOneTest("round_hte_14") }
+  @Test def test_round_hte_15(): Unit = { runner2.runOneTest("round_hte_15") }
+  @Test def test_round_hte_16(): Unit = { runner2.runOneTest("round_hte_16") }
+  @Test def test_round_hte_17(): Unit = { runner2.runOneTest("round_hte_17") }
+  @Test def test_round_hte_18(): Unit = { runner2.runOneTest("round_hte_18") }
 
   //DAFFODIL-1080
-  @Test def test_empty_02() { runner2.runOneTest("empty_02") }
-  @Test def test_exists_02() { runner2.runOneTest("exists_02") }
+  @Test def test_empty_02(): Unit = { runner2.runOneTest("empty_02") }
+  @Test def test_exists_02(): Unit = { runner2.runOneTest("exists_02") }
 
-  @Test def test_count_05b() { runner2.runOneTest("count_05b") }
+  @Test def test_count_05b(): Unit = { runner2.runOneTest("count_05b") }
 
   //DFDL-1097
   //@Test def test_local_name_06() { runner2.runOneTest("local_name_06") }
 
-  @Test def test_empty_01() { runner2.runOneTest("empty_01") }
-  @Test def test_empty_03() { runner2.runOneTest("empty_03") }
-  @Test def test_empty_04() { runner2.runOneTest("empty_04") }
-  @Test def test_empty_05() { runner2.runOneTest("empty_05") }
-  @Test def test_empty_06() { runner2.runOneTest("empty_06") }
-  @Test def test_empty_07() { runner2.runOneTest("empty_07") }
-  @Test def test_empty_08() { runner2.runOneTest("empty_08") }
-  @Test def test_empty_09() { runner2.runOneTest("empty_09") }
+  @Test def test_empty_01(): Unit = { runner2.runOneTest("empty_01") }
+  @Test def test_empty_03(): Unit = { runner2.runOneTest("empty_03") }
+  @Test def test_empty_04(): Unit = { runner2.runOneTest("empty_04") }
+  @Test def test_empty_05(): Unit = { runner2.runOneTest("empty_05") }
+  @Test def test_empty_06(): Unit = { runner2.runOneTest("empty_06") }
+  @Test def test_empty_07(): Unit = { runner2.runOneTest("empty_07") }
+  @Test def test_empty_08(): Unit = { runner2.runOneTest("empty_08") }
+  @Test def test_empty_09(): Unit = { runner2.runOneTest("empty_09") }
 
-  @Test def test_exists_01() { runner2.runOneTest("exists_01") }
-  @Test def test_exists_03() { runner2.runOneTest("exists_03") }
-  @Test def test_exists_04() { runner2.runOneTest("exists_04") }
-  @Test def test_exists_06() { runner2.runOneTest("exists_06") }
-  @Test def test_exists_07() { runner2.runOneTest("exists_07") }
-  @Test def test_exists_05() { runner2.runOneTest("exists_05") }
-  @Test def test_exists_08() { runner2.runOneTest("exists_08") }
-  @Test def test_exists_09() { runner2.runOneTest("exists_09") }
+  @Test def test_exists_01(): Unit = { runner2.runOneTest("exists_01") }
+  @Test def test_exists_03(): Unit = { runner2.runOneTest("exists_03") }
+  @Test def test_exists_04(): Unit = { runner2.runOneTest("exists_04") }
+  @Test def test_exists_06(): Unit = { runner2.runOneTest("exists_06") }
+  @Test def test_exists_07(): Unit = { runner2.runOneTest("exists_07") }
+  @Test def test_exists_05(): Unit = { runner2.runOneTest("exists_05") }
+  @Test def test_exists_08(): Unit = { runner2.runOneTest("exists_08") }
+  @Test def test_exists_09(): Unit = { runner2.runOneTest("exists_09") }
 
-  @Test def test_exists_10() { runner2.runOneTest("exists_10") }
+  @Test def test_exists_10(): Unit = { runner2.runOneTest("exists_10") }
 
-  @Test def test_exists_11() { runner2.runOneTest("exists_11") }
-  @Test def test_exists_12() { runner2.runOneTest("exists_12") }
+  @Test def test_exists_11(): Unit = { runner2.runOneTest("exists_11") }
+  @Test def test_exists_12(): Unit = { runner2.runOneTest("exists_12") }
 
   //DFDL-1189
   //@Test def test_exactly_one_01() { runner2.runOneTest("exactly_one_01") }
   //@Test def test_exactly_one_02() { runner2.runOneTest("exactly_one_02") }
   //@Test def test_exactly_one_03() { runner2.runOneTest("exactly_one_03") }
-  @Test def test_exactly_one_04() { runner2.runOneTest("exactly_one_04") }
+  @Test def test_exactly_one_04(): Unit = { runner2.runOneTest("exactly_one_04") }
   //@Test def test_exactly_one_05() { runner2.runOneTest("exactly_one_05") }
   //@Test def test_exactly_one_06() { runner2.runOneTest("exactly_one_06") }
 
-  @Test def test_count_01() { runner2.runOneTest("count_01") }
-  @Test def test_count_02() { runner2.runOneTest("count_02") }
-  @Test def test_count_03() { runner2.runOneTest("count_03") }
-  @Test def test_count_03b() { runner2.runOneTest("count_03b") }
-  @Test def test_count_04() { runner2.runOneTest("count_04") }
-  @Test def test_count_05c() { runner2.runOneTest("count_05c") }
-  @Test def test_count_06b() { runner2.runOneTest("count_06b") }
-  @Test def test_count_07() { runner2.runOneTest("count_07") }
-  @Test def test_count_08b() { runner2.runOneTest("count_08b") }
+  @Test def test_count_01(): Unit = { runner2.runOneTest("count_01") }
+  @Test def test_count_02(): Unit = { runner2.runOneTest("count_02") }
+  @Test def test_count_03(): Unit = { runner2.runOneTest("count_03") }
+  @Test def test_count_03b(): Unit = { runner2.runOneTest("count_03b") }
+  @Test def test_count_04(): Unit = { runner2.runOneTest("count_04") }
+  @Test def test_count_05c(): Unit = { runner2.runOneTest("count_05c") }
+  @Test def test_count_06b(): Unit = { runner2.runOneTest("count_06b") }
+  @Test def test_count_07(): Unit = { runner2.runOneTest("count_07") }
+  @Test def test_count_08b(): Unit = { runner2.runOneTest("count_08b") }
 
-  @Test def test_count_05() { runner2.runOneTest("count_05") }
-  @Test def test_count_06() { runner2.runOneTest("count_06") }
-  @Test def test_count_08() { runner2.runOneTest("count_08") }
+  @Test def test_count_05(): Unit = { runner2.runOneTest("count_05") }
+  @Test def test_count_06(): Unit = { runner2.runOneTest("count_06") }
+  @Test def test_count_08(): Unit = { runner2.runOneTest("count_08") }
 
-  @Test def test_local_name_01() { runner2.runOneTest("local_name_01") }
-  @Test def test_local_name_02() { runner2.runOneTest("local_name_02") }
-  @Test def test_local_name_03() { runner2.runOneTest("local_name_03") }
-  @Test def test_local_name_04() { runner2.runOneTest("local_name_04") }
-  @Test def test_local_name_05() { runner2.runOneTest("local_name_05") }
+  @Test def test_local_name_01(): Unit = { runner2.runOneTest("local_name_01") }
+  @Test def test_local_name_02(): Unit = { runner2.runOneTest("local_name_02") }
+  @Test def test_local_name_03(): Unit = { runner2.runOneTest("local_name_03") }
+  @Test def test_local_name_04(): Unit = { runner2.runOneTest("local_name_04") }
+  @Test def test_local_name_05(): Unit = { runner2.runOneTest("local_name_05") }
   //DFDL-1151
   //@Test def test_local_name_07() { runner2.runOneTest("local_name_07") }
 
   //DFDL-1101
-  @Test def test_namespace_uri_01() { runner2.runOneTest("namespace_uri_01") }
-  @Test def test_namespace_uri_02() { runner2.runOneTest("namespace_uri_02") }
+  @Test def test_namespace_uri_01(): Unit = { runner2.runOneTest("namespace_uri_01") }
+  @Test def test_namespace_uri_02(): Unit = { runner2.runOneTest("namespace_uri_02") }
   //DFDL-1114
-  @Test def test_namespace_uri_03() { runner2.runOneTest("namespace_uri_03") }
-  @Test def test_namespace_uri_04() { runner2.runOneTest("namespace_uri_04") }
-  @Test def test_namespace_uri_05() { runner2.runOneTest("namespace_uri_05") }
-  @Test def test_namespace_uri_06() { runner2.runOneTest("namespace_uri_06") }
-  @Test def test_namespace_uri_07() { runner2.runOneTest("namespace_uri_07") }
-  @Test def test_namespace_uri_08() { runner2.runOneTest("namespace_uri_08") }
+  @Test def test_namespace_uri_03(): Unit = { runner2.runOneTest("namespace_uri_03") }
+  @Test def test_namespace_uri_04(): Unit = { runner2.runOneTest("namespace_uri_04") }
+  @Test def test_namespace_uri_05(): Unit = { runner2.runOneTest("namespace_uri_05") }
+  @Test def test_namespace_uri_06(): Unit = { runner2.runOneTest("namespace_uri_06") }
+  @Test def test_namespace_uri_07(): Unit = { runner2.runOneTest("namespace_uri_07") }
+  @Test def test_namespace_uri_08(): Unit = { runner2.runOneTest("namespace_uri_08") }
 
   //DFDL-1233
-  @Test def test_nilled_02() { runner2.runOneTest("nilled_02") }
-  @Test def test_nilled_03() { runner2.runOneTest("nilled_03") }
+  @Test def test_nilled_02(): Unit = { runner2.runOneTest("nilled_02") }
+  @Test def test_nilled_03(): Unit = { runner2.runOneTest("nilled_03") }
 
-  @Test def test_concat_01() { runner2.runOneTest("concat_01") }
-  @Test def test_concat_02() { runner2.runOneTest("concat_02") }
-  @Test def test_concat_03() { runner2.runOneTest("concat_03") }
-  @Test def test_concat_04() { runner2.runOneTest("concat_04") }
-  @Test def test_concat_05() { runner2.runOneTest("concat_05") }
+  @Test def test_concat_01(): Unit = { runner2.runOneTest("concat_01") }
+  @Test def test_concat_02(): Unit = { runner2.runOneTest("concat_02") }
+  @Test def test_concat_03(): Unit = { runner2.runOneTest("concat_03") }
+  @Test def test_concat_04(): Unit = { runner2.runOneTest("concat_04") }
+  @Test def test_concat_05(): Unit = { runner2.runOneTest("concat_05") }
 
-  @Test def test_substring_01() { runner2.runOneTest("substring_01") }
-  @Test def test_substring_02() { runner2.runOneTest("substring_02") }
-  @Test def test_substring_03() { runner2.runOneTest("substring_03") }
-  @Test def test_substring_04() { runner2.runOneTest("substring_04") }
-  @Test def test_substring_05() { runner2.runOneTest("substring_05") }
-  @Test def test_substring_06() { runner2.runOneTest("substring_06") }
-  @Test def test_substring_07() { runner2.runOneTest("substring_07") }
-  @Test def test_substring_08() { runner2.runOneTest("substring_08") }
-  @Test def test_substring_09() { runner2.runOneTest("substring_09") }
-  @Test def test_substring_10() { runner2.runOneTest("substring_10") }
-  @Test def test_substring_11() { runner2.runOneTest("substring_11") }
+  @Test def test_substring_01(): Unit = { runner2.runOneTest("substring_01") }
+  @Test def test_substring_02(): Unit = { runner2.runOneTest("substring_02") }
+  @Test def test_substring_03(): Unit = { runner2.runOneTest("substring_03") }
+  @Test def test_substring_04(): Unit = { runner2.runOneTest("substring_04") }
+  @Test def test_substring_05(): Unit = { runner2.runOneTest("substring_05") }
+  @Test def test_substring_06(): Unit = { runner2.runOneTest("substring_06") }
+  @Test def test_substring_07(): Unit = { runner2.runOneTest("substring_07") }
+  @Test def test_substring_08(): Unit = { runner2.runOneTest("substring_08") }
+  @Test def test_substring_09(): Unit = { runner2.runOneTest("substring_09") }
+  @Test def test_substring_10(): Unit = { runner2.runOneTest("substring_10") }
+  @Test def test_substring_11(): Unit = { runner2.runOneTest("substring_11") }
 
-  @Test def test_stringlength_01() { runner2.runOneTest("stringlength_01") }
-  @Test def test_stringlength_02() { runner2.runOneTest("stringlength_02") }
-  @Test def test_stringlength_03() { runner2.runOneTest("stringlength_03") }
-  @Test def test_stringlength_04() { runner2.runOneTest("stringlength_04") }
+  @Test def test_stringlength_01(): Unit = { runner2.runOneTest("stringlength_01") }
+  @Test def test_stringlength_02(): Unit = { runner2.runOneTest("stringlength_02") }
+  @Test def test_stringlength_03(): Unit = { runner2.runOneTest("stringlength_03") }
+  @Test def test_stringlength_04(): Unit = { runner2.runOneTest("stringlength_04") }
 
-  @Test def test_uppercase_01() { runner2.runOneTest("uppercase_01") }
-  @Test def test_uppercase_02() { runner2.runOneTest("uppercase_02") }
-  @Test def test_uppercase_03() { runner2.runOneTest("uppercase_03") }
+  @Test def test_uppercase_01(): Unit = { runner2.runOneTest("uppercase_01") }
+  @Test def test_uppercase_02(): Unit = { runner2.runOneTest("uppercase_02") }
+  @Test def test_uppercase_03(): Unit = { runner2.runOneTest("uppercase_03") }
 
-  @Test def test_lowercase_01() { runner2.runOneTest("lowercase_01") }
-  @Test def test_lowercase_02() { runner2.runOneTest("lowercase_02") }
-  @Test def test_lowercase_03() { runner2.runOneTest("lowercase_03") }
+  @Test def test_lowercase_01(): Unit = { runner2.runOneTest("lowercase_01") }
+  @Test def test_lowercase_02(): Unit = { runner2.runOneTest("lowercase_02") }
+  @Test def test_lowercase_03(): Unit = { runner2.runOneTest("lowercase_03") }
 
-  @Test def test_lowercase_04() { runner2_utf8.runOneTest("lowercase_04") }
-  @Test def test_uppercase_04() { runner2_utf8.runOneTest("uppercase_04") }
-  @Test def test_uppercase_05() { runner2_utf8.runOneTest("uppercase_05") }
-  @Test def test_lowercase_05() { runner2_utf8.runOneTest("lowercase_05") }
+  @Test def test_lowercase_04(): Unit = { runner2_utf8.runOneTest("lowercase_04") }
+  @Test def test_uppercase_04(): Unit = { runner2_utf8.runOneTest("uppercase_04") }
+  @Test def test_uppercase_05(): Unit = { runner2_utf8.runOneTest("uppercase_05") }
+  @Test def test_lowercase_05(): Unit = { runner2_utf8.runOneTest("lowercase_05") }
 
-  @Test def test_contains_01() { runner2.runOneTest("contains_01") }
-  @Test def test_contains_02() { runner2.runOneTest("contains_02") }
-  @Test def test_contains_03() { runner2.runOneTest("contains_03") }
-  @Test def test_contains_04() { runner2.runOneTest("contains_04") }
-  @Test def test_contains_05() { runner2.runOneTest("contains_05") }
-  @Test def test_contains_06() { runner2.runOneTest("contains_06") }
-  @Test def test_contains_07() { runner2.runOneTest("contains_07") }
+  @Test def test_contains_01(): Unit = { runner2.runOneTest("contains_01") }
+  @Test def test_contains_02(): Unit = { runner2.runOneTest("contains_02") }
+  @Test def test_contains_03(): Unit = { runner2.runOneTest("contains_03") }
+  @Test def test_contains_04(): Unit = { runner2.runOneTest("contains_04") }
+  @Test def test_contains_05(): Unit = { runner2.runOneTest("contains_05") }
+  @Test def test_contains_06(): Unit = { runner2.runOneTest("contains_06") }
+  @Test def test_contains_07(): Unit = { runner2.runOneTest("contains_07") }
 
-  @Test def test_startswith_01() { runner2.runOneTest("startswith_01") }
-  @Test def test_startswith_02() { runner2.runOneTest("startswith_02") }
-  @Test def test_startswith_03() { runner2.runOneTest("startswith_03") }
-  @Test def test_startswith_04() { runner2.runOneTest("startswith_04") }
-  @Test def test_startswith_05() { runner2.runOneTest("startswith_05") }
-  @Test def test_startswith_06() { runner2.runOneTest("startswith_06") }
-  @Test def test_startswith_07() { runner2.runOneTest("startswith_07") }
+  @Test def test_startswith_01(): Unit = { runner2.runOneTest("startswith_01") }
+  @Test def test_startswith_02(): Unit = { runner2.runOneTest("startswith_02") }
+  @Test def test_startswith_03(): Unit = { runner2.runOneTest("startswith_03") }
+  @Test def test_startswith_04(): Unit = { runner2.runOneTest("startswith_04") }
+  @Test def test_startswith_05(): Unit = { runner2.runOneTest("startswith_05") }
+  @Test def test_startswith_06(): Unit = { runner2.runOneTest("startswith_06") }
+  @Test def test_startswith_07(): Unit = { runner2.runOneTest("startswith_07") }
 
-  @Test def test_endswith_01() { runner2.runOneTest("endswith_01") }
-  @Test def test_endswith_02() { runner2.runOneTest("endswith_02") }
-  @Test def test_endswith_03() { runner2.runOneTest("endswith_03") }
-  @Test def test_endswith_04() { runner2.runOneTest("endswith_04") }
-  @Test def test_endswith_05() { runner2.runOneTest("endswith_05") }
-  @Test def test_endswith_06() { runner2.runOneTest("endswith_06") }
-  @Test def test_endswith_07() { runner2.runOneTest("endswith_07") }
+  @Test def test_endswith_01(): Unit = { runner2.runOneTest("endswith_01") }
+  @Test def test_endswith_02(): Unit = { runner2.runOneTest("endswith_02") }
+  @Test def test_endswith_03(): Unit = { runner2.runOneTest("endswith_03") }
+  @Test def test_endswith_04(): Unit = { runner2.runOneTest("endswith_04") }
+  @Test def test_endswith_05(): Unit = { runner2.runOneTest("endswith_05") }
+  @Test def test_endswith_06(): Unit = { runner2.runOneTest("endswith_06") }
+  @Test def test_endswith_07(): Unit = { runner2.runOneTest("endswith_07") }
 
-  @Test def test_substringbefore_01() { runner2.runOneTest("substringbefore_01") }
-  @Test def test_substringbefore_02() { runner2.runOneTest("substringbefore_02") }
-  @Test def test_substringbefore_03() { runner2.runOneTest("substringbefore_03") }
-  @Test def test_substringbefore_04() { runner2.runOneTest("substringbefore_04") }
-  @Test def test_substringbefore_05() { runner2.runOneTest("substringbefore_05") }
-  @Test def test_substringbefore_06() { runner2.runOneTest("substringbefore_06") }
-  @Test def test_substringbefore_07() { runner2.runOneTest("substringbefore_07") }
+  @Test def test_substringbefore_01(): Unit = { runner2.runOneTest("substringbefore_01") }
+  @Test def test_substringbefore_02(): Unit = { runner2.runOneTest("substringbefore_02") }
+  @Test def test_substringbefore_03(): Unit = { runner2.runOneTest("substringbefore_03") }
+  @Test def test_substringbefore_04(): Unit = { runner2.runOneTest("substringbefore_04") }
+  @Test def test_substringbefore_05(): Unit = { runner2.runOneTest("substringbefore_05") }
+  @Test def test_substringbefore_06(): Unit = { runner2.runOneTest("substringbefore_06") }
+  @Test def test_substringbefore_07(): Unit = { runner2.runOneTest("substringbefore_07") }
 
-  @Test def test_substringafter_01() { runner2.runOneTest("substringafter_01") }
-  @Test def test_substringafter_02() { runner2.runOneTest("substringafter_02") }
-  @Test def test_substringafter_03() { runner2.runOneTest("substringafter_03") }
-  @Test def test_substringafter_04() { runner2.runOneTest("substringafter_04") }
-  @Test def test_substringafter_05() { runner2.runOneTest("substringafter_05") }
-  @Test def test_substringafter_06() { runner2.runOneTest("substringafter_06") }
-  @Test def test_substringafter_07() { runner2.runOneTest("substringafter_07") }
+  @Test def test_substringafter_01(): Unit = { runner2.runOneTest("substringafter_01") }
+  @Test def test_substringafter_02(): Unit = { runner2.runOneTest("substringafter_02") }
+  @Test def test_substringafter_03(): Unit = { runner2.runOneTest("substringafter_03") }
+  @Test def test_substringafter_04(): Unit = { runner2.runOneTest("substringafter_04") }
+  @Test def test_substringafter_05(): Unit = { runner2.runOneTest("substringafter_05") }
+  @Test def test_substringafter_06(): Unit = { runner2.runOneTest("substringafter_06") }
+  @Test def test_substringafter_07(): Unit = { runner2.runOneTest("substringafter_07") }
 
-  @Test def test_yearfromdatetime_01() { runner2.runOneTest("yearfromdatetime_01") }
-  @Test def test_yearfromdatetime_02() { runner2.runOneTest("yearfromdatetime_02") }
-  @Test def test_yearfromdatetime_03() { runner2.runOneTest("yearfromdatetime_03") }
-  @Test def test_monthfromdatetime_01() { runner2.runOneTest("monthfromdatetime_01") }
-  @Test def test_monthfromdatetime_02() { runner2.runOneTest("monthfromdatetime_02") }
-  @Test def test_dayfromdatetime_01() { runner2.runOneTest("dayfromdatetime_01") }
-  @Test def test_dayfromdatetime_02() { runner2.runOneTest("dayfromdatetime_02") }
-  @Test def test_hoursfromdatetime_01() { runner2.runOneTest("hoursfromdatetime_01") }
-  @Test def test_hoursfromdatetime_02() { runner2.runOneTest("hoursfromdatetime_02") }
-  @Test def test_minutesfromdatetime_01() { runner2.runOneTest("minutesfromdatetime_01") }
-  @Test def test_minutesfromdatetime_02() { runner2.runOneTest("minutesfromdatetime_02") }
-  @Test def test_secondsfromdatetime_01() { runner2.runOneTest("secondsfromdatetime_01") }
-  @Test def test_secondsfromdatetime_02() { runner2.runOneTest("secondsfromdatetime_02") }
-  @Test def test_secondsfromdatetime_03() { runner2.runOneTest("secondsfromdatetime_03") }
-  @Test def test_timezonefromdatetime_01() { runner2.runOneTest("timezonefromdatetime_01") }
-  @Test def test_timezonefromdatetime_02() { runner2.runOneTest("timezonefromdatetime_02") }
+  @Test def test_yearfromdatetime_01(): Unit = { runner2.runOneTest("yearfromdatetime_01") }
+  @Test def test_yearfromdatetime_02(): Unit = { runner2.runOneTest("yearfromdatetime_02") }
+  @Test def test_yearfromdatetime_03(): Unit = { runner2.runOneTest("yearfromdatetime_03") }
+  @Test def test_monthfromdatetime_01(): Unit = { runner2.runOneTest("monthfromdatetime_01") }
+  @Test def test_monthfromdatetime_02(): Unit = { runner2.runOneTest("monthfromdatetime_02") }
+  @Test def test_dayfromdatetime_01(): Unit = { runner2.runOneTest("dayfromdatetime_01") }
+  @Test def test_dayfromdatetime_02(): Unit = { runner2.runOneTest("dayfromdatetime_02") }
+  @Test def test_hoursfromdatetime_01(): Unit = { runner2.runOneTest("hoursfromdatetime_01") }
+  @Test def test_hoursfromdatetime_02(): Unit = { runner2.runOneTest("hoursfromdatetime_02") }
+  @Test def test_minutesfromdatetime_01(): Unit = { runner2.runOneTest("minutesfromdatetime_01") }
+  @Test def test_minutesfromdatetime_02(): Unit = { runner2.runOneTest("minutesfromdatetime_02") }
+  @Test def test_secondsfromdatetime_01(): Unit = { runner2.runOneTest("secondsfromdatetime_01") }
+  @Test def test_secondsfromdatetime_02(): Unit = { runner2.runOneTest("secondsfromdatetime_02") }
+  @Test def test_secondsfromdatetime_03(): Unit = { runner2.runOneTest("secondsfromdatetime_03") }
+  @Test def test_timezonefromdatetime_01(): Unit = { runner2.runOneTest("timezonefromdatetime_01") }
+  @Test def test_timezonefromdatetime_02(): Unit = { runner2.runOneTest("timezonefromdatetime_02") }
 
-  @Test def test_xfromdatetime_01() { runner2.runOneTest("xfromdatetime_01") }
-  @Test def test_xfromdatetime_02() { runner2.runOneTest("xfromdatetime_02") }
-  @Test def test_xfromdatetime_03() { runner2.runOneTest("xfromdatetime_03") }
-  @Test def test_xfromdatetime_04() { runner2.runOneTest("xfromdatetime_04") }
+  @Test def test_xfromdatetime_01(): Unit = { runner2.runOneTest("xfromdatetime_01") }
+  @Test def test_xfromdatetime_02(): Unit = { runner2.runOneTest("xfromdatetime_02") }
+  @Test def test_xfromdatetime_03(): Unit = { runner2.runOneTest("xfromdatetime_03") }
+  @Test def test_xfromdatetime_04(): Unit = { runner2.runOneTest("xfromdatetime_04") }
 
-  @Test def test_yearfromdate_01() { runner2.runOneTest("yearfromdate_01") }
-  @Test def test_yearfromdate_02() { runner2.runOneTest("yearfromdate_02") }
-  @Test def test_yearfromdate_03() { runner2.runOneTest("yearfromdate_03") }
-  @Test def test_monthfromdate_01() { runner2.runOneTest("monthfromdate_01") }
-  @Test def test_monthfromdate_02() { runner2.runOneTest("monthfromdate_02") }
-  @Test def test_dayfromdate_01() { runner2.runOneTest("dayfromdate_01") }
-  @Test def test_dayfromdate_02() { runner2.runOneTest("dayfromdate_02") }
-  @Test def test_timezonefromdate_01() { runner2.runOneTest("timezonefromdate_01") }
-  @Test def test_timezonefromdate_02() { runner2.runOneTest("timezonefromdate_02") }
+  @Test def test_yearfromdate_01(): Unit = { runner2.runOneTest("yearfromdate_01") }
+  @Test def test_yearfromdate_02(): Unit = { runner2.runOneTest("yearfromdate_02") }
+  @Test def test_yearfromdate_03(): Unit = { runner2.runOneTest("yearfromdate_03") }
+  @Test def test_monthfromdate_01(): Unit = { runner2.runOneTest("monthfromdate_01") }
+  @Test def test_monthfromdate_02(): Unit = { runner2.runOneTest("monthfromdate_02") }
+  @Test def test_dayfromdate_01(): Unit = { runner2.runOneTest("dayfromdate_01") }
+  @Test def test_dayfromdate_02(): Unit = { runner2.runOneTest("dayfromdate_02") }
+  @Test def test_timezonefromdate_01(): Unit = { runner2.runOneTest("timezonefromdate_01") }
+  @Test def test_timezonefromdate_02(): Unit = { runner2.runOneTest("timezonefromdate_02") }
 
-  @Test def test_xfromdate_01() { runner2.runOneTest("xfromdate_01") }
-  @Test def test_xfromdate_02() { runner2.runOneTest("xfromdate_02") }
-  @Test def test_xfromdate_03() { runner2.runOneTest("xfromdate_03") }
+  @Test def test_xfromdate_01(): Unit = { runner2.runOneTest("xfromdate_01") }
+  @Test def test_xfromdate_02(): Unit = { runner2.runOneTest("xfromdate_02") }
+  @Test def test_xfromdate_03(): Unit = { runner2.runOneTest("xfromdate_03") }
 
-  @Test def test_hoursfromtime_01() { runner2.runOneTest("hoursfromtime_01") }
-  @Test def test_hoursfromtime_02() { runner2.runOneTest("hoursfromtime_02") }
-  @Test def test_minutesfromtime_01() { runner2.runOneTest("minutesfromtime_01") }
-  @Test def test_minutesfromtime_02() { runner2.runOneTest("minutesfromtime_02") }
-  @Test def test_secondsfromtime_01() { runner2.runOneTest("secondsfromtime_01") }
-  @Test def test_secondsfromtime_02() { runner2.runOneTest("secondsfromtime_02") }
-  @Test def test_timezonefromtime_01() { runner2.runOneTest("timezonefromtime_01") }
-  @Test def test_timezonefromtime_02() { runner2.runOneTest("timezonefromtime_02") }
-  @Test def test_timezonefromtime_03() { runner2.runOneTest("timezonefromtime_03") }
+  @Test def test_hoursfromtime_01(): Unit = { runner2.runOneTest("hoursfromtime_01") }
+  @Test def test_hoursfromtime_02(): Unit = { runner2.runOneTest("hoursfromtime_02") }
+  @Test def test_minutesfromtime_01(): Unit = { runner2.runOneTest("minutesfromtime_01") }
+  @Test def test_minutesfromtime_02(): Unit = { runner2.runOneTest("minutesfromtime_02") }
+  @Test def test_secondsfromtime_01(): Unit = { runner2.runOneTest("secondsfromtime_01") }
+  @Test def test_secondsfromtime_02(): Unit = { runner2.runOneTest("secondsfromtime_02") }
+  @Test def test_timezonefromtime_01(): Unit = { runner2.runOneTest("timezonefromtime_01") }
+  @Test def test_timezonefromtime_02(): Unit = { runner2.runOneTest("timezonefromtime_02") }
+  @Test def test_timezonefromtime_03(): Unit = { runner2.runOneTest("timezonefromtime_03") }
 
-  @Test def test_xfromtime_01() { runner2.runOneTest("xfromtime_01") }
-  @Test def test_xfromtime_02() { runner2.runOneTest("xfromtime_02") }
-  @Test def test_xfromtime_03() { runner2.runOneTest("xfromtime_03") }
+  @Test def test_xfromtime_01(): Unit = { runner2.runOneTest("xfromtime_01") }
+  @Test def test_xfromtime_02(): Unit = { runner2.runOneTest("xfromtime_02") }
+  @Test def test_xfromtime_03(): Unit = { runner2.runOneTest("xfromtime_03") }
 
-  @Test def test_fn_text_01() { runner2.runOneTest("fn_text_01") }
-  @Test def test_fn_text_02() { runner2.runOneTest("fn_text_02") }
+  @Test def test_fn_text_01(): Unit = { runner2.runOneTest("fn_text_01") }
+  @Test def test_fn_text_02(): Unit = { runner2.runOneTest("fn_text_02") }
 
-  @Test def test_ubyte_constructor_01() { runner2.runOneTest("ubyte_constructor_01") }
-  @Test def test_ubyte_constructor_02() { runner2.runOneTest("ubyte_constructor_02") }
-  @Test def test_ubyte_constructor_03() { runner2.runOneTest("ubyte_constructor_03") }
-  @Test def test_ubyte_constructor_04() { runner2.runOneTest("ubyte_constructor_04") }
+  @Test def test_ubyte_constructor_01(): Unit = { runner2.runOneTest("ubyte_constructor_01") }
+  @Test def test_ubyte_constructor_02(): Unit = { runner2.runOneTest("ubyte_constructor_02") }
+  @Test def test_ubyte_constructor_03(): Unit = { runner2.runOneTest("ubyte_constructor_03") }
+  @Test def test_ubyte_constructor_04(): Unit = { runner2.runOneTest("ubyte_constructor_04") }
 
-  @Test def test_uint_constructor_01() { runner2.runOneTest("uint_constructor_01") }
-  @Test def test_uint_constructor_02() { runner2.runOneTest("uint_constructor_02") }
-  @Test def test_uint_constructor_03() { runner2.runOneTest("uint_constructor_03") }
-  @Test def test_uint_constructor_04() { runner2.runOneTest("uint_constructor_04") }
+  @Test def test_uint_constructor_01(): Unit = { runner2.runOneTest("uint_constructor_01") }
+  @Test def test_uint_constructor_02(): Unit = { runner2.runOneTest("uint_constructor_02") }
+  @Test def test_uint_constructor_03(): Unit = { runner2.runOneTest("uint_constructor_03") }
+  @Test def test_uint_constructor_04(): Unit = { runner2.runOneTest("uint_constructor_04") }
 
-  @Test def test_nonNeg_constructor_01() { runner2.runOneTest("nonNeg_constructor_01") }
-  @Test def test_nonNeg_constructor_02() { runner2.runOneTest("nonNeg_constructor_02") }
-  @Test def test_nonNeg_constructor_03() { runner2.runOneTest("nonNeg_constructor_03") }
-  @Test def test_nonNeg_constructor_04() { runner2.runOneTest("nonNeg_constructor_04") }
+  @Test def test_nonNeg_constructor_01(): Unit = { runner2.runOneTest("nonNeg_constructor_01") }
+  @Test def test_nonNeg_constructor_02(): Unit = { runner2.runOneTest("nonNeg_constructor_02") }
+  @Test def test_nonNeg_constructor_03(): Unit = { runner2.runOneTest("nonNeg_constructor_03") }
+  @Test def test_nonNeg_constructor_04(): Unit = { runner2.runOneTest("nonNeg_constructor_04") }
 
-  @Test def test_byte_constructor_01() { runner2.runOneTest("byte_constructor_01") }
-  @Test def test_byte_constructor_02() { runner2.runOneTest("byte_constructor_02") }
-  @Test def test_byte_constructor_03() { runner2.runOneTest("byte_constructor_03") }
-  @Test def test_byte_constructor_04() { runner2.runOneTest("byte_constructor_04") }
+  @Test def test_byte_constructor_01(): Unit = { runner2.runOneTest("byte_constructor_01") }
+  @Test def test_byte_constructor_02(): Unit = { runner2.runOneTest("byte_constructor_02") }
+  @Test def test_byte_constructor_03(): Unit = { runner2.runOneTest("byte_constructor_03") }
+  @Test def test_byte_constructor_04(): Unit = { runner2.runOneTest("byte_constructor_04") }
 
-  @Test def test_hexBinary_constructor_01() { runner2.runOneTest("hexBinary_constructor_01") }
-  @Test def test_hexBinary_constructor_02() { runner2.runOneTest("hexBinary_constructor_02") }
-  @Test def test_hexBinary_constructor_03() { runner2.runOneTest("hexBinary_constructor_03") }
-  @Test def test_hexBinary_constructor_04() { runner2.runOneTest("hexBinary_constructor_04") }
+  @Test def test_hexBinary_constructor_01(): Unit = { runner2.runOneTest("hexBinary_constructor_01") }
+  @Test def test_hexBinary_constructor_02(): Unit = { runner2.runOneTest("hexBinary_constructor_02") }
+  @Test def test_hexBinary_constructor_03(): Unit = { runner2.runOneTest("hexBinary_constructor_03") }
+  @Test def test_hexBinary_constructor_04(): Unit = { runner2.runOneTest("hexBinary_constructor_04") }
 
-  @Test def test_dfdlHexBinary_constructor_01() { runner2.runOneTest("dfdlHexBinary_constructor_01") }
-  @Test def test_dfdlHexBinary_constructor_02() { runner2.runOneTest("dfdlHexBinary_constructor_02") }
-  @Test def test_dfdlHexBinary_constructor_03() { runner2.runOneTest("dfdlHexBinary_constructor_03") }
-  @Test def test_dfdlHexBinary_constructor_04() { runner2.runOneTest("dfdlHexBinary_constructor_04") }
-  @Test def test_dfdlHexBinary_constructor_05() { runner2.runOneTest("dfdlHexBinary_constructor_05") }
+  @Test def test_dfdlHexBinary_constructor_01(): Unit = { runner2.runOneTest("dfdlHexBinary_constructor_01") }
+  @Test def test_dfdlHexBinary_constructor_02(): Unit = { runner2.runOneTest("dfdlHexBinary_constructor_02") }
+  @Test def test_dfdlHexBinary_constructor_03(): Unit = { runner2.runOneTest("dfdlHexBinary_constructor_03") }
+  @Test def test_dfdlHexBinary_constructor_04(): Unit = { runner2.runOneTest("dfdlHexBinary_constructor_04") }
+  @Test def test_dfdlHexBinary_constructor_05(): Unit = { runner2.runOneTest("dfdlHexBinary_constructor_05") }
 
-  @Test def test_dfdlByte_constructor_01() { runner2.runOneTest("dfdlByte_constructor_01") }
-  @Test def test_dfdlByte_constructor_02() { runner2.runOneTest("dfdlByte_constructor_02") }
-  @Test def test_dfdlByte_constructor_03() { runner2.runOneTest("dfdlByte_constructor_03") }
-  @Test def test_dfdlByte_constructor_04() { runner2.runOneTest("dfdlByte_constructor_04") }
-  @Test def test_dfdlByte_constructor_05() { runner2.runOneTest("dfdlByte_constructor_05") }
-  @Test def test_dfdlByte_constructor_06() { runner2.runOneTest("dfdlByte_constructor_06") }
-  @Test def test_dfdlByte_constructor_07() { runner2.runOneTest("dfdlByte_constructor_07") }
-  @Test def test_dfdlByte_constructor_08() { runner2.runOneTest("dfdlByte_constructor_08") }
-  @Test def test_dfdlByte_constructor_09() { runner2.runOneTest("dfdlByte_constructor_09") }
-  @Test def test_dfdlByte_constructor_10() { runner2.runOneTest("dfdlByte_constructor_10") }
+  @Test def test_dfdlByte_constructor_01(): Unit = { runner2.runOneTest("dfdlByte_constructor_01") }
+  @Test def test_dfdlByte_constructor_02(): Unit = { runner2.runOneTest("dfdlByte_constructor_02") }
+  @Test def test_dfdlByte_constructor_03(): Unit = { runner2.runOneTest("dfdlByte_constructor_03") }
+  @Test def test_dfdlByte_constructor_04(): Unit = { runner2.runOneTest("dfdlByte_constructor_04") }
+  @Test def test_dfdlByte_constructor_05(): Unit = { runner2.runOneTest("dfdlByte_constructor_05") }
+  @Test def test_dfdlByte_constructor_06(): Unit = { runner2.runOneTest("dfdlByte_constructor_06") }
+  @Test def test_dfdlByte_constructor_07(): Unit = { runner2.runOneTest("dfdlByte_constructor_07") }
+  @Test def test_dfdlByte_constructor_08(): Unit = { runner2.runOneTest("dfdlByte_constructor_08") }
+  @Test def test_dfdlByte_constructor_09(): Unit = { runner2.runOneTest("dfdlByte_constructor_09") }
+  @Test def test_dfdlByte_constructor_10(): Unit = { runner2.runOneTest("dfdlByte_constructor_10") }
 
-  @Test def test_dfdlUByte_constructor_01() { runner2.runOneTest("dfdlUByte_constructor_01") }
-  @Test def test_dfdlUByte_constructor_02() { runner2.runOneTest("dfdlUByte_constructor_02") }
-  @Test def test_dfdlUByte_constructor_03() { runner2.runOneTest("dfdlUByte_constructor_03") }
-  @Test def test_dfdlUByte_constructor_04() { runner2.runOneTest("dfdlUByte_constructor_04") }
-  @Test def test_dfdlUByte_constructor_05() { runner2.runOneTest("dfdlUByte_constructor_05") }
-  @Test def test_dfdlUByte_constructor_06() { runner2.runOneTest("dfdlUByte_constructor_06") }
-  @Test def test_dfdlUByte_constructor_07() { runner2.runOneTest("dfdlUByte_constructor_07") }
-  @Test def test_dfdlUByte_constructor_08() { runner2.runOneTest("dfdlUByte_constructor_08") }
-  @Test def test_dfdlUByte_constructor_09() { runner2.runOneTest("dfdlUByte_constructor_09") }
-  @Test def test_dfdlUByte_constructor_11() { runner2.runOneTest("dfdlUByte_constructor_11") }
+  @Test def test_dfdlUByte_constructor_01(): Unit = { runner2.runOneTest("dfdlUByte_constructor_01") }
+  @Test def test_dfdlUByte_constructor_02(): Unit = { runner2.runOneTest("dfdlUByte_constructor_02") }
+  @Test def test_dfdlUByte_constructor_03(): Unit = { runner2.runOneTest("dfdlUByte_constructor_03") }
+  @Test def test_dfdlUByte_constructor_04(): Unit = { runner2.runOneTest("dfdlUByte_constructor_04") }
+  @Test def test_dfdlUByte_constructor_05(): Unit = { runner2.runOneTest("dfdlUByte_constructor_05") }
+  @Test def test_dfdlUByte_constructor_06(): Unit = { runner2.runOneTest("dfdlUByte_constructor_06") }
+  @Test def test_dfdlUByte_constructor_07(): Unit = { runner2.runOneTest("dfdlUByte_constructor_07") }
+  @Test def test_dfdlUByte_constructor_08(): Unit = { runner2.runOneTest("dfdlUByte_constructor_08") }
+  @Test def test_dfdlUByte_constructor_09(): Unit = { runner2.runOneTest("dfdlUByte_constructor_09") }
+  @Test def test_dfdlUByte_constructor_11(): Unit = { runner2.runOneTest("dfdlUByte_constructor_11") }
 
-  @Test def test_dfdlShort_constructor_01() { runner2.runOneTest("dfdlShort_constructor_01") }
-  @Test def test_dfdlShort_constructor_02() { runner2.runOneTest("dfdlShort_constructor_02") }
-  @Test def test_dfdlShort_constructor_03() { runner2.runOneTest("dfdlShort_constructor_03") }
-  @Test def test_dfdlShort_constructor_04() { runner2.runOneTest("dfdlShort_constructor_04") }
-  @Test def test_dfdlShort_constructor_05() { runner2.runOneTest("dfdlShort_constructor_05") }
-  @Test def test_dfdlShort_constructor_06() { runner2.runOneTest("dfdlShort_constructor_06") }
-  @Test def test_dfdlShort_constructor_07() { runner2.runOneTest("dfdlShort_constructor_07") }
-  @Test def test_dfdlShort_constructor_08() { runner2.runOneTest("dfdlShort_constructor_08") }
-  @Test def test_dfdlShort_constructor_09() { runner2.runOneTest("dfdlShort_constructor_09") }
-  @Test def test_dfdlShort_constructor_11() { runner2.runOneTest("dfdlShort_constructor_11") }
+  @Test def test_dfdlShort_constructor_01(): Unit = { runner2.runOneTest("dfdlShort_constructor_01") }
+  @Test def test_dfdlShort_constructor_02(): Unit = { runner2.runOneTest("dfdlShort_constructor_02") }
+  @Test def test_dfdlShort_constructor_03(): Unit = { runner2.runOneTest("dfdlShort_constructor_03") }
+  @Test def test_dfdlShort_constructor_04(): Unit = { runner2.runOneTest("dfdlShort_constructor_04") }
+  @Test def test_dfdlShort_constructor_05(): Unit = { runner2.runOneTest("dfdlShort_constructor_05") }
+  @Test def test_dfdlShort_constructor_06(): Unit = { runner2.runOneTest("dfdlShort_constructor_06") }
+  @Test def test_dfdlShort_constructor_07(): Unit = { runner2.runOneTest("dfdlShort_constructor_07") }
+  @Test def test_dfdlShort_constructor_08(): Unit = { runner2.runOneTest("dfdlShort_constructor_08") }
+  @Test def test_dfdlShort_constructor_09(): Unit = { runner2.runOneTest("dfdlShort_constructor_09") }
+  @Test def test_dfdlShort_constructor_11(): Unit = { runner2.runOneTest("dfdlShort_constructor_11") }
 
-  @Test def test_dfdlUShort_constructor_01() { runner2.runOneTest("dfdlUShort_constructor_01") }
-  @Test def test_dfdlUShort_constructor_02() { runner2.runOneTest("dfdlUShort_constructor_02") }
-  @Test def test_dfdlUShort_constructor_03() { runner2.runOneTest("dfdlUShort_constructor_03") }
-  @Test def test_dfdlUShort_constructor_04() { runner2.runOneTest("dfdlUShort_constructor_04") }
-  @Test def test_dfdlUShort_constructor_05() { runner2.runOneTest("dfdlUShort_constructor_05") }
-  @Test def test_dfdlUShort_constructor_06() { runner2.runOneTest("dfdlUShort_constructor_06") }
-  @Test def test_dfdlUShort_constructor_07() { runner2.runOneTest("dfdlUShort_constructor_07") }
-  @Test def test_dfdlUShort_constructor_08() { runner2.runOneTest("dfdlUShort_constructor_08") }
-  @Test def test_dfdlUShort_constructor_09() { runner2.runOneTest("dfdlUShort_constructor_09") }
-  @Test def test_dfdlUShort_constructor_11() { runner2.runOneTest("dfdlUShort_constructor_11") }
+  @Test def test_dfdlUShort_constructor_01(): Unit = { runner2.runOneTest("dfdlUShort_constructor_01") }
+  @Test def test_dfdlUShort_constructor_02(): Unit = { runner2.runOneTest("dfdlUShort_constructor_02") }
+  @Test def test_dfdlUShort_constructor_03(): Unit = { runner2.runOneTest("dfdlUShort_constructor_03") }
+  @Test def test_dfdlUShort_constructor_04(): Unit = { runner2.runOneTest("dfdlUShort_constructor_04") }
+  @Test def test_dfdlUShort_constructor_05(): Unit = { runner2.runOneTest("dfdlUShort_constructor_05") }
+  @Test def test_dfdlUShort_constructor_06(): Unit = { runner2.runOneTest("dfdlUShort_constructor_06") }
+  @Test def test_dfdlUShort_constructor_07(): Unit = { runner2.runOneTest("dfdlUShort_constructor_07") }
+  @Test def test_dfdlUShort_constructor_08(): Unit = { runner2.runOneTest("dfdlUShort_constructor_08") }
+  @Test def test_dfdlUShort_constructor_09(): Unit = { runner2.runOneTest("dfdlUShort_constructor_09") }
+  @Test def test_dfdlUShort_constructor_11(): Unit = { runner2.runOneTest("dfdlUShort_constructor_11") }
 
-  @Test def test_dfdlInt_constructor_01() { runner2.runOneTest("dfdlInt_constructor_01") }
-  @Test def test_dfdlInt_constructor_02() { runner2.runOneTest("dfdlInt_constructor_02") }
-  @Test def test_dfdlInt_constructor_03() { runner2.runOneTest("dfdlInt_constructor_03") }
-  @Test def test_dfdlInt_constructor_04() { runner2.runOneTest("dfdlInt_constructor_04") }
-  @Test def test_dfdlInt_constructor_05() { runner2.runOneTest("dfdlInt_constructor_05") }
-  @Test def test_dfdlInt_constructor_06() { runner2.runOneTest("dfdlInt_constructor_06") }
-  @Test def test_dfdlInt_constructor_07() { runner2.runOneTest("dfdlInt_constructor_07") }
-  @Test def test_dfdlInt_constructor_08() { runner2.runOneTest("dfdlInt_constructor_08") }
-  @Test def test_dfdlInt_constructor_09() { runner2.runOneTest("dfdlInt_constructor_09") }
-  @Test def test_dfdlInt_constructor_11() { runner2.runOneTest("dfdlInt_constructor_11") }
-  @Test def test_dfdlInt_constructor_12() { runner2.runOneTest("dfdlInt_constructor_12") }
-  @Test def test_dfdlInt_constructor_13() { runner2.runOneTest("dfdlInt_constructor_13") }
-  @Test def test_dfdlInt_constructor_14() { runner2.runOneTest("dfdlInt_constructor_14") }
+  @Test def test_dfdlInt_constructor_01(): Unit = { runner2.runOneTest("dfdlInt_constructor_01") }
+  @Test def test_dfdlInt_constructor_02(): Unit = { runner2.runOneTest("dfdlInt_constructor_02") }
+  @Test def test_dfdlInt_constructor_03(): Unit = { runner2.runOneTest("dfdlInt_constructor_03") }
+  @Test def test_dfdlInt_constructor_04(): Unit = { runner2.runOneTest("dfdlInt_constructor_04") }
+  @Test def test_dfdlInt_constructor_05(): Unit = { runner2.runOneTest("dfdlInt_constructor_05") }
+  @Test def test_dfdlInt_constructor_06(): Unit = { runner2.runOneTest("dfdlInt_constructor_06") }
+  @Test def test_dfdlInt_constructor_07(): Unit = { runner2.runOneTest("dfdlInt_constructor_07") }
+  @Test def test_dfdlInt_constructor_08(): Unit = { runner2.runOneTest("dfdlInt_constructor_08") }
+  @Test def test_dfdlInt_constructor_09(): Unit = { runner2.runOneTest("dfdlInt_constructor_09") }
+  @Test def test_dfdlInt_constructor_11(): Unit = { runner2.runOneTest("dfdlInt_constructor_11") }
+  @Test def test_dfdlInt_constructor_12(): Unit = { runner2.runOneTest("dfdlInt_constructor_12") }
+  @Test def test_dfdlInt_constructor_13(): Unit = { runner2.runOneTest("dfdlInt_constructor_13") }
+  @Test def test_dfdlInt_constructor_14(): Unit = { runner2.runOneTest("dfdlInt_constructor_14") }
 
-  @Test def test_dfdlUInt_constructor_01() { runner2.runOneTest("dfdlUInt_constructor_01") }
-  @Test def test_dfdlUInt_constructor_02() { runner2.runOneTest("dfdlUInt_constructor_02") }
-  @Test def test_dfdlUInt_constructor_03() { runner2.runOneTest("dfdlUInt_constructor_03") }
-  @Test def test_dfdlUInt_constructor_04() { runner2.runOneTest("dfdlUInt_constructor_04") }
-  @Test def test_dfdlUInt_constructor_05() { runner2.runOneTest("dfdlUInt_constructor_05") }
-  @Test def test_dfdlUInt_constructor_06() { runner2.runOneTest("dfdlUInt_constructor_06") }
-  @Test def test_dfdlUInt_constructor_07() { runner2.runOneTest("dfdlUInt_constructor_07") }
-  @Test def test_dfdlUInt_constructor_08() { runner2.runOneTest("dfdlUInt_constructor_08") }
-  @Test def test_dfdlUInt_constructor_09() { runner2.runOneTest("dfdlUInt_constructor_09") }
-  @Test def test_dfdlUInt_constructor_11() { runner2.runOneTest("dfdlUInt_constructor_11") }
-  @Test def test_dfdlUInt_constructor_12() { runner2.runOneTest("dfdlUInt_constructor_12") }
+  @Test def test_dfdlUInt_constructor_01(): Unit = { runner2.runOneTest("dfdlUInt_constructor_01") }
+  @Test def test_dfdlUInt_constructor_02(): Unit = { runner2.runOneTest("dfdlUInt_constructor_02") }
+  @Test def test_dfdlUInt_constructor_03(): Unit = { runner2.runOneTest("dfdlUInt_constructor_03") }
+  @Test def test_dfdlUInt_constructor_04(): Unit = { runner2.runOneTest("dfdlUInt_constructor_04") }
+  @Test def test_dfdlUInt_constructor_05(): Unit = { runner2.runOneTest("dfdlUInt_constructor_05") }
+  @Test def test_dfdlUInt_constructor_06(): Unit = { runner2.runOneTest("dfdlUInt_constructor_06") }
+  @Test def test_dfdlUInt_constructor_07(): Unit = { runner2.runOneTest("dfdlUInt_constructor_07") }
+  @Test def test_dfdlUInt_constructor_08(): Unit = { runner2.runOneTest("dfdlUInt_constructor_08") }
+  @Test def test_dfdlUInt_constructor_09(): Unit = { runner2.runOneTest("dfdlUInt_constructor_09") }
+  @Test def test_dfdlUInt_constructor_11(): Unit = { runner2.runOneTest("dfdlUInt_constructor_11") }
+  @Test def test_dfdlUInt_constructor_12(): Unit = { runner2.runOneTest("dfdlUInt_constructor_12") }
 
-  @Test def test_dfdlLong_constructor_01() { runner2.runOneTest("dfdlLong_constructor_01") }
-  @Test def test_dfdlLong_constructor_02() { runner2.runOneTest("dfdlLong_constructor_02") }
-  @Test def test_dfdlLong_constructor_03() { runner2.runOneTest("dfdlLong_constructor_03") }
-  @Test def test_dfdlLong_constructor_04() { runner2.runOneTest("dfdlLong_constructor_04") }
-  @Test def test_dfdlLong_constructor_05() { runner2.runOneTest("dfdlLong_constructor_05") }
-  @Test def test_dfdlLong_constructor_06() { runner2.runOneTest("dfdlLong_constructor_06") }
-  @Test def test_dfdlLong_constructor_07() { runner2.runOneTest("dfdlLong_constructor_07") }
-  @Test def test_dfdlLong_constructor_08() { runner2.runOneTest("dfdlLong_constructor_08") }
-  @Test def test_dfdlLong_constructor_09() { runner2.runOneTest("dfdlLong_constructor_09") }
-  @Test def test_dfdlLong_constructor_11() { runner2.runOneTest("dfdlLong_constructor_11") }
-  @Test def test_dfdlLong_constructor_12() { runner2.runOneTest("dfdlLong_constructor_12") }
+  @Test def test_dfdlLong_constructor_01(): Unit = { runner2.runOneTest("dfdlLong_constructor_01") }
+  @Test def test_dfdlLong_constructor_02(): Unit = { runner2.runOneTest("dfdlLong_constructor_02") }
+  @Test def test_dfdlLong_constructor_03(): Unit = { runner2.runOneTest("dfdlLong_constructor_03") }
+  @Test def test_dfdlLong_constructor_04(): Unit = { runner2.runOneTest("dfdlLong_constructor_04") }
+  @Test def test_dfdlLong_constructor_05(): Unit = { runner2.runOneTest("dfdlLong_constructor_05") }
+  @Test def test_dfdlLong_constructor_06(): Unit = { runner2.runOneTest("dfdlLong_constructor_06") }
+  @Test def test_dfdlLong_constructor_07(): Unit = { runner2.runOneTest("dfdlLong_constructor_07") }
+  @Test def test_dfdlLong_constructor_08(): Unit = { runner2.runOneTest("dfdlLong_constructor_08") }
+  @Test def test_dfdlLong_constructor_09(): Unit = { runner2.runOneTest("dfdlLong_constructor_09") }
+  @Test def test_dfdlLong_constructor_11(): Unit = { runner2.runOneTest("dfdlLong_constructor_11") }
+  @Test def test_dfdlLong_constructor_12(): Unit = { runner2.runOneTest("dfdlLong_constructor_12") }
 
-  @Test def test_dfdlULong_constructor_01() { runner2.runOneTest("dfdlULong_constructor_01") }
-  @Test def test_dfdlULong_constructor_02() { runner2.runOneTest("dfdlULong_constructor_02") }
-  @Test def test_dfdlULong_constructor_03() { runner2.runOneTest("dfdlULong_constructor_03") }
-  @Test def test_dfdlULong_constructor_04() { runner2.runOneTest("dfdlULong_constructor_04") }
-  @Test def test_dfdlULong_constructor_05() { runner2.runOneTest("dfdlULong_constructor_05") }
-  @Test def test_dfdlULong_constructor_06() { runner2.runOneTest("dfdlULong_constructor_06") }
-  @Test def test_dfdlULong_constructor_07() { runner2.runOneTest("dfdlULong_constructor_07") }
-  @Test def test_dfdlULong_constructor_08() { runner2.runOneTest("dfdlULong_constructor_08") }
-  @Test def test_dfdlULong_constructor_09() { runner2.runOneTest("dfdlULong_constructor_09") }
-  @Test def test_dfdlULong_constructor_11() { runner2.runOneTest("dfdlULong_constructor_11") }
-  @Test def test_dfdlULong_constructor_12() { runner2.runOneTest("dfdlULong_constructor_12") }
+  @Test def test_dfdlULong_constructor_01(): Unit = { runner2.runOneTest("dfdlULong_constructor_01") }
+  @Test def test_dfdlULong_constructor_02(): Unit = { runner2.runOneTest("dfdlULong_constructor_02") }
+  @Test def test_dfdlULong_constructor_03(): Unit = { runner2.runOneTest("dfdlULong_constructor_03") }
+  @Test def test_dfdlULong_constructor_04(): Unit = { runner2.runOneTest("dfdlULong_constructor_04") }
+  @Test def test_dfdlULong_constructor_05(): Unit = { runner2.runOneTest("dfdlULong_constructor_05") }
+  @Test def test_dfdlULong_constructor_06(): Unit = { runner2.runOneTest("dfdlULong_constructor_06") }
+  @Test def test_dfdlULong_constructor_07(): Unit = { runner2.runOneTest("dfdlULong_constructor_07") }
+  @Test def test_dfdlULong_constructor_08(): Unit = { runner2.runOneTest("dfdlULong_constructor_08") }
+  @Test def test_dfdlULong_constructor_09(): Unit = { runner2.runOneTest("dfdlULong_constructor_09") }
+  @Test def test_dfdlULong_constructor_11(): Unit = { runner2.runOneTest("dfdlULong_constructor_11") }
+  @Test def test_dfdlULong_constructor_12(): Unit = { runner2.runOneTest("dfdlULong_constructor_12") }
 
-  @Test def test_xsDateTime_constructor_06() { runner2.runOneTest("xsDateTime_constructor_06") }
-  @Test def test_xsDateTime_constructor_07() { runner2.runOneTest("xsDateTime_constructor_07") }
-  @Test def test_xsDateTime_constructor_08() { runner2.runOneTest("xsDateTime_constructor_08") }
-  @Test def test_xsDateTime_constructor_09() { runner2.runOneTest("xsDateTime_constructor_09") }
-  @Test def test_xsDateTime_constructor_10() { runner2.runOneTest("xsDateTime_constructor_10") }
-  @Test def test_date_constructor_05() { runner2.runOneTest("date_constructor_05") }
-  @Test def test_date_constructor_06() { runner2.runOneTest("date_constructor_06") }
-  @Test def test_date_constructor_07() { runner2.runOneTest("date_constructor_07") }
-  @Test def test_date_constructor_08() { runner2.runOneTest("date_constructor_08") }
-  @Test def test_time_constructor_05() { runner2.runOneTest("time_constructor_05") }
-  @Test def test_time_constructor_06() { runner2.runOneTest("time_constructor_06") }
-  @Test def test_time_constructor_07() { runner2.runOneTest("time_constructor_07") }
-  @Test def test_time_constructor_08() { runner2.runOneTest("time_constructor_08") }
-  @Test def test_time_constructor_09() { runner2.runOneTest("time_constructor_09") }
+  @Test def test_xsDateTime_constructor_06(): Unit = { runner2.runOneTest("xsDateTime_constructor_06") }
+  @Test def test_xsDateTime_constructor_07(): Unit = { runner2.runOneTest("xsDateTime_constructor_07") }
+  @Test def test_xsDateTime_constructor_08(): Unit = { runner2.runOneTest("xsDateTime_constructor_08") }
+  @Test def test_xsDateTime_constructor_09(): Unit = { runner2.runOneTest("xsDateTime_constructor_09") }
+  @Test def test_xsDateTime_constructor_10(): Unit = { runner2.runOneTest("xsDateTime_constructor_10") }
+  @Test def test_date_constructor_05(): Unit = { runner2.runOneTest("date_constructor_05") }
+  @Test def test_date_constructor_06(): Unit = { runner2.runOneTest("date_constructor_06") }
+  @Test def test_date_constructor_07(): Unit = { runner2.runOneTest("date_constructor_07") }
+  @Test def test_date_constructor_08(): Unit = { runner2.runOneTest("date_constructor_08") }
+  @Test def test_time_constructor_05(): Unit = { runner2.runOneTest("time_constructor_05") }
+  @Test def test_time_constructor_06(): Unit = { runner2.runOneTest("time_constructor_06") }
+  @Test def test_time_constructor_07(): Unit = { runner2.runOneTest("time_constructor_07") }
+  @Test def test_time_constructor_08(): Unit = { runner2.runOneTest("time_constructor_08") }
+  @Test def test_time_constructor_09(): Unit = { runner2.runOneTest("time_constructor_09") }
 
-  @Test def test_time_constructor_01() { runner2.runOneTest("time_constructor_01") }
-  @Test def test_time_constructor_02() { runner2.runOneTest("time_constructor_02") }
-  @Test def test_time_constructor_03() { runner2.runOneTest("time_constructor_03") }
-  @Test def test_time_constructor_04() { runner2.runOneTest("time_constructor_04") }
+  @Test def test_time_constructor_01(): Unit = { runner2.runOneTest("time_constructor_01") }
+  @Test def test_time_constructor_02(): Unit = { runner2.runOneTest("time_constructor_02") }
+  @Test def test_time_constructor_03(): Unit = { runner2.runOneTest("time_constructor_03") }
+  @Test def test_time_constructor_04(): Unit = { runner2.runOneTest("time_constructor_04") }
 
   //DFDL-1124
   //@Test def test_date_constructor_01() { runner2.runOneTest("date_constructor_01") }
-  @Test def test_date_constructor_02() { runner2.runOneTest("date_constructor_02") }
+  @Test def test_date_constructor_02(): Unit = { runner2.runOneTest("date_constructor_02") }
   //@Test def test_date_constructor_02a() { runner2.runOneTest("date_constructor_02a") }
-  @Test def test_date_constructor_03() { runner2.runOneTest("date_constructor_03") }
+  @Test def test_date_constructor_03(): Unit = { runner2.runOneTest("date_constructor_03") }
   //@Test def test_date_constructor_03a() { runner2.runOneTest("date_constructor_03a") }
-  @Test def test_date_constructor_04() { runner2.runOneTest("date_constructor_04") }
+  @Test def test_date_constructor_04(): Unit = { runner2.runOneTest("date_constructor_04") }
   //@Test def test_nonNeg_constructor_02a() { runner2.runOneTest("nonNeg_constructor_02a") }
 
-  @Test def test_xsDateTime_constructor_01() { runner2.runOneTest("xsDateTime_constructor_01") }
-  @Test def test_xsDateTime_constructor_02() { runner2.runOneTest("xsDateTime_constructor_02") }
+  @Test def test_xsDateTime_constructor_01(): Unit = { runner2.runOneTest("xsDateTime_constructor_01") }
+  @Test def test_xsDateTime_constructor_02(): Unit = { runner2.runOneTest("xsDateTime_constructor_02") }
   //DFDL-1115
   //@Test def test_xsDateTime_constructor_03() { runner2.runOneTest("xsDateTime_constructor_03") }
-  @Test def test_xsDateTime_constructor_04() { runner2.runOneTest("xsDateTime_constructor_04") }
-  @Test def test_xsDateTime_constructor_05() { runner2.runOneTest("xsDateTime_constructor_05") }
+  @Test def test_xsDateTime_constructor_04(): Unit = { runner2.runOneTest("xsDateTime_constructor_04") }
+  @Test def test_xsDateTime_constructor_05(): Unit = { runner2.runOneTest("xsDateTime_constructor_05") }
 
-  @Test def test_double_constructor_01() { runner2.runOneTest("double_constructor_01") }
-  @Test def test_double_constructor_02() { runner2.runOneTest("double_constructor_02") }
-  @Test def test_double_constructor_03() { runner2.runOneTest("double_constructor_03") }
-  @Test def test_double_constructor_04() { runner2.runOneTest("double_constructor_04") }
-  @Test def test_double_constructor_05() { runner2.runOneTest("double_constructor_05") }
-  @Test def test_double_constructor_06() { runner2.runOneTest("double_constructor_06") }
-  @Test def test_double_constructor_07() { runner2.runOneTest("double_constructor_07") }
+  @Test def test_double_constructor_01(): Unit = { runner2.runOneTest("double_constructor_01") }
+  @Test def test_double_constructor_02(): Unit = { runner2.runOneTest("double_constructor_02") }
+  @Test def test_double_constructor_03(): Unit = { runner2.runOneTest("double_constructor_03") }
+  @Test def test_double_constructor_04(): Unit = { runner2.runOneTest("double_constructor_04") }
+  @Test def test_double_constructor_05(): Unit = { runner2.runOneTest("double_constructor_05") }
+  @Test def test_double_constructor_06(): Unit = { runner2.runOneTest("double_constructor_06") }
+  @Test def test_double_constructor_07(): Unit = { runner2.runOneTest("double_constructor_07") }
 
-  @Test def test_float_constructor_01() { runner2.runOneTest("float_constructor_01") }
-  @Test def test_float_constructor_02() { runner2.runOneTest("float_constructor_02") }
-  @Test def test_float_constructor_03() { runner2.runOneTest("float_constructor_03") }
-  @Test def test_float_constructor_04() { runner2.runOneTest("float_constructor_04") }
+  @Test def test_float_constructor_01(): Unit = { runner2.runOneTest("float_constructor_01") }
+  @Test def test_float_constructor_02(): Unit = { runner2.runOneTest("float_constructor_02") }
+  @Test def test_float_constructor_03(): Unit = { runner2.runOneTest("float_constructor_03") }
+  @Test def test_float_constructor_04(): Unit = { runner2.runOneTest("float_constructor_04") }
 
-  @Test def test_decimal_constructor_01() { runner2.runOneTest("decimal_constructor_01") }
-  @Test def test_decimal_constructor_02() { runner2.runOneTest("decimal_constructor_02") }
-  @Test def test_decimal_constructor_03() { runner2.runOneTest("decimal_constructor_03") }
-  @Test def test_decimal_constructor_04() { runner2.runOneTest("decimal_constructor_04") }
-  @Test def test_decimal_constructor_05() { runner2.runOneTest("decimal_constructor_05") }
-  @Test def test_decimal_constructor_06() { runner2.runOneTest("decimal_constructor_06") }
+  @Test def test_decimal_constructor_01(): Unit = { runner2.runOneTest("decimal_constructor_01") }
+  @Test def test_decimal_constructor_02(): Unit = { runner2.runOneTest("decimal_constructor_02") }
+  @Test def test_decimal_constructor_03(): Unit = { runner2.runOneTest("decimal_constructor_03") }
+  @Test def test_decimal_constructor_04(): Unit = { runner2.runOneTest("decimal_constructor_04") }
+  @Test def test_decimal_constructor_05(): Unit = { runner2.runOneTest("decimal_constructor_05") }
+  @Test def test_decimal_constructor_06(): Unit = { runner2.runOneTest("decimal_constructor_06") }
 
-  @Test def test_short_constructor_01() { runner2.runOneTest("short_constructor_01") }
-  @Test def test_short_constructor_02() { runner2.runOneTest("short_constructor_02") }
-  @Test def test_short_constructor_03() { runner2.runOneTest("short_constructor_03") }
-  @Test def test_short_constructor_04() { runner2.runOneTest("short_constructor_04") }
-  @Test def test_short_constructor_05() { runner2.runOneTest("short_constructor_05") }
-  @Test def test_short_constructor_06() { runner2.runOneTest("short_constructor_06") }
+  @Test def test_short_constructor_01(): Unit = { runner2.runOneTest("short_constructor_01") }
+  @Test def test_short_constructor_02(): Unit = { runner2.runOneTest("short_constructor_02") }
+  @Test def test_short_constructor_03(): Unit = { runner2.runOneTest("short_constructor_03") }
+  @Test def test_short_constructor_04(): Unit = { runner2.runOneTest("short_constructor_04") }
+  @Test def test_short_constructor_05(): Unit = { runner2.runOneTest("short_constructor_05") }
+  @Test def test_short_constructor_06(): Unit = { runner2.runOneTest("short_constructor_06") }
 
-  @Test def test_ushort_constructor_01() { runner2.runOneTest("ushort_constructor_01") }
-  @Test def test_ushort_constructor_02() { runner2.runOneTest("ushort_constructor_02") }
-  @Test def test_ushort_constructor_03() { runner2.runOneTest("ushort_constructor_03") }
-  @Test def test_ushort_constructor_04() { runner2.runOneTest("ushort_constructor_04") }
-  @Test def test_ushort_constructor_05() { runner2.runOneTest("ushort_constructor_05") }
+  @Test def test_ushort_constructor_01(): Unit = { runner2.runOneTest("ushort_constructor_01") }
+  @Test def test_ushort_constructor_02(): Unit = { runner2.runOneTest("ushort_constructor_02") }
+  @Test def test_ushort_constructor_03(): Unit = { runner2.runOneTest("ushort_constructor_03") }
+  @Test def test_ushort_constructor_04(): Unit = { runner2.runOneTest("ushort_constructor_04") }
+  @Test def test_ushort_constructor_05(): Unit = { runner2.runOneTest("ushort_constructor_05") }
 
-  @Test def test_ulong_constructor_01() { runner2.runOneTest("ulong_constructor_01") }
-  @Test def test_ulong_constructor_02() { runner2.runOneTest("ulong_constructor_02") }
-  @Test def test_ulong_constructor_03() { runner2.runOneTest("ulong_constructor_03") }
-  @Test def test_ulong_constructor_04() { runner2.runOneTest("ulong_constructor_04") }
-  @Test def test_ulong_constructor_05() { runner2.runOneTest("ulong_constructor_05") }
-  @Test def test_ulong_constructor_06() { runner2.runOneTest("ulong_constructor_06") }
-  @Test def test_ulong_constructor_07() { runner2.runOneTest("ulong_constructor_07") }
+  @Test def test_ulong_constructor_01(): Unit = { runner2.runOneTest("ulong_constructor_01") }
+  @Test def test_ulong_constructor_02(): Unit = { runner2.runOneTest("ulong_constructor_02") }
+  @Test def test_ulong_constructor_03(): Unit = { runner2.runOneTest("ulong_constructor_03") }
+  @Test def test_ulong_constructor_04(): Unit = { runner2.runOneTest("ulong_constructor_04") }
+  @Test def test_ulong_constructor_05(): Unit = { runner2.runOneTest("ulong_constructor_05") }
+  @Test def test_ulong_constructor_06(): Unit = { runner2.runOneTest("ulong_constructor_06") }
+  @Test def test_ulong_constructor_07(): Unit = { runner2.runOneTest("ulong_constructor_07") }
 
-  @Test def test_long_constructor_01() { runner2.runOneTest("long_constructor_01") }
-  @Test def test_long_constructor_02() { runner2.runOneTest("long_constructor_02") }
-  @Test def test_long_constructor_03() { runner2.runOneTest("long_constructor_03") }
-  @Test def test_long_constructor_04() { runner2.runOneTest("long_constructor_04") }
+  @Test def test_long_constructor_01(): Unit = { runner2.runOneTest("long_constructor_01") }
+  @Test def test_long_constructor_02(): Unit = { runner2.runOneTest("long_constructor_02") }
+  @Test def test_long_constructor_03(): Unit = { runner2.runOneTest("long_constructor_03") }
+  @Test def test_long_constructor_04(): Unit = { runner2.runOneTest("long_constructor_04") }
 
-  @Test def test_int_constructor_01() { runner2.runOneTest("int_constructor_01") }
-  @Test def test_int_constructor_02() { runner2.runOneTest("int_constructor_02") }
-  @Test def test_int_constructor_03() { runner2.runOneTest("int_constructor_03") }
-  @Test def test_int_constructor_04() { runner2.runOneTest("int_constructor_04") }
+  @Test def test_int_constructor_01(): Unit = { runner2.runOneTest("int_constructor_01") }
+  @Test def test_int_constructor_02(): Unit = { runner2.runOneTest("int_constructor_02") }
+  @Test def test_int_constructor_03(): Unit = { runner2.runOneTest("int_constructor_03") }
+  @Test def test_int_constructor_04(): Unit = { runner2.runOneTest("int_constructor_04") }
 
-  @Test def test_fnDateTime_constructor_01() { runner2.runOneTest("fnDateTime_constructor_01") }
-  @Test def test_fnDateTime_constructor_02() { runner2.runOneTest("fnDateTime_constructor_02") }
-  @Test def test_fnDateTime_constructor_03() { runner2.runOneTest("fnDateTime_constructor_03") }
-  @Test def test_fnDateTime_constructor_04() { runner2.runOneTest("fnDateTime_constructor_04") }
-  @Test def test_fnDateTime_constructor_05() { runner2.runOneTest("fnDateTime_constructor_05") }
-  @Test def test_fnDateTime_constructor_06() { runner2.runOneTest("fnDateTime_constructor_06") }
-  @Test def test_fnDateTime_constructor_07() { runner2.runOneTest("fnDateTime_constructor_07") }
-  @Test def test_fnDateTime_constructor_08() { runner2.runOneTest("fnDateTime_constructor_08") }
-  @Test def test_fnDateTime_constructor_09() { runner2.runOneTest("fnDateTime_constructor_09") }
-  @Test def test_fnDateTime_constructor_10() { runner2.runOneTest("fnDateTime_constructor_10") }
+  @Test def test_fnDateTime_constructor_01(): Unit = { runner2.runOneTest("fnDateTime_constructor_01") }
+  @Test def test_fnDateTime_constructor_02(): Unit = { runner2.runOneTest("fnDateTime_constructor_02") }
+  @Test def test_fnDateTime_constructor_03(): Unit = { runner2.runOneTest("fnDateTime_constructor_03") }
+  @Test def test_fnDateTime_constructor_04(): Unit = { runner2.runOneTest("fnDateTime_constructor_04") }
+  @Test def test_fnDateTime_constructor_05(): Unit = { runner2.runOneTest("fnDateTime_constructor_05") }
+  @Test def test_fnDateTime_constructor_06(): Unit = { runner2.runOneTest("fnDateTime_constructor_06") }
+  @Test def test_fnDateTime_constructor_07(): Unit = { runner2.runOneTest("fnDateTime_constructor_07") }
+  @Test def test_fnDateTime_constructor_08(): Unit = { runner2.runOneTest("fnDateTime_constructor_08") }
+  @Test def test_fnDateTime_constructor_09(): Unit = { runner2.runOneTest("fnDateTime_constructor_09") }
+  @Test def test_fnDateTime_constructor_10(): Unit = { runner2.runOneTest("fnDateTime_constructor_10") }
 
-  @Test def test_integer_constructor_01() { runner2.runOneTest("integer_constructor_01") }
-  @Test def test_integer_constructor_02() { runner2.runOneTest("integer_constructor_02") }
-  @Test def test_integer_constructor_03() { runner2.runOneTest("integer_constructor_03") }
-  @Test def test_integer_constructor_04() { runner2.runOneTest("integer_constructor_04") }
-  @Test def test_integer_constructor_05() { runner2.runOneTest("integer_constructor_05") }
-  @Test def test_integer_constructor_06() { runner2.runOneTest("integer_constructor_06") }
-  @Test def test_integer_constructor_07() { runner2.runOneTest("integer_constructor_07") }
+  @Test def test_integer_constructor_01(): Unit = { runner2.runOneTest("integer_constructor_01") }
+  @Test def test_integer_constructor_02(): Unit = { runner2.runOneTest("integer_constructor_02") }
+  @Test def test_integer_constructor_03(): Unit = { runner2.runOneTest("integer_constructor_03") }
+  @Test def test_integer_constructor_04(): Unit = { runner2.runOneTest("integer_constructor_04") }
+  @Test def test_integer_constructor_05(): Unit = { runner2.runOneTest("integer_constructor_05") }
+  @Test def test_integer_constructor_06(): Unit = { runner2.runOneTest("integer_constructor_06") }
+  @Test def test_integer_constructor_07(): Unit = { runner2.runOneTest("integer_constructor_07") }
 
-  @Test def test_testBit_0() { runner2.runOneTest("testBit_0") }
-  @Test def test_testBit_1() { runner2.runOneTest("testBit_1") }
-  @Test def test_testBit_2() { runner2.runOneTest("testBit_2") }
-  @Test def test_testBit_3() { runner2.runOneTest("testBit_3") }
-  @Test def test_testBit_4() { runner2.runOneTest("testBit_4") }
-  @Test def test_testBit_5() { runner2.runOneTest("testBit_5") }
+  @Test def test_testBit_0(): Unit = { runner2.runOneTest("testBit_0") }
+  @Test def test_testBit_1(): Unit = { runner2.runOneTest("testBit_1") }
+  @Test def test_testBit_2(): Unit = { runner2.runOneTest("testBit_2") }
+  @Test def test_testBit_3(): Unit = { runner2.runOneTest("testBit_3") }
+  @Test def test_testBit_4(): Unit = { runner2.runOneTest("testBit_4") }
+  @Test def test_testBit_5(): Unit = { runner2.runOneTest("testBit_5") }
 
-  @Test def test_stringLiteralFromString_obsolete() { runner2.runOneTest("stringLiteralFromString_obsolete") }
-  @Test def test_containsEntity_obsolete() { runner2.runOneTest("containsEntity_obsolete") }
+  @Test def test_stringLiteralFromString_obsolete(): Unit = { runner2.runOneTest("stringLiteralFromString_obsolete") }
+  @Test def test_containsEntity_obsolete(): Unit = { runner2.runOneTest("containsEntity_obsolete") }
 
-  @Test def test_encodeDFDLEntities_0() { runner2.runOneTest("encodeDFDLEntities_0") }
-  @Test def test_encodeDFDLEntities_1() { runner2.runOneTest("encodeDFDLEntities_1") }
-  @Test def test_encodeDFDLEntities_2() { runner2.runOneTest("encodeDFDLEntities_2") }
-  @Test def test_encodeDFDLEntities_3() { runner2.runOneTest("encodeDFDLEntities_3") }
-  @Test def test_encodeDFDLEntities_4() { runner2.runOneTest("encodeDFDLEntities_4") }
+  @Test def test_encodeDFDLEntities_0(): Unit = { runner2.runOneTest("encodeDFDLEntities_0") }
+  @Test def test_encodeDFDLEntities_1(): Unit = { runner2.runOneTest("encodeDFDLEntities_1") }
+  @Test def test_encodeDFDLEntities_2(): Unit = { runner2.runOneTest("encodeDFDLEntities_2") }
+  @Test def test_encodeDFDLEntities_3(): Unit = { runner2.runOneTest("encodeDFDLEntities_3") }
+  @Test def test_encodeDFDLEntities_4(): Unit = { runner2.runOneTest("encodeDFDLEntities_4") }
 
-  @Test def test_setBits_0() { runner2.runOneTest("setBits_0") }
-  @Test def test_setBits_1() { runner2.runOneTest("setBits_1") }
-  @Test def test_setBits_2() { runner2.runOneTest("setBits_2") }
+  @Test def test_setBits_0(): Unit = { runner2.runOneTest("setBits_0") }
+  @Test def test_setBits_1(): Unit = { runner2.runOneTest("setBits_1") }
+  @Test def test_setBits_2(): Unit = { runner2.runOneTest("setBits_2") }
 
-  @Test def test_containsDFDLEntities_0() { runner2.runOneTest("containsDFDLEntities_0") }
-  @Test def test_containsDFDLEntities_1() { runner2.runOneTest("containsDFDLEntities_1") }
-  @Test def test_containsDFDLEntities_2() { runner2.runOneTest("containsDFDLEntities_2") }
-  @Test def test_containsDFDLEntities_3() { runner2.runOneTest("containsDFDLEntities_3") }
-  @Test def test_containsDFDLEntities_4() { runner2.runOneTest("containsDFDLEntities_4") }
+  @Test def test_containsDFDLEntities_0(): Unit = { runner2.runOneTest("containsDFDLEntities_0") }
+  @Test def test_containsDFDLEntities_1(): Unit = { runner2.runOneTest("containsDFDLEntities_1") }
+  @Test def test_containsDFDLEntities_2(): Unit = { runner2.runOneTest("containsDFDLEntities_2") }
+  @Test def test_containsDFDLEntities_3(): Unit = { runner2.runOneTest("containsDFDLEntities_3") }
+  @Test def test_containsDFDLEntities_4(): Unit = { runner2.runOneTest("containsDFDLEntities_4") }
 
   //DFDL-1118
   //@Test def test_more_count_0() { runner2.runOneTest("more_count_0") }
   //@Test def test_more_count_1() { runner2.runOneTest("more_count_1") }
-  @Test def test_more_count_1b() { runner2.runOneTest("more_count_1b") }
+  @Test def test_more_count_1b(): Unit = { runner2.runOneTest("more_count_1b") }
   //@Test def test_more_count_1b_2() { runner2.runOneTest("more_count_1b_2") }
   //@Test def test_more_count_2() { runner2.runOneTest("more_count_2") }
-  @Test def test_more_count_3() { runner2.runOneTest("more_count_3") }
-  @Test def test_more_count_3b() { runner2.runOneTest("more_count_3b") }
+  @Test def test_more_count_3(): Unit = { runner2.runOneTest("more_count_3") }
+  @Test def test_more_count_3b(): Unit = { runner2.runOneTest("more_count_3b") }
 
-  @Test def test_more_count_4() { runner2.runOneTest("more_count_4") }
+  @Test def test_more_count_4(): Unit = { runner2.runOneTest("more_count_4") }
 
-  @Test def test_valueLength_0() { runner2.runOneTest("valueLength_0") }
-  @Test def test_valueLength_1() { runner2.runOneTest("valueLength_1") }
+  @Test def test_valueLength_0(): Unit = { runner2.runOneTest("valueLength_0") }
+  @Test def test_valueLength_1(): Unit = { runner2.runOneTest("valueLength_1") }
   // DFDL-1516:dfdl:contentLength & dfdl:valueLength specifying lengthUnits 'characters' and variable-width encodings
-  @Test def test_valueLength_2() { runner2.runOneTest("valueLength_2") }
-  @Test def test_valueLength_3() { runner2.runOneTest("valueLength_3") }
-  @Test def test_valueLength_4() { runner2.runOneTest("valueLength_4") }
-  @Test def test_valueLength_5() { runner2.runOneTest("valueLength_5") }
-  @Test def test_valueLength_6() { runner2.runOneTest("valueLength_6") }
-  @Test def test_valueLength_sde() { runner2.runOneTest("valueLength_sde") }
-  @Test def test_valueLength_unparse_0() { runner2.runOneTest("valueLength_unparse_0") }
+  @Test def test_valueLength_2(): Unit = { runner2.runOneTest("valueLength_2") }
+  @Test def test_valueLength_3(): Unit = { runner2.runOneTest("valueLength_3") }
+  @Test def test_valueLength_4(): Unit = { runner2.runOneTest("valueLength_4") }
+  @Test def test_valueLength_5(): Unit = { runner2.runOneTest("valueLength_5") }
+  @Test def test_valueLength_6(): Unit = { runner2.runOneTest("valueLength_6") }
+  @Test def test_valueLength_sde(): Unit = { runner2.runOneTest("valueLength_sde") }
+  @Test def test_valueLength_unparse_0(): Unit = { runner2.runOneTest("valueLength_unparse_0") }
   // DFDL-1516:dfdl:contentLength & dfdl:valueLength specifying lengthUnits 'characters' and variable-width encodings
-  @Test def test_valueLength_unparse_1() { runner2.runOneTest("valueLength_unparse_1") }
-  @Test def test_valueLength_unparse_2() { runner2.runOneTest("valueLength_unparse_2") }
-  @Test def test_valueLength_unparse_3() { runner2.runOneTest("valueLength_unparse_3") }
-  @Test def test_valueLength_unparse_4() { runner2.runOneTest("valueLength_unparse_4") }
+  @Test def test_valueLength_unparse_1(): Unit = { runner2.runOneTest("valueLength_unparse_1") }
+  @Test def test_valueLength_unparse_2(): Unit = { runner2.runOneTest("valueLength_unparse_2") }
+  @Test def test_valueLength_unparse_3(): Unit = { runner2.runOneTest("valueLength_unparse_3") }
+  @Test def test_valueLength_unparse_4(): Unit = { runner2.runOneTest("valueLength_unparse_4") }
 
-  @Test def test_contentLength_0() { runner2.runOneTest("contentLength_0") }
-  @Test def test_contentLength_1() { runner2.runOneTest("contentLength_1") }
-  @Test def test_contentLength_2() { runner2.runOneTest("contentLength_2") }
+  @Test def test_contentLength_0(): Unit = { runner2.runOneTest("contentLength_0") }
+  @Test def test_contentLength_1(): Unit = { runner2.runOneTest("contentLength_1") }
+  @Test def test_contentLength_2(): Unit = { runner2.runOneTest("contentLength_2") }
 
-  @Test def test_valueContentLength1() { runner2.runOneTest("valueContentLength1") }
-  @Test def test_valueContentLength2() { runner2.runOneTest("valueContentLength2") }
+  @Test def test_valueContentLength1(): Unit = { runner2.runOneTest("valueContentLength1") }
+  @Test def test_valueContentLength2(): Unit = { runner2.runOneTest("valueContentLength2") }
 
-  @Test def test_fn_not_declared() { runner2b.runOneTest("fn_not_declared") }
-  @Test def test_fn_not_declared_2() { runner2b.runOneTest("fn_not_declared_2") }
+  @Test def test_fn_not_declared(): Unit = { runner2b.runOneTest("fn_not_declared") }
+  @Test def test_fn_not_declared_2(): Unit = { runner2b.runOneTest("fn_not_declared_2") }
 
   // DFDL-313
   // Verified that we do get an error regarding an improperly formatted
@@ -957,77 +957,77 @@ class TestDFDLExpressions {
   // schema loading (SAXParse) level and would cause other tests within
   // the same file to fail.
   //
-  @Test def test_no_closing_brace() { runner3.runOneTest("no_closing_brace") } // no closing } for expression
+  @Test def test_no_closing_brace(): Unit = { runner3.runOneTest("no_closing_brace") } // no closing } for expression
 
-  @Test def test_valueLengthPair1() { runner5.runOneTest("valueLengthPair1") }
-  @Test def test_valueLengthPair2() { runner5.runOneTest("valueLengthPair2") }
-  @Test def test_valueLengthPair3() { runner5.runOneTest("valueLengthPair3") }
-  @Test def test_valueLengthAndOccurs1() { runner5.runOneTest("valueLengthAndOccurs1") }
+  @Test def test_valueLengthPair1(): Unit = { runner5.runOneTest("valueLengthPair1") }
+  @Test def test_valueLengthPair2(): Unit = { runner5.runOneTest("valueLengthPair2") }
+  @Test def test_valueLengthPair3(): Unit = { runner5.runOneTest("valueLengthPair3") }
+  @Test def test_valueLengthAndOccurs1(): Unit = { runner5.runOneTest("valueLengthAndOccurs1") }
 
   // Added from scala-new for DFDL-1198
-  @Test def test_array_index_oob_01() { runner.runOneTest("array_index_oob_01") }
-  @Test def test_array_index_oob_02() { runner.runOneTest("array_index_oob_02") }
-  @Test def test_array_index_oob_03() { runner.runOneTest("array_index_oob_03") }
-  @Test def test_array_index_oob_04() { runner.runOneTest("array_index_oob_04") }
-  @Test def test_array_index_oob_05() { runner.runOneTest("array_index_oob_05") }
+  @Test def test_array_index_oob_01(): Unit = { runner.runOneTest("array_index_oob_01") }
+  @Test def test_array_index_oob_02(): Unit = { runner.runOneTest("array_index_oob_02") }
+  @Test def test_array_index_oob_03(): Unit = { runner.runOneTest("array_index_oob_03") }
+  @Test def test_array_index_oob_04(): Unit = { runner.runOneTest("array_index_oob_04") }
+  @Test def test_array_index_oob_05(): Unit = { runner.runOneTest("array_index_oob_05") }
 
   // Added from scala-new for DFDL-1660
-  @Test def test_array_index_relative_path_subexpression_01() { runner.runOneTest("array_index_relative_path_subexpression_01") }
+  @Test def test_array_index_relative_path_subexpression_01(): Unit = { runner.runOneTest("array_index_relative_path_subexpression_01") }
 
   //DFDL-1702
-  @Test def test_mathPow01 { runner2.runOneTest("mathPow01") }
-  @Test def test_mathPow02 { runner2.runOneTest("mathPow02") }
-  @Test def test_mathPow03 { runner2.runOneTest("mathPow03") }
-  @Test def test_mathPow04 { runner2.runOneTest("mathPow04") }
-  @Test def test_mathPow05 { runner2.runOneTest("mathPow05") }
-  @Test def test_mathPow06 { runner2.runOneTest("mathPow06") }
-  @Test def test_mathPow07 { runner2.runOneTest("mathPow07") }
-  @Test def test_mathPow08 { runner2.runOneTest("mathPow08") }
-  @Test def test_mathPow09 { runner2.runOneTest("mathPow09") }
-  @Test def test_mathPow10 { runner2.runOneTest("mathPow10") }
-  @Test def test_mathPow11 { runner2.runOneTest("mathPow11") }
-  @Test def test_mathPow12 { runner2.runOneTest("mathPow12") }
-  @Test def test_mathPow13 { runner2.runOneTest("mathPow13") }
-  @Test def test_mathPow14 { runner2.runOneTest("mathPow14") }
-  @Test def test_mathPow15 { runner2.runOneTest("mathPow15") }
-  @Test def test_mathPow16 { runner2.runOneTest("mathPow16") }
-  @Test def test_mathPow17 { runner2.runOneTest("mathPow17") }
-  @Test def test_mathPow18 { runner2.runOneTest("mathPow18") }
-  @Test def test_mathPow19 { runner2.runOneTest("mathPow19") }
-  @Test def test_mathPow20 { runner2.runOneTest("mathPow20") }
-  @Test def test_mathPow21 { runner2.runOneTest("mathPow21") }
-  @Test def test_mathPow22 { runner2.runOneTest("mathPow22") }
-  @Test def test_mathPow23 { runner2.runOneTest("mathPow23") }
-  @Test def test_mathPow24 { runner2.runOneTest("mathPow24") }
-  @Test def test_mathPow25 { runner2.runOneTest("mathPow25") }
-  @Test def test_mathPow26 { runner2.runOneTest("mathPow26") }
-  @Test def test_mathPow27 { runner2.runOneTest("mathPow27") }
-  @Test def test_mathPow28 { runner2.runOneTest("mathPow28") }
-  @Test def test_mathPow29 { runner2.runOneTest("mathPow29") }
-  @Test def test_mathPow30 { runner2.runOneTest("mathPow30") }
-  @Test def test_mathPow31 { runner2.runOneTest("mathPow31") }
-  @Test def test_mathPow32 { runner2.runOneTest("mathPow32") }
-  @Test def test_mathPow33 { runner2.runOneTest("mathPow33") }
-  @Test def test_mathPow34 { runner2.runOneTest("mathPow34") }
+  @Test def test_mathPow01: Unit = { runner2.runOneTest("mathPow01") }
+  @Test def test_mathPow02: Unit = { runner2.runOneTest("mathPow02") }
+  @Test def test_mathPow03: Unit = { runner2.runOneTest("mathPow03") }
+  @Test def test_mathPow04: Unit = { runner2.runOneTest("mathPow04") }
+  @Test def test_mathPow05: Unit = { runner2.runOneTest("mathPow05") }
+  @Test def test_mathPow06: Unit = { runner2.runOneTest("mathPow06") }
+  @Test def test_mathPow07: Unit = { runner2.runOneTest("mathPow07") }
+  @Test def test_mathPow08: Unit = { runner2.runOneTest("mathPow08") }
+  @Test def test_mathPow09: Unit = { runner2.runOneTest("mathPow09") }
+  @Test def test_mathPow10: Unit = { runner2.runOneTest("mathPow10") }
+  @Test def test_mathPow11: Unit = { runner2.runOneTest("mathPow11") }
+  @Test def test_mathPow12: Unit = { runner2.runOneTest("mathPow12") }
+  @Test def test_mathPow13: Unit = { runner2.runOneTest("mathPow13") }
+  @Test def test_mathPow14: Unit = { runner2.runOneTest("mathPow14") }
+  @Test def test_mathPow15: Unit = { runner2.runOneTest("mathPow15") }
+  @Test def test_mathPow16: Unit = { runner2.runOneTest("mathPow16") }
+  @Test def test_mathPow17: Unit = { runner2.runOneTest("mathPow17") }
+  @Test def test_mathPow18: Unit = { runner2.runOneTest("mathPow18") }
+  @Test def test_mathPow19: Unit = { runner2.runOneTest("mathPow19") }
+  @Test def test_mathPow20: Unit = { runner2.runOneTest("mathPow20") }
+  @Test def test_mathPow21: Unit = { runner2.runOneTest("mathPow21") }
+  @Test def test_mathPow22: Unit = { runner2.runOneTest("mathPow22") }
+  @Test def test_mathPow23: Unit = { runner2.runOneTest("mathPow23") }
+  @Test def test_mathPow24: Unit = { runner2.runOneTest("mathPow24") }
+  @Test def test_mathPow25: Unit = { runner2.runOneTest("mathPow25") }
+  @Test def test_mathPow26: Unit = { runner2.runOneTest("mathPow26") }
+  @Test def test_mathPow27: Unit = { runner2.runOneTest("mathPow27") }
+  @Test def test_mathPow28: Unit = { runner2.runOneTest("mathPow28") }
+  @Test def test_mathPow29: Unit = { runner2.runOneTest("mathPow29") }
+  @Test def test_mathPow30: Unit = { runner2.runOneTest("mathPow30") }
+  @Test def test_mathPow31: Unit = { runner2.runOneTest("mathPow31") }
+  @Test def test_mathPow32: Unit = { runner2.runOneTest("mathPow32") }
+  @Test def test_mathPow33: Unit = { runner2.runOneTest("mathPow33") }
+  @Test def test_mathPow34: Unit = { runner2.runOneTest("mathPow34") }
 
   // DFDL-1771
-  @Test def test_expr_path_past_root1 { runner7.runOneTest("test_expr_path_past_root1") }
+  @Test def test_expr_path_past_root1: Unit = { runner7.runOneTest("test_expr_path_past_root1") }
 
   // DFDL-1804
-  @Test def test_traceComplex { runner7.runOneTest("traceComplex") }
+  @Test def test_traceComplex: Unit = { runner7.runOneTest("traceComplex") }
 
   //DFDL-1076
-  @Test def test_nilled_01() { runner2.runOneTest("nilled_01") }
+  @Test def test_nilled_01(): Unit = { runner2.runOneTest("nilled_01") }
 
   // DFDL-1617 - should detect errors due to query-style expressions
-  @Test def test_query_style_01 { runner6.runOneTest("query_style_01") }
-  @Test def test_query_style_02 { runner6.runOneTest("query_style_02") }
+  @Test def test_query_style_01: Unit = { runner6.runOneTest("query_style_01") }
+  @Test def test_query_style_02: Unit = { runner6.runOneTest("query_style_02") }
 
   //DFDL-1221
-  @Test def test_beyondRoot_01() { runner.runOneTest("beyondRoot_01") }
+  @Test def test_beyondRoot_01(): Unit = { runner.runOneTest("beyondRoot_01") }
 
   //DFDL-711
-  @Test def test_short_parent_axis_01() { runner.runOneTest("short_parent_axis_01") }
+  @Test def test_short_parent_axis_01(): Unit = { runner.runOneTest("short_parent_axis_01") }
 
-  @Test def test_element_long_form_whitespace() { runner.runOneTest("element_long_form_whitespace") }
+  @Test def test_element_long_form_whitespace(): Unit = { runner.runOneTest("element_long_form_whitespace") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -58,70 +58,70 @@ class TestDFDLExpressions2 {
   import TestDFDLExpressions2._
 
   // DFDL-1669
-  @Test def test_dfdl_1669_unsignedLong_conversion() { runner5.runOneTest("test_dfdl_1669_unsignedLong_conversion") }
+  @Test def test_dfdl_1669_unsignedLong_conversion(): Unit = { runner5.runOneTest("test_dfdl_1669_unsignedLong_conversion") }
 
   //DFDL-1657
-  @Test def test_valueLengthRef1 { runner6.runOneTest("valueLengthRef1") }
+  @Test def test_valueLengthRef1: Unit = { runner6.runOneTest("valueLengthRef1") }
 
   //DFDL-1706
-  @Test def test_valueLengthDfdlLength { runner6.runOneTest("valueLengthDfdlLength") }
-  @Test def test_valueLengthDfdlOccursCount { runner6.runOneTest("valueLengthDfdlOccursCount") }
-  @Test def test_valueLengthDfdlEncoding { runner6.runOneTest("valueLengthDfdlEncoding") }
+  @Test def test_valueLengthDfdlLength: Unit = { runner6.runOneTest("valueLengthDfdlLength") }
+  @Test def test_valueLengthDfdlOccursCount: Unit = { runner6.runOneTest("valueLengthDfdlOccursCount") }
+  @Test def test_valueLengthDfdlEncoding: Unit = { runner6.runOneTest("valueLengthDfdlEncoding") }
 
   //DFDL-1691
-  @Test def test_div01 { runner.runOneTest("div01") }
-  @Test def test_div02 { runner.runOneTest("div02") }
-  @Test def test_div03 { runner.runOneTest("div03") }
-  @Test def test_div04 { runner.runOneTest("div04") }
-  @Test def test_div05 { runner.runOneTest("div05") }
-  @Test def test_div06 { runner.runOneTest("div06") }
-  @Test def test_div07 { runner.runOneTest("div07") }
-  @Test def test_div08 { runner.runOneTest("div08") }
-  @Test def test_div09 { runner.runOneTest("div09") }
-  @Test def test_div10 { runner.runOneTest("div10") }
-  @Test def test_div11 { runner.runOneTest("div11") }
-  @Test def test_div12 { runner.runOneTest("div12") }
-  @Test def test_div13 { runner.runOneTest("div13") }
-  @Test def test_div14 { runner.runOneTest("div14") }
-  @Test def test_div15 { runner.runOneTest("div15") }
-  @Test def test_div16 { runner.runOneTest("div16") }
-  @Test def test_div17 { runner.runOneTest("div17") }
-  @Test def test_div18 { runner.runOneTest("div18") }
-  @Test def test_div19 { runner.runOneTest("div19") }
-  @Test def test_div20 { runner.runOneTest("div20") }
-  @Test def test_div21 { runner.runOneTest("div21") }
-  @Test def test_div22 { runner.runOneTest("div22") }
-  @Test def test_div23 { runner.runOneTest("div23") }
-  @Test def test_div24 { runner.runOneTest("div24") }
+  @Test def test_div01: Unit = { runner.runOneTest("div01") }
+  @Test def test_div02: Unit = { runner.runOneTest("div02") }
+  @Test def test_div03: Unit = { runner.runOneTest("div03") }
+  @Test def test_div04: Unit = { runner.runOneTest("div04") }
+  @Test def test_div05: Unit = { runner.runOneTest("div05") }
+  @Test def test_div06: Unit = { runner.runOneTest("div06") }
+  @Test def test_div07: Unit = { runner.runOneTest("div07") }
+  @Test def test_div08: Unit = { runner.runOneTest("div08") }
+  @Test def test_div09: Unit = { runner.runOneTest("div09") }
+  @Test def test_div10: Unit = { runner.runOneTest("div10") }
+  @Test def test_div11: Unit = { runner.runOneTest("div11") }
+  @Test def test_div12: Unit = { runner.runOneTest("div12") }
+  @Test def test_div13: Unit = { runner.runOneTest("div13") }
+  @Test def test_div14: Unit = { runner.runOneTest("div14") }
+  @Test def test_div15: Unit = { runner.runOneTest("div15") }
+  @Test def test_div16: Unit = { runner.runOneTest("div16") }
+  @Test def test_div17: Unit = { runner.runOneTest("div17") }
+  @Test def test_div18: Unit = { runner.runOneTest("div18") }
+  @Test def test_div19: Unit = { runner.runOneTest("div19") }
+  @Test def test_div20: Unit = { runner.runOneTest("div20") }
+  @Test def test_div21: Unit = { runner.runOneTest("div21") }
+  @Test def test_div22: Unit = { runner.runOneTest("div22") }
+  @Test def test_div23: Unit = { runner.runOneTest("div23") }
+  @Test def test_div24: Unit = { runner.runOneTest("div24") }
 
-  @Test def test_idiv01 { runner.runOneTest("idiv01") }
-  @Test def test_idiv02 { runner.runOneTest("idiv02") }
-  @Test def test_idiv03 { runner.runOneTest("idiv03") }
-  @Test def test_idiv04 { runner.runOneTest("idiv04") }
-  @Test def test_idiv05 { runner.runOneTest("idiv05") }
-  @Test def test_idiv06 { runner.runOneTest("idiv06") }
-  @Test def test_idiv07 { runner.runOneTest("idiv07") }
-  @Test def test_idiv08 { runner.runOneTest("idiv08") }
-  @Test def test_idiv09 { runner.runOneTest("idiv09") }
-  @Test def test_idiv10 { runner.runOneTest("idiv10") }
-  @Test def test_idiv11 { runner.runOneTest("idiv11") }
-  @Test def test_idiv12 { runner.runOneTest("idiv12") }
-  @Test def test_idiv13 { runner.runOneTest("idiv13") }
-  @Test def test_idiv14 { runner.runOneTest("idiv14") }
-  @Test def test_idiv15 { runner.runOneTest("idiv15") }
-  @Test def test_idiv16 { runner.runOneTest("idiv16") }
-  @Test def test_idiv17 { runner.runOneTest("idiv17") }
-  @Test def test_idiv18 { runner.runOneTest("idiv18") }
-  @Test def test_idiv19 { runner.runOneTest("idiv19") }
-  @Test def test_idiv20 { runner.runOneTest("idiv20") }
+  @Test def test_idiv01: Unit = { runner.runOneTest("idiv01") }
+  @Test def test_idiv02: Unit = { runner.runOneTest("idiv02") }
+  @Test def test_idiv03: Unit = { runner.runOneTest("idiv03") }
+  @Test def test_idiv04: Unit = { runner.runOneTest("idiv04") }
+  @Test def test_idiv05: Unit = { runner.runOneTest("idiv05") }
+  @Test def test_idiv06: Unit = { runner.runOneTest("idiv06") }
+  @Test def test_idiv07: Unit = { runner.runOneTest("idiv07") }
+  @Test def test_idiv08: Unit = { runner.runOneTest("idiv08") }
+  @Test def test_idiv09: Unit = { runner.runOneTest("idiv09") }
+  @Test def test_idiv10: Unit = { runner.runOneTest("idiv10") }
+  @Test def test_idiv11: Unit = { runner.runOneTest("idiv11") }
+  @Test def test_idiv12: Unit = { runner.runOneTest("idiv12") }
+  @Test def test_idiv13: Unit = { runner.runOneTest("idiv13") }
+  @Test def test_idiv14: Unit = { runner.runOneTest("idiv14") }
+  @Test def test_idiv15: Unit = { runner.runOneTest("idiv15") }
+  @Test def test_idiv16: Unit = { runner.runOneTest("idiv16") }
+  @Test def test_idiv17: Unit = { runner.runOneTest("idiv17") }
+  @Test def test_idiv18: Unit = { runner.runOneTest("idiv18") }
+  @Test def test_idiv19: Unit = { runner.runOneTest("idiv19") }
+  @Test def test_idiv20: Unit = { runner.runOneTest("idiv20") }
 
-  @Test def test_add01 { runner.runOneTest("add01") }
+  @Test def test_add01: Unit = { runner.runOneTest("add01") }
 
   // DFDL-1719
-  @Test def test_if_expression_type_01 { runner5.runOneTest("if_expression_type_01") }
-  @Test def test_if_expression_type_02 { runner5.runOneTest("if_expression_type_02") }
-  @Test def test_if_expression_type_03 { runner5.runOneTest("if_expression_type_03") }
-  @Test def test_if_expression_type_04 { runner5.runOneTest("if_expression_type_04") }
-  @Test def test_if_expression_type_05 { runner5.runOneTest("if_expression_type_05") }
-  @Test def test_if_expression_type_06 { runner5.runOneTest("if_expression_type_06") }
+  @Test def test_if_expression_type_01: Unit = { runner5.runOneTest("if_expression_type_01") }
+  @Test def test_if_expression_type_02: Unit = { runner5.runOneTest("if_expression_type_02") }
+  @Test def test_if_expression_type_03: Unit = { runner5.runOneTest("if_expression_type_03") }
+  @Test def test_if_expression_type_04: Unit = { runner5.runOneTest("if_expression_type_04") }
+  @Test def test_if_expression_type_05: Unit = { runner5.runOneTest("if_expression_type_05") }
+  @Test def test_if_expression_type_06: Unit = { runner5.runOneTest("if_expression_type_06") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
@@ -47,6 +47,6 @@ class TestDFDLExpressions3 {
 
   // DAFFODIL-2182
   // @Test def test_array_self_expr1() { runner.runOneTest("test_array_self_expr1") }
-  @Test def test_array_self_expr2() { runner.runOneTest("test_array_self_expr2") }
+  @Test def test_array_self_expr2(): Unit = { runner.runOneTest("test_array_self_expr2") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
@@ -35,5 +35,5 @@ class TestDynamicSeparator {
   import TestDynamicSeparator._
 
   // DAFFODIL-2092
-  @Test def test_dynSepAllWhitespace() { runner.runOneTest("dynSepAllWhitespace") }
+  @Test def test_dynSepAllWhitespace(): Unit = { runner.runOneTest("dynSepAllWhitespace") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section24/regular_expressions/TestRegularExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section24/regular_expressions/TestRegularExpressions.scala
@@ -25,7 +25,7 @@ object TestRegularExpressions {
   val testDir = "/org/apache/daffodil/section24/regular_expressions/"
   val runner = Runner(testDir, "RegularExpressions.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -35,14 +35,14 @@ class TestRegularExpressions {
 
   import TestRegularExpressions._
 
-  @Test def test_entity_in_regex_fail() { runner.runOneTest("entity_in_regex_fail") }
-  @Test def test_entity_in_regex_fail_2() { runner.runOneTest("entity_in_regex_fail_2") }
-  @Test def test_entity_in_regex_fail_3() { runner.runOneTest("entity_in_regex_fail_3") }
-  @Test def test_entity_in_regex_fail_4() { runner.runOneTest("entity_in_regex_fail_4") }
+  @Test def test_entity_in_regex_fail(): Unit = { runner.runOneTest("entity_in_regex_fail") }
+  @Test def test_entity_in_regex_fail_2(): Unit = { runner.runOneTest("entity_in_regex_fail_2") }
+  @Test def test_entity_in_regex_fail_3(): Unit = { runner.runOneTest("entity_in_regex_fail_3") }
+  @Test def test_entity_in_regex_fail_4(): Unit = { runner.runOneTest("entity_in_regex_fail_4") }
 
-  @Test def test_testRegEx_01() { runner.runOneTest("testRegEx_01") }
-  @Test def test_testRegEx_02() { runner.runOneTest("testRegEx_02") }
-  @Test def test_testRegEx_03() { runner.runOneTest("testRegEx_03") }
+  @Test def test_testRegEx_01(): Unit = { runner.runOneTest("testRegEx_01") }
+  @Test def test_testRegEx_02(): Unit = { runner.runOneTest("testRegEx_02") }
+  @Test def test_testRegEx_03(): Unit = { runner.runOneTest("testRegEx_03") }
 
   // DFDL-517
   // // Unsupported Java 7 features (should return Schema Definition Errors)
@@ -52,9 +52,9 @@ class TestRegularExpressions {
   // @Test def test_testRegEx_07() { runner.runOneTest("testRegEx_07") }
 
   // DFDL-922
-  @Test def test_testRegEx_08() { runner.runOneTest("testDFDL-922") }
-  @Test def test_testRegEx_09() { runner.runOneTest("testDFDL-922_2") }
+  @Test def test_testRegEx_08(): Unit = { runner.runOneTest("testDFDL-922") }
+  @Test def test_testRegEx_09(): Unit = { runner.runOneTest("testDFDL-922_2") }
 
   // DAFFODIL-809
-  @Test def test_assertWithPattern1() { runner.runOneTest("testAssertWithPattern1") }
+  @Test def test_assertWithPattern1(): Unit = { runner.runOneTest("testAssertWithPattern1") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section31/escape_characters/TestEscapes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section31/escape_characters/TestEscapes.scala
@@ -26,7 +26,7 @@ object TestEscapes {
   val testDir = "/org/apache/daffodil/section31/escape_characters/"
   val runner = Runner(testDir, "Escapes.tdml")
 
-  @AfterClass def shutDown() {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }
@@ -34,96 +34,96 @@ object TestEscapes {
 class TestEscapes {
   import TestEscapes._
 
-  @Test def test_escape_entry1() { runner.runOneTest("escape_entry1") }
-  @Test def test_escape_entry2() { runner.runOneTest("escape_entry2") }
-  @Test def test_escape_entry3() { runner.runOneTest("escape_entry3") }
-  @Test def test_escape_entry4() { runner.runOneTest("escape_entry4") }
-  @Test def test_escape_entry5() { runner.runOneTest("escape_entry5") }
-  @Test def test_escape_entry6() { runner.runOneTest("escape_entry6") }
-  @Test def test_escape_entry7() { runner.runOneTest("escape_entry7") }
-  @Test def test_escape_entry8() { runner.runOneTest("escape_entry8") }
-  @Test def test_escape_entry9() { runner.runOneTest("escape_entry9") }
-  @Test def test_escape_entry10() { runner.runOneTest("escape_entry10") }
-  @Test def test_escape_entry11() { runner.runOneTest("escape_entry11") }
-  @Test def test_escape_entry12() { runner.runOneTest("escape_entry12") }
+  @Test def test_escape_entry1(): Unit = { runner.runOneTest("escape_entry1") }
+  @Test def test_escape_entry2(): Unit = { runner.runOneTest("escape_entry2") }
+  @Test def test_escape_entry3(): Unit = { runner.runOneTest("escape_entry3") }
+  @Test def test_escape_entry4(): Unit = { runner.runOneTest("escape_entry4") }
+  @Test def test_escape_entry5(): Unit = { runner.runOneTest("escape_entry5") }
+  @Test def test_escape_entry6(): Unit = { runner.runOneTest("escape_entry6") }
+  @Test def test_escape_entry7(): Unit = { runner.runOneTest("escape_entry7") }
+  @Test def test_escape_entry8(): Unit = { runner.runOneTest("escape_entry8") }
+  @Test def test_escape_entry9(): Unit = { runner.runOneTest("escape_entry9") }
+  @Test def test_escape_entry10(): Unit = { runner.runOneTest("escape_entry10") }
+  @Test def test_escape_entry11(): Unit = { runner.runOneTest("escape_entry11") }
+  @Test def test_escape_entry12(): Unit = { runner.runOneTest("escape_entry12") }
 
-  @Test def test_escape_entry2_1() { runner.runOneTest("escape_entry2_1") }
-  @Test def test_escape_entry2_2() { runner.runOneTest("escape_entry2_2") }
-  @Test def test_escape_entry2_3() { runner.runOneTest("escape_entry2_3") }
-  @Test def test_escape_entry2_4() { runner.runOneTest("escape_entry2_4") }
-  @Test def test_escape_entry2_5() { runner.runOneTest("escape_entry2_5") }
-  @Test def test_escape_entry2_6() { runner.runOneTest("escape_entry2_6") }
-  @Test def test_escape_entry2_7() { runner.runOneTest("escape_entry2_7") }
-  @Test def test_escape_entry2_8() { runner.runOneTest("escape_entry2_8") }
-  @Test def test_escape_entry2_9() { runner.runOneTest("escape_entry2_9") }
-  @Test def test_escape_entry2_10() { runner.runOneTest("escape_entry2_10") }
-  @Test def test_escape_entry2_11() { runner.runOneTest("escape_entry2_11") }
-  @Test def test_escape_entry2_12() { runner.runOneTest("escape_entry2_12") }
-  @Test def test_escape_entry2_13() { runner.runOneTest("escape_entry2_13") }
-  @Test def test_escape_entry2_14() { runner.runOneTest("escape_entry2_14") }
-  @Test def test_escape_entry2_15() { runner.runOneTest("escape_entry2_15") }
-  @Test def test_escape_entry2_16() { runner.runOneTest("escape_entry2_16") }
-  @Test def test_escape_entry2_17() { runner.runOneTest("escape_entry2_17") }
-  @Test def test_escape_entry2_18() { runner.runOneTest("escape_entry2_18") }
+  @Test def test_escape_entry2_1(): Unit = { runner.runOneTest("escape_entry2_1") }
+  @Test def test_escape_entry2_2(): Unit = { runner.runOneTest("escape_entry2_2") }
+  @Test def test_escape_entry2_3(): Unit = { runner.runOneTest("escape_entry2_3") }
+  @Test def test_escape_entry2_4(): Unit = { runner.runOneTest("escape_entry2_4") }
+  @Test def test_escape_entry2_5(): Unit = { runner.runOneTest("escape_entry2_5") }
+  @Test def test_escape_entry2_6(): Unit = { runner.runOneTest("escape_entry2_6") }
+  @Test def test_escape_entry2_7(): Unit = { runner.runOneTest("escape_entry2_7") }
+  @Test def test_escape_entry2_8(): Unit = { runner.runOneTest("escape_entry2_8") }
+  @Test def test_escape_entry2_9(): Unit = { runner.runOneTest("escape_entry2_9") }
+  @Test def test_escape_entry2_10(): Unit = { runner.runOneTest("escape_entry2_10") }
+  @Test def test_escape_entry2_11(): Unit = { runner.runOneTest("escape_entry2_11") }
+  @Test def test_escape_entry2_12(): Unit = { runner.runOneTest("escape_entry2_12") }
+  @Test def test_escape_entry2_13(): Unit = { runner.runOneTest("escape_entry2_13") }
+  @Test def test_escape_entry2_14(): Unit = { runner.runOneTest("escape_entry2_14") }
+  @Test def test_escape_entry2_15(): Unit = { runner.runOneTest("escape_entry2_15") }
+  @Test def test_escape_entry2_16(): Unit = { runner.runOneTest("escape_entry2_16") }
+  @Test def test_escape_entry2_17(): Unit = { runner.runOneTest("escape_entry2_17") }
+  @Test def test_escape_entry2_18(): Unit = { runner.runOneTest("escape_entry2_18") }
 
-  @Test def test_escape_entry3_1() { runner.runOneTest("escape_entry3_1") }
-  @Test def test_escape_entry3_2() { runner.runOneTest("escape_entry3_2") }
-  @Test def test_escape_entry3_3() { runner.runOneTest("escape_entry3_3") }
-  @Test def test_escape_entry3_4() { runner.runOneTest("escape_entry3_4") }
-  @Test def test_escape_entry3_5() { runner.runOneTest("escape_entry3_5") }
-  @Test def test_escape_entry3_6() { runner.runOneTest("escape_entry3_6") }
-  @Test def test_escape_entry3_7() { runner.runOneTest("escape_entry3_7") }
-  @Test def test_escape_entry3_8() { runner.runOneTest("escape_entry3_8") }
-  @Test def test_escape_entry3_9() { runner.runOneTest("escape_entry3_9") }
-  @Test def test_escape_entry3_10() { runner.runOneTest("escape_entry3_10") }
-  @Test def test_escape_entry3_11() { runner.runOneTest("escape_entry3_11") }
-  @Test def test_escape_entry3_12() { runner.runOneTest("escape_entry3_12") }
-  @Test def test_escape_entry3_13() { runner.runOneTest("escape_entry3_13") }
-  @Test def test_escape_entry3_14() { runner.runOneTest("escape_entry3_14") }
-  @Test def test_escape_entry3_15() { runner.runOneTest("escape_entry3_15") }
-  @Test def test_escape_entry3_16() { runner.runOneTest("escape_entry3_16") }
-  @Test def test_escape_entry3_17() { runner.runOneTest("escape_entry3_17") }
-  @Test def test_escape_entry3_18() { runner.runOneTest("escape_entry3_18") }
-  @Test def test_escape_entry3_19() { runner.runOneTest("escape_entry3_19") }
-  @Test def test_escape_entry3_20() { runner.runOneTest("escape_entry3_20") }
-  @Test def test_escape_entry3_21() { runner.runOneTest("escape_entry3_21") }
-  @Test def test_escape_entry3_22() { runner.runOneTest("escape_entry3_22") }
-  @Test def test_escape_entry3_23() { runner.runOneTest("escape_entry3_23") }
-  @Test def test_escape_entry3_24() { runner.runOneTest("escape_entry3_24") }
-  @Test def test_escape_entry3_25() { runner.runOneTest("escape_entry3_25") }
-  @Test def test_escape_entry3_26() { runner.runOneTest("escape_entry3_26") }
-  @Test def test_escape_entry3_27() { runner.runOneTest("escape_entry3_27") }
-  @Test def test_escape_entry3_28() { runner.runOneTest("escape_entry3_28") }
-  @Test def test_escape_entry3_29() { runner.runOneTest("escape_entry3_29") }
-  @Test def test_escape_entry3_30() { runner.runOneTest("escape_entry3_30") }
-  @Test def test_escape_entry3_31() { runner.runOneTest("escape_entry3_31") }
+  @Test def test_escape_entry3_1(): Unit = { runner.runOneTest("escape_entry3_1") }
+  @Test def test_escape_entry3_2(): Unit = { runner.runOneTest("escape_entry3_2") }
+  @Test def test_escape_entry3_3(): Unit = { runner.runOneTest("escape_entry3_3") }
+  @Test def test_escape_entry3_4(): Unit = { runner.runOneTest("escape_entry3_4") }
+  @Test def test_escape_entry3_5(): Unit = { runner.runOneTest("escape_entry3_5") }
+  @Test def test_escape_entry3_6(): Unit = { runner.runOneTest("escape_entry3_6") }
+  @Test def test_escape_entry3_7(): Unit = { runner.runOneTest("escape_entry3_7") }
+  @Test def test_escape_entry3_8(): Unit = { runner.runOneTest("escape_entry3_8") }
+  @Test def test_escape_entry3_9(): Unit = { runner.runOneTest("escape_entry3_9") }
+  @Test def test_escape_entry3_10(): Unit = { runner.runOneTest("escape_entry3_10") }
+  @Test def test_escape_entry3_11(): Unit = { runner.runOneTest("escape_entry3_11") }
+  @Test def test_escape_entry3_12(): Unit = { runner.runOneTest("escape_entry3_12") }
+  @Test def test_escape_entry3_13(): Unit = { runner.runOneTest("escape_entry3_13") }
+  @Test def test_escape_entry3_14(): Unit = { runner.runOneTest("escape_entry3_14") }
+  @Test def test_escape_entry3_15(): Unit = { runner.runOneTest("escape_entry3_15") }
+  @Test def test_escape_entry3_16(): Unit = { runner.runOneTest("escape_entry3_16") }
+  @Test def test_escape_entry3_17(): Unit = { runner.runOneTest("escape_entry3_17") }
+  @Test def test_escape_entry3_18(): Unit = { runner.runOneTest("escape_entry3_18") }
+  @Test def test_escape_entry3_19(): Unit = { runner.runOneTest("escape_entry3_19") }
+  @Test def test_escape_entry3_20(): Unit = { runner.runOneTest("escape_entry3_20") }
+  @Test def test_escape_entry3_21(): Unit = { runner.runOneTest("escape_entry3_21") }
+  @Test def test_escape_entry3_22(): Unit = { runner.runOneTest("escape_entry3_22") }
+  @Test def test_escape_entry3_23(): Unit = { runner.runOneTest("escape_entry3_23") }
+  @Test def test_escape_entry3_24(): Unit = { runner.runOneTest("escape_entry3_24") }
+  @Test def test_escape_entry3_25(): Unit = { runner.runOneTest("escape_entry3_25") }
+  @Test def test_escape_entry3_26(): Unit = { runner.runOneTest("escape_entry3_26") }
+  @Test def test_escape_entry3_27(): Unit = { runner.runOneTest("escape_entry3_27") }
+  @Test def test_escape_entry3_28(): Unit = { runner.runOneTest("escape_entry3_28") }
+  @Test def test_escape_entry3_29(): Unit = { runner.runOneTest("escape_entry3_29") }
+  @Test def test_escape_entry3_30(): Unit = { runner.runOneTest("escape_entry3_30") }
+  @Test def test_escape_entry3_31(): Unit = { runner.runOneTest("escape_entry3_31") }
 
-  @Test def test_escape_entry4_1() { runner.runOneTest("escape_entry4_1") }
-  @Test def test_escape_entry4_2() { runner.runOneTest("escape_entry4_2") }
-  @Test def test_escape_entry4_3() { runner.runOneTest("escape_entry4_3") }
-  @Test def test_escape_entry4_4() { runner.runOneTest("escape_entry4_4") }
-  @Test def test_escape_entry4_5() { runner.runOneTest("escape_entry4_5") }
-  @Test def test_escape_entry4_6() { runner.runOneTest("escape_entry4_6") }
-  @Test def test_escape_entry4_7() { runner.runOneTest("escape_entry4_7") }
-  @Test def test_escape_entry4_8() { runner.runOneTest("escape_entry4_8") }
-  @Test def test_escape_entry4_9() { runner.runOneTest("escape_entry4_9") }
-  @Test def test_escape_entry4_10() { runner.runOneTest("escape_entry4_10") }
-  @Test def test_escape_entry4_11() { runner.runOneTest("escape_entry4_11") }
-  @Test def test_escape_entry4_12() { runner.runOneTest("escape_entry4_12") }
-  @Test def test_escape_entry4_13() { runner.runOneTest("escape_entry4_13") }
-  @Test def test_escape_entry4_14() { runner.runOneTest("escape_entry4_14") }
-  @Test def test_escape_entry4_15() { runner.runOneTest("escape_entry4_15") }
-  @Test def test_escape_entry4_16() { runner.runOneTest("escape_entry4_16") }
-  @Test def test_escape_entry4_17() { runner.runOneTest("escape_entry4_17") }
-  @Test def test_escape_entry4_18() { runner.runOneTest("escape_entry4_18") }
-  @Test def test_escape_entry4_19() { runner.runOneTest("escape_entry4_19") }
-  @Test def test_escape_entry4_20() { runner.runOneTest("escape_entry4_20") }
-  @Test def test_escape_entry4_21() { runner.runOneTest("escape_entry4_21") }
-  @Test def test_escape_entry4_22() { runner.runOneTest("escape_entry4_22") }
-  @Test def test_escape_entry4_23() { runner.runOneTest("escape_entry4_23") }
-  @Test def test_escape_entry4_24() { runner.runOneTest("escape_entry4_24") }
-  @Test def test_escape_entry4_25() { runner.runOneTest("escape_entry4_25") }
-  @Test def test_escape_entry4_26() { runner.runOneTest("escape_entry4_26") }
-  @Test def test_escape_entry4_27() { runner.runOneTest("escape_entry4_27") }
+  @Test def test_escape_entry4_1(): Unit = { runner.runOneTest("escape_entry4_1") }
+  @Test def test_escape_entry4_2(): Unit = { runner.runOneTest("escape_entry4_2") }
+  @Test def test_escape_entry4_3(): Unit = { runner.runOneTest("escape_entry4_3") }
+  @Test def test_escape_entry4_4(): Unit = { runner.runOneTest("escape_entry4_4") }
+  @Test def test_escape_entry4_5(): Unit = { runner.runOneTest("escape_entry4_5") }
+  @Test def test_escape_entry4_6(): Unit = { runner.runOneTest("escape_entry4_6") }
+  @Test def test_escape_entry4_7(): Unit = { runner.runOneTest("escape_entry4_7") }
+  @Test def test_escape_entry4_8(): Unit = { runner.runOneTest("escape_entry4_8") }
+  @Test def test_escape_entry4_9(): Unit = { runner.runOneTest("escape_entry4_9") }
+  @Test def test_escape_entry4_10(): Unit = { runner.runOneTest("escape_entry4_10") }
+  @Test def test_escape_entry4_11(): Unit = { runner.runOneTest("escape_entry4_11") }
+  @Test def test_escape_entry4_12(): Unit = { runner.runOneTest("escape_entry4_12") }
+  @Test def test_escape_entry4_13(): Unit = { runner.runOneTest("escape_entry4_13") }
+  @Test def test_escape_entry4_14(): Unit = { runner.runOneTest("escape_entry4_14") }
+  @Test def test_escape_entry4_15(): Unit = { runner.runOneTest("escape_entry4_15") }
+  @Test def test_escape_entry4_16(): Unit = { runner.runOneTest("escape_entry4_16") }
+  @Test def test_escape_entry4_17(): Unit = { runner.runOneTest("escape_entry4_17") }
+  @Test def test_escape_entry4_18(): Unit = { runner.runOneTest("escape_entry4_18") }
+  @Test def test_escape_entry4_19(): Unit = { runner.runOneTest("escape_entry4_19") }
+  @Test def test_escape_entry4_20(): Unit = { runner.runOneTest("escape_entry4_20") }
+  @Test def test_escape_entry4_21(): Unit = { runner.runOneTest("escape_entry4_21") }
+  @Test def test_escape_entry4_22(): Unit = { runner.runOneTest("escape_entry4_22") }
+  @Test def test_escape_entry4_23(): Unit = { runner.runOneTest("escape_entry4_23") }
+  @Test def test_escape_entry4_24(): Unit = { runner.runOneTest("escape_entry4_24") }
+  @Test def test_escape_entry4_25(): Unit = { runner.runOneTest("escape_entry4_25") }
+  @Test def test_escape_entry4_26(): Unit = { runner.runOneTest("escape_entry4_26") }
+  @Test def test_escape_entry4_27(): Unit = { runner.runOneTest("escape_entry4_27") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
@@ -25,7 +25,7 @@ object TestUdfsInSchemas {
 
   val runner = Runner(testDir, "udfs.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -34,28 +34,28 @@ object TestUdfsInSchemas {
 class TestUdfsInSchemas {
   import TestUdfsInSchemas._
 
-  @Test def test_udf_defaultNamespace() { runner.runOneTest("test_udf_defaultNamespace") }
-  @Test def test_udf_fnNotFound() { runner.runOneTest("test_udf_fnNotFound") }
-  @Test def test_udf_numArgsIncorrect() { runner.runOneTest("test_udf_numArgsIncorrect") }
-  @Test def test_udf_argsTypesIncorrect() { runner.runOneTest("test_udf_argsTypesIncorrect") }
-  @Test def test_udf_noArgs() { runner.runOneTest("test_udf_noArgs") }
-  @Test def test_boxedIntParamRetType() { runner.runOneTest("test_boxedIntParamRetType") }
-  @Test def test_primitiveIntParamRetType() { runner.runOneTest("test_primitiveIntParamRetType") }
-  @Test def test_boxedByteParamRetType() { runner.runOneTest("test_boxedByteParamRetType") }
-  @Test def test_primitiveByteParamRetType() { runner.runOneTest("test_primitiveByteParamRetType") }
-  @Test def test_primitiveByteArrayParamRetType() { runner.runOneTest("test_primitiveByteArrayParamRetType") }
-  @Test def test_boxedShortParamRetType() { runner.runOneTest("test_boxedShortParamRetType") }
-  @Test def test_primitiveShortParamRetType() { runner.runOneTest("test_primitiveShortParamRetType") }
-  @Test def test_boxedLongParamRetType() { runner.runOneTest("test_boxedLongParamRetType") }
-  @Test def test_primitiveLongParamRetType() { runner.runOneTest("test_primitiveLongParamRetType") }
-  @Test def test_boxedDoubleParamRetType() { runner.runOneTest("test_boxedDoubleParamRetType") }
-  @Test def test_primitiveDoubleParamRetType() { runner.runOneTest("test_primitiveDoubleParamRetType") }
-  @Test def test_boxedFloatParamRetType() { runner.runOneTest("test_boxedFloatParamRetType") }
-  @Test def test_primitiveFloatParamRetType() { runner.runOneTest("test_primitiveFloatParamRetType") }
-  @Test def test_boxedBooleanParamRetType() { runner.runOneTest("test_boxedBooleanParamRetType") }
-  @Test def test_primitiveBooleanParamRetType() { runner.runOneTest("test_primitiveBooleanParamRetType") }
-  @Test def test_javaBigIntegerParamRetType() { runner.runOneTest("test_javaBigIntegerParamRetType") }
-  @Test def test_javaBigDecimalParamRetType() { runner.runOneTest("test_javaBigDecimalParamRetType") }
-  @Test def test_stringParamRetType() { runner.runOneTest("test_stringParamRetType") }
+  @Test def test_udf_defaultNamespace(): Unit = { runner.runOneTest("test_udf_defaultNamespace") }
+  @Test def test_udf_fnNotFound(): Unit = { runner.runOneTest("test_udf_fnNotFound") }
+  @Test def test_udf_numArgsIncorrect(): Unit = { runner.runOneTest("test_udf_numArgsIncorrect") }
+  @Test def test_udf_argsTypesIncorrect(): Unit = { runner.runOneTest("test_udf_argsTypesIncorrect") }
+  @Test def test_udf_noArgs(): Unit = { runner.runOneTest("test_udf_noArgs") }
+  @Test def test_boxedIntParamRetType(): Unit = { runner.runOneTest("test_boxedIntParamRetType") }
+  @Test def test_primitiveIntParamRetType(): Unit = { runner.runOneTest("test_primitiveIntParamRetType") }
+  @Test def test_boxedByteParamRetType(): Unit = { runner.runOneTest("test_boxedByteParamRetType") }
+  @Test def test_primitiveByteParamRetType(): Unit = { runner.runOneTest("test_primitiveByteParamRetType") }
+  @Test def test_primitiveByteArrayParamRetType(): Unit = { runner.runOneTest("test_primitiveByteArrayParamRetType") }
+  @Test def test_boxedShortParamRetType(): Unit = { runner.runOneTest("test_boxedShortParamRetType") }
+  @Test def test_primitiveShortParamRetType(): Unit = { runner.runOneTest("test_primitiveShortParamRetType") }
+  @Test def test_boxedLongParamRetType(): Unit = { runner.runOneTest("test_boxedLongParamRetType") }
+  @Test def test_primitiveLongParamRetType(): Unit = { runner.runOneTest("test_primitiveLongParamRetType") }
+  @Test def test_boxedDoubleParamRetType(): Unit = { runner.runOneTest("test_boxedDoubleParamRetType") }
+  @Test def test_primitiveDoubleParamRetType(): Unit = { runner.runOneTest("test_primitiveDoubleParamRetType") }
+  @Test def test_boxedFloatParamRetType(): Unit = { runner.runOneTest("test_boxedFloatParamRetType") }
+  @Test def test_primitiveFloatParamRetType(): Unit = { runner.runOneTest("test_primitiveFloatParamRetType") }
+  @Test def test_boxedBooleanParamRetType(): Unit = { runner.runOneTest("test_boxedBooleanParamRetType") }
+  @Test def test_primitiveBooleanParamRetType(): Unit = { runner.runOneTest("test_primitiveBooleanParamRetType") }
+  @Test def test_javaBigIntegerParamRetType(): Unit = { runner.runOneTest("test_javaBigIntegerParamRetType") }
+  @Test def test_javaBigDecimalParamRetType(): Unit = { runner.runOneTest("test_javaBigDecimalParamRetType") }
+  @Test def test_stringParamRetType(): Unit = { runner.runOneTest("test_stringParamRetType") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestEnvelopePayload.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestEnvelopePayload.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.tdml.Runner
 object TestEnvelopePayload {
   var runner = Runner("/org/apache/daffodil/unparser/", "envelopePayload.tdml")
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 }
@@ -32,8 +32,8 @@ object TestEnvelopePayload {
 class TestEnvelopePayload {
   import TestEnvelopePayload._
 
-  @Test def test_ep1() { runner.runOneTest("ep1") }
-  @Test def test_ep2() { runner.runOneTest("ep2") }
-  @Test def test_ep3() { runner.runOneTest("ep3") }
+  @Test def test_ep1(): Unit = { runner.runOneTest("ep1") }
+  @Test def test_ep2(): Unit = { runner.runOneTest("ep2") }
+  @Test def test_ep3(): Unit = { runner.runOneTest("ep3") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestOVCAndLength.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestOVCAndLength.scala
@@ -27,7 +27,7 @@ object TestOVCAndLength {
   val aa = testDir + "OVCAndLengthTest.tdml"
   var runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner = null
   }
 }
@@ -35,8 +35,8 @@ object TestOVCAndLength {
 class TestOVCAndLength {
   import TestOVCAndLength._
 
-  @Test def test_ovcContentLengthCycle1() { runner.runOneTest("ovcContentLengthCycle1") }
+  @Test def test_ovcContentLengthCycle1(): Unit = { runner.runOneTest("ovcContentLengthCycle1") }
 
-  @Test def test_ovcContentLengthCycle2() { runner.runOneTest("ovcContentLengthCycle2") }
+  @Test def test_ovcContentLengthCycle2(): Unit = { runner.runOneTest("ovcContentLengthCycle2") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
@@ -26,7 +26,7 @@ object TestParseUnparseMode {
   val runner = Runner(testDir, "parseUnparseModeTest.tdml",
     validateDFDLSchemas = false) // there are UPA errors in some test schemas
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 
@@ -36,11 +36,11 @@ class TestParseUnparseMode {
 
   import TestParseUnparseMode._
 
-  @Test def test_parse1() { runner.runOneTest("parse1") }
+  @Test def test_parse1(): Unit = { runner.runOneTest("parse1") }
 
-  @Test def test_unparse1() { runner.runOneTest("unparse1") }
+  @Test def test_unparse1(): Unit = { runner.runOneTest("unparse1") }
 
-  @Test def test_unparse2() { runner.runOneTest("unparse2") }
+  @Test def test_unparse2(): Unit = { runner.runOneTest("unparse2") }
 
-  @Test def test_unparse3() { runner.runOneTest("unparse3") }
+  @Test def test_unparse3(): Unit = { runner.runOneTest("unparse3") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestUnparseNegInfoset.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestUnparseNegInfoset.scala
@@ -27,7 +27,7 @@ object TestUnparseNegInfoset {
   val aa = testDir + "unparseNegInfosetTest.tdml"
   var runner = new DFDLTestSuite(Misc.getRequiredResource(aa), validateTDMLFile = false)
 
-  @AfterClass def tearDown() {
+  @AfterClass def tearDown(): Unit = {
     runner = null
   }
 }
@@ -35,21 +35,21 @@ object TestUnparseNegInfoset {
 class TestUnparseNegInfoset {
   import TestUnparseNegInfoset._
 
-  @Test def test_schemaElementRoot1Good() { runner.runOneTest("schemaElementRoot1Good") }
-  @Test def test_schemaElementRoot2Good() { runner.runOneTest("schemaElementRoot2Good") }
+  @Test def test_schemaElementRoot1Good(): Unit = { runner.runOneTest("schemaElementRoot1Good") }
+  @Test def test_schemaElementRoot2Good(): Unit = { runner.runOneTest("schemaElementRoot2Good") }
 
-  @Test def test_unexpectedNextNone() { runner.runOneTest("unexpectedNextNone") }
-  @Test def test_unexpectedNextSingle() { runner.runOneTest("unexpectedNextSingle") }
-  @Test def test_unexpectedNextMultiple() { runner.runOneTest("unexpectedNextMultiple") }
+  @Test def test_unexpectedNextNone(): Unit = { runner.runOneTest("unexpectedNextNone") }
+  @Test def test_unexpectedNextSingle(): Unit = { runner.runOneTest("unexpectedNextSingle") }
+  @Test def test_unexpectedNextMultiple(): Unit = { runner.runOneTest("unexpectedNextMultiple") }
 
-  @Test def test_uenxpectedChildNone() { runner.runOneTest("unexpectedChildNone") }
-  @Test def test_unexpectedChildSingle() { runner.runOneTest("unexpectedChildSingle") }
-  @Test def test_unexpectedChildMultiple() { runner.runOneTest("unexpectedChildMultiple") }
-  @Test def test_unexpectedChildSameAsSibling() { runner.runOneTest("unexpectedChildSameAsSibling") }
+  @Test def test_uenxpectedChildNone(): Unit = { runner.runOneTest("unexpectedChildNone") }
+  @Test def test_unexpectedChildSingle(): Unit = { runner.runOneTest("unexpectedChildSingle") }
+  @Test def test_unexpectedChildMultiple(): Unit = { runner.runOneTest("unexpectedChildMultiple") }
+  @Test def test_unexpectedChildSameAsSibling(): Unit = { runner.runOneTest("unexpectedChildSameAsSibling") }
 
-  @Test def test_nilledTrueNonNillable() { runner.runOneTest("nilledTrueNonNillable") }
-  @Test def test_nilledFalseNonNillable() { runner.runOneTest("nilledFalseNonNillable") }
-  @Test def test_nilledSimpleWithContent() { runner.runOneTest("nilledSimpleWithContent") }
-  @Test def test_nilledComplexWithContent() { runner.runOneTest("nilledComplexWithContent") }
-  @Test def test_nilledBadValue() { runner.runOneTest("nilledBadValue") }
+  @Test def test_nilledTrueNonNillable(): Unit = { runner.runOneTest("nilledTrueNonNillable") }
+  @Test def test_nilledFalseNonNillable(): Unit = { runner.runOneTest("nilledFalseNonNillable") }
+  @Test def test_nilledSimpleWithContent(): Unit = { runner.runOneTest("nilledSimpleWithContent") }
+  @Test def test_nilledComplexWithContent(): Unit = { runner.runOneTest("nilledComplexWithContent") }
+  @Test def test_nilledBadValue(): Unit = { runner.runOneTest("nilledBadValue") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/RC-Test5.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/RC-Test5.scala
@@ -26,7 +26,7 @@ object RCTest5 {
   val runner = Runner(testDir, "test-5.tdml.xml")
   val runner6 = Runner(testDir, "test-6.tdml.xml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner6.reset
   }
@@ -37,7 +37,7 @@ class RCTest5 {
 
   import RCTest5._
 
-  @Test def test5p() { runner.runOneTest("parse-test-5") }
+  @Test def test5p(): Unit = { runner.runOneTest("parse-test-5") }
 
   // DAFFODIL-2217
   // @Test def test5u() { runner.runOneTest("unparse-test-5") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSSPNeverDiagnostic.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSSPNeverDiagnostic.scala
@@ -25,7 +25,7 @@ object TestSSPNeverDiagnostic {
   val testDir = "/org/apache/daffodil/usertests/"
   val runner = Runner(testDir, "testSSPNeverDiagnostic.tdml.xml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
@@ -26,7 +26,7 @@ object TestUserSubmittedTests {
   val runner = Runner(testDir, "UserSubmittedTests.tdml")
   val runner2 = Runner(testDir, "nameDOB_test.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner2.reset
   }
@@ -37,13 +37,13 @@ class TestUserSubmittedTests {
 
   import TestUserSubmittedTests._
 
-  @Test def test_prefix_separator_as_variable() {
+  @Test def test_prefix_separator_as_variable(): Unit = {
     runner.runOneTest("test_prefix_separator_as_variable")
   }
-  @Test def test_DFDL_2262() { runner.runOneTest("test_DFDL_2262") }
+  @Test def test_DFDL_2262(): Unit = { runner.runOneTest("test_DFDL_2262") }
 
-  @Test def test_nameDOB_test2_pass() { runner2.runOneTest("nameDOB_test2_pass") }
-  @Test def test_nameDOB_test2_fail() { runner2.runOneTest("nameDOB_test2_fail") }
+  @Test def test_nameDOB_test2_pass(): Unit = { runner2.runOneTest("nameDOB_test2_pass") }
+  @Test def test_nameDOB_test2_fail(): Unit = { runner2.runOneTest("nameDOB_test2_fail") }
 
   /*//DFDL-1118
   @Test def test_dfdl_782() = {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/xml/test/unit/TestDaffodilXMLLoader.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/xml/test/unit/TestDaffodilXMLLoader.scala
@@ -52,7 +52,7 @@ class TestDaffodilXMLLoader {
    * If the error is detected, then it must have found and used the
    * user-specified catalog.
    */
-  @Test def testThisTestRig() {
+  @Test def testThisTestRig(): Unit = {
 
     // LoggingDefaults.setLoggingLevel(LogLevel.Debug)
 
@@ -120,7 +120,7 @@ class TestDaffodilXMLLoader {
    * so if the built-in schema is used, it will find this error. So the
    * test passes if the error is detected.
    */
-  @Test def testThatUserCatalogCannotOverrideDaffodilInternalCatalog1() {
+  @Test def testThatUserCatalogCannotOverrideDaffodilInternalCatalog1(): Unit = {
 
     // LoggingDefaults.setLoggingLevel(LogLevel.Debug)
 
@@ -185,7 +185,7 @@ class TestDaffodilXMLLoader {
    *
    * Test passes if there is no invalid data error.
    */
-  @Test def testThatUserCatalogCannotOverrideDaffodilInternalCatalog2() {
+  @Test def testThatUserCatalogCannotOverrideDaffodilInternalCatalog2(): Unit = {
 
     // LoggingDefaults.setLoggingLevel(LogLevel.Debug)
 

--- a/project/UpdateEclipseClasspaths.scala
+++ b/project/UpdateEclipseClasspaths.scala
@@ -70,7 +70,7 @@ object UpdateEclipseClasspaths extends App {
 
   lazy val baseURI = baseFile.toURI
 
-  def updateOneClasspathFile(cpf: java.io.File) {
+  def updateOneClasspathFile(cpf: java.io.File): Unit = {
     val cpNode = scala.xml.XML.loadFile(cpf)
     /*
      * There is an issue with the XML loader that reverses the order of the attributes
@@ -88,7 +88,7 @@ object UpdateEclipseClasspaths extends App {
     writeXMLFile(newCP, cpf.toString)
   }
 
-  def writeXML(xml: Node, out: { def print(s: String): Unit } = System.out) {
+  def writeXML(xml: Node, out: { def print(s: String): Unit } = System.out): Unit = {
     val formattedSpec = pp.format(xml)
     out.print("<?xml version='1.0' encoding='UTF-8'?>\n")
     out.print("\n")
@@ -96,7 +96,7 @@ object UpdateEclipseClasspaths extends App {
     out.print("\n")
   }
 
-  def writeXMLFile(xml: Node, outputFilename: String) {
+  def writeXMLFile(xml: Node, outputFilename: String): Unit = {
     val f = new java.io.File(outputFilename)
     f.getParentFile().mkdirs()
     val ps = new PrintStream(f)

--- a/test-stdLayout/src/test/scala/org1/TestOrg1.scala
+++ b/test-stdLayout/src/test/scala/org1/TestOrg1.scala
@@ -25,7 +25,7 @@ object TestOrg1 {
   val runner = Runner("org1", "testStdLayout.tdml")
   val runner2 = Runner("org1", "testSchemaFilesUnderSrcTest.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner2.reset
   }

--- a/test-stdLayout/src/test/scala/org2/TestOrg2.scala
+++ b/test-stdLayout/src/test/scala/org2/TestOrg2.scala
@@ -25,7 +25,7 @@ object TestOrg2 {
   val runner = Runner("org2", "testSchemaFilesUnderSrcTest2.tdml")
   val runner2 = Runner("org2", "testEmbeddedSchema.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
     runner2.reset
   }

--- a/test-stdLayout/src/test/scala/org2/TestPayloadAndTypes.scala
+++ b/test-stdLayout/src/test/scala/org2/TestPayloadAndTypes.scala
@@ -24,7 +24,7 @@ import org.junit.AfterClass
 object TestPayloadAndTypes {
   val runner = Runner("org2", "testPayloadAndTypes.tdml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner.reset
   }
 }

--- a/tutorials/src/test/scala/org/apache/daffodil/tutorials/TestTutorials.scala
+++ b/tutorials/src/test/scala/org/apache/daffodil/tutorials/TestTutorials.scala
@@ -26,7 +26,7 @@ object TestTutorials {
   val runner4 = Runner("/", "tdmlTutorial.tdml.xml")
   val runner5 = Runner("/", "bugReportTemplate.tdml.xml")
 
-  @AfterClass def shutDown {
+  @AfterClass def shutDown: Unit = {
     runner1.reset
     runner4.reset
     runner5.reset
@@ -38,16 +38,16 @@ class TestTutorials {
 
   // removed for now. This will probably go back into this tutorial
   // @Test def test_MIL2045_47001D_1() { runner1.runOneTest("TestMIL2045_47001D_1") }
-  @Test def test_leastSignificantBitFirst() { runner1.runOneTest("leastSignificantBitFirst") }
-  @Test def test_leastSignificantBitFirstRTL() { runner1.runOneTest("leastSignificantBitFirstRTL") }
-  @Test def test_mostSignificantBitFirst() { runner1.runOneTest("mostSignificantBitFirst") }
-  @Test def test_littleEndianLeastFirstLTR() { runner1.runOneTest("littleEndianLeastFirstLTR") }
-  @Test def test_littleEndianLeastFirstRTL() { runner1.runOneTest("littleEndianLeastFirstRTL") }
+  @Test def test_leastSignificantBitFirst(): Unit = { runner1.runOneTest("leastSignificantBitFirst") }
+  @Test def test_leastSignificantBitFirstRTL(): Unit = { runner1.runOneTest("leastSignificantBitFirstRTL") }
+  @Test def test_mostSignificantBitFirst(): Unit = { runner1.runOneTest("mostSignificantBitFirst") }
+  @Test def test_littleEndianLeastFirstLTR(): Unit = { runner1.runOneTest("littleEndianLeastFirstLTR") }
+  @Test def test_littleEndianLeastFirstRTL(): Unit = { runner1.runOneTest("littleEndianLeastFirstRTL") }
 
-  @Test def test_bugReportParse1() { runner4.runOneTest("dateTimeTest") }
-  @Test def test_bugReportUnparse1() { runner4.runOneTest("unparseDateTimeTest") }
+  @Test def test_bugReportParse1(): Unit = { runner4.runOneTest("dateTimeTest") }
+  @Test def test_bugReportUnparse1(): Unit = { runner4.runOneTest("unparseDateTimeTest") }
 
-  @Test def test_bugReportTemplateParse1() { runner5.runOneTest("dateTimeTest") }
-  @Test def test_bugReportTemplateUnparse1() { runner5.runOneTest("unparseDateTimeTest") }
+  @Test def test_bugReportTemplateParse1(): Unit = { runner5.runOneTest("dateTimeTest") }
+  @Test def test_bugReportTemplateUnparse1(): Unit = { runner5.runOneTest("unparseDateTimeTest") }
 
 }


### PR DESCRIPTION
Use Scalafix `ProcedureSyntax` rule to fix the deprecated procedure syntax usage.

DAFFODIL-1673
