### PR TITLE
Replace NoRep terminology with InputValueCalc

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.grammar.Gram
 import org.apache.daffodil.grammar.NamedGram
 import org.apache.daffodil.grammar.Terminal
 import org.apache.daffodil.processors.parsers.ElementParser
-import org.apache.daffodil.processors.parsers.ElementParserNoRep
+import org.apache.daffodil.processors.parsers.ElementParserInputValueCalc
 import org.apache.daffodil.processors.parsers.Parser
 import org.apache.daffodil.processors.parsers.CaptureEndOfContentLengthParser
 import org.apache.daffodil.processors.parsers.CaptureEndOfValueLengthParser
@@ -37,7 +37,7 @@ import org.apache.daffodil.processors.unparsers.CaptureStartOfValueLengthUnparse
 import org.apache.daffodil.processors.unparsers.ElementOVCSpecifiedLengthUnparser
 import org.apache.daffodil.processors.unparsers.ElementOVCUnspecifiedLengthUnparser
 import org.apache.daffodil.processors.unparsers.ElementSpecifiedLengthUnparser
-import org.apache.daffodil.processors.unparsers.ElementUnparserNoRep
+import org.apache.daffodil.processors.unparsers.ElementUnparserInputValueCalc
 import org.apache.daffodil.processors.unparsers.ElementUnspecifiedLengthUnparser
 import org.apache.daffodil.processors.unparsers.ElementUnusedUnparser
 import org.apache.daffodil.processors.unparsers.LeftCenteredPaddingUnparser
@@ -302,7 +302,7 @@ class ElementParseAndUnspecifiedLength(context: ElementBase, eBeforeGram: Gram, 
         eRepTypeParser
       )
     else
-      new ElementParserNoRep(
+      new ElementParserInputValueCalc(
         context.erd,
         context.name,
         patDiscrim,
@@ -325,7 +325,7 @@ class ElementParseAndUnspecifiedLength(context: ElementBase, eBeforeGram: Gram, 
       // dfdl:inputValueCalc case.
       // This unparser will assume the events are in the event stream, having been inferred and put
       // in place by the next element resolver.
-      new ElementUnparserNoRep(context.erd, uSetVar)
+      new ElementUnparserInputValueCalc(context.erd, uSetVar)
     }
   }
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -72,7 +72,7 @@ sealed trait RepMoveMixin {
  * whether to place separators, and there should not be any separator
  * corresponding to an IVC element.
  */
-class ElementUnparserNoRep(
+class ElementUnparserInputValueCalc(
   erd: ElementRuntimeData,
   setVarUnparsers: Array[Unparser])
   extends ElementUnparserBase(

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
@@ -283,7 +283,7 @@ class ElementParser(
   }
 }
 
-class ElementParserNoRep(
+class ElementParserInputValueCalc(
   erd: ElementRuntimeData,
   name: String,
   patDiscrim: Maybe[Parser],
@@ -310,7 +310,7 @@ class ElementParserNoRep(
   // if there is no rep (inputValueCalc), then we do create a new child so that index must advance,
   // but we don't create anything new as far as the group is concerned, and we don't want
   // the group 'thinking' that there's a prior sibling inside the group and placing a
-  // separator after it. So in the case of NoRep, we don't advance group child, just element child.
+  // separator after it. So in the case of InputValueCalc, we don't advance group child, just element child.
   override def move(state: PState): Unit = {
     state.mpstate.moveOverOneElementChildOnly
   }


### PR DESCRIPTION
A simple text replacement to remove the outdated terminology "NoRep" with "InputValueCalc" which actually appears in the spec.

DAFFODIL-1533