### PR TITLE
Addressed Daffodil-2122 default="0|1" causes exception for xs:boolean…

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -699,7 +699,13 @@ object NodeInfo extends Enum {
     protected sealed trait BooleanKind extends AnySimpleType.Kind
     case object Boolean extends PrimTypeNode(AnyAtomic) with BooleanKind with PrimNonNumeric with BooleanView {
       type Kind = BooleanKind
-      protected override def fromString(s: String): DataValueBool = s.toBoolean
+      protected override def fromString(s: String): DataValueBool = {
+        s match {
+          case "0" | "false" => false
+          case "1" | "true" => true
+          case _ => throw new IllegalArgumentException("Must be one of 0, 1, true, or false")
+        }
+      }
     }
 
     protected sealed trait AnyURIKind extends AnySimpleType.Kind

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/boolean/boolean.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/boolean/boolean.tdml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite suiteName="Boolean"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:ex="http://example.com"
+  xmlns:tns="http://example.com"
+  defaultRoundTrip="onePass">
+  
+  <tdml:defineSchema name="BooleanDefaultSchema" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <xs:element name="root1" dfdl:initiator="default1,default2,default3,default4:">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=";" dfdl:separatorPosition="postfix">
+          <xs:element name="record" maxOccurs="unbounded">
+            <xs:complexType>
+                <xs:sequence dfdl:separator=','>
+                  <xs:element name="default1" type="xs:boolean" default="true" dfdl:textBooleanTrueRep="true" dfdl:textBooleanFalseRep="false" />
+                  <xs:element name="default2" type="xs:boolean" default="false" dfdl:textBooleanTrueRep="true" dfdl:textBooleanFalseRep="false" />
+                  <xs:element name="default3" type="xs:boolean" default="1" dfdl:textBooleanTrueRep="1" dfdl:textBooleanFalseRep="0" />
+                  <xs:element name="default4" type="xs:boolean" default="0" dfdl:textBooleanTrueRep="1" dfdl:textBooleanFalseRep="0" />
+                </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <!--
+  Test name: booleanDefault
+  Schema: BooleanDefaultSchema, root booleanDefault
+  Purpose: This test demonstrates parsing of valid boolean default values
+  -->
+
+  <tdml:parserTestCase name="booleanDefault" root="root1"
+                       model="BooleanDefaultSchema"
+                       roundTrip="onePass"
+                       description="Test valid boolean default values.">
+    <tdml:document>default1,default2,default3,default4:false,true,0,1;</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root1>
+          <record>
+            <default1>false</default1>
+            <default2>true</default2>
+            <default3>false</default3>
+            <default4>true</default4>
+          </record>
+        </ex:root1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="BooleanDefaultSDE" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <xs:element name="root1" dfdl:initiator="default1:">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=";" dfdl:separatorPosition="postfix">
+          <xs:element name="record" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:sequence dfdl:separator=','>
+                <xs:element name="default1" type="xs:boolean" default="FALSE" dfdl:textBooleanTrueRep="TRUE" dfdl:textBooleanFalseRep="FALSE" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <!--
+  Test name: booleanDefaultSDE
+  Schema: BooleanDefaultSchemaSDE, root booleanDefault
+  Purpose: This test demonstrates parsing of invalid default values
+-->
+
+  <tdml:parserTestCase  name="booleanDefaultSDE" root="root1"
+                        model="BooleanDefaultSDE"
+                        description="Test SDE due to SAXParseException resulting from invalid default value">
+    <tdml:document>default1:TRUE;</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid value constraint value</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="BooleanInputValueCalc" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="tns:GeneralFormat"  lengthKind="delimited" />
+    <xs:element name="root1" dfdl:initiator="boolStr:">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=";" dfdl:separatorPosition="postfix">
+          <xs:element name="record" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:sequence dfdl:separator=','>
+                <xs:element name="boolStr" type="xs:string" />
+                <xs:element name="bool" type="xs:boolean" dfdl:inputValueCalc="{ xs:boolean(../boolStr) }" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <!--
+  Test name: booleanInputValueCalc
+  Schema: BooleanInputValueCalc, root root1
+  Purpose: This test demonstrates parsing of a valid boolean value using InputValueCalc
+  -->
+
+  <tdml:parserTestCase name="booleanInputValueCalc" root="root1"
+                       model="BooleanInputValueCalc"
+                       roundTrip="onePass"
+                       description="Demonstrates parsing of a valid boolean value using InputValueCalc">
+    <tdml:document>boolStr:true;</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root1>
+          <record>
+            <boolStr>true</boolStr>
+            <bool>true</bool>
+          </record>
+        </ex:root1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+  Test name: booleanInputValueCalcError
+  Schema: BooleanInputValueCalc, root root1
+  Purpose: This test demonstrates parsing of invalid boolean values using InputValueCalc
+  -->
+
+  <tdml:parserTestCase name="booleanInputValueCalcError" root="root1"
+                       model="BooleanInputValueCalc"
+                       roundTrip="onePass"
+                       description="Demonstrates parsing of invalid boolean values using InputValueCalc">
+    <tdml:document>boolStr:TRUE;</tdml:document>
+    <tdml:errors>
+      <tdml:error>Must be one of 0, 1, true, or false</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+</testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/boolean/TestBoolean.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/boolean/TestBoolean.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section13.boolean
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.{AfterClass, Test}
+
+object TestBoolean {
+  lazy val runner = Runner("/org/apache/daffodil/section13/boolean/", "boolean.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+
+}
+
+class TestBoolean {
+  import TestBoolean._
+  @Test def test_booleanDefault(): Unit = { runner.runOneTest("booleanDefault") }
+  @Test def test_booleanDefaultSDE(): Unit = { runner.runOneTest("booleanDefaultSDE") }
+  @Test def test_booleanInputValueCalc(): Unit = { runner.runOneTest("booleanInputValueCalc") }
+  @Test def test_booleanInputValueCalcError(): Unit = { runner.runOneTest("booleanInputValueCalcError") }
+}


### PR DESCRIPTION
… types

Modified NodeInfo.scala trait BooleanKind LN 699 to allow
boolean default values true, false, 0 and 1.
Created boolean.tdml and TestBoolean.scala

Daffodil-2122