### PR TITLE
Alert user to use blobs instead of hexBinary

### DIFF
--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -521,7 +521,6 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
 
   def skip(nBits: Long, finfo: FormatInfo): Boolean = {
     // threadCheck()
-    Assert.usage(nBits <= Int.MaxValue)
     if (!this.isDefinedForLength(nBits)) return false
     setBitPos0b(bitPos0b + nBits)
     true

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BlobLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/BlobLengthParsers.scala
@@ -47,6 +47,8 @@ sealed abstract class BlobLengthParser(override val context: ElementRuntimeData)
 
     val array = new Array[Byte](start.tunable.blobChunkSizeInBytes)
     val blobChunkSizeInBits = start.tunable.blobChunkSizeInBytes * 8
+    if (blobChunkSizeInBits > Int.MaxValue)
+      start.SDE("blobChunkSizeInBytes is too large. blobChunkSizeInBytes must be less than " + (Int.MaxValue / 8))
 
     while (remainingBitsToGet > 0) {
       val bitsToGet = Math.min(remainingBitsToGet, blobChunkSizeInBits).toInt

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/HexBinaryLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/HexBinaryLengthParsers.scala
@@ -33,13 +33,16 @@ sealed abstract class HexBinaryLengthParser(override val context: ElementRuntime
   override final def parse(start: PState): Unit = {
     val dis = start.dataInputStream
     val currentElement = start.simpleElement
-    val nBits = getLengthInBits(start).toInt
+    val nBits = getLengthInBits(start)
     if (nBits == 0) {
       currentElement.setDataValue(zeroLengthArray)
+    } else if (nBits > Int.MaxValue) {
+      // Integer overflow will occurr, recommend using blob instead of hexBinary
+      PE(start, "Data is too large for xs:hexBinary. Consider using blobs instead: https://s.apache.org/daffodil-blob-feature")
     } else if (!dis.isDefinedForLength(nBits)) {
       PENotEnoughBits(start, nBits, dis.remainingBits)
     } else {
-      val array =  start.dataInputStream.getByteArray(nBits, start)
+      val array =  start.dataInputStream.getByteArray(nBits.toInt, start)
       currentElement.setDataValue(array)
     }
   }


### PR DESCRIPTION
The test files provided for this bug were bumping into the limits of
integer values, which we cannot create an array that is larger than
Int.MaxValue. In cases such as this, blobs should be used instead. Given
that this error is originating from the official NITF schema, we should
update the NITF schema to take advantage of blobs for large payloads.

DAFFODIL-2401