### PR TITLE
Fix multiple discriminator behavior and free up marks when resolved

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,8 @@ lazy val io               = Project("daffodil-io", file("daffodil-io")).configs(
                               .settings(commonSettings, usesMacros)
 
 lazy val runtime1         = Project("daffodil-runtime1", file("daffodil-runtime1")).configs(IntegrationTest)
-                              .dependsOn(io, lib % "test->test", udf)
-                              .settings(commonSettings)
+                              .dependsOn(io, lib % "test->test", udf, macroLib % "compile-internal, test-internal")
+                              .settings(commonSettings, usesMacros)
 
 lazy val runtime1Unparser = Project("daffodil-runtime1-unparser", file("daffodil-runtime1-unparser")).configs(IntegrationTest)
                               .dependsOn(runtime1, lib % "test->test", runtime1 % "test->test")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -346,7 +346,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_1338_CLI_Debugger_discriminatorInfo(): Unit = {
+  @Test def test_1338_CLI_Debugger_pointsOfUncertaintyInfo(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input5.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -358,18 +358,20 @@ class TestCLIdebugger {
       shell.sendLine(cmd)
       shell.expect(contains("(debug)"))
 
-      shell.sendLine("break e3")
-      shell.sendLine("break e4")
-      shell.sendLine("display info discriminator")
+      shell.sendLine("display info pointsOfUncertainty")
 
-      shell.sendLine("continue")
-      shell.expect(contains("discriminator: true"))
+      shell.sendLine("step")
+      shell.expect(contains("pointsOfUncertainty:"))
+      shell.expect(contains("(none)"))
 
-      shell.sendLine("continue")
-      shell.expect(contains("discriminator: true"))
+      shell.sendLine("step")
+      shell.expect(contains("pointsOfUncertainty:"))
+      shell.expect(contains("bitPos: 0, context: choice[1]"))
 
-      shell.sendLine("continue")
-      shell.expect(contains("<e4>400</e4>"))
+      shell.sendLine("step")
+      shell.expect(contains("pointsOfUncertainty:"))
+      shell.expect(contains("(none)"))
+
       shell.sendLine("quit")
     } finally {
       shell.close()

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
@@ -110,7 +110,7 @@ class UnorderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceC
 
   override lazy val parser: Parser = {
 
-    lazy val choiceParser = new ChoiceParser(srd, parsers.toVector, unordered = true)
+    lazy val choiceParser = new ChoiceParser(srd, parsers.toVector)
 
     sq.hasSeparator match {
       case true => {

--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/processors/parsers/PointOfUncertaintyMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/processors/parsers/PointOfUncertaintyMacros.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processors.parsers
+
+import scala.reflect.macros.blackbox.Context
+
+
+object PointOfUncertaintyMacros {
+
+  /**
+   * For creating a point of uncertainty and ensuring that it is cleaned up
+   * appropriately. This allows the use of standard scala-style syntax to
+   * create and use points of uncertainties, while avoiding allocating
+   * functions. Thus, this allows something like this:
+   *
+   *   pstate.withPointOfUncertainty { pou =>
+   *     // code that implements parsing, and may potentially reset to,
+   *     // discard, or resolve this pou variable
+   *   }
+   *
+   * Upon completion of the block, if the new point of uncertainty has not been
+   * discarded, reset to, or resovled, this pou will then be discarded,
+   * ensuring that Marks are always cleaned up appropriately.
+   */
+  def withPointOfUncertainty[A, B](c: Context)(pouID: c.Expr[String], context: c.Tree)(func: c.Expr[A => B]) = {
+
+    import c.universe._
+    
+    val state = TermName(c.freshName("state"))
+    val id = TermName(c.freshName("id"))
+    val pou = TermName(c.freshName("pou"))
+    val ctx = TermName(c.freshName("context"))
+
+    func.tree match {
+
+      // The func tree is something like (param => body), where param is the
+      // name the caller wants to name the point of uncertainty mark, and body
+      // is the code that uses this point of uncertainty. We transform this
+      // code to create a new point of uncertainty, evaluate the body, and then
+      // use a finally block to ensure we discard the PoU if it has not been
+      // resolved.
+      case q"""($param: $_) => $body""" => {
+
+        // The "body" uses the "param" variable name, and scala doesn't like it
+        // if we just create a new variable with this name, with a very unclear
+        // error message. Instead, we need to create a "fresh" variable name to
+        // hold he new point of uncertainty, and then transform the body so
+        // that all instances of "param" are replaced with our new fresh name.
+        val transformer = new Transformer {
+          override def transform(tree: Tree): Tree = tree match {
+            case Ident(`param`) => Ident(pou)
+            case other => super.transform(other)
+          }
+        }
+        val newBody = transformer.transform(c.untypecheck(body))
+
+        q"""{
+          // ensure we do not evaluate passed in parameters more than once
+          val $state = ${c.prefix}
+          val $id = $pouID
+          val $ctx = $context
+
+          // create our new point of uncertainty
+          val $pou = $state.createPointOfUncertainty($id, $ctx)
+          try {
+            // evalute the transformed body, which can use this new point of uncertainty
+            $newBody
+          } finally {
+            // if the pou still exists at this point, then simply discard it.
+            // This is likely because an exception occurred, or just because we
+            // do not require that parsers discard PoUs, with the understanding
+            // that it will always happen here
+            if (!$state.isPointOfUncertaintyResolved($pou)) {
+              $state.discardPointOfUncertainty($pou)
+            }
+          }
+        }"""
+      }
+    }
+
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -77,7 +77,6 @@ trait StateForDebugger {
   def currentLocation: DataLocation
   def arrayPos: Long
   def bitLimit0b: MaybeULong
-  def discriminator: Boolean = false
 }
 
 case class TupleForDebugger(
@@ -86,8 +85,8 @@ case class TupleForDebugger(
   val groupPos: Long,
   val currentLocation: DataLocation,
   val arrayPos: Long,
-  val bitLimit0b: MaybeULong,
-  override val discriminator: Boolean) extends StateForDebugger
+  val bitLimit0b: MaybeULong)
+  extends StateForDebugger
 
 trait SetProcessorMixin {
   private var maybeProcessor_ : Maybe[Processor] = Nope
@@ -430,8 +429,7 @@ abstract class ParseOrUnparseState protected (
       groupPos,
       currentLocation,
       arrayPos,
-      bitLimit0b,
-      discriminator)
+      bitLimit0b)
   }
 
   final override def schemaFileLocation = getContext().schemaFileLocation

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
@@ -96,34 +96,24 @@ abstract class ElementParserBase(
 
   def parse(pstate: PState): Unit = {
 
+    // Note that pattern discriminators and asserts do not advance the position
+    // in the input stream, so there is no need to mark/reset the inputstream
     if (patDiscrimParser.isDefined) {
-      val startingBitPos = pstate.dataInputStream.mark("ElementParserBase1")
       patDiscrimParser.get.parse1(pstate)
-      // Pattern fails at the start of the Element
       if (pstate.processorStatus ne Success) {
-        pstate.dataInputStream.discard(startingBitPos)
         return
-      } else {
-        pstate.dataInputStream.reset(startingBitPos)
       }
     } else if (patAssertParser.length > 0) {
-      val startingBitPos = pstate.dataInputStream.mark("ElementParserBase2")
       var i: Int = 0
       val size = patAssertParser.size
       while (i < size) {
         val d = patAssertParser(i)
         d.parse1(pstate)
-        // Pattern fails at the start of the Element
         if (pstate.processorStatus ne Success) {
-          pstate.dataInputStream.discard(startingBitPos)
           return
         }
         i += 1
       }
-      // backup again. If all pattern discriminators and/or asserts
-      // have passed, now we parse the element. But we backup
-      // as if the pattern matching had not advanced the state.
-      pstate.dataInputStream.reset(startingBitPos)
     }
 
     parseBegin(pstate)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
@@ -17,14 +17,8 @@
 
 package org.apache.daffodil.processors.parsers
 
-import java.io.StringWriter
-import java.io.PrintWriter
-
 import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.Success
-import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.exceptions.UnsuppressableException
-import org.apache.daffodil.dsom.SchemaDefinitionDiagnosticBase
 
 abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueParser: Parser)
   extends CombinatorParser(ctxt) {
@@ -33,55 +27,23 @@ abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueP
   override lazy val runtimeDependencies = Vector()
 
   def parse(pstate: PState): Unit = {
-    var mark: PState.Mark = pstate.mark("NilOrValueParser")
-    var markLeakCausedByException = false
 
-    try {
+    // This isn't technically a point of uncertainty. Nothing in the nilParser
+    // can discriminate this PoU. We are really just using this as a technique
+    // to be able to reset back to this point if the nil parser fails.
+    pstate.withPointOfUncertainty("NilOrValueParser", ctxt) { pou =>
+
       nilParser.parse1(pstate)
 
       if (pstate.processorStatus ne Success) {
-        pstate.reset(mark)
-        mark = null
+        // did not find a nil. reset back to the pou and try to parse the value
+        pstate.resetToPointOfUncertainty(pou)
         valueParser.parse1(pstate)
       } else {
-        pstate.discard(mark)
-        mark = null
-      }
-
-    } catch {
-      // Similar try/catch/finally logic for returning marks is also used in
-      // the Sequence parser base. The logic isn't
-      // easily factored out so it is duplicated. Changes made here should also
-      // be made there. Only these parsers deal with taking marks, so this logic
-      // should not be needed elsewhere.
-      //
-      // TODO: Refactor by hoisting this logic into CombinatorParser using same
-      // technique as in SequenceParserBase's tryParseDetectMarkLeaks and parseOne
-      // methods. That way this code really can live in exactly one place.
-      //
-      case t: Throwable => {
-        if (mark != null) {
-          markLeakCausedByException = true
-          if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException] && !t.isInstanceOf[java.lang.Error]) {
-            val stackTrace = new StringWriter()
-            t.printStackTrace(new PrintWriter(stackTrace))
-            Assert.invariantFailed("Exception thrown with mark not returned: " + t + "\nStackTrace:\n" + stackTrace)
-          }
-        }
-        throw t
-      }
-    } finally {
-      var markLeak = false;
-      if (mark != null) {
-        pstate.discard(mark)
-        markLeak = true;
-      }
-
-      if (markLeak && !markLeakCausedByException) {
-        // likely a logic bug, throw assertion
-        Assert.invariantFailed("mark not returned, likely a logic bug")
+        // no-op. We found nil, withPointOfUncertainty will discard the pou
       }
     }
+
   }
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
@@ -17,20 +17,14 @@
 
 package org.apache.daffodil.processors.parsers
 
-import java.io.StringWriter
-import java.io.PrintWriter
-
 import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.dsom.RuntimeSchemaDefinitionError
-import org.apache.daffodil.dsom.SchemaDefinitionDiagnosticBase
 import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.exceptions.UnsuppressableException
 import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Processor
 import org.apache.daffodil.processors.RuntimeData
 import org.apache.daffodil.processors.Success
 import org.apache.daffodil.processors.Evaluatable
-import org.apache.daffodil.util.LogLevel
 import org.apache.daffodil.util.Maybe.One
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.util.Misc
@@ -181,8 +175,7 @@ final class SeqCompParser(context: RuntimeData, val childParsers: Vector[Parser]
 
 class ChoiceParser(
   ctxt: RuntimeData,
-  val childParsers: Vector[Parser],
-  val unordered: Boolean = false)
+  val childParsers: Vector[Parser])
   extends CombinatorParser(ctxt) {
   override lazy val runtimeDependencies = Vector()
   override lazy val childProcessors = childParsers
@@ -190,131 +183,53 @@ class ChoiceParser(
   override def nom = "choice"
 
   def parse(pstate: PState): Unit = {
-    var pBefore: PState.Mark = null
-    var markLeakCausedByException = false;
 
-    try {
-      pstate.pushPointOfUncertainty
-      var diagnostics: Seq[Diagnostic] = Nil
-      var i = 0
-      var parser: Parser = null
-      val limit = childParsers.length
-      var returnFlag = false
-      var discriminatedFailure = false
-      while (!returnFlag && i < limit) {
-        parser = childParsers(i)
-        i += 1
-        log(LogLevel.Debug, "Trying choice alternative: %s", parser)
-        pBefore = pstate.mark("ChoiceParser1")
-        try {
-          parser.parse1(pstate)
-        } catch {
-          case d: SchemaDefinitionDiagnosticBase => {
-            pstate.discard(pBefore)
-            pBefore = null
-            throw d
-          }
-        }
+    var diagnostics: Seq[Diagnostic] = Nil
+    var i = 0
+    val numAlternatives = childParsers.length
+    
+    var successfullyParsedChildBranch = false
+
+    while (!successfullyParsedChildBranch && i < numAlternatives) {
+
+      val parser = childParsers(i)
+      i += 1
+
+      pstate.withPointOfUncertainty("ChoiceParser", ctxt) { pou =>
+
+        parser.parse1(pstate)
+
         if (pstate.processorStatus eq Success) {
-          log(LogLevel.Debug, "Choice alternative success: %s", parser)
-          pstate.discard(pBefore)
-          pBefore = null
-          returnFlag = true
+          // Choice branch was successfull. Break out of the loop and let
+          // withPointOfUncertainty discard the pou
+          successfullyParsedChildBranch = true
         } else {
-          // If we get here, then we had a failure
-          log(LogLevel.Debug, "Choice alternative failed: %s", parser)
-          //
-          // capture diagnostics
-          //
+          // Failed to parse this branch alternative. Create diagnostic and
+          // check if anything resolved the associated point of uncertainty
+
           val diag = new ChoiceBranchFailed(context.schemaFileLocation, pstate, pstate.diagnostics)
           diagnostics = diag +: diagnostics
-          //
-          // check for discriminator evaluated to true.
-          //
-          if (pstate.discriminator == true) {
-            log(LogLevel.Debug, "Failure, but discriminator true. Additional alternatives discarded.")
-            // If so, then we don't run the next alternative, we
-            // consume this discriminator status result (so it doesn't ripple upward)
-            // and return the failed state with all the diagnostics.
-            //
-            val allDiags = new EntireChoiceFailed(context.schemaFileLocation, pstate, diagnostics.reverse)
-            pstate.discard(pBefore) // because disc set, we don't unwind side effects on input stream & infoset
-            pBefore = null
-            pstate.setFailed(allDiags)
 
-            // We are actually dealing with an unordered sequence, which uses ChoiceParser behind
-            // the scenes. Because a discriminator was set, but the discriminated content failed,
-            // we need to make sure that this discriminator information gets passed back up to the
-            // unordered sequence parser and will know to fail the entire unordered sequence.
-            if (unordered)
-              discriminatedFailure = true
-
-            returnFlag = true
+          if (pstate.isPointOfUncertaintyResolved(pou)) {
+            // A discriminator resolved the point of uncertainty associated with
+            // this choice. Since this branch failed, we will not attempt any
+            // more alternatives. We set i to the numAlternatives to break out of
+            // this loop. Once we break out, a PE will be created.
+            i = numAlternatives
           } else {
-            //
-            // Here we have a failure, but no discriminator was set, so we try the next alternative.
-            // Which means we just go around the loop
-            //
-            // But we have to unwind side-effects on input-stream, infoset, variables, etc.
-            pstate.reset(pBefore)
-            pBefore = null
-            returnFlag = false
+            // We have a failure, but nothing resolved the point of uncertainty
+            // associated with this choice. Reset back to the point of
+            // uncertainty to unwind any side-effects from the branch and
+            // attempt the next alternative.
+            pstate.resetToPointOfUncertainty(pou)
           }
         }
       }
-      Assert.invariant(i <= limit)
-      if (returnFlag == false) {
-        Assert.invariant(i == limit)
-        // Out of alternatives. All of them failed.
-        val allDiags = new EntireChoiceFailed(context.schemaFileLocation, pstate, diagnostics.reverse)
-        pstate.setFailed(allDiags)
-        log(LogLevel.Debug, "All Choice alternatives failed.")
-      }
+    }
 
-      pstate.popPointOfUncertainty
-
-      // This is only used for unordered sequences. If we hit a failure after parsing a discriminator,
-      // we need to pass this discriminator out of the make shift ChoiceParser and back to the
-      // unordered sequence parser. So, now that the inner choice discriminator is off the stack, we
-      // are setting the discriminator of the outer unordered sequence loop, ensuring that while we
-      // have two physical discriminators (outer for the loop, inner for the choice), this is making
-      // it behave as if there is only a single discriminator
-      if (discriminatedFailure)
-        pstate.setDiscriminator(true)
-
-    } catch {
-      // Similar try/catch/finally logic for returning marks is also used in
-      // the Sequence parser base. The logic isn't
-      // easily factored out so it is duplicated. Changes made here should also
-      // be made there. Only these parsers deal with taking marks, so this logic
-      // should not be needed elsewhere.
-      //
-      // TODO: Refactor by hoisting this logic into CombinatorParser using same
-      // technique as in SequenceParserBase's tryParseDetectMarkLeaks and parseOne
-      // methods. That way this code really can live in exactly one place.
-      //
-      case t: Throwable => {
-        if (pBefore != null) {
-          markLeakCausedByException = true
-          if (!t.isInstanceOf[SchemaDefinitionDiagnosticBase] && !t.isInstanceOf[UnsuppressableException] && !t.isInstanceOf[java.lang.Error]) {
-            val stackTrace = new StringWriter()
-            t.printStackTrace(new PrintWriter(stackTrace))
-            Assert.invariantFailed("Exception thrown with mark not returned: " + t + "\nStackTrace:\n" + stackTrace)
-          }
-        }
-        throw t
-      }
-    } finally {
-      var markLeak = false;
-      if (pBefore != null) {
-        pstate.discard(pBefore)
-        markLeak = true;
-      }
-
-      if (markLeak && !markLeakCausedByException) {
-        // likely a logic bug, throw assertion
-        Assert.invariantFailed("mark not returned, likely a logic bug")
-      }
+    if (!successfullyParsedChildBranch) {
+      val allDiags = new EntireChoiceFailed(context.schemaFileLocation, pstate, diagnostics.reverse)
+      pstate.setFailed(allDiags)
     }
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
@@ -746,15 +746,65 @@
     
     <xs:element name="r1" dfdl:lengthKind="implicit">
       <xs:complexType>
-        <xs:choice>
+        <xs:choice> <!-- should not be discriminated -->
           <xs:choice dfdl:initiatedContent="yes"> <!-- should be discriminated -->
-            <!-- This element is OCK 'implicit' minOccurs 1, So first 
-              element will discriminate the choice. There is no PoU for the first 
-              array element. This test is making sure we're not ALSO discriminating
-              the outer choice. -->
-              <xs:element name="e" dfdl:initiator="+" type="xs:int"
-                 dfdl:terminator=";"
-                 minOccurs="1" maxOccurs="2" dfdl:occursCountKind="implicit"/>
+            <!--
+              This element is OCK 'implicit', minOccurs 1, with
+              initiatedContent. Because implicit minOcurrs 1, the first element
+              is not a point of uncertainty. So when we successfully parse the
+              initiator of the first element, the initiated content
+              discriminates inner choice. When we attempt to parse a second "e"
+              element and it fails, we backtrack to the outer choice, which
+              should not be discriminated, and then parse that data as the
+              "correct" element.
+            -->
+            <xs:element name="e" type="xs:int" dfdl:initiator="+" dfdl:terminator=";"
+               minOccurs="1" maxOccurs="2" dfdl:occursCountKind="implicit"/>
+            <xs:element name="incorrect" type="xs:string" dfdl:initiator="+"/>
+          </xs:choice>
+          <xs:element name="correct" type="xs:string"/>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="r2" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:choice> <!-- should not be discriminated -->
+          <xs:choice dfdl:initiatedContent="yes"> <!-- should be discriminated -->
+            <!--
+              This element is OCK 'fixed' with initiatedContent. Because fixed
+              occurences, no elements are points of uncertainties. There is only
+              the choice. So when we successfully parse the initiator of the
+              first element, the initiated content discriminates inner choice.
+              When we attempt to parse a second "e", it should not discriminate
+              the outer choice. If we then fail to parse a thrid "e", we
+              backtrack to the outer choice, which should not be discriminated,
+              and then parse that data as the "correct" element.
+            -->
+            <xs:element name="e" type="xs:int" dfdl:initiator="+" dfdl:terminator=";"
+               minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed"/>
+            <xs:element name="incorrect" type="xs:string" dfdl:initiator="+"/>
+          </xs:choice>
+          <xs:element name="correct" type="xs:string"/>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="r3" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:choice> <!-- should not be discriminated -->
+          <xs:choice dfdl:initiatedContent="yes"> <!-- should be discriminated -->
+            <!--
+              This element is OCK 'parsed', minOccurs 1, with initiatedContent.
+              Even though minOccurs 1, because OKC is parsed the first element
+              is a point of uncertainty. So when we successfully parse the
+              initiator of the first element, the first element PoU is resolved
+              as well as the inner choice PoU. When that first parse fails, we
+              backtrack to the outer choice, which should not be discriminated,
+              and then parse that data as the "correct" element.
+            -->
+            <xs:element name="e" type="xs:int" dfdl:initiator="+" dfdl:terminator=";"
+               minOccurs="1" maxOccurs="2" dfdl:occursCountKind="parsed"/>
             <xs:element name="incorrect" type="xs:string" dfdl:initiator="+"/>
           </xs:choice>
           <xs:element name="correct" type="xs:string"/>
@@ -776,4 +826,31 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>  
+
+  <tdml:parserTestCase name="fixedArrayInitiatedContentDiscriminatesChoice"
+    model="s4"
+    description="Test array children's initiators discriminate enclosing choice properly.">
+    <tdml:document><![CDATA[+1;+2;+a;]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <r2>
+          <correct>+1;+2;+a;</correct>
+        </r2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="parsedArrayMin1InitiatedContentDiscriminatesChoice"
+    model="s4"
+    description="Test array children's initiators discriminate enclosing choice properly.">
+    <tdml:document><![CDATA[+a;]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <r3>
+          <correct>+a;</correct>
+        </r3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
@@ -38,10 +38,7 @@ class TestDiscriminators {
 
   @Test def test_discriminatorGuidesChoice(): Unit = { runner.runOneTest("discriminatorGuidesChoice") }
   @Test def test_discriminatorGuidesChoice2(): Unit = { runner.runOneTest("discriminatorGuidesChoice2") }
-  @Test def test_discriminatorGuidesChoice3() = {
-    //LoggingDefaults.setLoggingLevel(LogLevel.Debug)
-    runner.runOneTest("discriminatorGuidesChoice3")
-  }
+  @Test def test_discriminatorGuidesChoice3(): Unit = { runner.runOneTest("discriminatorGuidesChoice3") }
   @Test def test_discriminatorGuidesChoice4(): Unit = { runner.runOneTest("discriminatorGuidesChoice4") }
   @Test def test_discriminatorGuidesChoice5(): Unit = { runner.runOneTest("discriminatorGuidesChoice5") }
 
@@ -81,6 +78,5 @@ class TestDiscriminators {
   @Test def test_multipleDiscriminators2(): Unit = { runner2.runOneTest("multipleDiscriminators2") }
   @Test def test_multipleDiscriminators3(): Unit = { runner2.runOneTest("multipleDiscriminators3") }
   @Test def test_multipleDiscriminators4(): Unit = { runner2.runOneTest("multipleDiscriminators4") }
-  // DAFFODIL-2371
-  //@Test def test_multipleDiscriminators5(): Unit = { runner2.runOneTest("multipleDiscriminators5") }
+  @Test def test_multipleDiscriminators5(): Unit = { runner2.runOneTest("multipleDiscriminators5") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
@@ -49,6 +49,9 @@ class TestChoiceGroupInitiatedContent {
   // Test for DAFFODIL-2143
   @Test def test_arrayOptionalChildDiscriminatesElementAndChoice1(): Unit = { runner_01.runOneTest("arrayOptionalChildDiscriminatesElementAndChoice1") }
 
+  @Test def test_fixedArrayInitiatedContentDiscriminatesChoice1(): Unit = { runner_01.runOneTest("fixedArrayInitiatedContentDiscriminatesChoice") }
+  @Test def test_parsedArrayMin1InitiatedContentDiscriminatesChoice1(): Unit = { runner_01.runOneTest("parsedArrayMin1InitiatedContentDiscriminatesChoice") }
+
   @Test def test_arrayOfChoice(): Unit = { runner_01.runOneTest("arrayOfChoice") }
   @Test def test_arrayOfChoice2(): Unit = { runner_01.runOneTest("arrayOfChoice2") }
   @Test def test_discriminatorNesting1(): Unit = { runner_01.runOneTest("discriminatorNesting1") }


### PR DESCRIPTION
Currently we maintain a separator discriminator stack, and parser would
push, pop, and modify this stack appropriately to make parse decisions.

One problem with this implementation is that discriminators only ever
modify the state on the top of the stack, which means that multiple
discriminators are essentially no-ops, rather than resolving points of
uncertainty up the stack.

Another problem is that discriminators are not tied to Marks in any way,
so resolving a discriminator does not immediately discard the Mark, and
thus memory associated with that Mark cannot be freed until the parse
unwinds.

To resolve both issues, this patch completely removes the discriminator
stack, and instead replace it with a stack of Marks, each of which
represents a points of uncertainties. Resolving a point of uncertainty
(e.g. from a discriminator) simply discards the mark on the top of the
stack. This frees up the Mark and associated memory, as well as allows
multiple discriminator behavior to discriminate multiple points of
uncertainty.

To determine if a point of uncertainty was resolved, parsers must simply
check if the associated Mark is at the top of the stack. If it is not,
then something discriminated the point of uncertainty. To simplify this
logic, multiple helper functions and methods are created to ensure
points of uncertainty are created/destroyed/handled correctly.

DAFFODIL-2371