### PR TITLE
Expand the diagnostic message for dfdl:checkConstraints(.)

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dpath/Expression.scala
@@ -623,24 +623,20 @@ case class WholeExpression(
     }
 
     if (!allowCoercion) {
-      val (relevantExpr: Expression, detailMsg: String) =
-        Conversion.polymorphicExpressionDiagnostics(inherentType, targetType, subExpr)
       if (tunable.allowExpressionResultCoercion) {
         SDW(
           WarnID.DeprecatedExpressionResultCoercion,
           "In expression %s, result type (%s) should be manually cast to the expected type (%s) with the appropriate constructor." +
-            "Performing deprecated automatic conversion.%s",
-          relevantExpr.text,
+            "Performing deprecated automatic conversion.",
+          wholeExpressionText,
           inherentType,
-          targetType,
-          detailMsg)
+          targetType)
       } else {
         SDE(
-          "In expression %s, result type (%s) must be manually cast to the expected type (%s) with the approrpriate constructor.%s",
-          relevantExpr.text,
+          "In expression %s, result type (%s) must be manually cast to the expected type (%s) with the approrpriate constructor.",
+          wholeExpressionText,
           inherentType,
-          targetType,
-          detailMsg)
+          targetType)
       }
     }
 
@@ -1033,7 +1029,7 @@ sealed abstract class DownStepExpression(s: String, predArg: Option[PredicateExp
                     val sfl = ci.schemaFileLocation.locationDescription
                     val qn = ci.namedQName.toQNameString
                     val msg = "element %s in expression %s with %s type at %s".format(
-                      qn, wholePath.text, tname, sfl)
+                      qn, wholePath.wholeExpressionText, tname, sfl)
                     msg
                   }
                   perUsePointStrings
@@ -1057,6 +1053,7 @@ sealed abstract class DownStepExpression(s: String, predArg: Option[PredicateExp
     (relevantExpr, detailMsg)
   }
 }
+
 
 // TODO: Is ".[i]" ever a valid expression in DFDL?
 // Perhaps. Doesn't work currently though. See DAFFODIL-2182

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPolymorphicUpwardRelativeExpressions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestPolymorphicUpwardRelativeExpressions.scala
@@ -144,8 +144,8 @@ class TestPolymorphicUpwardRelativeExpressions extends Logging {
     }
     val msg = e.getMessage()
     val hasSDE = msg.contains("Schema Definition Error")
-    val hasPolyInt = msg.contains("../../poly with xs:int")
-    val hasPolyDate = msg.contains("../../poly with xs:date")
+    val hasPolyInt = msg.contains("../../poly eq 5 with xs:int")
+    val hasPolyDate = msg.contains("../../poly eq 5 with xs:date")
     val hasDifferentPhrase = msg.contains("different types at different points")
     assertTrue(hasSDE)
     assertTrue(hasPolyInt)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/assertions/assert.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/assertions/assert.tdml
@@ -429,10 +429,10 @@
     model="s1" description="Section 7 - negative test for assert expression - DFDL-7-043R">
     <tdml:document><![CDATA[1:2;3,4.]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Assertion failed</tdml:error>
-      <tdml:error>Parsed value was:</tdml:error>
-      <tdml:error><![CDATA[<seq_02><e1>1</e1><e2>2</e2><e3>3</e3><e4>4</e4></seq_02>]]></tdml:error>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>xs:int(.) eq 42</tdml:error>
+      <tdml:error>cannot be converted</tdml:error>
+      <tdml:error>xs:int</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
@@ -42,8 +42,8 @@ class TestAssertions {
 
   // DAFFODIL-752
   //@Test def test_assertFailShowsValue() { runner.runOneTest("assertFailShowsValue") }
-  // DFDL-1043
-  // @Test def test_assertFailShowsValue2() { runner.runOneTest("assertFailShowsValue2") }
+
+  @Test def test_assertFailShowsValue2(): Unit = { runner.runOneTest("assertFailShowsValue2") }
   @Test def test_assertFailShowsDetails(): Unit = { runner.runOneTest("assertFailShowsDetails") }
   @Test def test_assertWithWhitespace(): Unit = { runner.runOneTest("assertWithWhitespace") }
   @Test def test_assertWithWhitespaceAndCdata(): Unit = { runner.runOneTest("assertWithWhitespaceAndCdata") }


### PR DESCRIPTION
The diagnostic message only displays "." as the error.
This commit adds the full expression text to the diagnostic message
for the case of test_checkConstraintsComplexTypeFails.
This case does not invlolve inputValueCalc.

The case of test_assertFailShowsValue2 indicated in the ticket
invloves inputValueCalc and is addressed in Daffodil-1035 Lone "."
in a dfdl:inputValueCalc expression should be an error

Daffodil-1043