### PR TITLE
RFC: Evaluate suspensions earlier

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
@@ -41,11 +41,16 @@ class AlignmentFillUnparserSuspendableOperation(
   extends SuspendableOperation {
 
   override def test(ustate: UState) = {
+    // DONE
     val dos = ustate.dataOutputStream
     if (dos.maybeAbsBitPos0b.isEmpty) {
       log(LogLevel.Debug, "%s %s Unable to align to %s bits because there is no absolute bit position.", this, ustate, alignmentInBits)
     }
-    dos.maybeAbsBitPos0b.isDefined
+    val res = dos.maybeAbsBitPos0b.isDefined
+    if (!res) {
+      dos.trackBlockedSuspension(this)
+    }
+    res
   }
 
   override def continuation(state: UState): Unit = {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StreamSplitterMixin.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/StreamSplitterMixin.scala
@@ -99,6 +99,7 @@ final class RegionSplitSuspendableOperation(override val rd: TermRuntimeData)
    * When retried, the test succeeds.
    */
   override def test(ustate: UState): Boolean = {
+    // HUH?
     if (secondTime) true
     else {
       secondTime = true


### PR DESCRIPTION
This is part 1 to reducing memory required during unparse. The goal here is to evaluate suspensions and thus reduce buffering while unparsing rather than waiting until the very end of unparse. Split into two commits to easy reviewing.

The first commit fixes an issue where a suspension could create another suspension, which breaks assumptions about how suspensions work. Please take a look and see if this is a reasonble way to resolve this issue. I don't believe there are any other cases where a suspension could create a suspension.

The second comment is what actually evalutes suspensions ealier, using a technique similar to garbage collection, maintaining a young and old list of suspensions and evaluating them at different times. 