### PR TITLE
Add expressionAllowed to a few more findPropertyOption calls

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ChoiceGroup.scala
@@ -105,7 +105,7 @@ abstract class ChoiceTermBase(
   requiredEvaluationsIfActivated(branchesAreNotIVCElements)
   requiredEvaluationsIfActivated(modelGroupRuntimeData.preSerialization)
 
-  final protected lazy val optionChoiceDispatchKeyRaw = findPropertyOption("choiceDispatchKey")
+  final protected lazy val optionChoiceDispatchKeyRaw = findPropertyOption("choiceDispatchKey", expressionAllowed  = true)
   final protected lazy val choiceDispatchKeyRaw = requireProperty(optionChoiceDispatchKeyRaw)
 
   lazy val optionChoiceDispatchKeyKindRaw = findPropertyOption("choiceDispatchKeyKind")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -91,10 +91,10 @@ trait ElementBase
 
   override def name: String
 
-  final lazy val inputValueCalcOption = findPropertyOption("inputValueCalc")
+  final lazy val inputValueCalcOption = findPropertyOption("inputValueCalc", expressionAllowed = true)
 
   final lazy val outputValueCalcOption = {
-    val optOVC = findPropertyOption("outputValueCalc")
+    val optOVC = findPropertyOption("outputValueCalc", expressionAllowed = true)
     schemaDefinitionWhen(optOVC.isDefined && isOptional, "dfdl:outputValueCalc cannot be defined on optional elements.")
     schemaDefinitionWhen(optOVC.isDefined && isArray, "dfdl:outputValueCalc cannot be defined on array elements.")
     schemaDefinitionWhen(optOVC.isDefined && isComplexType, "dfdl:outputValueCalc cannot be defined on complexType elements.")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SimpleTypes.scala
@@ -321,8 +321,8 @@ abstract class SimpleTypeDefBase(xml: Node, lexicalParent: SchemaComponent)
     }
   }
 
-  lazy val optInputTypeCalc = findPropertyOption("inputTypeCalc")
-  lazy val optOutputTypeCalc = findPropertyOption("outputTypeCalc")
+  lazy val optInputTypeCalc = findPropertyOption("inputTypeCalc", expressionAllowed = true)
+  lazy val optOutputTypeCalc = findPropertyOption("outputTypeCalc", expressionAllowed = true)
 
   lazy val optTypeCalculator: Option[TypeCalculator] = LV('optTypeCalculator) {
     optRepType.flatMap(repType => {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ByteOrderMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ByteOrderMixin.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.schema.annotation.props.Found
 trait ByteOrderAnalysisMixin extends GrammarMixin { self: Term =>
 
   final protected lazy val thereIsAByteOrderDefined: Boolean = {
-    val byteOrdLookup = this.findPropertyOption("byteOrder")
+    val byteOrdLookup = this.findPropertyOption("byteOrder", expressionAllowed = true)
     byteOrdLookup match {
       case n: NotFound => false
       case f: Found => true

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/ByHandMixins.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/schema/annotation/props/ByHandMixins.scala
@@ -392,7 +392,7 @@ object BinaryBooleanFalseRepType {
 trait TextStandardExponentCharacterMixin
 
 trait TextStandardExponentRepMixin extends PropertyMixin {
-  protected final lazy val optionTextStandardExponentRepRaw = findPropertyOption("textStandardExponentRep")
+  protected final lazy val optionTextStandardExponentRepRaw = findPropertyOption("textStandardExponentRep", expressionAllowed = true)
   protected final lazy val textStandardExponentRepRaw = requireProperty(optionTextStandardExponentRepRaw)
 
   // Deprecated textStandardExponentCharacter


### PR DESCRIPTION
findPropertyOptions properties expressionAllowed was added to:
choiceDispatchKey
inputValueCalc
outputValueCalc
inputTypeCalc
outputTypeCalc
textStandardExponentRep
byteOrder

Properties expressionAllowed deliberately not added to:
choiceDispatchKeyKind
choiceBranchKeyKind
floating
escapeSchemeRef
fillByte
choiceLength
escapeBlockStart
escapeBlockEnd
extraEscapedCharacters
binaryBooleanTrueRep
binaryBooleanFalseRep
textOutputMinLength
hiddenGroupRef
repValues
repValueRanges
repType
ignoreCase
textBidi
choiceBranchKey
choiceBranchKeyRanges
textStandardBase
textStandardExponentRep
textStandardExponentCharacter
emptyElementParsePolicy
currency


DAFFODIL-879