### PR TITLE
Stream infoset events while parsing and reduce memory usage

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -1022,7 +1022,7 @@ class TestCLIdebugger {
 
       shell.sendLine("continue")
       shell.expect(contains("<a>2</a>"))
-      shell.expect(contains("<g />"))
+      shell.expect(contains("<g></g>"))
     } finally {
       shell.close()
     }
@@ -1097,7 +1097,7 @@ class TestCLIdebugger {
       shell.expect(contains("hidden: true"))
 
       shell.sendLine("continue")
-      shell.expect(contains("<h />"))
+      shell.expect(contains("<h></h>"))
     } finally {
       shell.close()
     }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dpath/TestDFDLExpressionEvaluation.scala
@@ -50,7 +50,7 @@ class TestDFDLExpressionEvaluation extends Parsers {
 
     val dis = InputSourceDataInputStream(java.nio.ByteBuffer.allocate(0)) // fake. Zero bits available.
     val outputter = new NullInfosetOutputter()
-    val pstate = PState.createInitialPState(doc, erd, dis, outputter, dp)
+    val pstate = PState.createInitialPState(doc, erd, dis, outputter, dp, areDebugging = false)
     val result = compiledExpr.evaluate(pstate)
     body(result)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
@@ -51,7 +51,18 @@ class TestSimpleTypeUnions {
     <xs:simpleType name="oneOrTwo">
       <xs:union memberTypes="ex:int1Type ex:int2Type"/>
     </xs:simpleType>
-    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:oneOrTwo"/>)
+    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:oneOrTwo">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <!--
+            this assert always passes, but uses e1 in an expression to prevent
+            the InfosetWalker from freeing it, which allows the tests to
+            inspect runtime internals
+          -->
+          <dfdl:assert test="{ fn:true() or /ex:e1 eq 0 }" />
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>)
 
   @Test def testUnion01: Unit = {
 
@@ -86,7 +97,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionFirstUnionMemberOk: Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "1")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:int1Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -96,7 +107,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionSecondUnionMemberOk: Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "2")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:int2Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -106,7 +117,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionNoUnionMemberOK: Unit = {
     val (result, _) = TestUtils.testString(testSchema1, "3")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
     assertEquals(3, dv.intValue())
     assertTrue(i.unionMemberRuntimeData.isEmpty)
@@ -179,11 +190,22 @@ class TestSimpleTypeUnions {
         </xs:simpleType>
       </xs:union>
     </xs:simpleType>
-    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:eType"/>)
+    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:eType">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <!--
+            this assert always passes, but uses e1 in an expression to prevent
+            the InfosetWalker from freeing it, which allows the tests to
+            inspect runtime internals
+          -->
+          <dfdl:assert test="{ fn:true() or /ex:e1 eq 0 }" />
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>)
 
   @Test def testUnionNot3: Unit = {
     val (result, _) = TestUtils.testString(testSchema2, "3")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
     assertEquals(3, dv.intValue())
     assertTrue(i.unionMemberRuntimeData.isEmpty)
@@ -208,7 +230,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionNot3_01: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "1")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:int12Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -218,7 +240,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionNot3_02: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "2")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:int12Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -228,7 +250,7 @@ class TestSimpleTypeUnions {
 
   @Test def testUnionNot3_03: Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "-1")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:negIntType", umstrd.diagnosticDebugName) // anonymous simple type gets this name from base.
     assertTrue(i.valid.get)
@@ -270,11 +292,22 @@ class TestSimpleTypeUnions {
         <xs:pattern value="foo[1234]bar"/>
       </xs:restriction>
     </xs:simpleType>
-    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:foo3bar"/>)
+    <xs:element name="e1" dfdl:lengthKind="delimited" type="ex:foo3bar">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <!--
+            this assert always passes, but uses e1 in an expression to prevent
+            the InfosetWalker from freeing it, which allows the tests to
+            inspect runtime internals
+          -->
+          <dfdl:assert test="{ fn:true() or /ex:e1 eq '' }" />
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>)
 
   @Test def testRestrictionOnUnion_01: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo3bar")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:foo3or4bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -284,7 +317,7 @@ class TestSimpleTypeUnions {
 
   @Test def testRestrictionOnUnion_02: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo1bar")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:foo1or2bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -294,7 +327,7 @@ class TestSimpleTypeUnions {
 
   @Test def testRestrictionOnUnion_03: Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo2bar")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:foo1or2bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
