### PR TITLE
Reduce performance degradation caused by commit b0f59ef7c8

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -95,6 +95,11 @@ final class MStackOfMaybe[T <: AnyRef] {
     else One(m)
   }
 
+  @inline final def setTop(m: Maybe[T]) = {
+    if (m.isDefined) delegate.setTop(m.get)
+    else delegate.setTop(nullT)
+  }
+
   @inline final def top: Maybe[T] = {
     val m = delegate.top
     if (m eq null) Nope
@@ -144,6 +149,7 @@ final class MStackOf[T <: AnyRef]
 
   @inline final def push(t: T) = delegate.push(t)
   @inline final def pop: T = delegate.pop.asInstanceOf[T]
+  @inline final def setTop(t: T) = delegate.setTop(t)
   @inline final def top: T = delegate.top.asInstanceOf[T]
   @inline final def bottom: T = delegate.bottom.asInstanceOf[T]
   @inline final def isEmpty = delegate.isEmpty
@@ -260,6 +266,18 @@ protected abstract class MStack[@specialized T] private[util] (
     table(index) = nullValue
     x
   }
+
+  /**
+   * Change the value on top value of a stack. In some cases, this can be more
+   * performant than popping the top and then pushing a new value
+   *
+   * @param x The element to set to the top of the stack
+   */
+  @inline final def setTop(x: T): Unit = {
+    if (index == 0) Assert.usageError("Stack empty")
+    table(index - 1) = x
+  }
+
 
   /**
    * View the top element of the stack.

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -432,7 +432,7 @@ sealed trait RegularElementUnparserStartEndStrategy
           } else {
             val doc = state.documentElement
             doc.addChild(res, state.tunable) // DIDocument, which is never a current node, must have the child added
-            doc.setFinal() // that's the only child.
+            doc.isFinal = true // that's the only child.
           }
           res
         } else {
@@ -477,7 +477,7 @@ sealed trait RegularElementUnparserStartEndStrategy
       }
       val cur = state.currentInfosetNode
       if (cur.isComplex)
-        cur.asComplex.setFinal()
+        cur.isFinal = true
       state.currentInfosetNodeStack.pop
 
       move(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -451,12 +451,12 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     val bos = new java.io.ByteArrayOutputStream()
     val xml = new XMLTextInfosetOutputter(bos, true)
     val iw = InfosetWalker(
-      ie.asInstanceOf[DINode],
+      ie.asInstanceOf[DIElement],
       xml,
       walkHidden = !DebuggerConfig.removeHidden,
       ignoreBlocks = true,
       removeUnneeded = false)
-    iw.walk()
+    iw.walk(lastWalk = true)
     bos.toString("UTF-8")
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/FNFunctions.scala
@@ -38,7 +38,7 @@ import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.exceptions.SchemaFileLocation
 import org.apache.daffodil.exceptions.UnsuppressableException
 import org.apache.daffodil.infoset.DIElement
-import org.apache.daffodil.infoset.DIFinalizable
+import org.apache.daffodil.infoset.DINode
 import org.apache.daffodil.infoset.DataValue.DataValueBigDecimal
 import org.apache.daffodil.infoset.DataValue.DataValueBigInt
 import org.apache.daffodil.infoset.DataValue.DataValueBool
@@ -564,7 +564,7 @@ trait ExistsKind {
       }
       case UnparserBlocking => {
         dstate.currentNode match {
-          case c: DIFinalizable if (c.isFinal) => false
+          case c: DINode if (c.isFinal) => false
           case _ => throw th
         }
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -424,14 +424,14 @@ class DataProcessor private (
     val pr = new ParseResult(this, state)
     if (!pr.isProcessingError) {
 
-      // By the time we get here, all infoset nodes have been setFinal, all
+      // By the time we get here, all infoset nodes have been set final, all
       // walker blocks released, and all elements walked. The one exception
-      // is that the root node has not been set final because setFinal is
+      // is that the root node has not been set final because isFinal is
       // handled by the sequence parser and there is no sequence around the
       // root node. So mark it as final and do one last walk to end the
       // document.
-      state.infoset.contents(0).setFinal()
-      state.walker.walk()
+      state.infoset.contents(0).isFinal = true
+      state.walker.walk(lastWalk = true)
       Assert.invariant(state.walker.isFinished)
 
       if (maybeValidationBytes.isDefined) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementKindParsers.scala
@@ -219,8 +219,6 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
             pstate.resetToPointOfUncertainty(pou)
           }
 
-          val savedLastChildNode = pstate.infoset.contents.lastOption
-
           // Note that we are intentionally not pushing/popping a new
           // discriminator here, as is done in the ChoiceCombinatorParser and
           // AltCompParser. This has the effect that if a branch of this direct
@@ -240,16 +238,9 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
             // sequence surrounding them and so they aren't set final. In order
             // to set these elements final, we do it here as well. We will
             // attempt to walk the infoset after the PoU is discarded.
-            //
-            // Note that we must do a null check because it's possible there was
-            // a sequence, which figured out the element was final, walked it and
-            // it was removed.
-            val newLastChildNode = pstate.infoset.contents.lastOption
-            if (newLastChildNode != savedLastChildNode) {
-              val last = newLastChildNode.get
-              if (last != null) {
-                last.setFinal()
-              }
+            val newLastChildNode = pstate.infoset.maybeLastChild
+            if (newLastChildNode.isDefined) {
+              newLastChildNode.get.isFinal = true
             }
 
           } else {
@@ -260,7 +251,6 @@ abstract class ChoiceDispatchCombinatorParserBase(rd: TermRuntimeData,
         }
       }
     }
-    pstate.walker.walk()
 
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -120,7 +120,6 @@ trait WithDetachedParser {
 
       res
     }
-    pstate.walker.walk()
 
     pstate.setParent(priorElement)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/NilEmptyCombinatorParsers.scala
@@ -43,7 +43,6 @@ abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueP
         // no-op. We found nil, withPointOfUncertainty will discard the pou
       }
     }
-    pstate.walker.walk()
 
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/Parser.scala
@@ -190,8 +190,6 @@ class ChoiceParser(
     
     var successfullyParsedChildBranch = false
 
-    val savedLastChildNode = pstate.infoset.contents.lastOption
-
     while (!successfullyParsedChildBranch && i < numAlternatives) {
 
       val parser = childParsers(i)
@@ -211,16 +209,9 @@ class ChoiceParser(
           // sequence surrounding them and so they aren't set final. In order
           // to set these elements final, we do it here as well. We will
           // attempt to walk the infoset after the PoU is discarded.
-          //
-          // Note that we must do a null check because it's possible there was
-          // a sequence, which figured out the element was final, walked it and
-          // it was removed.
-          val newLastChildNode = pstate.infoset.contents.lastOption
-          if (newLastChildNode != savedLastChildNode) {
-            val last = newLastChildNode.get
-            if (last != null) {
-              last.setFinal()
-            }
+          val newLastChildNode = pstate.infoset.maybeLastChild
+          if (newLastChildNode.isDefined) {
+            newLastChildNode.get.isFinal = true
           }
 
         } else {


### PR DESCRIPTION
- Remove the DIFinalizable trait and setFinal function and replace with
  direct modification of isFinal. Scala created some pretty inefficient
  byte code for this which actually made a noticeable difference in
  performance when removed.
- Add function to DINodes to efficiently return a Maybe of the last
  child. This replaces the lastOption and avoids an Option allocation
- Remove the containerNode def and just keep track of the container node
  in the InfosetWalker with a new stack. Avoids virtual function calls
  and instanceOf/asInstanceOf.
- Skip batches of walk() calls. This avoids the overhead related to step
  logic when no progress is being made due to PoU's and allows batching
  of steps rather than stepping each time a infoset node is added.
- Replace the various infoset walker objects with functions. Rather than
  returning objects in a Maybe and calling a function in those optionst,
  just call the functions directly and return a boolean that says
  whether a step was taken. Essentially the same logic, but avoids
  object creation and virtual functions.
- Avoid accessing the top of the infoset walker stacks multiple times.
  Instead, access once and pass down as parameters. These stack accesses
  actually showed up quite a bit in profiling
- Remove match/case on types, and instead use functions to imply the
  type. Avoids instanceOf/asInstanceOf which have a noticeable
  overhead in inner loops
- Add a new setTop function to modify the top of an MStack. Avoids logic
  to pop and then push a new value.
- Remove extra logic about saved last child node, this didn't make much
  of a difference in when we called set final, and just added extra
  overhead
- Remove calls to walk() made when PoU's were resolved. Instead, only
  walk() when new elements are added. Elements are added all the time so
  these extra calls just added overhead. The new step skipping logic
  also helps with this.

DAFFODIL-2396