### PR TITLE
Added SDWs for discouraged assert and discriminator placements

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -26,6 +26,7 @@ import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 import org.apache.daffodil.schema.annotation.props.gen.SequenceKind
 import org.apache.daffodil.Implicits.ns2String
+import org.apache.daffodil.api.WarnID
 import org.apache.daffodil.dsom.walker.SequenceView
 import org.apache.daffodil.grammar.SequenceGrammarMixin
 import org.apache.daffodil.schema.annotation.props.Found
@@ -40,6 +41,7 @@ import org.apache.daffodil.processors.SeparatorUnparseEv
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.runtime1.ChoiceBranchImpliedSequenceRuntime1Mixin
 import org.apache.daffodil.schema.annotation.props.FindPropertyMixin
+
 
 /**
  * Base for anything sequence-like.
@@ -91,6 +93,8 @@ abstract class SequenceGroupTermBase(
 
 
   requiredEvaluationsIfActivated(checkIfValidUnorderedSequence)
+
+  requiredEvaluationsIfActivated(checkIfNonEmptyAndDiscrimsOrAsserts)
 
   protected def apparentXMLChildren: Seq[Node]
 
@@ -146,6 +150,18 @@ abstract class SequenceGroupTermBase(
       res
     }
   }.value
+
+  /**
+   * Provides validation for assert and discriminator placement
+   */
+  protected final lazy val checkIfNonEmptyAndDiscrimsOrAsserts: Unit = {
+    val msg = "Counterintuitive placement detected. Wrap the discriminator or assert " +
+      "in an empty sequence to evaluate before the contents."
+    if (groupMembers.size > 0 && discriminatorStatements.size > 0)
+      SDW(WarnID.DiscouragedDiscriminatorPlacement, msg)
+    if (groupMembers.size > 0 && assertStatements.size > 0)
+      SDW(WarnID.DiscouragedAssertPlacement, msg)
+  }
 
   /**
    * Provides unordered sequence checks.  Will SDE if invalid.

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -453,6 +453,8 @@
           <xs:enumeration value="deprecatedPropertyDFDLXError" />
           <xs:enumeration value="deprecatedPropertyDFDLError" />
           <xs:enumeration value="deprecatedPropertySeparatorPolicy" />
+          <xs:enumeration value="discouragedDiscriminatorPlacement" />
+          <xs:enumeration value="discouragedAssertPlacement" />
           <xs:enumeration value="emptyElementParsePolicyError" />
           <xs:enumeration value="encodingErrorPolicyError" />
           <xs:enumeration value="escapeSchemeRefUndefined" />

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/discriminator.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/discriminator.tdml
@@ -28,6 +28,94 @@
   defaultRoundTrip="true" 
   defaultValidation="on">
 
+  <tdml:defineSchema name="discrimAssertPlacement">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <xs:element name="root-discrim" dfdl:lengthKind="implicit" >
+      <xs:complexType>
+        <xs:sequence dfdl:separator="," dfdl:separatorPosition="infix">
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:discriminator testKind="pattern"
+                                  testPattern="\p{L}{3}"
+                                  message="discriminator failed for pattern '\p{L}{3}'" />
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:element ref="ex:description" dfdl:lengthKind="delimited"/>
+          <xs:element ref="ex:quantity" dfdl:lengthKind="delimited"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="root-assert" dfdl:lengthKind="implicit" >
+      <xs:complexType>
+        <xs:sequence dfdl:separator="," dfdl:separatorPosition="infix">
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:assert testKind="pattern"
+                                  testPattern="\p{L}{3}"
+                                  message="assert failed for pattern '\p{L}{3}'" />
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:element ref="ex:description" dfdl:lengthKind="delimited"/>
+          <xs:element ref="ex:quantity" dfdl:lengthKind="delimited"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="description" type="xs:string" />
+    <xs:element name="quantity" type="xs:int" />
+  </tdml:defineSchema>
+
+  <!--
+  Test name: discrimPlacementSDW
+  Schema: discrimPlacement, root root-discrim
+  Purpose: This test demonstrates the SDW resulting from discouraged discriminator placement
+  -->
+
+  <tdml:parserTestCase name="discrimPlacementSDW"
+                       root="root-discrim" model="discrimAssertPlacement"
+                       description="This test demonstrates the SDW resulting from discouraged discriminator placement">
+    <tdml:document>Hat,2</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root-discrim>
+          <description>Hat</description>
+          <quantity>2</quantity>
+        </root-discrim>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Wrap the discriminator or assert in an empty sequence</tdml:warning>
+    </tdml:warnings>
+  </tdml:parserTestCase>
+
+  <!--
+  Test name: assertPlacementSDW
+  Schema: discrimAssertPlacement, root root-assert
+  Purpose: This test demonstrates the SDW resulting from discouraged assert placement
+  -->
+
+  <tdml:parserTestCase name="assertPlacementSDW"
+                       root="root-assert" model="discrimAssertPlacement"
+                       description="This test demonstrates the SDW resulting from discouraged assert placement">
+    <tdml:document>Hat,2</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root-assert>
+          <description>Hat</description>
+          <quantity>2</quantity>
+        </root-assert>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Wrap the discriminator or assert in an empty sequence</tdml:warning>
+    </tdml:warnings>
+  </tdml:parserTestCase>
+
   <tdml:defineSchema name="s0">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" />

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
@@ -79,4 +79,8 @@ class TestDiscriminators {
   @Test def test_multipleDiscriminators3(): Unit = { runner2.runOneTest("multipleDiscriminators3") }
   @Test def test_multipleDiscriminators4(): Unit = { runner2.runOneTest("multipleDiscriminators4") }
   @Test def test_multipleDiscriminators5(): Unit = { runner2.runOneTest("multipleDiscriminators5") }
+
+  @Test def test_discrimPlacementSDW(): Unit = { runner.runOneTest("discrimPlacementSDW") }
+  @Test def test_assertPlacementSDW(): Unit = { runner.runOneTest("assertPlacementSDW") }
+
 }


### PR DESCRIPTION
Modified: SequenceGroup adding checkDiscrimAndAssertPlacement
to check for miplaced assert and discriminators
Modified: discriminator.tdml
adding discrimPlacementSDW and assertPlacementSDW
Modified: TestDiscriminators.scala to add runners
Modified: daffodil-propgen dafext.xsd adding new warnings

Daffodil-2277