### PR TITLE
Add test_nulPattern1

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/NulChars.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/NulChars.tdml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tdml:testSuite
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:ex="http://example.com"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  defaultRoundTrip="onePass"
+  defaultValidation="on">
+
+  <tdml:defineSchema name="nullTest">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+    <dfdl:format ref="ex:GeneralFormat"/>
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="foo" dfdl:lengthKind="pattern" dfdl:lengthPattern="\x{0000}{3,3}">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="&#xE000;*"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="padRoot">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation><![CDATA[
+              Models padding that must be all zero bytes.
+            ]]></xs:documentation>
+      </xs:annotation>
+      <xs:sequence dfdl:separator="%NUL;" dfdl:separatorSuppressionPolicy="anyEmpty" dfdl:separatorPosition="infix"
+                   dfdl:encoding="iso-8859-1">
+        <!--
+        The intention here is to capture any non-nul chars in these nz elements
+        Notice that they are an array with maxOccurs="0" which means validity checking will
+        issue an error if ANY of these occur. That's what we want, an error on any non-nul character.
+        -->
+        <xs:element name="nz" type="xs:string" minOccurs="0" maxOccurs="0"
+                    dfdl:lengthPattern='[^\x{00}]+' dfdl:lengthKind="pattern"
+                    dfdl:occursCountKind="parsed" dfdl:encoding="iso-8859-1" dfdlx:emptyElementParsePolicy="treatAsMissing">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nulPattern1" model="nullTest"
+    validation="on">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root><foo>&#xE000;&#xE000;&#xE000;</foo></ex:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="nulPad1" model="nullTest"
+                       validation="on">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:padRoot></ex:padRoot>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.section05.facets
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestNulChars {
+  lazy val runner = Runner("/org/apache/daffodil/section05/facets", "NulChars.tdml")
+
+  @AfterClass def shutDown = {
+    runner.reset
+  }
+}
+
+import TestNulChars._
+
+class TestNulChars {
+
+  // DAFFODIL-2363 &#xE000; (NUL replacement into XML) can't be used in pattern facet. With full validation.
+  // @Test def test_nulPattern1() = { runner.runOneTest("nulPattern1") }
+
+  // DAFFODIL-2364 - infinite loop
+  // @Test def test_nulPad1() = { runner.runOneTest("nulPad1") }
+
+  @Test def ignoreThisDummyTestToPreventIDEFromRemovingImports(): Unit = {
+    // TODO Delete this dummy test once at least one of the above tests is made to work.
+    runner
+  }
+}


### PR DESCRIPTION
Shows that <xs:pattern value="&#xE000;*"/> doesn't work as a
pattern to match the E000 substitution characters that Daffodil
uses in XML to replace ASCII NUL characters.

This just adds the test showing the problem. Doesn't attempt to fix it. 

DAFFODIL-2363