@@ -304,7 +337,7 @@ class TestSimpleTypeUnions {
 
   @Test def testRestrictionOnUnionFail_01: Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "foo4bar")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
     assertEquals("foo4bar", dv)
     assertTrue(i.unionMemberRuntimeData.isEmpty)
@@ -333,7 +366,7 @@ class TestSimpleTypeUnions {
    */
   @Test def testRestrictionOnUnionFail_02: Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "notfoo1bar")
-    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].root.asInstanceOf[DISimple]
+    val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
     assertEquals("notfoo1bar", dv)
     assertTrue(i.unionMemberRuntimeData.isEmpty)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfoset.scala
@@ -66,7 +66,7 @@ object TestInfoset {
     val infosetRootNode = {
       val ustate = unparseResult.resultState.asInstanceOf[UStateMain]
       val diDocument: DIDocument = ustate.documentElement
-      val rootElement = diDocument.getRootElement().asInstanceOf[DIElement]
+      val rootElement = diDocument.contents(0).asInstanceOf[DIElement]
       Assert.invariant(rootElement ne null)
       rootElement
     }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
@@ -278,7 +278,7 @@ class TestInfosetInputterFromReader {
     val Seq(fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
     val doc = inp.documentElement
     val Start(bar_s: DIComplex) = is.next
-    doc.addChild(bar_s)
+    doc.addChild(bar_s, tunable)
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(fooERD)
     val StartArray(foo_arr_s) = is.next

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -269,9 +269,9 @@ protected abstract class MStack[@specialized T] private[util] (
    *
    *  @return the element on top of the stack.
    */
-  @inline final def top: T = table(index - 1).asInstanceOf[T]
+  @inline final def top: T = table(index - 1)
 
-  @inline final def bottom: T = table(0).asInstanceOf[T]
+  @inline final def bottom: T = table(0)
 
   @inline final def isEmpty: Boolean = index == 0
 
@@ -307,7 +307,7 @@ protected abstract class MStack[@specialized T] private[util] (
       Assert.usage(hasNext)
       Assert.usage(initialIndex <= index) // can't make it smaller than when initialized.
       currentIndex -= 1
-      table(currentIndex).asInstanceOf[T]
+      table(currentIndex)
     }
 
     /**

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -431,7 +431,7 @@ sealed trait RegularElementUnparserStartEndStrategy
             c.addChild(res, state.tunable)
           } else {
             val doc = state.documentElement
-            doc.addChild(res) // DIDocument, which is never a current node, must have the child added
+            doc.addChild(res, state.tunable) // DIDocument, which is never a current node, must have the child added
             doc.setFinal() // that's the only child.
           }
           res

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DFDLXFunctions.scala
@@ -20,10 +20,9 @@ package org.apache.daffodil.dpath
 import java.math.{ BigInteger => JBigInt }
 
 import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.infoset.DINode
 import org.apache.daffodil.infoset.DISimple
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
-import org.apache.daffodil.infoset.InfosetCommon
-import org.apache.daffodil.infoset.XMLTextInfosetOutputter
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.processors.parsers.ParseError
 import org.apache.daffodil.processors.unparsers.UState
@@ -33,14 +32,6 @@ import org.apache.daffodil.util.Maybe.One
 
 case class DFDLXTrace(recipe: CompiledDPath, msg: String)
   extends RecipeOpWithSubRecipes(recipe) {
-
-  private def asXMLString(ie: InfosetCommon) = {
-    val bos = new java.io.ByteArrayOutputStream()
-    val xml = new XMLTextInfosetOutputter(bos, true)
-    ie.visit(xml, false)
-    xml.endDocument() // causes the outputter to flush to the stream
-    bos.toString("UTF-8")
-  }
 
   override def run(dstate: DState): Unit = {
     recipe.run(dstate)
@@ -52,7 +43,7 @@ case class DFDLXTrace(recipe: CompiledDPath, msg: String)
         dstate.setCurrentValue(v)
         v.toString()
       }
-      case other: InfosetCommon => "\n" + asXMLString(other)
+      case other: DINode => other.namedQName.toString
     }
     System.err.println("trace " + msg + ":" + nodeString)
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/Infoset.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/Infoset.scala
@@ -27,11 +27,7 @@ import org.apache.daffodil.xml.NS
 
 object INoWarn2 { ImplicitsSuppressUnusedImportWarning() }
 
-trait InfosetCommon {
-  def visit(handler: InfosetOutputter, removeHidden: Boolean = true): Unit
-}
-
-trait InfosetArray extends InfosetCommon {
+trait InfosetArray {
   def append(ie: InfosetElement): Unit
   def getOccurrence(occursIndex: Long): InfosetElement
   def length: Long
@@ -94,11 +90,9 @@ trait InfosetSimpleElement extends InfosetElement {
 }
 
 trait InfosetDocument extends InfosetItem {
-  def getRootElement(): InfosetElement
-  def setRootElement(root: InfosetElement, tunable: DaffodilTunables): Unit
 }
 
-trait InfosetItem extends InfosetCommon {
+trait InfosetItem {
   /**
    * The totalElementCount is the total count of how many elements this InfosetItem contains.
    *

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetWalker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetWalker.scala
@@ -1,0 +1,453 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.infoset
+
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.util.MStackOfInt
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe.One
+import org.apache.daffodil.util.Maybe.Nope
+
+object InfosetWalker {
+
+  /**
+   * Create an infoset walker starting with a specified DINode. If the caller
+   * starts the InfosetWalker at a specified DINode that is not a DIDocument
+   * (which is often the case with the debugger) the InfosetWalker will walk
+   * the node and its children, but will not walk any siblings of the node.
+   * Regardless whether the DINode is a DIDocument or something else, the
+   * InfosetWalker will still always call the start/endDocument functions of
+   * the InfosetOutputter.
+   *
+   * @param root
+   *
+   *   The DINode to start walking the infoset
+   *
+   * @param outputter
+   *
+   *   The InfosetOutputter to output events while walking the infoset
+   *
+   * @param walkHidden
+   *
+   *   Whether or not to walk infoset elements that are considered hidden. This
+   *   should usually only be set to true while debugging
+   *
+   * @param ignoreBlocks
+   *
+   *   Whether or not to ignore blocks when walking the infoset, which are used
+   *   to prevent creation of infoset events that might be backtracked. This
+   *   should usually only be set to true while debugging
+   *
+   * @param removeUnneeded
+   *
+   *   Whether or not to remove infoset nodes once it is determined that they
+   *   will no longer be used by Daffodil. This should usually be set to true
+   *   except while debugging
+   */
+  def apply(
+    root: DINode,
+    outputter: InfosetOutputter,
+    walkHidden: Boolean,
+    ignoreBlocks: Boolean,
+    removeUnneeded: Boolean): InfosetWalker = {
+
+    // Determine the container of the root node and the index in which it
+    // appears in that node
+    val (startingContainerNode, startingContainerIndex) = root match {
+      case d: DIDocument => {
+        // We want to start at the zero'th child index of the document
+        (d, 0)
+      }
+      case _ => {
+        // This case should only be hit when using the debugger to start
+        // walking at a node that isn't the root DIDocument. This gets the
+        // container of the root node to start at and finds the index in that
+        // container
+        (root.containerNode, root.containerNode.contents.indexOf(root))
+      }
+    }
+    new InfosetWalker(
+      startingContainerNode,
+      startingContainerIndex,
+      outputter,
+      walkHidden,
+      ignoreBlocks,
+      removeUnneeded)
+  }
+
+}
+
+/**
+ * The purpose of this class is to walk Daffodil's internal infoset
+ * representation (i.e. DINodes), starting at a specified DINode, and call the
+ * appropriate functions on the InfosetOutputter. The InfosetOutputter provided
+ * to this class determines how the internal infoset is projectted to the user
+ * (e.g. XML, json, SAX events).
+ *
+ * Calling the walk() method causes the InfosetWalker to begin this process. At
+ * any point as determined by the walker, it may pause the walk. Thus, the
+ * entire infoset is not guaranteed to have been walked when the walk() method
+ * returns. In fact, it is possible that no progress could be made. It is up to
+ * the caller to call walk() at appropriate times where it is likely that a
+ * walk could make progress.
+ *
+ * The isFinished() method can be used to determine if the walker walked the
+ * entire infoset or not.
+ *
+ * @param startingContainerNode
+ *
+ *   The container DINode of the element to start at. This should be either a
+ *   DIComplex, DIDocument, or DIArray. DISimple is technically allowed, but
+ *   will not create any useful events as it contains no children.
+ *
+ * @param startingContainerIndex
+ *
+ *   The child index of the element in the startingContainerNode
+ *
+ * @param outputter
+ *
+ *   The InfosetOutputter to output events while walking the infoset
+ *
+ * @param walkHidden
+ *
+ *   Whether or not to walk infoset elements that are considered hidden. This
+ *   should usually only be set to true while debugging
+ *
+ * @param ignoreBlocks
+ *
+ *   Whether or not to ignore blocks when walking the infoset, which are used
+ *   to prevent creation of infoset events that might be backtracked. This
+ *   should usually only be set to true while debugging
+ *
+ * @param removeUnneeded
+ *
+ *   Whether or not to remove infoset nodes once it is determined that they
+ *   will no longer be used by Daffodil. This should usually be set to true
+ *   except while debugging
+ */
+class InfosetWalker private (
+  startingContainerNode: DINode,
+  startingContainerIndex: Int,
+  val outputter: InfosetOutputter,
+  walkHidden: Boolean,
+  ignoreBlocks: Boolean,
+  removeUnneeded: Boolean) {
+
+  /**
+   * These two pieces of mutable state are all that is needed to keep track of
+   * where we are in the infoset. The element that the walker will output an
+   * event for when step() is called is referenced by its container DINode
+   * (either a DIComplex/DIDocument or DIArray) which is stored in
+   * containerNode, and its index within that containing node (which is the
+   * value on the top of the containerIndexStack). Once step() creates the
+   * appropriate event for the element, it will mutate this state so the next
+   * call to step creates events for the next element in the infoset.
+   *
+   * To step to the next sibling of an element, we only need to increment the
+   * index on the top of the stack, since siblings have the same container.
+   *
+   * To step into a DIComplex/DIArray, we mutate containerNode to be the
+   * DIComplex/DIArray we want to step into and push a zero onto the container
+   * index stack so that the next element is the zero'th child of that
+   * container.
+   *
+   * To step out of a DIComplex/DIArray, we mutate containerNode to be the
+   * container of the containerNode and pop off the top of the stack. We then
+   * can perform the logic to step to the next sibling.
+   *
+   * Special helper functions are created to make the above logic more clear.
+   *
+   * Note that we initialize the top of the container index stack with one less
+   * than the starting container index. This lets the getNextStep function know
+   * that we have not yet started the document. Once the document is started,
+   * we increment this value on the top of the stack so that the starting index
+   * is correct.
+   */
+  private var containerNode: DINode = startingContainerNode
+  private var containerIndexStack: MStackOfInt = {
+    val stack = MStackOfInt()
+    stack.push(startingContainerIndex - 1)
+    stack
+  }
+
+  private var finished = false
+
+  /**
+   * Determine if the walker has finished walking.
+   */
+  def isFinished = finished
+
+  /**
+   * Take zero or more steps in the infoset. This may or may not walk the
+   * entire infoset. If isFinished returns false, walk can be called again to
+   * continue attempting to walk the infoset where it left off. Because this is
+   * not guaranteed to make any progress, the caller should attempt to only
+   * call walk() when infoset state has changed such that progress may be
+   * possible.
+   *
+   * It is an error to call walk() if isFinished returns true
+   */
+  def walk(): Unit = {
+    Assert.usage(!finished)
+
+    var maybeNextStep: Maybe[InfosetWalkerStep] = Nope
+    while ({
+      maybeNextStep = getNextStep()
+      maybeNextStep.isDefined
+    }) {
+      maybeNextStep.get.step()
+    }
+  }
+
+  /**
+   * Determine the next step to take, if any
+   */
+  private def getNextStep(): Maybe[InfosetWalkerStep] = {
+    if (finished) {
+      Nope
+    } else if ((containerNode ne startingContainerNode) || containerIndexStack.top == startingContainerIndex) {
+      // The containerNode is either some child of the starting node (container
+      // node != starting container code) or we are exactly on the starting
+      // node (container node == starting container node && top of index stack
+      // == starting index). So we can potentially take a normal step.
+      //
+      // This doesn't necessarily mean we have a step though, since there may
+      // be PoU's that could backtrack and so we can't create events yet, or
+      // other kinds of blocks could exist. So we need to inspect the infoset
+      // state to determine if we can actually create events for the current
+      // infoset node and take a step.
+      if (ignoreBlocks || canTakeStep()) {
+        One(InfosetWalkerStepMove)
+      } else {
+        Nope
+      }
+    } else {
+      // We only get here if the container node is the starting container node,
+      // but the top of the index is not the index of the root node. This means
+      // the next step is either a start or end step.
+      //
+      // If the top of the index stack is less than the starting index, then we
+      // have not started the document yet (because we initialize the index
+      // stack with one less than the starting index). The next step must be a
+      // start step. The InfosetWalkerStepStart is responsible for creating the
+      // right event and updating the containerIndexStack to reference the
+      // correct starting index.
+      //
+      // Otherwise the top of the index stack must be greater than the starting
+      // index because we have moved passed the starting element index, and
+      // thus the next step is an end step. The InfosetWalkerStepEnd is
+      // responsible for creating the endDocument event and cleaning up state.
+      if (containerIndexStack.top < startingContainerIndex) {
+        One(InfosetWalkerStepStart)
+      } else {
+        One(InfosetWalkerStepEnd)
+      }
+    }
+  }
+
+  private def canTakeStep(): Boolean = {
+
+    if (containerNode.infosetWalkerBlockCount > 0) {
+      // This happens in two cases:
+      //
+      // 1) If we have already walked into a complex type that includes an
+      //    unordered sequence. When we start adding the unordered sequence we
+      //    increment the infosetWalkerBlockCount of the container because we
+      //    can't increment the infosetWalkerBlockCount of the yet to be
+      //    created unordered sequence elements. So we take no further steps
+      //    until the unordered sequence is finished and the block is removed
+      // 2) When we are speculatively parsing elements. When an element may or
+      //    may not exist, we set a point of uncertainty before it is created.
+      //    Setting this mark increments the block count of the container
+      //    element because this optional element does not exist yet.
+      //
+      // In both cases we cannot take a step until the block is removed
+      false
+
+    } else {
+      // no blocks on the container, figure out if we can take a step for the
+      // element and the child index of this container 
+
+      val children = containerNode.contents
+      val childIndex = containerIndexStack.top
+
+      if (childIndex < children.size) {
+        // There is a child element at this index. Taking a step would create
+        // the events for, and moved passed, this element.
+        val elem = children(childIndex)
+        if (elem.infosetWalkerBlockCount > 0) {
+          // This element has a block associated with it, likely meaning we are
+          // speculatively parsing this element and so it may or may not exist.
+          // We cannot walk into it until we figure it out and the block is
+          // removed.
+          false
+        } else if (elem.isInstanceOf[DISimple] && !elem.isFinal) {
+          // This is a simple element that is not final, i.e. we are still
+          // doing some parsing for this simple element. Wait until we finish
+          // that parse before stepping into it.
+          false
+        } else {
+          true
+        }
+      } else {
+        // There is not currently a child at this index.
+        if (containerNode.isFinal) {
+          // This container is final, no more children will be added. So we
+          // can make a step that will end this container
+          true
+        } else {
+          // This container is not final, meaning we are potentially waiting
+          // for more another child to be added at this index. In this case, we
+          // cannot make a step until a child is added or the container is
+          // marked as final
+          false
+        }
+      }
+    }
+  }
+
+  private trait InfosetWalkerStep {
+    /**
+     * Output events associated with this step kind, and mutate the
+     * InfosetWalker state to walk to the next node in the infoset
+     */
+    def step(): Unit
+
+    final def moveToFirstChild(newContainer: DINode): Unit = {
+      containerNode = newContainer
+      containerIndexStack.push(0)
+    }
+
+    final def moveToContainer(): Unit = {
+      containerNode = containerNode.containerNode
+      containerIndexStack.pop
+    }
+
+    final def moveToNextSibling(): Unit = {
+      containerIndexStack.push(containerIndexStack.pop + 1)
+    }
+  }
+
+  private object InfosetWalkerStepStart extends InfosetWalkerStep {
+    /**
+     * Start the document. Note that because the top of container index is
+     * initialized to one less that the starting index, we also call
+     * moveToNextSibling to increment the starting index to the correct
+     * position.
+     */
+    override def step(): Unit = {
+      outputter.startDocument()
+      moveToNextSibling()
+    }
+  }
+
+  private object InfosetWalkerStepEnd extends InfosetWalkerStep {
+    /**
+     * End document and clean up state. Setting finished to true causes
+     * the next step to be None, walk() will return, and the caller
+     * should not call walk() again because it is finished.
+     */
+    override def step(): Unit = {
+      outputter.endDocument()
+      containerNode = null
+      containerIndexStack = null
+      finished = true
+    }
+  }
+
+  private object InfosetWalkerStepMove extends InfosetWalkerStep {
+    /**
+     * Output start/end events for DIComplex/DIArray/DISimple, and mutate state
+     * so we are looking at the next node in the infoset.
+     */
+    def step(): Unit = {
+      val children = containerNode.contents
+      val childIndex = containerIndexStack.top
+
+      if (childIndex < children.size) {
+        // This block means we need to create a start event for the element in
+        // the children array at childIndex. We then need to mutate the walker
+        // state so the next call to step() is for either the first child of
+        // this element or the next sibling.
+
+        children(childIndex) match {
+          case s: DISimple => {
+            if (!s.isHidden || walkHidden) {
+              outputter.startSimple(s)
+              outputter.endSimple(s)
+            }
+            if (removeUnneeded) {
+              // now we can remove this simple element to free up memory
+              containerNode.freeChildIfNoLongerNeeded(containerIndexStack.top)
+            }
+            moveToNextSibling()
+          }
+          case c: DIComplex => {
+            if (!c.isHidden || walkHidden) {
+              outputter.startComplex(c)
+              moveToFirstChild(c)
+            } else {
+              moveToNextSibling()
+            }
+          }
+          case a: DIArray => {
+            if (!a.isHidden || walkHidden) {
+              outputter.startArray(a)
+              moveToFirstChild(a)
+            } else {
+              moveToNextSibling()
+            }
+          }
+        }
+
+      } else {
+        // This else block means that we incremented the index stack past the
+        // number of children in this container (must be a DIComplex/DIDocument
+        // or DIArray), which means we have created events for all if its
+        // children. So we must now create the appropriate end event for the
+        // container and then mutate the state so that we are looking at its
+        // next sibling. Note that if there is no next sibling, that will be
+        // found the next time step() is called (because we incremented past
+        // this element) and we will fall into this block again, call the end
+        // function again, and repeat the process.
+
+        // create appropriate end event
+        containerNode match {
+          case a: DIArray => {
+            outputter.endArray(a)
+          }
+          case c: DIComplex => {
+            outputter.endComplex(c)
+          }
+          case _ => Assert.impossible()
+        }
+
+        // we've ended this array/complex associated with the container, so we
+        // now want to move to the parent container, potentially free up the
+        // memory associated with this container, and then move to the next
+        // sibling of this container
+        moveToContainer()
+        if (removeUnneeded) {
+          containerNode.freeChildIfNoLongerNeeded(containerIndexStack.top)
+        }
+        moveToNextSibling()
+      }
+    }
+  }
+
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/TeeInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/TeeInfosetOutputter.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.infoset
+
+
+/**
+ * Receive infoset events and forward them to one or more InfosetOutputters.
+ * For infoset events that return a boolean, this returns true only if all
+ * outputters return true, otherwise false is returned. Additionally, all
+ * events are called on all the outputters regardless of the return of any
+ * previous outputters.
+ *
+ * @param outputters
+ *
+ *    InfosetOutputters to send all events
+ */
+class TeeInfosetOutputter(outputters: InfosetOutputter*)
+  extends InfosetOutputter {
+
+  override def reset(): Unit = {
+    outputters.foreach { _.reset() }
+  }
+
+  override def startSimple(simple: DISimple): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.startSimple(simple)
+    }
+  }
+  
+  override def endSimple(simple: DISimple): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.endSimple(simple)
+    }
+  }
+
+  override def startComplex(complex: DIComplex): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.startComplex(complex)
+    }
+  }
+
+  override def endComplex(complex: DIComplex): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.endComplex(complex)
+    }
+  }
+
+  override def startArray(array: DIArray): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.startArray(array)
+    }
+  }
+
+  override def endArray(array: DIArray): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.endArray(array)
+    }
+  }
+
+  override def startDocument(): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.startDocument()
+    }
+  }
+
+  override def endDocument(): Boolean = {
+    outputters.foldLeft(true) { case (res, outputter) =>
+      res & outputter.endDocument()
+    }
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
@@ -219,6 +219,8 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
             pstate.resetToPointOfUncertainty(pou)
           }
 
