### PR TITLE
Correctly expand varargs in String.format call

### DIFF
--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestExceptions.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestExceptions.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.io
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TestExceptions {
+
+  @Test def testBacktrackingException(): Unit = {
+    val be = new BacktrackingException(123, 456)
+    val msg = be.getMessage()
+    assertTrue(msg.contains("123"))
+    assertTrue(msg.contains("456"))
+  }
+
+}

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
@@ -33,7 +33,7 @@ abstract class ThinException protected (dummy: Int, cause: Throwable, fmt: Strin
   extends Exception(null, cause, false, false) {
 
   private lazy val msg_ =
-    if (fmt ne null) fmt.format(args)
+    if (fmt ne null) fmt.format(args: _*)
     else if (cause ne null) cause.getMessage()
     else Misc.getNameFromClass(this)
 


### PR DESCRIPTION
Without using _ :* for the varargs, the format string is not properly
expanded and results in an IllegalFormatConversionException. This
currently only occurs when the BacktrackingException is created because
it's the only exception that uses the var args constructor with the
ThinException.

DAFFODIL-2394