### PR TITLE
Re-enable codecov.io pull request comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,5 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Prevents codecov from creating a test coverage comment in a pull request
-comment: off
+coverage:
+  status:
+    project: off
+    patch: 
+      default:
+        target: auto
+
+comment: false


### PR DESCRIPTION
The default behavior for codecov.io is to create a comment for each PR
to describe how it changes codecov. We previously had this disabled, but
it makes this less visiable. Delete the codecov.io config file to
re-enable PR comments to encourage new pull requests to ensure they code
has test coverage.

DAFFODIL-2403