+          val savedLastChildNode = pstate.infoset.contents.lastOption
+
           // Note that we are intentionally not pushing/popping a new
           // discriminator here, as is done in the ChoiceCombinatorParser and
           // AltCompParser. This has the effect that if a branch of this direct
@@ -232,6 +234,24 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
 
           if (pstate.processorStatus eq Success) {
             log(LogLevel.Debug, "Choice dispatch success: %s", parser)
+
+            // We usually rely on the sequence parser to set elements as final.
+            // But choices with scalar elements do not necessarily have a
+            // sequence surrounding them and so they aren't set final. In order
+            // to set these elements final, we do it here as well. We will
+            // attempt to walk the infoset after the PoU is discarded.
+            //
+            // Note that we must do a null check because it's possible there was
+            // a sequence, which figured out the element was final, walked it and
+            // it was removed.
+            val newLastChildNode = pstate.infoset.contents.lastOption
+            if (newLastChildNode != savedLastChildNode) {
+              val last = newLastChildNode.get
+              if (last != null) {
+                last.setFinal()
+              }
+            }
+
           } else {
             log(LogLevel.Debug, "Choice dispatch failed: %s", parser)
             val diag = new ChoiceDispatchFailed(context.schemaFileLocation, pstate, pstate.diagnostics)
@@ -240,6 +260,7 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
         }
       }
     }
