### PR TITLE
Update license information for Scala dependencies to Apache v2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -238,41 +238,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles source from 'Scala', including the following files:
-    - daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
-  These files are available under the BSD-3-Clause licnese:
-
-    Copyright (c) 2002-  EPFL
-    Copyright (c) 2011-  Lightbend, Inc.
-
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of the EPFL nor the names of its contributors may be
-      used to endorse or promote products derived from this software without
-      specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-
   This product bundles material copied or derived from W3C, including the
   following files:
     - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd)

--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,19 @@ Based on source code originally developed by
 - The Univerisity of Illinois National Center for Supercomputing Applications (http://www.ncsa.illinois.edu/)
 - Tresys Technology (http://www.tresys.com/)
 - International Business Machines Corporation (http://www.ibm.com)
+
+The following NOTICE information applies to components distributed with this project:
+
+This product includes derived works from Scala
+  Scala
+  Copyright (c) 2002-2020 EPFL
+  Copyright (c) 2011-2020 Lightbend, Inc.
+
+  Scala includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+  The derived work is adapted from scala/src/library/scala/Symbol.scala:
+    https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
+  and can be found in:
+    daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala

--- a/build.sbt
+++ b/build.sbt
@@ -217,12 +217,10 @@ lazy val libManagedSettings = Seq(
 
 lazy val ratSettings = Seq(
   ratLicenses := Seq(
-    ("BSD2 ", Rat.BSD2_LICENSE_NAME, Rat.LICENSE_TEXT_PASSERA),
-    ("BSD3 ", Rat.BSD3_LICENSE_NAME, Rat.LICENSE_TEXT_SCALA)
+    ("BSD2 ", Rat.BSD2_LICENSE_NAME, Rat.LICENSE_TEXT_PASSERA)
   ),
 
   ratLicenseFamilies := Seq(
-    Rat.BSD3_LICENSE_NAME,
     Rat.BSD2_LICENSE_NAME
   ),
 

--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -237,44 +237,6 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles 'Scala', including the following files:
-    - lib/org.scala-lang.modules.scala-parser-combinators_2.12-1.1.1.jar
-    - lib/org.scala-lang.modules.scala-xml_2.12-1.1.0.jar
-    - lib/org.scala-lang.scala-library-2.12.11.jar
-    - org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-3.0.0.jar
-  These files are available under the BSD-3-Clause licnese:
-
-    Copyright (c) 2002-  EPFL
-    Copyright (c) 2011-  Lightbend, Inc.
-
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of the EPFL nor the names of its contributors may be
-      used to endorse or promote products derived from this software without
-      specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-
   This product bundles material copied or derived from W3C, including the
   following files:
     - org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-3.0.0.jar

--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -82,6 +82,39 @@ Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-2.10.2.jar)
   in some artifacts (usually source distributions); but is always available
   from the source code management (SCM) system project uses.
 
+Scala (lib/org.scala-lang.scala-library-2.12.11.jar)
+      (org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-3.0.0.jar)
+  Scala parser combinators
+  Copyright (c) 2002-2020 EPFL
+  Copyright (c) 2011-2020 Lightbend, Inc.
+
+  Scala includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+  The derived work is adapted from scala/src/library/scala/Symbol.scala:
+    https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
+  and can be found in:
+    daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+
+Scala Parser Combinators (lib/org.scala-lang.modules.scala-parser-combinators_2.12-1.1.1.jar)
+  Scala parser combinators
+  Copyright (c) 2002-2020 EPFL
+  Copyright (c) 2011-2020 Lightbend, Inc.
+
+  Scala includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+Scala XML (lib/org.scala-lang.modules.scala-xml_2.12-1.1.0.jar)
+  scala-xml
+  Copyright (c) 2002-2020 EPFL
+  Copyright (c) 2011-2020 Lightbend, Inc.
+
+  scala-xml includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
 Woodstox (lib/com.fasterxml.woodstox.woodstox-core-5.1.0.jar)
   This product currently only contains code developed by authors
   of specific components, as identified by the source code files.

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
@@ -1,67 +1,36 @@
 /*
- * Copyright (c) 2002-  EPFL
- * Copyright (c) 2011-  Lightbend, Inc.
+ * Scala (https://www.scala-lang.org)
  *
- * All rights reserved.
+ * Copyright EPFL and Lightbend, Inc.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
  *
- * * Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * * Neither the name of the EPFL nor the names of its contributors may be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
-
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
 
 package org.apache.daffodil.util
 
 /**
- * The following code was taken from the scala tree:
- *   scala/v2.11.7/src/library/scala/Symbol.scala
+ * The following code was copied unmodified from Scala source:
+ *   https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
  *
- * The UniquenessCache class provides a simple way to cache/intern unique
- * objects. Since they are interened, they can be compared using reference
- * equality. Below is the Symbol class from scala which shows a simple example
- * of how to use this. See also Namespaces.scala for a slightly more complex
- * usage.
+ * This class provides a simple way to get unique objects for equal strings.
+ * Because they are interned, they can be compared using reference equality.
+ * This is normally used for scala Symbols. See also Namespaces.scala for a
+ * slightly more comple xusage.
  */
-
 abstract class UniquenessCache[K, V >: Null]
 {
   import java.lang.ref.WeakReference
   import java.util.WeakHashMap
   import java.util.concurrent.locks.ReentrantReadWriteLock
 
-  private val rwl = new ReentrantReadWriteLock()
-  private val rlock = rwl.readLock
-  private val wlock = rwl.writeLock
-  private val map = new WeakHashMap[K, WeakReference[V]]
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
 
   protected def valueFromKey(k: K): V
   protected def keyFromValue(v: V): Option[K]
@@ -84,8 +53,8 @@ abstract class UniquenessCache[K, V >: Null]
         else {
           // If we don't remove the old String key from the map, we can
           // wind up with one String as the key and a different String as
-          // as the name field in the Symbol, which can lead to surprising
-          // GC behavior and duplicate Symbols. See SI-6706.
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
           map remove name
           val sym = valueFromKey(name)
           map.put(name, new WeakReference(sym))

--- a/project/Rat.scala
+++ b/project/Rat.scala
@@ -126,7 +126,6 @@ object Rat {
   )
 
   lazy val BSD2_LICENSE_NAME = "BSD 2-Clause License"
-  lazy val BSD3_LICENSE_NAME = "BSD 3-Clause License"
 
   lazy val LICENSE_TEXT_PASSERA =
 """
@@ -152,35 +151,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-"""
-
-  lazy val LICENSE_TEXT_SCALA =
-"""
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the EPFL nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
 """
 
 }


### PR DESCRIPTION
Scala, Scala XML, and Scala Parser Combinator libraries all relicensed
from BSD-3 to Apache v2. This means we no longer need to maintain
separate license information in the LICENSE and bin.LICENSE files, but
need to copy the NOTICE information into NOTICE and bin.NOTICE.

This makes the appropriate LICENSE/NOTICE changes, updates the Apache
Rat config to no longer need a special case for the Scala license, and
updates to the latest Apache v2 licensed version of UniquenessCache.

DAFFODIL-2355