### PR TITLE
RFC: Evaluate suspensions earlier

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/SequenceGrammarMixin.scala
@@ -183,7 +183,18 @@ trait SequenceGrammarMixin
    */
   lazy val hasSeparator = !separatorParseEv.isConstantEmptyString
 
-  lazy val sequenceSeparator = prod("separator", hasSeparator) {
-    delimMTA ~ SequenceSeparator(this)
+  /**
+   * Note that the sequence separator does not include the delimMTA grammar
+   * like initiators/terminators. This is because unparsing needs to uncouple
+   * MTA and Separator unparsers to properly support optional separators with
+   * potential alignment. Grammars are expected to handle the delimMTA when
+   * necessary
+   */
+  lazy val sequenceSeparatorMTA = prod("sequenceSeparatorMTA", hasSeparator) {
+    delimMTA
   }
+  lazy val sequenceSeparator = prod("separator", hasSeparator) {
+    SequenceSeparator(this)
+  }
+
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/TermGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/TermGrammarMixin.scala
@@ -66,7 +66,7 @@ trait TermGrammarMixin
   /**
    * Mandatory text alignment for delimiters
    */
-  protected final lazy val delimMTA = prod(
+  final lazy val delimMTA = prod(
     "delimMTA",
     {
       hasDelimiters

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceChild.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceChild.scala
@@ -92,6 +92,8 @@ abstract class SequenceChild(protected val sq: SequenceTermBase, child: Term, gr
   protected def separatedHelper: SeparatedHelper
   protected def unseparatedHelper: UnseparatedHelper
 
+  protected lazy val sepMtaGram = sq.delimMTA
+
   protected lazy val sepGram = {
     sscb match {
       case _: PositionalLike =>
@@ -101,8 +103,8 @@ abstract class SequenceChild(protected val sq: SequenceTermBase, child: Term, gr
     sq.sequenceSeparator
   }
 
-  protected lazy val sepParser = sepGram.parser
-  protected lazy val sepUnparser = sepGram.unparser
+  protected lazy val sepParser = (sepMtaGram ~ sepGram).parser
+  protected lazy val sepUnparser = (sepMtaGram ~ sepGram).unparser
 
   final protected def srd = sq.sequenceRuntimeData
   final protected def trd = child.termRuntimeData

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -99,6 +99,7 @@ trait SchemaSetRuntime1Mixin { self : SchemaSet =>
         //        diags.foreach { diag => log(LogLevel.Error, diag.toString()) }
       } else {
         log(LogLevel.Compile, "Parser = %s.", ssrd.parser.toString)
+        log(LogLevel.Compile, "Unparser = %s.", ssrd.unparser.toString)
         log(LogLevel.Compile, "Compilation (DataProcesor) completed with no errors.")
       }
       dataProc

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
@@ -84,11 +84,20 @@ object Assert extends Assert {
   def usage(testAbortsIfFalse: Boolean): Unit = macro AssertMacros.usageMacro1
 
   /**
-   * test for something that the program is supposed to be insuring.
+   * test for something that the program is supposed to be ensuring.
    *
    * This is for more complex invariants than the simple 'impossible' case.
    */
   def invariant(testAbortsIfFalse: Boolean): Unit = macro AssertMacros.invariantMacro1
+
+  /**
+   * test for something that the program is supposed to be ensuring, with a custom error message.
+   *
+   * This is for more complex invariants than the simple 'impossible' case.
+   *
+   * The msg parameter is only evaluated if the test fails
+   */
+  def invariant(testAbortsIfFalse: Boolean, msg: String): Unit = macro AssertMacros.invariantMacro2
 
   /**
    * Conditional behavior for NYIs

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Logger.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Logger.scala
@@ -96,18 +96,6 @@ abstract class LogWriter {
   }
 }
 
-object ForUnitTestLogWriter extends LogWriter {
-  var loggedMsg: String = null
-  //  protected val writer = actor { loop { react { case msg : String =>
-  //    loggedMsg = msg
-  //    Console.out.println("Was Logged: " + loggedMsg)
-  //    Console.out.flush()
-  //    } } }
-  def write(msg: String): Unit = {
-    loggedMsg = msg
-  }
-}
-
 object NullLogWriter extends LogWriter {
   //protected val writer = actor { loop { react { case msg : String => } } }
   def write(msg: String): Unit = {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
@@ -21,63 +21,72 @@ import org.junit.Assert._
 import org.apache.daffodil.exceptions._
 import org.junit.Test
 
-class MyClass extends Logging {
-
-  lazy val msg = {
-    // System.err.println("computing the message string.")
-    "Message %s"
-  }
-
-  lazy val argString = {
-    // System.err.println("computing the argument string.")
-    "about nothing at all."
-  }
-
-  lazy val bombArg: String = Assert.abort("bombArg should not be evaluated")
-  lazy val bombMsg: String = Assert.abort("bombMsg should not be evaluated")
-
-  def logSomething(): Unit = {
-
-    ForUnitTestLogWriter.loggedMsg = null
-
-    setLogWriter(ForUnitTestLogWriter)
-
-    // won't log because below threshhold. Won't even evaluate args.
-    log(LogLevel.Debug, msg, bombArg) // Won't show up in log. Won't bomb.
-
-    // alas, no by-name passing of var-args.
-    // so instead, we pass by name, a by-name/lazy constructed tuple
-    // instead.
-
-    // Illustrates that our Glob object, because its parts are all passed by name,
-    // does NOT force evaluation of the pieces that go into it.
-    // So it really makes the whole system behave like it was entirely lazy.
-
-    // If we're logging below the threshhold of Debug, then this log line
-    // doesn't evaluate bombMsg or bombArg. So it is ok if those are expensive
-    // to compute.
-
-    log(LogLevel.Debug, bombMsg, bombArg) // bomb is not evaluated at all.
-    log(LogLevel.Error, msg, argString) // Will show up in log.
-
-    setLoggingLevel(LogLevel.Info)
-    setLogWriter(ConsoleWriter)
+class ForUnitTestLogWriter extends LogWriter {
+  var loggedMsg: String = null
+  def write(msg: String): Unit = {
+    loggedMsg = msg
   }
 }
 
 class TestLogger {
-
   @Test def test1(): Unit = {
-    val c = new MyClass
+
+    class A extends Logging {
+
+      lazy val msg = "Message %s"
+      lazy val argString = "about nothing at all."
+
+      lazy val bombArg: String = Assert.abort("bombArg should not be evaluated")
+      lazy val bombMsg: String = Assert.abort("bombMsg should not be evaluated")
+
+      def logSomething(): Unit = {
+        // won't log because below threshhold. Won't even evaluate args.
+        log(LogLevel.Debug, msg, bombArg) // Won't show up in log. Won't bomb.
+
+        // alas, no by-name passing of var-args.
+        // so instead, we pass by name, a by-name/lazy constructed tuple
+        // instead.
+
+        // Illustrates that our Glob object, because its parts are all passed by name,
+        // does NOT force evaluation of the pieces that go into it.
+        // So it really makes the whole system behave like it was entirely lazy.
+
+        // If we're logging below the threshhold of Debug, then this log line
+        // doesn't evaluate bombMsg or bombArg. So it is ok if those are expensive
+        // to compute.
+
+        log(LogLevel.Debug, bombMsg, bombArg) // bomb is not evaluated at all.
+        log(LogLevel.Error, msg, argString) // Will show up in log.
+      }
+    }
+
+
+    val lw = new ForUnitTestLogWriter
+    val c = new A
     c.setLoggingLevel(LogLevel.Error)
+    c.setLogWriter(lw)
     c.logSomething()
-    Console.out.flush()
-    val fromLog = ForUnitTestLogWriter.loggedMsg
-    // println(fromLog)
+    val fromLog = lw.loggedMsg
     val hasExpected = fromLog.contains("Message about nothing at all.")
     val doesntHaveUnexpected = !fromLog.contains("number 1")
     assertTrue(hasExpected)
     assertTrue(doesntHaveUnexpected)
+  }
+
+  @Test def test_var_args_different_primitives(): Unit = {
+
+    class A extends Logging {
+      def logSomething(): Unit = {
+        log(LogLevel.Error, "Message: int=%d float=%f", 1, 3.0)
+      }
+    }
+
+    val lw = new ForUnitTestLogWriter
+    val a = new A
+    a.setLoggingLevel(LogLevel.Error)
+    a.setLogWriter(lw)
+    a.logSomething()
+    assertTrue(lw.loggedMsg.contains("Message: int=1 float=3.0"))
   }
 
 }

--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/exceptions/AssertMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/exceptions/AssertMacros.scala
@@ -57,6 +57,16 @@ object AssertMacros {
     """
   }
 
+  def invariantMacro2(c: Context)(testAbortsIfFalse: c.Tree, msg: c.Tree): c.Tree = {
+    import c.universe._
+
+    q"""
+    if (!($testAbortsIfFalse)) {
+         Assert.abort("Invariant broken. " + { $msg })
+    }
+    """
+  }
+
   def notYetImplementedMacro0(c: Context)(): c.Tree = {
     import c.universe._
 

--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/util/LoggerMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/util/LoggerMacros.scala
@@ -59,7 +59,7 @@ object LoggerMacros {
       val $level = $lvl
       val $l = $level.lvl
       if ($ths.getLoggingLevel().lvl >= $l)
-        $ths.doLogging($level, $msg, Seq(..$args))
+        $ths.doLogging($level, $msg, Seq[Any](..$args))
     }
     """
   }

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -400,6 +400,32 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="unparseSuspensionWaitOld" type="xs:int" default="100" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              While unparsing, some unparse actions require "suspending" which
+              requires buffering unparse output until the suspension can be
+              evaluated. Daffodil periodically attempts to reevaluate these
+              suspensions so that these buffers can be released. We attempt to
+              evaluate young suspensions shortly after creation with the hope
+              that it will succeed and we can release associated buffers. But if
+              a young suspension fails it is moved to the old suspension list.
+              Old suspensions are evaluated less frequently since they are less
+              likely to succeeded. This minimizes the overhead related to
+              evaluating suspensions that are likely to fail. The
+              unparseSuspensionWaitYoung and unparseSuspensionWaitOld
+              values determine how many elements are unparsed before evaluating
+              young and old suspensions, respectively.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="unparseSuspensionWaitYoung" type="xs:int" default="5" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              See unparseSuspensionWaitOld
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
       </xs:all>
     </xs:complexType>
   </xs:element>

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -481,6 +481,8 @@ sealed trait RegularElementUnparserStartEndStrategy
       state.currentInfosetNodeStack.pop
 
       move(state)
+
+      state.asInstanceOf[UStateMain].evalSuspensions(isFinal = false)
     }
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/FramingUnparsers.scala
@@ -35,12 +35,12 @@ class SkipRegionUnparser(
   }
 }
 
-class AlignmentFillUnparserSuspendableOperation(
-  alignmentInBits: Int,
-  override val rd: TermRuntimeData)
-  extends SuspendableOperation {
+trait AlignmentFillUnparserSuspendableMixin { this: SuspendableOperation =>
 
-  override def test(ustate: UState) = {
+  def alignmentInBits: Int
+  def rd: TermRuntimeData
+
+  def test(ustate: UState) = {
     val dos = ustate.dataOutputStream
     if (dos.maybeAbsBitPos0b.isEmpty) {
       log(LogLevel.Debug, "%s %s Unable to align to %s bits because there is no absolute bit position.", this, ustate, alignmentInBits)
@@ -48,7 +48,7 @@ class AlignmentFillUnparserSuspendableOperation(
     dos.maybeAbsBitPos0b.isDefined
   }
 
-  override def continuation(state: UState): Unit = {
+  def continuation(state: UState): Unit = {
     val dos = state.dataOutputStream
     val b4 = dos.relBitPos0b
     if (!dos.align(alignmentInBits, state))
@@ -61,6 +61,12 @@ class AlignmentFillUnparserSuspendableOperation(
       log(LogLevel.Debug, "%s moved %s bits to align to %s(bits).", this, delta, alignmentInBits)
   }
 }
+
+class AlignmentFillUnparserSuspendableOperation(
+  override val alignmentInBits: Int,
+  override val rd: TermRuntimeData)
+  extends SuspendableOperation
+  with AlignmentFillUnparserSuspendableMixin
 
 class AlignmentFillUnparser(
   alignmentInBits: Int,

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceUnparserBases.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SequenceUnparserBases.scala
@@ -34,9 +34,4 @@ abstract class OrderedSequenceUnparserBase(
   // Sequences of nothing (no initiator, no terminator, nothing at all) should
   // have been optimized away
   Assert.invariant(childUnparsers.length > 0)
-
-  // Since some of the grammar terms might have folded away to EmptyGram,
-  // the number of unparsers here may be different from the number of
-  // children of the sequence group.
-  Assert.invariant(srd.groupMembers.length >= childUnparsers.length - 1) // minus 1 for the separator unparser
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -443,7 +443,7 @@ sealed abstract class LengthState(ie: DIElement)
 
   def isEndUndef = {
     val r = maybeEndPos0bInBits.isEmpty
-    if (r) Assert.invariant(maybeStartDataOutputStream.isEmpty)
+    if (r) Assert.invariant(maybeEndDataOutputStream.isEmpty)
     r
   }
 
@@ -583,7 +583,7 @@ sealed abstract class LengthState(ie: DIElement)
 
   def setAbsEndPos0bInBits(absPosInBits0b: ULong): Unit = {
     maybeEndPos0bInBits = MaybeULong(absPosInBits0b.longValue)
-    maybeStartDataOutputStream = Nope
+    maybeEndDataOutputStream = Nope
   }
 
   def setRelEndPos0bInBits(relPosInBits0b: ULong, dos: DataOutputStream): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -575,7 +575,7 @@ class DataProcessor private (
       unparserState.dataProc.get.init(ssrd.unparser)
       out.setPriorBitOrder(ssrd.elementRuntimeData.defaultBitOrder)
       doUnparse(unparserState)
-      unparserState.evalSuspensions(unparserState) // handles outputValueCalc that were suspended due to forward references.
+      unparserState.evalSuspensions(isFinal = true)
       unparserState.unparseResult
     } catch {
       case ue: UnparseError => {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspensionTracker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspensionTracker.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processors
+
+import scala.collection.mutable.Queue
+
+import org.apache.daffodil.dsom.RuntimeSchemaDefinitionError
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.util.LogLevel
+import org.apache.daffodil.util.Logging
+
+class SuspensionTracker(suspensionWaitYoung: Int, suspensionWaitOld: Int)
+  extends Logging {
+
+  private val suspensionsYoung = new Queue[Suspension]
+  private val suspensionsOld = new Queue[Suspension]
+
+  private var count: Int = 0
+
+  private var suspensionStatTracked: Int = 0
+  private var suspensionStatRuns: Int = 0
+
+  def trackSuspension(s: Suspension): Unit = {
+    suspensionsYoung.enqueue(s)
+    suspensionStatTracked += 1
+  }
+
+  /**
+   * Attempts to evaluate suspensions. Old suspensions are evaluated less
+   * frequently than young suspensions. Any young suspensions that fail to
+   * evaluate are moved to the old suspensions list. If we evaluate old
+   * suspensions, we attempt to evaluate them first, with the hope that their
+   * resolution might make the young suspensions more likely to evaluate.
+   */
+  def evalSuspensions(): Unit = {
+    if (count % suspensionWaitOld == 0) {
+      evalSuspensionQueue(suspensionsOld)
+    }
+    if (count % suspensionWaitYoung == 0) {
+      evalSuspensionQueue(suspensionsYoung)
+      while (suspensionsYoung.nonEmpty) {
+        suspensionsOld.enqueue(suspensionsYoung.dequeue)
+      }
+    }
+
+    if (count == suspensionWaitOld) {
+      count = 0 
+    } else {
+      count += 1
+    }
+  }
+
+  /**
+   * Evaluates all suspensions until either they are all evaluated or a
+   * deadlock is detected. This moves all young suspensions to the old queue,
+   * and evaluates all old suspensions. If the old queue is non-empty, that
+   * means some suspensions are blocked, likely due to a circular deadlock, and
+   * we output diagnostics.
+   */
+  def requireFinal(): Unit = {
+    while (suspensionsYoung.nonEmpty) {
+      suspensionsOld.enqueue(suspensionsYoung.dequeue)
+    }
+
+    evalSuspensionQueue(suspensionsOld)
+
+    Assert.invariant(
+      suspensionsOld.length != 1,
+      "Single suspended expression making no forward progress. " + suspensionsOld(0))
+
+    if (suspensionsOld.nonEmpty) {
+      throw new SuspensionDeadlockException(suspensionsOld.seq)
+    }
+
+    log(
+      LogLevel.Debug,
+      "Suspension runs/tracked: %d/%d (%.2f%%)",
+      suspensionStatRuns,
+      suspensionStatTracked,
+      (suspensionStatRuns.toFloat / suspensionStatTracked) * 100)
+  }
+
+  /**
+   * Attempt to evaluate suspensions on the provie queue. Keep repeating the
+   * evaluates as long as some progress is being made. Suspensions that
+   * evaluate sucessfully are removed from the queue. Once suspensions make no
+   * further progress and are all blocked, we return. Blocked suspensions put
+   * back on the same queue.
+   */
+  private def evalSuspensionQueue(queue: Queue[Suspension]): Unit = {
+    var countOfNotMakingProgress = 0
+    while (!queue.isEmpty && countOfNotMakingProgress < queue.length) {
+      val s = queue.dequeue
+      suspensionStatRuns += 1
+      s.runSuspension()
+      if (!s.isDone) queue.enqueue(s)
+      if (s.isDone || s.isMakingProgress) {
+        countOfNotMakingProgress = 0
+      } else {
+        countOfNotMakingProgress += 1
+      }
+    }
+  }
+
+}
+
+class SuspensionDeadlockException(suspExprs: Seq[Suspension])
+  extends RuntimeSchemaDefinitionError(
+    suspExprs(0).rd.schemaFileLocation,
+    suspExprs(0).savedUstate,
+    "Expressions/Unparsers are circularly deadlocked (mutually defined):\n%s",
+    suspExprs.groupBy { _.rd }.mapValues { _(0) }.values.mkString(" - ", "\n - ", ""))

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceParsers.scala
@@ -25,6 +25,8 @@ trait Separated { self: SequenceChildParser =>
   def spos: SeparatorPosition
   def trd: TermRuntimeData
   def parseResultHelper: SeparatedSequenceChildParseResultHelper
+ 
+  override def childProcessors: Vector[Processor] = Vector(self.childParser) :+ sep
 
   import SeparatorPosition._
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -3681,4 +3681,62 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+
+  <tdml:defineSchema name="separatorMTA">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+    <dfdl:format ref="ex:GeneralFormat"
+      lengthUnits="bits"
+      alignmentUnits="bits"
+      fillByte="%#rFF;"/>
+
+    <xs:element name="e1">
+      <xs:complexType>
+        <xs:sequence
+          dfdl:separator=","
+          dfdl:separatorPosition="prefix"
+          dfdl:separatorSuppressionPolicy="anyEmpty"
+          dfdl:encoding="US-ASCII" dfdl:alignment="8">
+          <xs:element name="a" type="xs:string" maxOccurs="unbounded"
+            dfdl:lengthKind="pattern" dfdl:lengthPattern="."
+            dfdl:encoding="X-DFDL-BASE4-MSBF" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <!--
+     Test Name: separatorMTA_01
+        Schema: separatorMTA
+        Root: root
+        Purpose: This test demonstrates that with the correct separator
+          suppression, separators are only unparsed when elements unparse to
+          non-zero length. Infoset elements that unparse to zero length
+          essentially disappear. This also tests that when we determine a field
+          is zero length and do not unparse the seprator, that we also do not
+          unparse mandatory text alignment associated with that separator
+  -->
+
+  <tdml:unparserTestCase name="separatorMTA_01"
+    model="separatorMTA"
+    description="Section 12.1 - Aligned Data" roundTrip="none">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e1>
+          <ex:a>0</ex:a>
+          <ex:a></ex:a>
+          <ex:a>1</ex:a>
+          <ex:a></ex:a>
+        </ex:e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="bits">00101100</tdml:documentPart> <!-- us-ascii comma separator -->
+      <tdml:documentPart type="bits">00 111111</tdml:documentPart> <!-- base-4 "0" string + mta fill bits-->
+      <tdml:documentPart type="bits">00101100</tdml:documentPart> <!-- us-ascii comma separator -->
+      <tdml:documentPart type="bits">01</tdml:documentPart> <!-- base-4 "1" string (no mta fill bits)-->
+    </tdml:document>
+  </tdml:unparserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
@@ -191,4 +191,6 @@ class TestAlignedData {
   @Test def test_fillByte_04() = { runner1.runOneTest("fillByte_04") }
   @Test def test_fillByte_05() = { runner1.runOneTest("fillByte_05") }
   @Test def test_fillByte_06() = { runner1.runOneTest("fillByte_06") }
+
+  @Test def test_separatorMTA_01() = { runner1.runOneTest("separatorMTA_01") }
 }


### PR DESCRIPTION
This is part 1 to reducing memory required during unparse. The goal here is to evaluate suspensions and thus reduce buffering while unparsing rather than waiting until the very end of unparse. Split into two commits to easy reviewing.

The first commit fixes an issue where a suspension could create another suspension, which breaks assumptions about how suspensions work. Please take a look and see if this is a reasonble way to resolve this issue. I don't believe there are any other cases where a suspension could create a suspension.

The second comment is what actually evalutes suspensions ealier, using a technique similar to garbage collection, maintaining a young and old list of suspensions and evaluating them at different times. 