+    pstate.walker.walk()
 
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -120,6 +120,7 @@ trait WithDetachedParser {
 
       res
     }
+    pstate.walker.walk()
 
     pstate.setParent(priorElement)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
@@ -43,6 +43,7 @@ abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueP
         // no-op. We found nil, withPointOfUncertainty will discard the pou
       }
     }
+    pstate.walker.walk()
 
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
@@ -27,7 +27,8 @@ trait Unseparated { self: SequenceChildParser =>
   final def parseOne(pstate: PState, requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     val prevBitPosBeforeChild = pstate.bitPos0b
     self.childParser.parse1(pstate)
-    parseResultHelper.computeParseAttemptStatus(self, prevBitPosBeforeChild, pstate, requiredOptional)
+    val res = parseResultHelper.computeParseAttemptStatus(self, prevBitPosBeforeChild, pstate, requiredOptional)
+    res
   }
 
   final def isPositional = true


### PR DESCRIPTION
- Create a new InfosetWalker class that walks the infoset with the
  ability to pause and continue were it last paused. A new
  infosetWalkerBlockCount reference counter is used to determine when
  the backtracking is possible and so the walker must pause.
  Additionally, isFinal is extended to all types (including simple
  types) and set during parsing so that the infoset walker knows when
  nodes will have no more changes (e.g. DIComplex/DIArray will have no
  more children added)
- Use this new InfosetWalker anytime an infoset is needed (e.g. parse
  results, debugging, validation, etc). The visit() methods are no
  longer needed and are removed.
- Change the XMLTextInfosetOutputter to output empty complex types as
  <foo></foo> rather than <foo />. When we get a startComplex event, we
  may not know yet if there are any children, so we can't immediately
  create a self closing start tag. Instead, always create an open tag,
  and be careful about how we create a close tag so we don't create
  empty complex types with newlines in them.
- Remove special handling of root element on DIDocument. Treat it just
  like any other DIComplex, except we only care about the zero'th
  element. There was a bug in special casing that caused issues with
  streaming elements.
- Set DINodes to null after creating end events for them. This allows
  the java garbage collector to clean up these elements to allow for
  true streaming style behavior when possible. The one case where we
  cannot do this is when elements are used in expressions. For now, they
  simply are not freed until parse completes.

DAFFODIL-934