### PR TITLE
Tests for textNumberPattern and padding unexpected behaviors.

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/usertests/UserSubmittedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/usertests/UserSubmittedTests.tdml
@@ -132,4 +132,55 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+	<tdml:defineSchema name="dfdlwg1" elementFormDefault="unqualified">
+		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+		<dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+
+		<!-- wrong way to get zero-extended 9-digit numbers -->
+		<xs:element name="r" dfdl:textNumberPattern="#0" type="ex:numeric9_custom1"/>
+
+		<!-- right way to get zero-extended 9-digit numbers -->
+		<xs:element name="r2" dfdl:textNumberPattern="#00000000" type="ex:numeric9_custom1"/>
+
+		<xs:simpleType name="numeric9_custom1"
+		  dfdl:textOutputMinLength="9"
+			dfdl:textPadKind="padChar"
+			dfdl:textTrimKind="padChar"
+			dfdl:textNumberPadCharacter="0">
+			<xs:restriction base="xsd:decimal">
+				<xs:totalDigits value="9"/><!-- note totalDigits for an integer does NOT include any sign. -->
+			</xs:restriction>
+		</xs:simpleType>
+
+	</tdml:defineSchema>
+
+	<tdml:unparserTestCase name="textNumberPattern1" model="dfdlwg1"
+	  description="illustrates that text number padding on left
+	  (right justified numbers) does not go between the sign and the
+	  value digits but before the entire number representation. This is
+    the right behavior per the DFDL spec.">
+		<tdml:document><![CDATA[0000000-1]]></tdml:document>
+		<tdml:infoset><tdml:dfdlInfoset>
+			<ex:r>-1</ex:r>
+		</tdml:dfdlInfoset></tdml:infoset>
+	</tdml:unparserTestCase>
+
+	<tdml:unparserTestCase name="textNumberPattern2" model="dfdlwg1"
+  	description="illustrates the proper technique for getting the sign to appear
+  	before the digits of a right-justified number. Negative sign case.">
+		<tdml:document><![CDATA[-00000001]]></tdml:document>
+		<tdml:infoset><tdml:dfdlInfoset>
+			<ex:r2>-1</ex:r2>
+		</tdml:dfdlInfoset></tdml:infoset>
+	</tdml:unparserTestCase>
+
+	<tdml:unparserTestCase name="textNumberPattern3" model="dfdlwg1"
+	  description="illustrates the proper technique for getting the sign to appear
+  	before the digits of a right-justified number. Positive (without sign) case.">
+		<tdml:document><![CDATA[000000001]]></tdml:document>
+		<tdml:infoset><tdml:dfdlInfoset>
+			<ex:r2>1</ex:r2>
+		</tdml:dfdlInfoset></tdml:infoset>
+	</tdml:unparserTestCase>
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
@@ -42,6 +42,12 @@ class TestUserSubmittedTests {
   }
   @Test def test_DFDL_2262(): Unit = { runner.runOneTest("test_DFDL_2262") }
 
+  // DAFFODIL-2378 (decided as not a bug. These tests characterize that behavior.)
+  @Test def testTextNumberPattern1(): Unit = { runner.runOneTest("textNumberPattern1") }
+  @Test def testTextNumberPattern2(): Unit = { runner.runOneTest("textNumberPattern2") }
+  @Test def testTextNumberPattern3(): Unit = { runner.runOneTest("textNumberPattern3") }
+
+
   @Test def test_nameDOB_test2_pass(): Unit = { runner2.runOneTest("nameDOB_test2_pass") }
   @Test def test_nameDOB_test2_fail(): Unit = { runner2.runOneTest("nameDOB_test2_fail") }
 


### PR DESCRIPTION
Came up in DFDL workgroup email discussions.

The behavior was determined to be working as designed, and conforming to the spec.

This is just adding the tests for good measure here.

Ticket was closed as "not a bug".

DAFFODIL-2378