### PR TITLE
SAX Unparse Implementation

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
@@ -184,7 +184,7 @@ object Util {
   def newTempFile(filePrefix: String, fileSuffix: String, optFileContents: Option[String] = None): File = {
     val inputFile = File.createTempFile(filePrefix, fileSuffix)
     inputFile.deleteOnExit
-    if( optFileContents.nonEmpty) {
+    if (optFileContents.nonEmpty) {
       val contents = optFileContents.get
       val pw = new PrintWriter(inputFile)
       pw.write(contents)

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -1156,4 +1156,24 @@ class TestCLIparsing {
     }
   }
 
+  @Test def test_XXX_CLI_Parsing_SimpleParse_sax(): Unit = {
+
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
+    val (testSchemaFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile)) else (schemaFile)
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format(Util.echoN("Hello") + "| %s parse -I sax -s %s -r e1", Util.binPath, testSchemaFile)
+
+      shell.sendLine(cmd)
+      shell.expect(contains("""<tns:e1 xmlns:tns="http://example.com">Hello</tns:e1>"""))
+
+      shell.send("exit\n")
+      shell.expect(eof)
+    } finally {
+      shell.close()
+    }
+  }
+
 }

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
@@ -56,6 +56,37 @@ class TestCLIPerformance {
     }
   }
 
+  @Test def test_XXX_CLI_Performance_2_Threads_2_Times_sax(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = Util.startIncludeErrors("")
+
+    try {
+      val cmd = String.format("%s performance -I sax -N 2 -t 2 -s %s -r matrix %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("total parse time (sec):"))
+      shell.expect(contains("avg rate (files/sec):"))
+
+      val exitCodeCmd = if (Util.isWindows) "echo %errorlevel%" else "echo $?"
+      shell.sendLine(exitCodeCmd)
+
+      if (Util.isWindows) shell.expect(contains(exitCodeCmd + "\n"))
+      else shell.expect(contains("\n"))
+
+      val sExitCode = shell.expect(contains("\n")).getBefore()
+      val exitCode = Integer.parseInt(sExitCode.trim())
+      if (exitCode != 0)
+        fail("Tests failed. Exit code: " + exitCode)
+
+      shell.sendLine("exit")
+      shell.expect(eof())
+    } finally {
+      shell.close()
+    }
+  }
+
   @Test def test_3394_CLI_Performance_3_Threads_20_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
@@ -160,6 +191,37 @@ class TestCLIPerformance {
 
     try {
       val cmd = String.format("%s performance --unparse -N 2 -t 2 -s %s -r e3 %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("total unparse time (sec):"))
+      shell.expect(contains("avg rate (files/sec):"))
+
+      val exitCodeCmd = if (Util.isWindows) "echo %errorlevel%" else "echo $?"
+      shell.sendLine(exitCodeCmd)
+
+      if (Util.isWindows) shell.expect(contains(exitCodeCmd + "\n"))
+      else shell.expect(contains("\n"))
+
+      val sExitCode = shell.expect(contains("\n")).getBefore()
+      val exitCode = Integer.parseInt(sExitCode.trim())
+      if (exitCode != 0)
+        fail("Tests failed. Exit code: " + exitCode)
+
+      shell.sendLine("exit")
+      shell.expect(eof())
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_sax(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = Util.startIncludeErrors("")
+
+    try {
+      val cmd = String.format("%s performance --unparse -I sax -N 2 -t 2 -s %s -r e3 %s", Util.binPath, testSchemaFile, testInputFile)
       shell.sendLine(cmd)
       shell.expect(contains("total unparse time (sec):"))
       shell.expect(contains("avg rate (files/sec):"))

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
@@ -557,6 +557,27 @@ class TestCLIunparsing {
     }
   }
 
+  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_sax(): Unit = {
+
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input18.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format("%s unparse -I sax -s %s --root e1 %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("Hello"))
+
+      shell.send("exit\n")
+      shell.expect(eof)
+      shell.close()
+    } finally {
+      shell.close()
+    }
+  }
+
   @Test def test_XXX_CLI_Unparsing_Stream_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input19.txt")
@@ -573,5 +594,6 @@ class TestCLIunparsing {
       shell.close()
     }
   }
+
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseAPI.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processor
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+
+import scala.xml.SAXParseException
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.infoset.DaffodilParseOutputStreamContentHandler
+import org.apache.daffodil.processors.ParseResult
+import org.apache.daffodil.xml.XMLUtils
+import org.jdom2.input.sax.BuilderErrorHandler
+import org.jdom2.input.sax.SAXHandler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.xml.sax.InputSource
+import org.xml.sax.SAXNotRecognizedException
+import org.xml.sax.SAXNotSupportedException
+
+class TestSAXParseAPI {
+  import TestSAXParseUnparseAPI._
+
+  @Test def testDaffodilParseXMLReader_setFeatureUnsupported(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val snr = intercept[SAXNotRecognizedException] {
+      xmlReader.setFeature("http://xml.org/sax/features/validation", true)
+    }
+    assertTrue(snr.getMessage.contains("Feature unsupported"))
+    assertTrue(snr.getMessage.contains("Supported features are:"))
+  }
+
+  @Test def testDaffodilParseXMLReader_get_setFeature(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val feature = "http://xml.org/sax/features/namespace-prefixes"
+    val origValue = xmlReader.getFeature(feature)
+    assertFalse(origValue)
+    xmlReader.setFeature(feature, true)
+    val newValue = xmlReader.getFeature(feature)
+    assertTrue(newValue)
+  }
+
+  @Test def testDaffodilParseXMLReader_setProperty_unsupported(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val property: AnyRef = "Hello"
+    val snr = intercept[SAXNotRecognizedException] {
+      xmlReader.setProperty("http://xml.org/sax/properties/xml-string", property)
+    }
+    assertTrue(snr.getMessage.contains("Property unsupported"))
+  }
+
+  @Test def testDaffodilParseXMLReader_setProperty_badValue(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val property: String = XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY
+    val propertyVal: AnyRef = "/tmp/i/am/a/directory"
+    val sns = intercept[SAXNotSupportedException](
+      xmlReader.setProperty(property, propertyVal)
+    )
+    assertTrue(sns.getMessage.contains("Unsupported value for property"))
+  }
+
+  @Test def testDaffodilParseXMLReader_get_setProperty(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val property: String = XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX
+    val propertyVal: AnyRef ="testing-blobs"
+    val origValue = xmlReader.getProperty(property)
+    assertNotEquals(propertyVal, origValue)
+    xmlReader.setProperty(property, propertyVal)
+    val newValue = xmlReader.getProperty(property)
+    assertEquals(propertyVal, newValue.asInstanceOf[String])
+  }
+
+  @Test def testDaffodilParseXMLReader_get_setContentHandler(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val parseContentHandler = new SAXHandler()
+    val origValue = xmlReader.getContentHandler
+    assertNull(origValue)
+    xmlReader.setContentHandler(parseContentHandler)
+    val newValue = xmlReader.getContentHandler
+    assertTrue(newValue.isInstanceOf[SAXHandler])
+  }
+
+  @Test def testDaffodilParseXMLReader_get_setErrorHandler(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val eh = new BuilderErrorHandler()
+    val origValue = xmlReader.getErrorHandler
+    assertNull(origValue)
+    xmlReader.setErrorHandler(eh)
+    val newValue = xmlReader.getErrorHandler
+    assertTrue(newValue.isInstanceOf[BuilderErrorHandler])
+  }
+
+  @Test def testDaffodilParseXMLReader_parse_inputSource_no_backing_stream(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val input = new InputSource()
+    val ioe = intercept[IOException](
+      xmlReader.parse(input)
+    )
+    assertTrue(ioe.getMessage.contains("InputSource must be backed by InputStream"))
+  }
+
+  @Test def testDaffodilParseXMLReader_parse_inputSource_with_backing_stream(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val baos = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baos)
+    xmlReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = testData.getBytes()
+    val bais = new ByteArrayInputStream(inArray)
+    val input = new InputSource(bais)
+    xmlReader.parse(input)
+    val pr = xmlReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baos.toString))
+  }
+
+  @Test def testDaffodilParseXMLReader_parse_inputStream(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val baos = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baos)
+    xmlReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = testData.getBytes()
+    val bais = new ByteArrayInputStream(inArray)
+    xmlReader.parse(bais)
+    val pr = xmlReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baos.toString))
+  }
+
+  @Test def testDaffodilParseXMLReader_parse_byteArray(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val baos = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baos)
+    xmlReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = testData.getBytes()
+    xmlReader.parse(inArray)
+    val pr = xmlReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baos.toString))
+  }
+
+  @Test def testDaffodilParseXMLReader_parse_errorHandler_empty_byteArray(): Unit = {
+    val xmlReader = dp.newXMLReaderInstance
+    val baos = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baos)
+    xmlReader.setContentHandler(parseOutputStreamContentHandler)
+    val eh = new BuilderErrorHandler
+    xmlReader.setErrorHandler(eh)
+    val inArray = "".getBytes()
+    val spe = intercept[SAXParseException](
+      xmlReader.parse(inArray)
+    )
+    val pr = xmlReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(pr.isError)
+    assertTrue(spe.getMessage.contains("Insufficient bits in data"))
+  }
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processor
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import scala.xml.Elem
+
+import javax.xml.parsers.SAXParserFactory
+import org.apache.daffodil.compiler.Compiler
+import org.apache.daffodil.infoset.DaffodilParseOutputStreamContentHandler
+import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
+import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
+import org.apache.daffodil.io.InputSourceDataInputStream
+import org.apache.daffodil.processors.DataProcessor
+import org.apache.daffodil.processors.ParseResult
+import org.apache.daffodil.util.SchemaUtils
+import org.apache.daffodil.xml.XMLUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.xml.sax.InputSource
+
+object TestSAXParseUnparseAPI {
+  val testSchema: Elem = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat"/>,
+      <xs:element name="list" type="tns:example1"/>
+      <xs:complexType name="example1">
+        <xs:sequence>
+          <xs:element name="w" type="xs:int" dfdl:length="1" dfdl:lengthKind="explicit" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:complexType>
+  )
+  val testInfoset: Elem = <list xmlns="http://example.com"><w>9</w><w>1</w><w>0</w></list>
+  val testInfosetString: String = testInfoset.toString()
+  val testData = "910"
+
+  lazy val dp: DataProcessor = testDataprocessor(testSchema)
+
+  def testDataprocessor(testSchema: scala.xml.Elem): DataProcessor = {
+    val schemaCompiler = Compiler()
+    val pf = schemaCompiler.compileNode(testSchema)
+    if (pf.isError) {
+      val msgs = pf.getDiagnostics.map { _.getMessage() }.mkString("\n")
+      fail("pf compile errors: " + msgs)
+    }
+    pf.sset.root.erd.preSerialization // force evaluation of all compile-time constructs
+    val dp = pf.onPath("/").asInstanceOf[DataProcessor]
+    if (dp.isError) {
+      val msgs = dp.getDiagnostics.map { _.getMessage() }.mkString("\n")
+      fail("dp compile errors: " + msgs)
+    }
+    dp
+  }
+}
+
+class TestSAXParseUnparseAPI {
+  import TestSAXParseUnparseAPI._
+
+  @Test def test_DaffodilParseXMLReader_parse_DaffodilUnparseContentHandler_unparse(): Unit = {
+    val parseXMLReader = dp.newXMLReaderInstance
+    val baosParse = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baosParse)
+    parseXMLReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = testData.getBytes()
+    val baisParse = new ByteArrayInputStream(inArray)
+    val inputSourceParse = new InputSource(baisParse)
+    parseXMLReader.parse(inputSourceParse)
+    val pr = parseXMLReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baosParse.toString))
+
+    val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
+    unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
+    unparseXMLReader.setContentHandler(unparseContentHandler)
+    val baisUnparse = new ByteArrayInputStream(baosParse.toByteArray)
+    val inputSourceUnparse = new InputSource(baisUnparse)
+    unparseXMLReader.parse(inputSourceUnparse)
+    val ur = unparseContentHandler.getUnparseResult
+    val unparsedData = baosUnparse.toString
+    assertTrue(!ur.isError)
+    assertEquals(testData, unparsedData)
+  }
+
+  @Test def test_DataProcessor_parse_DaffodilUnparseContentHandler_unparse(): Unit = {
+    val inArray = testData.getBytes()
+    val isdis = InputSourceDataInputStream(inArray)
+    val sioo = new ScalaXMLInfosetOutputter()
+    val pr = dp.parse(isdis, sioo)
+    val parsedData = sioo.getResult()
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, parsedData)
+
+    val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
+    unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
+    unparseXMLReader.setContentHandler(unparseContentHandler)
+    val baisUnparse = new ByteArrayInputStream(parsedData.toString.getBytes)
+    val inputSourceUnparse = new InputSource(baisUnparse)
+    unparseXMLReader.parse(inputSourceUnparse)
+    val ur = unparseContentHandler.getUnparseResult
+    val unparsedData = baosUnparse.toString
+    assertTrue(!ur.isError)
+    assertEquals(testData, unparsedData)
+  }
+
+  @Test def test_DaffodilUnparseContentHandler_unparse_DaffodilParseXMLReader_parse(): Unit = {
+    val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
+    unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
+    unparseXMLReader.setContentHandler(unparseContentHandler)
+    val baisUnparse = new ByteArrayInputStream(testInfosetString.getBytes)
+    val inputSourceUnparse = new InputSource(baisUnparse)
+    unparseXMLReader.parse(inputSourceUnparse)
+    val ur = unparseContentHandler.getUnparseResult
+    val unparsedData = baosUnparse.toString
+    assertTrue(!ur.isError)
+    assertEquals(testData, unparsedData)
+
+    val parseXMLReader = dp.newXMLReaderInstance
+    val baosParse = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baosParse)
+    parseXMLReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = baosUnparse.toByteArray
+    val baisParse = new ByteArrayInputStream(inArray)
+    val inputSourceParse = new InputSource(baisParse)
+    parseXMLReader.parse(inputSourceParse)
+    val pr = parseXMLReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baosParse.toString))
+  }
+
+  @Test def test_DaffodilUnparseContentHandler_unparse_DataProcessor_parse(): Unit = {
+    val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
+    unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
+    unparseXMLReader.setContentHandler(unparseContentHandler)
+    val baisUnparse = new ByteArrayInputStream(testInfosetString.getBytes)
+    val inputSourceUnparse = new InputSource(baisUnparse)
+    unparseXMLReader.parse(inputSourceUnparse)
+    val ur = unparseContentHandler.getUnparseResult
+    val unparsedData = baosUnparse.toString
+    assertTrue(!ur.isError)
+    assertEquals(testData, unparsedData)
+
+    val inArray = unparsedData.getBytes()
+    val isdis = InputSourceDataInputStream(inArray)
+    val sioo = new ScalaXMLInfosetOutputter()
+    val pr = dp.parse(isdis, sioo)
+    val parsedData = sioo.getResult()
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, parsedData)
+  }
+
+  @Test def test_DaffodilParseXMLReader_parse_DataProcessor_unparse(): Unit = {
+    val parseXMLReader = dp.newXMLReaderInstance
+    val baosParse = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baosParse)
+    parseXMLReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = testData.getBytes()
+    val baisParse = new ByteArrayInputStream(inArray)
+    val inputSourceParse = new InputSource(baisParse)
+    parseXMLReader.parse(inputSourceParse)
+    val parsedNode = scala.xml.XML.loadString(baosParse.toString)
+    val pr = parseXMLReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, parsedNode)
+
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val sii = new ScalaXMLInfosetInputter(parsedNode)
+    val ur = dp.unparse(sii, wbcUnparse)
+    val unparsedData = baosUnparse.toString
+    assertTrue(!ur.isError)
+    assertEquals(testData, unparsedData)
+  }
+
+  @Test def test_DataProcessor_unparse_DaffodilParseXMLReader_parse(): Unit = {
+    val baosUnparse = new ByteArrayOutputStream()
+    val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
+    val sii = new ScalaXMLInfosetInputter(testInfoset)
+    val ur = dp.unparse(sii, wbcUnparse)
+    assertTrue(!ur.isError)
+    assertEquals(testData, baosUnparse.toString)
+
+    val parseXMLReader = dp.newXMLReaderInstance
+    val baosParse = new ByteArrayOutputStream()
+    val parseOutputStreamContentHandler = new DaffodilParseOutputStreamContentHandler(baosParse)
+    parseXMLReader.setContentHandler(parseOutputStreamContentHandler)
+    val inArray = baosUnparse.toByteArray
+    val baisParse = new ByteArrayInputStream(inArray)
+    val inputSourceParse = new InputSource(baisParse)
+    parseXMLReader.parse(inputSourceParse)
+    val pr = parseXMLReader.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT).asInstanceOf[ParseResult]
+    assertTrue(!pr.isError)
+    assertEquals(testInfoset, scala.xml.XML.loadString(baosParse.toString))
+  }
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXUnparseAPI.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processor
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import javax.xml.parsers.SAXParserFactory
+import org.apache.daffodil.xml.XMLUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.xml.sax.InputSource
+import org.xml.sax.XMLReader
+
+class TestSAXUnparseAPI {
+  import TestSAXParseUnparseAPI._
+
+  @Test def testUnparseContentHandler_unparse(): Unit = {
+    val xmlReader: XMLReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    val bao = new ByteArrayOutputStream()
+    val wbc = java.nio.channels.Channels.newChannel(bao)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbc)
+    xmlReader.setContentHandler(unparseContentHandler)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, true)
+    val bai = new ByteArrayInputStream(testInfosetString.getBytes)
+    xmlReader.parse(new InputSource(bai))
+    val ur = unparseContentHandler.getUnparseResult
+    assertTrue(!ur.isError)
+    assertEquals(testData, bao.toString)
+  }
+
+  @Test def testUnparseContentHandler_unparse_namespace_feature(): Unit = {
+    val xmlReader: XMLReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    val bao = new ByteArrayOutputStream()
+    val wbc = java.nio.channels.Channels.newChannel(bao)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbc)
+    xmlReader.setContentHandler(unparseContentHandler)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, false)
+    val bai = new ByteArrayInputStream(testInfosetString.getBytes)
+    xmlReader.parse(new InputSource(bai))
+    val ur = unparseContentHandler.getUnparseResult
+    assertTrue(!ur.isError)
+    assertEquals(testData, bao.toString)
+  }
+
+  @Test def testUnparseContentHandler_unparse_namespace_prefix_feature(): Unit = {
+    val xmlReader: XMLReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    val bao = new ByteArrayOutputStream()
+    val wbc = java.nio.channels.Channels.newChannel(bao)
+    val unparseContentHandler = dp.newContentHandlerInstance(wbc)
+    xmlReader.setContentHandler(unparseContentHandler)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, false)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, true)
+    val bai = new ByteArrayInputStream(testInfosetString.getBytes)
+    xmlReader.parse(new InputSource(bai))
+    val ur = unparseContentHandler.getUnparseResult
+    assertTrue(!ur.isError)
+    assertEquals(testData, bao.toString)
+  }
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
@@ -351,7 +351,8 @@ class Fakes private () {
     override def withTunables(tunables: Map[String,String]): DFDL.DataProcessor = this
     override def withValidationMode(mode: ValidationMode.Type): DFDL.DataProcessor = this
 
-    override def newXMLReaderInstance: DFDL.DaffodilXMLReader = null
+    override def newXMLReaderInstance: DFDL.DaffodilParseXMLReader = null
+    override def newContentHandlerInstance(output: DFDL.Output): DFDL.DaffodilUnparseContentHandler = null
   }
   lazy val fakeDP = new FakeDataProcessor
 

--- a/daffodil-japi/src/main/java/org/apache/daffodil/japi/package-info.java
+++ b/daffodil-japi/src/main/java/org/apache/daffodil/japi/package-info.java
@@ -22,9 +22,10 @@
  *
  * <h3>Overview</h3>
  *
- * The {@link org.apache.daffodil.japi.Daffodil} object is a factory object to create a {@link org.apache.daffodil.japi.Compiler}. The
- * {@link org.apache.daffodil.japi.Compiler} provides a method to compile a provided DFDL schema into a
- * {@link org.apache.daffodil.japi.ProcessorFactory}, which creates a {@link org.apache.daffodil.japi.DataProcessor}:
+ * The {@link org.apache.daffodil.japi.Daffodil} object is a factory object to create a
+ * {@link org.apache.daffodil.japi.Compiler}. The {@link org.apache.daffodil.japi.Compiler} provides
+ * a method to compile a provided DFDL schema into a {@link org.apache.daffodil.japi.ProcessorFactory},
+ * which creates a {@link org.apache.daffodil.japi.DataProcessor}:
  *
  * <pre>
  * {@code
@@ -33,49 +34,55 @@
  * DataProcessor dp = pf.onPath("/");
  * }</pre>
  *
- * The {@link org.apache.daffodil.japi.DataProcessor} provides the necessary functions to parse and unparse
- * data, returning a {@link org.apache.daffodil.japi.ParseResult} or {@link org.apache.daffodil.japi.UnparseResult}, respectively. These
- * contain information about the parse/unparse, such as whether or not the
- * processing succeeded with any diagnostic information.
+ * The {@link org.apache.daffodil.japi.DataProcessor} provides the necessary functions to parse and
+ * unparse data, returning a {@link org.apache.daffodil.japi.ParseResult} or
+ * {@link org.apache.daffodil.japi.UnparseResult}, respectively. These contain information about the
+ * parse/unparse, such as whether or not the processing succeeded with any diagnostic information.
  *
- * The {@link org.apache.daffodil.japi.DataProcessor} also provides a function to create a
- * {@link org.apache.daffodil.japi.DaffodilXMLReader} that can be used to perform parsing via the
- * SAX API.
+ * The {@link org.apache.daffodil.japi.DataProcessor} also provides two functions that can be used to
+ * perform parsing/unparsing via the SAX API. The first creates a
+ * {@link org.apache.daffodil.japi.DaffodilParseXMLReader} which is used for parsing, and the
+ * second creates a {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler} which is used for
+ * unparsing.
  *
  * <pre>
  * {@code
- * DaffodilXMLReader xmlRdr = dp.newXMLReaderInstance();
+ * DaffodilParseXMLReader xmlReader = dp.newXMLReaderInstance();
+ * DaffodilUnparseContentHandler unparseContentHandler = dp.newContentHandlerInstance(output);
  * }</pre>
  *
- * The {@link org.apache.daffodil.japi.DaffodilXMLReader} has several methods that allow one to
+ * The {@link org.apache.daffodil.japi.DaffodilParseXMLReader} has several methods that allow one to
  * set properties and handlers (such as ContentHandlers or ErrorHandlers) for the reader. One can
  * use any contentHandler/errorHandler as long as they extend the
  * {@link org.xml.sax.ContentHandler} and {@link org.xml.sax.ErrorHandler} interfaces
- * respectively. One can also set properties for the {@link org.apache.daffodil.japi.DaffodilXMLReader}
- * using {@link org.apache.daffodil.japi.DaffodilXMLReader#setProperty(java.lang.String, java.lang.Object)}.
+ * respectively. One can also set properties for the {@link org.apache.daffodil.japi.DaffodilParseXMLReader}
+ * using {@link org.apache.daffodil.japi.DaffodilParseXMLReader#setProperty(java.lang.String,
+ * java.lang.Object)}.
  *
  * The following properties can be set as follows:
+ *
+ * <p><i>The constants below have literal values starting with
+ * "urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:sax:" and ending with "BlobDirectory",
+ * "BlobPrefix" and "BlobSuffix" respectively.</i></p>
+ *
  * <pre>
  * {@code
- * xmlRdr.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY(), "/tmp/");
- * xmlRdr.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX(), "daffodil-sax-");
- * xmlRdr.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBSUFFIX(), ".bin");
+ * xmlReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBDIRECTORY(),
+ *  Paths.get(System.getProperty("java.io.tmpdir"))); // value type: java.nio.file.Paths
+ * xmlReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBPREFIX(), "daffodil-sax-"); // value type String
+ * xmlReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBSUFFIX(), ".bin"); // value type String
  * }
  * </pre>
  *
- * The variables above start with "urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:sax:" and end
- * with BlobDirectory, BlobPrefix and BlobSuffix respectively.
- *
- * The properites can be retrieved using the same variables with
- * {@link org.apache.daffodil.japi.DaffodilXMLReader#getProperty(java.lang.String)}
+ * The properties can be retrieved using the same variables with
+ * {@link org.apache.daffodil.japi.DaffodilParseXMLReader#getProperty(java.lang.String)} and casting
+ * to the appropriate type as listed above.
  *
  * The following handlers can be set as follows:
  * <pre>
  * {@code
- * xmlRdr.setContentHandler(contentHandler);
- * xmlRdr.setErrorHandler(errorHandler);
- * xmlRdr.setDTDHandler(dtdHandler);
- * xmlRdr.setEntityResolver(entityResolver);
+ * xmlReader.setContentHandler(contentHandler);
+ * xmlReader.setErrorHandler(errorHandler);
  * }
  * </pre>
  *
@@ -84,25 +91,30 @@
  * {@code
  * org.xml.sax.ContentHandler
  * org.xml.sax.ErrorHandler
- * org.xml.sax.DTDHandler
- * org.xml.sax.EntityResolver
  * }
  * </pre>
  *
  * The {@link org.apache.daffodil.japi.ParseResult} can be found as a property within the
- * {@link org.apache.daffodil.japi.DaffodilXMLReader} using
- * {@link org.apache.daffodil.japi.DaffodilXMLReader#getProperty(java.lang.String)} together
- * with the following uri: "urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:sax:ParseResult" or
- * XMLUtils.DAFFODIL_SAX_URN_PARSERESULT().
+ * {@link org.apache.daffodil.japi.DaffodilParseXMLReader} using this uri:
+ * "urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:sax:ParseResult" or
+ * {@link org.apache.daffodil.japi.DaffodilParseXMLReader#DAFFODIL_SAX_URN_PARSERESULT()}.
+ *
+ * In order for a successful unparse to happen, the SAX API requires the
+ * unparse to be kicked off by a parse call to any {@link org.xml.sax.XMLReader} implementation that
+ * has the {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler} registered as its content
+ * handler. To retrieve the {@link org.apache.daffodil.japi.UnparseResult}, one can use
+ * {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler#getUnparseResult()} once the
+ * XMLReader.parse run is complete.
  *
  * <h4>Parse</h4>
  *
  * <h5>Dataprocessor Parse</h5>
  *
- * The {@link org.apache.daffodil.japi.DataProcessor#parse(org.apache.daffodil.japi.io.InputSourceDataInputStream, org.apache.daffodil.japi.infoset.InfosetOutputter)} method accepts input data to parse in the form
- * of a {@link org.apache.daffodil.japi.io.InputSourceDataInputStream} and an {@link org.apache.daffodil.japi.infoset.InfosetOutputter}
- * to determine the output representation of the infoset (e.g. Scala XML Nodes,
- * JDOM2 Documents, etc.):
+ * The {@link org.apache.daffodil.japi.DataProcessor#parse(org.apache.daffodil.japi.io.InputSourceDataInputStream,
+ * org.apache.daffodil.japi.infoset.InfosetOutputter)} method accepts input data to parse in the form
+ * of a {@link org.apache.daffodil.japi.io.InputSourceDataInputStream} and an
+ * {@link org.apache.daffodil.japi.infoset.InfosetOutputter} to determine the output representation
+ * of the infoset (e.g. Scala XML Nodes, JDOM2 Documents, etc.):
  *
  * <pre>
  * {@code
@@ -112,11 +124,13 @@
  * Document doc = jdomOutputter.getResult();
  * }</pre>
  *
- * The {@link org.apache.daffodil.japi.DataProcessor#parse(org.apache.daffodil.japi.io.InputSourceDataInputStream, org.apache.daffodil.japi.infoset.InfosetOutputter)} method is thread-safe and may be called multiple
+ * The {@link org.apache.daffodil.japi.DataProcessor#parse(org.apache.daffodil.japi.io.InputSourceDataInputStream,
+ * org.apache.daffodil.japi.infoset.InfosetOutputter)} method is thread-safe and may be called multiple
  * times without the need to create other data processors. However,
- * {@link org.apache.daffodil.japi.infoset.InfosetOutputter}'s are not thread safe, requiring a unique instance per
- * thread. An {@link org.apache.daffodil.japi.infoset.InfosetOutputter} should call {@link org.apache.daffodil.japi.infoset.InfosetOutputter#reset()} before
- * reuse (or a new one should be allocated). For example:
+ * {@link org.apache.daffodil.japi.infoset.InfosetOutputter}'s are not thread safe, requiring a
+ * unique instance per thread. An {@link org.apache.daffodil.japi.infoset.InfosetOutputter} should
+ * call {@link org.apache.daffodil.japi.infoset.InfosetOutputter#reset()} before reuse (or a new one
+ * should be allocated). For example:
  *
  * <pre>
  * {@code
@@ -129,7 +143,8 @@
  * }
  * }</pre>
  *
- * One can repeat calls to parse() using the same InputSourceDataInputStream to continue parsing where the previous parse ended. For example:
+ * One can repeat calls to parse() using the same InputSourceDataInputStream to continue parsing
+ * where the previous parse ended. For example:
  *
  * <pre>
  * {@code
@@ -145,41 +160,41 @@
  * }</pre>
  *
  * <h5>SAX Parse</h5>
- * The {@link org.apache.daffodil.japi.DaffodilXMLReader#parse(
+ * The {@link org.apache.daffodil.japi.DaffodilParseXMLReader#parse(
  * org.apache.daffodil.japi.io.InputSourceDataInputStream)} method accepts input data to parse in
  * the form of a {@link org.apache.daffodil.japi.io.InputSourceDataInputStream}. The output
  * representation of the infoset, as well as how parse errors are handled, are dependent on the
- * content handler and the error handler provided to the {@link org.apache.daffodil.japi.DaffodilXMLReader}. For example the
- * {@link org.jdom2.input.sax.SAXHandler} provides a JDOM representation, whereas other Content
- * Handlers may output directly to an {@link java.io.OutputStream} or {@link java.io.Writer}.
+ * content handler and the error handler provided to the {@link org.apache.daffodil.japi.DaffodilParseXMLReader}.
+ * For example the {@link org.jdom2.input.sax.SAXHandler} provides a JDOM representation, whereas
+ * other ContentHandlers may output directly to a {@link java.io.OutputStream} or {@link java.io.Writer}.
  *
  * <pre>
  * {@code
  * SAXHandler contentHandler = new SAXHandler();
- * xmlRdr.setContentHandler(contentHandler);
+ * xmlReader.setContentHandler(contentHandler);
  * InputSourceDataInputStream is = new InputSourceDataInputStream(data);
  * xmlReader.parse(is);
- * ParseResult pr = (ParseResult) xmlRdr.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT());
+ * ParseResult pr = (ParseResult) xmlReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT());
  * Document doc = saxHandler.getDocument();
  * }</pre>
  *
- * The The {@link org.apache.daffodil.japi.DaffodilXMLReader#parse(
+ * The The {@link org.apache.daffodil.japi.DaffodilParseXMLReader#parse(
  * org.apache.daffodil.japi.io.InputSourceDataInputStream)} method is not thread-safe and may
  * only be called again/reused once a parse operation is completed. This can be done multiple
- * times without the need to create new DaffodilXMLReaders, ContentHandlers or ErrorHandlers. It
- * might be necessary to reset whatever ContentHandler is used (or allocate a new one). A
- * thread-safe implementation would require unique instances of the DaffodilXMLReader and its
+ * times without the need to create new DaffodilParseXMLReaders, ContentHandlers or ErrorHandlers.
+ * It might be necessary to reset whatever ContentHandler is used (or allocate a new one). A
+ * thread-safe implementation would require unique instances of the DaffodilParseXMLReader and its
  * components. For example:
  *
  * <pre>
  * {@code
  * SAXHandler contentHandler = new SAXHandler();
- * xmlRdr.setContentHandler(contentHandler);
+ * xmlReader.setContentHandler(contentHandler);
  * for (File f : inputFiles) {
  *   contentHandler.reset();
  *   InputSourceDataInputStream is = new InputSourceDataInputStream(new FileInputStream(f));
  *   xmlReader.parse(is);
- *   ParseResult pr = (ParseResult) xmlRdr.getProperty("urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:sax:ParseResult");
+ *   ParseResult pr = (ParseResult) xmlReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT());
  *   Document doc = saxHandler.getDocument();
  * }
  * }
@@ -192,12 +207,12 @@
  * {@code
  * InputSourceDataInputStream is = new InputSourceDataInputStream(dataStream);
  * SAXHandler contentHandler = new SAXHandler();
- * xmlRdr.setContentHandler(contentHandler);
+ * xmlReader.setContentHandler(contentHandler);
  * Boolean keepParsing = true;
  * while (keepParsing) {
  *   contentHandler.reset();
- *   xmlRdr.parse(is);
- *   val pr = xmlRdr.getProperty(XMLUtils.DAFFODIL_SAX_URN_PARSERESULT());
+ *   xmlReader.parse(is);
+ *   val pr = xmlReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT());
  *   ...
  *   keepParsing = !pr.location().isAtEnd() && !pr.isError();
  * }
@@ -206,8 +221,11 @@
  *
  * <h4>Unparse</h4>
  *
- * The same {@link org.apache.daffodil.japi.DataProcessor} used for parse can be used to unparse an infoset
- * via the {@link org.apache.daffodil.japi.DataProcessor#unparse(org.apache.daffodil.japi.infoset.InfosetInputter, java.nio.channels.WritableByteChannel)} method. An {@link org.apache.daffodil.japi.infoset.InfosetInputter}
+ * <h5>Dataprocessor Unparse</h5>
+ *
+ * The same {@link org.apache.daffodil.japi.DataProcessor} used for parse can be used to unparse an
+ * infoset via the {@link org.apache.daffodil.japi.DataProcessor#unparse(org.apache.daffodil.japi.infoset.InfosetInputter,
+ * java.nio.channels.WritableByteChannel)} method. An {@link org.apache.daffodil.japi.infoset.InfosetInputter}
  * provides the infoset to unparse, with the unparsed data written to the
  * provided {@link java.nio.channels.WritableByteChannel}. For example:
  *
@@ -217,15 +235,67 @@
  * UnparseResult ur = dp.unparse(jdomInputter, wbc)
  * }</pre>
  *
+ * <h5>SAX Unparse</h5>
+ *
+ * In order to kick off an unparse via the SAX API, one must register the
+ * {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler} as the contentHandler for an
+ * XMLReader implementation. The call to the
+ * {@link org.apache.daffodil.japi.DataProcessor#newContentHandlerInstance(java.nio.channels.WritableByteChannel)}
+ * method must be provided with the {@link java.nio.channels.WritableByteChannel}, where the unparsed
+ * data ought to be written to. Any XMLReader implementation is permissible, as long as they have
+ * XML Namespace support.
+ *
+ * <pre>
+ * {@code
+ *  ByteArrayInputStream is = new ByteArrayInputStream(data);
+ *  ByteArrayOutputStream os = new ByteArrayOutputStream();
+ *  WritableByteChannel wbc = java.nio.channels.Channels.newChannel(os);
+ *  DaffodilUnparseContentHandler unparseContentHandler = dp.newContentHandlerInstance(wbc);
+ *  try {
+ *   XMLReader xmlReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
+ *   xmlReader.setContentHandler(unparseContentHandler)
+ *   xmlReader.parse(is)
+ *  } catch (ParserConfigurationException | SAXException e) {
+ *   ...
+ * `} catch catch (DaffodilUnparseErrorSAXException | DaffodilUnhandledSAXException e) {
+ *   ...
+ *  }
+ * }
+ * </pre>
+ *
+ * The call to the XMLReader.parse method must be wrapped in a try/catch, as
+ * {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler} relies on throwing an exception to
+ * end processing in the case of any errors/failures.
+ * There are two kinds of errors to expect
+ * {@link org.apache.daffodil.japi.DaffodilUnparseErrorSAXException}, for the case when the
+ * {@link org.apache.daffodil.japi.UnparseResult#isError()}, and
+ * {@link org.apache.daffodil.japi.DaffodilUnparseErrorSAXException}, for any other errors.
+ *
+ * In the case of an {@link org.apache.daffodil.japi.DaffodilUnhandledSAXException},
+ * {@link org.apache.daffodil.japi.DaffodilUnparseContentHandler#getUnparseResult()} will return null.
+ *
+ * <pre>
+ * {@code
+ *  try {
+ *    xmlReader.parse(new InputSource(is));
+ *  } catch (DaffodilUnparseErrorSAXException | DaffodilUnhandledSAXException e) {
+ *    ...
+ *  }
+ *  UnparseResult ur = unparseContentHandler.getUnparseResult();
+ * }
+ * </pre>
+ *
+ *
  * <h3>Failures and Diagnostics</h3>
  *
  * It is possible that failures could occur during the creation of the
- * {@link org.apache.daffodil.japi.ProcessorFactory}, {@link org.apache.daffodil.japi.DataProcessor}, or {@link org.apache.daffodil.japi.ParseResult}. However, rather than
- * throwing an exception on error (e.g. invalid DFDL schema, parse
- * error, etc), these classes extend {@link org.apache.daffodil.japi.WithDiagnostics}, which is used to
- * determine if an error occurred, and any diagnostic information (see
- * {@link org.apache.daffodil.japi.Diagnostic}) related to the step. Thus, before continuing, one must check
- * {@link org.apache.daffodil.japi.WithDiagnostics#isError}. For example:
+ * {@link org.apache.daffodil.japi.ProcessorFactory}, {@link org.apache.daffodil.japi.DataProcessor},
+ * or {@link org.apache.daffodil.japi.ParseResult}. However, rather than throwing an exception on
+ * error (e.g. invalid DFDL schema, parse error, etc), these classes extend
+ * {@link org.apache.daffodil.japi.WithDiagnostics}, which is used to determine if an error occurred,
+ * and any diagnostic information (see {@link org.apache.daffodil.japi.Diagnostic}) related to the step.
+ * Thus, before continuing, one must check {@link org.apache.daffodil.japi.WithDiagnostics#isError}.
+ * For example:
  *
  * <pre>
  * {@code
@@ -270,10 +340,10 @@
  *
  * <pre>
  * {@code
- * DaffodilXMLReader xmlRdr = dp.newXMLReaderInstance();
+ * DaffodilParseXMLReader xmlReader = dp.newXMLReaderInstance();
  * ... // setting appropriate handlers
  * xmlReader.parse(data);
- * ParseResult pr = xmlRdr.getProperty("...ParseResult");
+ * ParseResult pr = xmlReader.getProperty("...ParseResult");
  * }</pre>
  *
  */

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -25,7 +25,6 @@ import org.apache.daffodil.japi.infoset._
 import org.apache.daffodil.japi.io.InputSourceDataInputStream
 import org.apache.daffodil.debugger.{ InteractiveDebugger => SInteractiveDebugger }
 import org.apache.daffodil.debugger.{ TraceDebuggerRunner => STraceDebuggerRunner }
-
 import scala.collection.JavaConverters._
 import java.io.File
 import java.nio.channels.Channels
@@ -36,9 +35,12 @@ import org.apache.daffodil.api.{ DataLocation => SDataLocation }
 import org.apache.daffodil.api.{ Diagnostic => SDiagnostic }
 import org.apache.daffodil.api.{ LocationInSchemaFile => SLocationInSchemaFile }
 import org.apache.daffodil.api.{ WithDiagnostics => SWithDiagnostics }
+import org.apache.daffodil.api.DFDL.{ DaffodilUnhandledSAXException => SDaffodilUnhandledSAXException }
+import org.apache.daffodil.api.DFDL.{ DaffodilUnparseErrorSAXException => SDaffodilUnparseErrorSAXException }
 import org.apache.daffodil.compiler.{ ProcessorFactory => SProcessorFactory }
 import org.apache.daffodil.processors.{ DataProcessor => SDataProcessor }
-import org.apache.daffodil.processors.{ DaffodilXMLReader => SDaffodilXMLReader }
+import org.apache.daffodil.processors.{ DaffodilParseXMLReader => SDaffodilParseXMLReader }
+import org.apache.daffodil.processors.{ DaffodilUnparseContentHandler => SDaffodilUnparseContentHandler }
 import org.apache.daffodil.processors.{ ParseResult => SParseResult }
 import org.apache.daffodil.processors.{ UnparseResult => SUnparseResult }
 import org.apache.daffodil.util.{ ConsoleWriter => SConsoleWriter }
@@ -59,6 +61,7 @@ import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Maybe._
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.xml.NS
+import org.apache.daffodil.xml.XMLUtils
 
 /**
  * API Suitable for Java programmers to use.
@@ -672,10 +675,17 @@ class DataProcessor private[japi] (private var dp: SDataProcessor)
   def save(output: WritableByteChannel): Unit = dp.save(output)
 
   /**
-   *  Obtain a new [[DaffodilXMLReader]] from the current [[DataProcessor]].
+   *  Obtain a new [[DaffodilParseXMLReader]] from the current [[DataProcessor]].
    */
-  def newXMLReaderInstance: DaffodilXMLReader =
-    new DaffodilXMLReader(xmlrdr = dp.newXMLReaderInstance.asInstanceOf[SDaffodilXMLReader])
+  def newXMLReaderInstance: DaffodilParseXMLReader =
+    new DaffodilParseXMLReader(xmlrdr = dp.newXMLReaderInstance.asInstanceOf[SDaffodilParseXMLReader])
+
+  /**
+   *  Obtain a new [[DaffodilUnparseContentHandler]] from the current [[DataProcessor]].
+   */
+  def newContentHandlerInstance(output: WritableByteChannel): DaffodilUnparseContentHandler =
+    new DaffodilUnparseContentHandler(sContentHandler =
+      dp.newContentHandlerInstance(output).asInstanceOf[SDaffodilUnparseContentHandler])
 
   /**
    * Parse input data with a specified length
@@ -850,10 +860,32 @@ class InvalidParserException private[japi] (cause: org.apache.daffodil.compiler.
 class InvalidUsageException private[japi] (cause: org.apache.daffodil.processors.InvalidUsageException) extends Exception(cause.getMessage(), cause.getCause())
 
 /**
+ * This exception will be thrown when unparseResult.isError returns true during a SAX Unparse
+ */
+class DaffodilUnparseErrorSAXException private[japi] (exception: SDaffodilUnparseErrorSAXException)
+  extends org.xml.sax.SAXException(exception.getMessage)
+
+/**
+ * This exception will be thrown when an unexpected error occurs during the SAX unparse
+ */
+class DaffodilUnhandledSAXException private[japi] (exception: SDaffodilUnhandledSAXException)
+  extends org.xml.sax.SAXException(exception.getMessage, new Exception(exception.getCause))
+
+/**
+ * The full URIs needed for setting/getting properties for the [[DaffodilParseXMLReader]]
+ */
+object DaffodilParseXMLReader {
+  val DAFFODIL_SAX_URN_PARSERESULT: String = XMLUtils.DAFFODIL_SAX_URN_PARSERESULT
+  val DAFFODIL_SAX_URN_BLOBDIRECTORY: String = XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY
+  val DAFFODIL_SAX_URN_BLOBPREFIX: String = XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX
+  val DAFFODIL_SAX_URN_BLOBSUFFIX: String = XMLUtils.DAFFODIL_SAX_URN_BLOBSUFFIX
+}
+
+/**
  * SAX method of parsing schema and getting the DFDL Infoset via some
  * org.xml.sax.ContentHandler, based on the org.xml.sax.XMLReader interface
  */
-class DaffodilXMLReader private[japi] (xmlrdr: SDaffodilXMLReader) extends org.xml.sax.XMLReader {
+class DaffodilParseXMLReader private[japi] (xmlrdr: SDaffodilParseXMLReader) extends org.xml.sax.XMLReader {
   /**
    * Get the value of the feature flag
    * @param name feature flag whose value is to be retrieved
@@ -873,7 +905,15 @@ class DaffodilXMLReader private[japi] (xmlrdr: SDaffodilXMLReader) extends org.x
    * @param name property whose value is to be retrieved
    * @return value of the property
    */
-  override def getProperty(name: String): AnyRef = xmlrdr.getProperty(name)
+  override def getProperty(name: String): AnyRef = {
+    val res = xmlrdr.getProperty(name)
+    if (name == DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT) {
+      val pr = new ParseResult(res.asInstanceOf[SParseResult], Nope)
+      pr
+    } else {
+      res
+    }
+  }
 
   /**
    * Set the value of the property
@@ -966,4 +1006,72 @@ class DaffodilXMLReader private[japi] (xmlrdr: SDaffodilXMLReader) extends org.x
    * @param arr data to be parsed
    */
   def parse(arr: Array[Byte]): Unit = xmlrdr.parse(arr)
+}
+
+/**
+ * Accepts SAX callback events from any SAX XMLReader for unparsing
+ */
+class DaffodilUnparseContentHandler private[japi] (sContentHandler: SDaffodilUnparseContentHandler)
+  extends org.xml.sax.ContentHandler {
+
+  private val contentHandler: org.xml.sax.ContentHandler = sContentHandler
+
+  /**
+   * Returns the result of the SAX unparse containing diagnostic information. In the case of an
+   * DaffodilUnhandledSAXException, this will return null.
+   */
+  def getUnparseResult: UnparseResult = {
+    val ur = sContentHandler.getUnparseResult.asInstanceOf[SUnparseResult]
+    if (ur == null) null
+    else new UnparseResult(ur)
+  }
+
+  override def setDocumentLocator(locator: org.xml.sax.Locator): Unit =
+    contentHandler.setDocumentLocator(locator)
+
+  override def startDocument(): Unit =
+    try {
+      contentHandler.startDocument()
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def endDocument(): Unit =
+    try {
+      contentHandler.endDocument()
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def startPrefixMapping(prefix: String, uri: String): Unit =
+    contentHandler.startPrefixMapping(prefix, uri)
+  override def endPrefixMapping(prefix: String): Unit =
+    contentHandler.endPrefixMapping(prefix)
+
+  override def startElement(uri: String, localName: String, qName: String, atts: org.xml.sax.Attributes): Unit =
+    try {
+      contentHandler.startElement(uri, localName, qName, atts)
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def endElement(uri: String, localName: String, qName: String): Unit =
+    try {
+      contentHandler.endElement(uri, localName, qName)
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def characters(ch: Array[Char], start: Int, length: Int): Unit =
+    contentHandler.characters(ch, start, length)
+  override def ignorableWhitespace(ch: Array[Char], start: Int, length: Int): Unit =
+    contentHandler.ignorableWhitespace(ch, start, length)
+  override def processingInstruction(target: String, data: String): Unit =
+    contentHandler.processingInstruction(target, data)
+  override def skippedEntity(name: String): Unit =
+    contentHandler.skippedEntity(name)
 }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -33,10 +33,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.daffodil.infoset.DaffodilOutputContentHandler;
 import org.apache.daffodil.japi.*;
 import org.apache.daffodil.japi.infoset.XMLTextInfosetOutputter;
-import org.apache.daffodil.xml.XMLUtils;
 import org.jdom2.output.Format;
 import org.junit.Test;
 
@@ -47,6 +45,9 @@ import org.apache.daffodil.japi.logger.LogLevel;
 import org.apache.daffodil.japi.io.InputSourceDataInputStream;
 
 public class TestJavaAPI {
+
+    String SAX_NAMESPACES_FEATURE = "http://xml.org/sax/features/namespaces";
+    String SAX_NAMESPACE_PREFIXES_FEATURE = "http://xml.org/sax/features/namespace-prefixes";
 
     private java.io.File getResource(String resPath) {
         try {
@@ -959,13 +960,13 @@ public class TestJavaAPI {
 
     @Test
     public void testJavaAPI20() throws IOException, ClassNotFoundException {
-        // Test SAX parsing
+        // Test SAX parsing/unparsing
         org.apache.daffodil.japi.Compiler c = Daffodil.compiler();
         java.io.File schemaFile = getResource("/test/japi/mySchema1.dfdl.xsd");
         ProcessorFactory pf = c.compileFile(schemaFile);
         DataProcessor dp = pf.onPath("/");
         dp = reserializeDataProcessor(dp);
-        DaffodilXMLReader xri = dp.newXMLReaderInstance();
+        DaffodilParseXMLReader parseXMLReader = dp.newXMLReaderInstance();
 
         java.io.File file = getResource("/test/japi/myData.dat");
         java.io.FileInputStream fisDP = new java.io.FileInputStream(file);
@@ -977,29 +978,55 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(disDP, outputter);
         String infosetDPString = xmlBos.toString();
 
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        DaffodilOutputContentHandler contentHandler = new DaffodilOutputContentHandler(bos, true);
+        org.jdom2.input.sax.SAXHandler contentHandler = new org.jdom2.input.sax.SAXHandler();
         SAXErrorHandlerForJAPITest errorHandler = new SAXErrorHandlerForJAPITest();
-        xri.setContentHandler(contentHandler);
-        xri.setErrorHandler(errorHandler);
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY(),
+        parseXMLReader.setContentHandler(contentHandler);
+        parseXMLReader.setErrorHandler(errorHandler);
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBDIRECTORY(),
                 Paths.get(System.getProperty("java.io.tmpdir")));
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX(),
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBPREFIX(),
                 "daffodil-sapi-");
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBSUFFIX(),
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBSUFFIX(),
                 ".sax.blob");
-        xri.parse(disSAX);
-        org.apache.daffodil.processors.ParseResult resSAX =
-                (org.apache.daffodil.processors.ParseResult) xri.getProperty(
-                        XMLUtils.DAFFODIL_SAX_URN_PARSERESULT());
+        parseXMLReader.parse(disSAX);
+        ParseResult resSAX = (ParseResult) parseXMLReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT());
         boolean err = errorHandler.isError();
         ArrayList<Diagnostic> diags = errorHandler.getDiagnostics();
-        String infosetSAXString = bos.toString();
+        Format pretty = Format.getPrettyFormat().setLineSeparator(System.getProperty("line.separator"));
+        String infosetSAXString = new  org.jdom2.output.XMLOutputter(pretty).outputString(contentHandler.getDocument());
 
         assertFalse(err);
-        assertTrue(resSAX.resultState().currentLocation().isAtEnd());
+        assertTrue(resSAX.location().isAtEnd());
         assertTrue(diags.isEmpty());
         assertEquals(infosetDPString, infosetSAXString);
+
+        // test unparse
+        ByteArrayOutputStream unparseBos = new java.io.ByteArrayOutputStream();
+        WritableByteChannel wbc = java.nio.channels.Channels.newChannel(unparseBos);
+
+        // prep for SAX unparse
+        DaffodilUnparseContentHandler unparseContentHandler = dp.newContentHandlerInstance(wbc);
+        try {
+            org.xml.sax.XMLReader unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance()
+                    .newSAXParser().getXMLReader();
+            unparseXMLReader.setContentHandler(unparseContentHandler);
+            unparseXMLReader.setErrorHandler(errorHandler);
+            unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true);
+            unparseXMLReader.setFeature(SAX_NAMESPACE_PREFIXES_FEATURE, true);
+            ByteArrayInputStream is = new ByteArrayInputStream(infosetSAXString.getBytes());
+            // kickstart unparse
+            unparseXMLReader.parse(new org.xml.sax.InputSource(is));
+        } catch (javax.xml.parsers.ParserConfigurationException | org.xml.sax.SAXException e) {
+            fail("Error: " + e);
+        }
+
+        UnparseResult saxUr = unparseContentHandler.getUnparseResult();
+        wbc.close();
+
+        boolean saxErr = saxUr.isError();
+        assertFalse(saxErr);
+        assertTrue(saxUr.getDiagnostics().isEmpty());
+        assertEquals("42", unparseBos.toString());
     }
 
 
@@ -1011,22 +1038,21 @@ public class TestJavaAPI {
         ProcessorFactory pf = c.compileFile(schemaFile);
         DataProcessor dp = pf.onPath("/");
         dp = reserializeDataProcessor(dp);
-        DaffodilXMLReader xri = dp.newXMLReaderInstance();
+        DaffodilParseXMLReader parseXMLReader = dp.newXMLReaderInstance();
 
         java.io.File file = getResource("/test/japi/myDataBroken.dat");
         java.io.FileInputStream fis = new java.io.FileInputStream(file);
         InputSourceDataInputStream dis = new InputSourceDataInputStream(fis);
 
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        DaffodilOutputContentHandler contentHandler = new DaffodilOutputContentHandler(bos, false);
+        org.jdom2.input.sax.SAXHandler contentHandler = new org.jdom2.input.sax.SAXHandler();
         SAXErrorHandlerForJAPITest errorHandler = new SAXErrorHandlerForJAPITest();
-        xri.setContentHandler(contentHandler);
-        xri.setErrorHandler(errorHandler);
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY(),
+        parseXMLReader.setContentHandler(contentHandler);
+        parseXMLReader.setErrorHandler(errorHandler);
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBDIRECTORY(),
                 Paths.get(System.getProperty("java.io.tmpdir")));
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX(), "daffodil-sapi-");
-        xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBSUFFIX(), ".sax.blob");
-        xri.parse(dis);
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBPREFIX(), "daffodil-sapi-");
+        parseXMLReader.setProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_BLOBSUFFIX(), ".sax.blob");
+        parseXMLReader.parse(dis);
         boolean err = errorHandler.isError();
         ArrayList<Diagnostic> diags = errorHandler.getDiagnostics();
 
@@ -1092,6 +1118,56 @@ public class TestJavaAPI {
         assertTrue(debugger.lines.contains("----------------------------------------------------------------- 1\n"));
 
         // reset the global logging and debugger state
+        Daffodil.setLogWriter(new ConsoleLogWriter());
+        Daffodil.setLoggingLevel(LogLevel.Info);
+    }
+
+    @Test
+    public void testJavaAPI23() throws IOException, ClassNotFoundException {
+        // test SAX unparsing with errors
+        LogWriterForJAPITest lw = new LogWriterForJAPITest();
+
+        Daffodil.setLogWriter(lw);
+        Daffodil.setLoggingLevel(LogLevel.Info);
+
+        org.apache.daffodil.japi.Compiler c = Daffodil.compiler();
+
+        java.io.File schemaFile = getResource("/test/japi/mySchema1.dfdl.xsd");
+        ProcessorFactory pf = c.compileFile(schemaFile);
+        DataProcessor dp = pf.onPath("/");
+        dp = reserializeDataProcessor(dp);
+
+        java.io.File file = getResource("/test/japi/myInfosetBroken.xml");
+        java.io.FileInputStream fis = new java.io.FileInputStream(file);
+        ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        WritableByteChannel wbc = java.nio.channels.Channels.newChannel(bos);
+        // prep for SAX
+        DaffodilUnparseContentHandler unparseContentHandler = dp.newContentHandlerInstance(wbc);
+        try {
+            org.xml.sax.XMLReader unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance()
+                    .newSAXParser().getXMLReader();
+            unparseXMLReader.setContentHandler(unparseContentHandler);
+            unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true);
+            unparseXMLReader.setFeature(SAX_NAMESPACE_PREFIXES_FEATURE, true);
+            // kickstart unparse
+            unparseXMLReader.parse(new org.xml.sax.InputSource(fis));
+        } catch (DaffodilUnparseErrorSAXException | DaffodilUnhandledSAXException ignored) {
+            // do nothing; UnparseError is handled below while we don't expect Unhandled in this test
+        } catch (javax.xml.parsers.ParserConfigurationException | org.xml.sax.SAXException e) {
+            fail("Error: " + e);
+        }
+
+        UnparseResult res = unparseContentHandler.getUnparseResult();
+        boolean err = res.isError();
+        assertTrue(err);
+
+        java.util.List<Diagnostic> diags = res.getDiagnostics();
+        assertEquals(1, diags.size());
+        Diagnostic d = diags.get(0);
+        assertTrue(d.getMessage().contains("wrong"));
+        assertTrue(d.getMessage().contains("e2"));
+
+        // reset the global logging state
         Daffodil.setLogWriter(new ConsoleLogWriter());
         Daffodil.setLoggingLevel(LogLevel.Info);
     }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Coroutines.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Coroutines.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.apache.daffodil.util
+
+ import java.util.concurrent.ArrayBlockingQueue
+
+ import scala.util.Try
+ import scala.util.Success
+ import scala.util.Failure
+
+ import org.apache.daffodil.exceptions.Assert
+ import org.apache.daffodil.exceptions.UnsuppressableException
+
+ /**
+  * General purpose Co-routines.
+  *
+  * Some design concerns: if these are used along with lazy vals and other things
+  * that make use of synchronized methods, there could be interactions.
+  *
+  * Definition of Coroutine - separate stacks, but NO CONCURRENCY. Only one
+  * of a set of coroutines is running at any given time.
+  */
+ trait Coroutine[T] {
+
+   private val queueCapacity: Int = 1
+   private val inboundQueue = new ArrayBlockingQueue[Try[T]](queueCapacity)
+
+   private val self = this
+
+   /**
+    * Override this in the main thread to be
+    *
+    * `override final def isMain = true`
+    *
+    * This suppresses creation of a thread for when the main
+    * thread is itself one of the co-routines.
+    */
+   protected def isMain: Boolean = false
+
+   private var thread_ : Option[Thread] = None
+
+   private final def init(): Unit = {
+     if (!isMain && thread_.isEmpty) {
+       val thr = new Thread {
+         override def run(): Unit = self.run()
+       }
+       thread_ = Some(thr)
+       thr.start()
+     }
+   }
+
+   /**
+    * Call when a co-routine resumes another (to provide a result of some sort)
+    * and then terminates. The coroutine calling this must return from the run()
+    * method immediately after calling this.
+    */
+   final def resumeFinal(coroutine: Coroutine[T], in: Try[T]): Unit = {
+     coroutine.init()
+     coroutine.inboundQueue.put(in) // allows other to run  final
+   }
+
+   /**
+    * Call when one co-routine wants to resume another, tranmitting a
+    * argument value to it.
+    *
+    * The current co-routine will be suspended until it is resumed later.
+    */
+   final def resume(coroutine: Coroutine[T], in: Try[T]): Try[T] = {
+     resumeFinal(coroutine, in)
+     val res = waitForResume() // blocks until it is resumed
+     res
+   }
+
+   final def waitForResume(): Try[T] = {
+     inboundQueue.take
+   }
+
+   protected def run(): Unit
+ }
+
+ /**
+  * Convert something that has callbacks (e.g., SAX-like parser that calls back on events)
+  * into a pull-style API aka Iterator.
+  *
+  * Exceptions are reported on the thread doing the pulling, aka the consumer.
+  *
+  * Rules:
+  * (1) you have no access to the thing that generates call-backs other than
+  * you can start it. It can be an opaque library you cannot modify.
+  * (2) the generator code does not have to be thread safe. Hence, only one thread can
+  * be executing at a time here. There MUST BE NO CONCURRENCY. Two threads are necessary here,
+  * but only one will be executing at a time.
+  * (3) Finite storage - no building up of an arbitrary list/stream.
+  *
+  * Concepts adapted from
+  * https://gist.github.com/dportabella/5766099
+  * and
+  * https://scalaenthusiast.wordpress.com/2013/06/12/transform-a-callback-function-to-an-iteratorlist-in-scala/
+  */
+
+ final class InvertControl[S](body: => Unit) extends Iterator[S] with Coroutine[S] {
+
+   private object EndMarker extends Throwable
+   private val EndOfData = Failure(EndMarker)
+
+   /**
+    * The producer will run the body function, and from within it,
+    * calls to setNext() will
+    * produce the values for the consumer. The consumer (main thread)
+    * just uses ordinary next/hasNext calls to get the values.
+    *
+    * After the last value is produced, the consumer is resumed with EndOfData
+    * and the producer terminates.
+    */
+   class Producer(val consumer: Coroutine[S]) extends Coroutine[S] {
+     override final def run(): Unit = {
+       try {
+         waitForResume()
+         body
+         resumeFinal(consumer, EndOfData)
+       } catch {
+         case s: scala.util.control.ControlThrowable => throw s
+         case u: UnsuppressableException => throw u
+         case e: Exception => resumeFinal(consumer, Failure(e))
+       }
+     }
+
+     final def setNext(e: S): Unit = {
+       resume(consumer, Success(e))
+     }
+   }
+
+   def setNext(s: S): Unit =
+     producer.setNext(s)
+
+   private val producer = new Producer(this)
+
+   override def isMain = true
+
+   private var failed = false
+
+   private val dummy: Try[S] = Success(null.asInstanceOf[S])
+
+   private def gen: Stream[S] = {
+     val x = resume(producer, dummy) // producer isn't sent anything. It's just resumed to get another value.
+     x match {
+       case EndOfData => Stream.Empty
+       case Success(v) => v #:: gen
+       case Failure(e) => {
+         failed = true
+         throw e
+       }
+     }
+   }
+
+   private lazy val iterator = gen.toIterator
+
+   override def hasNext: Boolean = {
+     if (failed) false
+     else iterator.hasNext
+   }
+   override def next(): S = {
+     if (failed) throw new IllegalStateException()
+     else iterator.next()
+   }
+
+   override def run(): Unit= {
+     Assert.invariantFailed("Main thread co-routine run method should not be called.")
+   }
+
+ }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
@@ -226,6 +226,22 @@ object Misc {
   }
 
   /**
+   * Returns true if a StringBuilder contains all whitespace
+   */
+  def isAllWhitespace(sb: StringBuilder): Boolean = {
+    if (sb.isEmpty) false
+    else {
+      var in = 0
+      val sbLen = sb.length
+      while (in < sbLen) {
+        if (!sb.charAt(in).isWhitespace) return false
+        in += 1
+      }
+      true
+    }
+  }
+
+  /**
    * Returns the primary version of daffodil from the jar
    */
   def getDaffodilVersion: String = {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -424,6 +424,9 @@ object XMLUtils {
   val DAFFODIL_SAX_URN_BLOBPREFIX: String = DAFFODIL_SAX_URN_ROOT + ":BlobPrefix"
   val DAFFODIL_SAX_URN_BLOBSUFFIX: String = DAFFODIL_SAX_URN_ROOT + ":BlobSuffix"
 
+  val SAX_NAMESPACES_FEATURE = "http://xml.org/sax/features/namespaces"
+  val SAX_NAMESPACE_PREFIXES_FEATURE = "http://xml.org/sax/features/namespace-prefixes"
+
 
   val FILE_ATTRIBUTE_NAME = "file"
   val LINE_ATTRIBUTE_NAME = "line"

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -24,9 +24,14 @@ import java.io.File
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.externalvars.Binding
 import org.apache.daffodil.infoset.InfosetInputter
+import org.apache.daffodil.infoset.InfosetInputterEventType
 import org.apache.daffodil.infoset.InfosetOutputter
 import org.apache.daffodil.processors.Failure
 import org.apache.daffodil.io.InputSourceDataInputStream
+import org.apache.daffodil.util.Coroutine
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe.Nope
+import org.xml.sax.SAXException
 
 /**
  * This file contains traits that define an abstract API that any DFDL processor
@@ -181,9 +186,14 @@ object DFDL {
     def setTunables(tunables: Map[String,String]): Unit
 
     /**
-     * Creates a new instance of XMLReader for SAX Parsing/Unparsing
+     * Creates a new instance of XMLReader for SAX Parsing
      */
-    def newXMLReaderInstance: DaffodilXMLReader
+    def newXMLReaderInstance: DaffodilParseXMLReader
+
+    /**
+     * Creates a new instance of DaffodilUnparseContentHandler for SAX Unparsing
+     */
+    def newContentHandlerInstance(output: DFDL.Output): DaffodilUnparseContentHandler
 
     /**
      * Unparses (that is, serializes) data to the output, returns an object which contains any diagnostics.
@@ -196,11 +206,77 @@ object DFDL {
     def parse(input: InputSourceDataInputStream, output: InfosetOutputter): ParseResult
   }
 
-  trait DaffodilXMLReader extends org.xml.sax.XMLReader {
+  trait DaffodilParseXMLReader extends org.xml.sax.XMLReader {
     def parse(is: java.io.InputStream): Unit
     def parse(in: InputSourceDataInputStream): Unit
     def parse(ab: Array[Byte]): Unit
   }
+
+  trait DaffodilUnparseContentHandler extends org.xml.sax.ContentHandler with ProducerCoroutine {
+    def getUnparseResult: UnparseResult
+    def enableInputterResolutionOfRelativeInfosetBlobURIs(): Unit
+  }
+
+  /**
+   * Used in SAXInfosetEvent.causeError to identify when an unparseResult.isError is true
+   */
+  class DaffodilUnparseErrorSAXException(unparseResult: UnparseResult)
+    extends org.xml.sax.SAXException(unparseResult.getDiagnostics.mkString("\n"))
+
+  /**
+   * Used in SAXInfosetEvent.causeError to identify when an unexpected error occurs
+   */
+  class DaffodilUnhandledSAXException(description: String, cause: Exception)
+    extends org.xml.sax.SAXException(description, cause)
+
+  class SAXInfosetEvent() {
+    var localName: Maybe[String] = Nope
+    var simpleText: Maybe[String] = Nope
+    var namespaceURI: Maybe[String] = Nope
+    var eventType: Maybe[InfosetInputterEventType] = Nope
+    var nilValue: Maybe[String] = Nope
+    var causeError: Maybe[SAXException] = Nope
+    var unparseResult: Maybe[UnparseResult] = Nope
+
+    def isError: Boolean = causeError.isDefined
+
+    def clear(): Unit = {
+      localName = Nope
+      simpleText = Nope
+      namespaceURI = Nope
+      eventType = Nope
+      nilValue = Nope
+      causeError = Nope
+      unparseResult = Nope
+    }
+
+    def isEmpty: Boolean = {
+      localName.isEmpty &&
+        simpleText.isEmpty &&
+        namespaceURI.isEmpty &&
+        eventType.isEmpty &&
+        nilValue.isEmpty &&
+        causeError.isEmpty &&
+        unparseResult.isEmpty
+    }
+
+    override def toString: String = {
+      val errorState = if (isError) "ERROR" else ""
+      s"$errorState ${if (eventType.isDefined) eventType.get else "No_EventType"}:" +
+        s"{${if (namespaceURI.isDefined) namespaceURI.get else ""}}" +
+        s"${if (localName.isDefined) localName.get else "No_Name"}:" +
+        s"(${if (simpleText.isDefined) simpleText.get else "No_content"})"
+    }
+  }
+
+  trait ProducerCoroutine extends Coroutine[SAXInfosetEvent] {
+    override def isMain = true
+    override protected def run(): Unit = {
+      throw new Error("Main thread co-routine run method should not be called.")
+    }
+  }
+
+  trait ConsumerCoroutine extends Coroutine[SAXInfosetEvent]
 
   trait ParseResult extends Result with WithDiagnostics {
     def resultState: State

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.infoset
+
+import java.net.URI
+import java.net.URISyntaxException
+
+import scala.util.Try
+
+import org.apache.daffodil.api.DFDL
+import org.apache.daffodil.api.DFDL.DaffodilUnhandledSAXException
+import org.apache.daffodil.api.DFDL.DaffodilUnparseErrorSAXException
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndDocument
+import org.apache.daffodil.util.Maybe.One
+import org.apache.daffodil.util.MaybeBoolean
+import org.apache.daffodil.util.Misc
+import org.apache.daffodil.xml.XMLUtils
+
+/**
+ * The SAXInfosetInputter consumes SAXInfosetEvent objects from the DaffodilUnparseContentHandler
+ * class and converts them to events that the DataProcessor unparse can use. This class contains two
+ * SAXInfosetEvent objects, the current event the unparse method is processing and the next event
+ * to be processed later.
+ *
+ * This class together with the DaffodilUnparseContentHandler use coroutines to ensure that only one event,
+ * at a time, is passed between the two classes. The following is the general process:
+ *
+ * - the run method is called, with a StartDocument event already loaded on the inputter's queue.
+ * This is collected and stored in the currentEvent member
+ * - The dp.unparse method is called, and it calls hasNext to make sure an event exists to be
+ * processed and then queries the currentEvent. The hasNext call also queues the nextEvent by
+ * transferring control to the contentHandler so it can load the next event.
+ * - After it is done with the currentEvent, it calls inputter.next to get the next event, and that
+ * copies the queued nextEvent into the currentEvent
+ * - This process continues until the currentEvent contains an EndDocument event, at which point, the
+ * nextEvent is cleared, endDocumentReceived is set to true and hasNext will return false
+ * - This ends the unparse process, and the unparseResult and/or any Errors are set on the event. We
+ * call resumeFinal passing along that element, terminating this thread and resuming the
+ * contentHandler for the last time.
+ *
+ * @param unparseContentHandler producer coroutine that sends the SAXInfosetEvent to this class
+ * @param dp dataprocessor that we use to kickstart the unparse process and that consumes the
+ *           currentEvent
+ * @param output  outputChannel of choice where the unparsed data is stored
+ */
+class SAXInfosetInputter(
+  unparseContentHandler: DFDL.DaffodilUnparseContentHandler,
+  dp: DFDL.DataProcessor,
+  output: DFDL.Output)
+  extends InfosetInputter with DFDL.ConsumerCoroutine {
+
+  /**
+   * allows support for converting relative URIs in Blobs to absolute URIs, this is necessary
+   * for running TDML tests as they allow relative URIs. Because Daffodil proper only uses
+   * absolute URIs, we hide this functionality behind this flag. It can be set to true by calling
+   * the unparseContentHandler.enableInputterResolutionOfRelativeInfosetBlobURIs(), which calls the
+   * inputter's enableResolutionOfRelativeInfosetBlobURIs() function to set the below variable to true
+   */
+  private var resolveRelativeInfosetBlobURIs: Boolean = false
+
+  private var endDocumentReceived = false
+  private lazy val currentEvent: DFDL.SAXInfosetEvent = new DFDL.SAXInfosetEvent
+  private lazy val nextEvent: DFDL.SAXInfosetEvent = new DFDL.SAXInfosetEvent
+
+  override def getEventType(): InfosetInputterEventType = currentEvent.eventType.orNull
+
+  override def getLocalName(): String = currentEvent.localName.orNull
+
+  override def getNamespaceURI(): String = currentEvent.namespaceURI.orNull
+
+  override def getSimpleText(primType: NodeInfo.Kind): String = {
+    val res = if (currentEvent.simpleText.isDefined) {
+      currentEvent.simpleText.get
+    } else {
+      throw new NonTextFoundInSimpleContentException(getLocalName())
+    }
+    primType match {
+      case _: NodeInfo.String.Kind =>
+        val remapped = XMLUtils.remapPUAToXMLIllegalCharacters(res)
+        remapped
+      case _: NodeInfo.AnyURI.Kind if resolveRelativeInfosetBlobURIs && res.nonEmpty =>
+        val absUri = resolveRelativeBlobURIs(res)
+        absUri
+      case _ =>
+        res
+    }
+  }
+
+  override def isNilled(): MaybeBoolean = {
+    val _isNilled = if (currentEvent.nilValue.isDefined) {
+      val nilValue = currentEvent.nilValue.get
+      if (nilValue == "true" || nilValue == "1") {
+        MaybeBoolean(true)
+      } else if (nilValue == "false" || nilValue == "0") {
+        MaybeBoolean(false)
+      } else {
+        throw new InvalidInfosetException("xsi:nil property is not a valid boolean: '" + nilValue +
+          "' for element " + getLocalName())
+      }
+    } else {
+      MaybeBoolean.Nope
+    }
+    _isNilled
+  }
+
+  override def hasNext(): Boolean = {
+    if (endDocumentReceived) false
+    else if (!nextEvent.isEmpty) true
+    else {
+      val event = this.resume(unparseContentHandler, Try(currentEvent))
+      copyEvent(source = event, dest = nextEvent)
+      true
+    }
+  }
+
+  override def next(): Unit = {
+    if (hasNext()) {
+      copyEvent(source = Try(nextEvent), dest = currentEvent)
+      nextEvent.clear()
+      if (currentEvent.eventType.contains(EndDocument)) endDocumentReceived = true
+    } else {
+      // we should never call next() if hasNext() is false
+      Assert.abort()
+    }
+  }
+
+  def copyEvent(source: Try[DFDL.SAXInfosetEvent], dest: DFDL.SAXInfosetEvent): Unit= {
+    if (source.isFailure) dest.clear()
+    else {
+      val src = source.get
+      dest.eventType = src.eventType
+      dest.namespaceURI = src.namespaceURI
+      dest.localName = src.localName
+      dest.nilValue = src.nilValue
+      dest.simpleText = src.simpleText
+    }
+  }
+
+  def enableResolutionOfRelativeInfosetBlobURIs(): Unit = resolveRelativeInfosetBlobURIs = true
+
+  /**
+   * TDML files must allow blob URI's to be relative, but Daffodil
+   * requires them to be absolute with a scheme. So search for the file
+   * using TDML semantics and convert to an absolute URI. This function will
+   * only be called if resolveRelativeInfosetBlobURIs is true
+   */
+  private def resolveRelativeBlobURIs(res: String): String = {
+    try {
+      val uri = new URI(res)
+      if (!uri.getPath.startsWith("/")) {
+        val abs = Misc.searchResourceOption(uri.getPath, None)
+        abs.get.toString
+      } else {
+        res
+      }
+    } catch {
+      case _: URISyntaxException => res
+    }
+  }
+
+  override val supportsNamespaces: Boolean = true
+
+  override def fini: Unit = {
+    // do nothing
+  }
+
+  override protected def run(): Unit = {
+    try {
+      // startDocument kicks off this entire process, so it should be on the queue so the
+      // waitForResume call can grab it. That is set to our current event, so when hasNext is called
+      // the nextEvent after the StartDocument can be queued
+      copyEvent(source = this.waitForResume(), dest = currentEvent)
+      val unparseResult = dp.unparse(this, output)
+      currentEvent.unparseResult = One(unparseResult)
+      if (unparseResult.isError) {
+        // unparseError is contained within unparseResult
+        currentEvent.causeError = One(new DaffodilUnparseErrorSAXException(unparseResult))
+      }
+    } catch {
+      case e: Exception => {
+        currentEvent.causeError = One(new DaffodilUnhandledSAXException(e.getMessage, e))
+      }
+    } finally {
+      this.resumeFinal(unparseContentHandler, Try(currentEvent))
+    }
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
@@ -33,7 +33,7 @@ import org.xml.sax.Locator
 import org.xml.sax.SAXException
 import org.xml.sax.helpers.AttributesImpl
 
-class SAXInfosetOutputter(xmlReader: DFDL.DaffodilXMLReader)
+class SAXInfosetOutputter(xmlReader: DFDL.DaffodilParseXMLReader)
   extends InfosetOutputter
   with XMLInfosetOutputter {
   /**
@@ -42,79 +42,103 @@ class SAXInfosetOutputter(xmlReader: DFDL.DaffodilXMLReader)
    */
   override def reset(): Unit = {
     // this doesn't do anything as the ContentHandler API does not support
-    // resetting, but some implemented ContentHandlers, such as the JDOM SaxHandler,
+    // resetting, but some implemented ContentHandlers, such as the JDOM SAXHandler,
     // do support resetting so it's up to the creator of the contentHandler, to call
     // their contentHandler's reset if applicable and if necessary
   }
 
   override def startDocument(): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      contentHandler.startDocument()
+    if (contentHandler != null) {
+      try {
+        contentHandler.startDocument()
+        true
+      } catch {
+        case _: SAXException => false
+      }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
   override def endDocument(): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      contentHandler.endDocument()
+    if (contentHandler != null) {
+      try {
+        contentHandler.endDocument()
+        true
+      } catch {
+        case _: SAXException => false
+      }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
   override def startSimple(diSimple: DISimple): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      doStartElement(diSimple, contentHandler)
-      if (diSimple.hasValue) {
-        val text =
-          if (diSimple.erd.optPrimType.get.isInstanceOf[NodeInfo.String.Kind]) {
-            val s = remapped(diSimple.dataValueAsString)
-            scala.xml.Utility.escape(s)
-          } else {
-            diSimple.dataValueAsString
-          }
-        val arr = text.toCharArray
-        contentHandler.characters(arr, 0, arr.length)
+    if (contentHandler != null) {
+      try {
+        doStartElement(diSimple, contentHandler)
+        if (diSimple.hasValue) {
+          val text =
+            if (diSimple.erd.optPrimType.get.isInstanceOf[NodeInfo.String.Kind]) {
+              val s = remapped(diSimple.dataValueAsString)
+              scala.xml.Utility.escape(s)
+            } else {
+              diSimple.dataValueAsString
+            }
+          val arr = text.toCharArray
+          contentHandler.characters(arr, 0, arr.length)
+        }
+        true
+      } catch {
+        case _: SAXException => false
       }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
   override def endSimple(diSimple: DISimple): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      doEndElement(diSimple, contentHandler)
+    if (contentHandler != null) {
+      try {
+        doEndElement(diSimple, contentHandler)
+        true
+      } catch {
+        case _: SAXException => false
+      }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
   override def startComplex(diComplex: DIComplex): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      doStartElement(diComplex, contentHandler)
+    if (contentHandler != null) {
+      try {
+        doStartElement(diComplex, contentHandler)
+        true
+      } catch {
+        case _: SAXException => false
+      }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
   override def endComplex(diComplex: DIComplex): Boolean = {
     val contentHandler = xmlReader.getContentHandler
-    try {
-      doEndElement(diComplex, contentHandler)
+    if (contentHandler != null) {
+      try {
+        doEndElement(diComplex, contentHandler)
+        true
+      } catch {
+        case _: SAXException => false
+      }
+    } else {
       true
-    } catch {
-      case _: SAXException => false
     }
   }
 
@@ -194,7 +218,7 @@ class SAXInfosetOutputter(xmlReader: DFDL.DaffodilXMLReader)
 
 }
 
-class DaffodilOutputContentHandler(out: OutputStream, pretty: Boolean = false)
+class DaffodilParseOutputStreamContentHandler(out: OutputStream, pretty: Boolean = false)
   extends ContentHandler with Indentable with XMLInfosetOutputter {
   private val writer = new OutputStreamWriter(out)
   private var prefixMapping: NamespaceBinding = null
@@ -271,7 +295,7 @@ class DaffodilOutputContentHandler(out: OutputStream, pretty: Boolean = false)
     outputNewlineStack.push(false)
   }
 
-  override def endElement(uri: String, localName: String,  qName: String): Unit = {
+  override def endElement(uri: String, localName: String, qName: String): Unit = {
     decrementIndentation()
     if (outputNewline) {
       if (pretty) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilUnparseContentHandler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilUnparseContentHandler.scala
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processors
+
+import scala.util.Try
+import scala.xml.NamespaceBinding
+
+import javax.xml.XMLConstants
+import org.apache.daffodil.api.DFDL
+import org.apache.daffodil.api.DFDL.DaffodilUnhandledSAXException
+import org.apache.daffodil.api.DFDL.DaffodilUnparseErrorSAXException
+import org.apache.daffodil.infoset.IllegalContentWhereEventExpected
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndDocument
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndElement
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartDocument
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartElement
+import org.apache.daffodil.infoset.SAXInfosetInputter
+import org.apache.daffodil.util.MStackOf
+import org.apache.daffodil.util.Maybe.Nope
+import org.apache.daffodil.util.Maybe.One
+import org.apache.daffodil.util.Misc
+import org.xml.sax.Attributes
+import org.xml.sax.Locator
+
+/**
+ * DaffodilUnparseContentHandler produces SAXInfosetEvent objects for the SAXInfosetInputter to
+ * consume and convert to an event that the Dataprocessor unparse can use. The SAXInfosetEvent object
+ * is built from information that is passed to the ContentHandler from an XMLReader parser. In
+ * order to receive the uri and prefix information from the XMLReader, the XMLReader must have
+ * support for XML Namespaces
+ *
+ * This class, together with the SAXInfosetInputter, uses coroutines to ensure that only one event,
+ * at a time, is passed between the two classes. The following is the general process:
+ *
+ * - an external call is made to parse an XML Document
+ * - this class receives a StartDocument call, which is the first SAXInfosetEvent that is sent to
+ * the SAXInfosetInputter. That event is put on the inputter's queue, this thread is paused, and
+ * that inputter's thread is run
+ * - when the SAXInfosetInputter is done processing an event and is ready for a new event, it
+ * sends the completed event via the coroutine system, and loads it on the contentHandler's
+ * queue, which restarts this thread and pauses that one. In the expected case, the events will
+ * contain no new information, until the unparse is completed, otherwise it will contain error
+ * information
+ * -  this process continues until the EndDocument method is called. Once that SAXInfosetEvent is
+ * sent to the inputter, it signals the end of events coming from the contentHandler. This
+ * ends the unparseProcess and returns the event with the unparseResult and/or any error
+ * information
+ *
+ * @param dp dataprocessor object that will be used to call the parse
+ * @param output outputChannel of choice where the unparsed data is stored
+ */
+class DaffodilUnparseContentHandler(
+  dp: DFDL.DataProcessor,
+  output: DFDL.Output)
+  extends DFDL.DaffodilUnparseContentHandler {
+  private lazy val inputter = new SAXInfosetInputter(this, dp, output)
+  private var unparseResult: DFDL.UnparseResult = _
+  private lazy val infosetEvent: DFDL.SAXInfosetEvent = new DFDL.SAXInfosetEvent
+  private lazy val characterData = new StringBuilder
+  private var prefixMapping: NamespaceBinding = _
+  private lazy val prefixMappingTrackingStack = new MStackOf[NamespaceBinding]
+  /**
+   * This is a flag that is set to true when startPrefixMapping is called. When true, we make
+   * the assumption that we don't need to use the Attributes parameter from startElement to get the
+   * namespaceURI information and will solely rely on start/endPrefixMapping. If false, we will use
+   * Attributes to get the namespaceURI info.
+   */
+  private var contentHandlerPrefixMappingUsed = false
+
+  /**
+   * returns null in the case of an DaffodilUnhandledSAXException
+   */
+  def getUnparseResult: DFDL.UnparseResult = unparseResult
+
+  def enableInputterResolutionOfRelativeInfosetBlobURIs(): Unit = inputter.enableResolutionOfRelativeInfosetBlobURIs()
+
+  override def setDocumentLocator(locator: Locator): Unit = {
+    // do nothing
+  }
+
+  override def startDocument(): Unit = {
+    infosetEvent.eventType = One(StartDocument)
+    sendToInputter()
+  }
+
+  override def endDocument(): Unit = {
+    infosetEvent.eventType = One(EndDocument)
+    sendToInputter()
+  }
+
+  override def startPrefixMapping(prefix: String, uri: String): Unit = {
+    if (!contentHandlerPrefixMappingUsed) contentHandlerPrefixMappingUsed = true
+    val pre = if (prefix == "") null else prefix
+    prefixMapping = NamespaceBinding(pre, uri, prefixMapping)
+  }
+
+  /**
+   * XMLReader does not guarantee the order of the prefixes called for this function, but it does
+   * guarantee that this method is called after its corresponding endElement, which means we can
+   * can just take off the top mappings, because the element that might have cared about the order
+   * is already done using the prefixMappings
+   */
+  override def endPrefixMapping(prefix: String): Unit = {
+    prefixMapping = if (prefixMapping == null) prefixMapping else prefixMapping.parent
+  }
+
+  /**
+   * Uses Attributes, which is passed in to the startElement callback, to extract prefix mappings and
+   * populate the global prefixMapping
+   */
+  def mapPrefixMappingFromAttributesImpl(atts:Attributes): Unit = {
+    var i = 0
+    while (i < atts.getLength) {
+      val qName = atts.getQName(i)
+      val uri =  atts.getValue(i)
+      if (qName == "xmlns") {
+        prefixMapping = NamespaceBinding(null, uri, prefixMapping)
+      } else if (qName.startsWith("xmlns:")) {
+        val prefix = qName.substring(6)
+        prefixMapping = NamespaceBinding(prefix, uri, prefixMapping)
+      } else {
+        // do nothing, not a namespace mapping attribute
+      }
+      i += 1
+    }
+  }
+
+  override def startElement(uri: String, localName: String, qName: String, atts: Attributes): Unit = {
+    // we need to check if the characters data is all whitespace, if it is we drop the whitespace
+    // data, if it is not, it is an error as starting a new element with actual characterData means
+    // we haven't hit an endElement yet, which means we're in a complexElement and a complexElement
+    // cannot have character content
+    if (characterData.nonEmpty && !Misc.isAllWhitespace(characterData)) {
+      throw new IllegalContentWhereEventExpected("Non-whitespace characters in complex " +
+        "Element: " + characterData.toString
+      )
+    } else {
+      // reset since it was whitespace only
+      characterData.setLength(0)
+    }
+
+    if (!contentHandlerPrefixMappingUsed) {
+      // this is for the situation where the XMLReader doesn't use the start/endPrefixMappings to
+      // pass along namespaceMapping informayion, so prefix information must be determined via
+      // the Attribute param.
+      // we always pushes but mapPrefixMappingFromAttributesImpl won't always add a mapping
+      // since atts can be empty
+      prefixMappingTrackingStack.push(prefixMapping)
+      mapPrefixMappingFromAttributesImpl(atts)
+    }
+
+    if (!infosetEvent.isEmpty && infosetEvent.localName.isDefined) {
+      // we started another element while we were in the process of building a startElement
+      // this means the first element was complex and we are ready for the inputter queue
+      sendToInputter()
+    }
+    // use Attributes to determine xsi:nil value
+    val nilIn = atts.getIndex(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil")
+    infosetEvent.nilValue = if (nilIn >= 0) {
+      val nilValue = atts.getValue(nilIn)
+      One(nilValue)
+    } else {
+      Nope
+    }
+
+    // set localName and namespaceURI
+    setLocalNameAndNamespaceUri(uri, localName, qName)
+
+    infosetEvent.eventType = One(StartElement)
+  }
+
+  override def endElement(uri: String, localName: String, qName: String): Unit = {
+    // if infosetEvent is a startElement, send that first
+    if (infosetEvent.eventType.contains(StartElement)) {
+      // any characterData that exists at this point is valid data as padding data has been
+      // taken care of in startElement
+      val maybeNewStr = One(characterData.toString)
+      infosetEvent.simpleText = maybeNewStr
+      characterData.setLength(0)
+      sendToInputter()
+    }
+
+    // set localName and namespaceURI
+    setLocalNameAndNamespaceUri(uri, localName, qName)
+
+    infosetEvent.eventType = One(EndElement)
+
+    if (!contentHandlerPrefixMappingUsed) {
+      // always pops
+      prefixMapping = prefixMappingTrackingStack.pop
+    }
+    sendToInputter()
+  }
+
+  override def characters(ch: Array[Char], start: Int, length: Int): Unit = {
+    characterData.appendAll(ch, start, length)
+  }
+
+  private def sendToInputter(): Unit = {
+    val infosetEventWithResponse = this.resume(inputter, Try(infosetEvent))
+    infosetEvent.clear()
+    // if event is wrapped in a Try failure, we will not have an unparseResult, so we only set
+    // unparseResults for events wrapped in Try Success, including those events that have expected
+    // errors
+    if (infosetEventWithResponse.isSuccess && infosetEventWithResponse.get.unparseResult.isDefined) {
+      unparseResult = infosetEventWithResponse.get.unparseResult.get
+    }
+    // the exception from events wrapped in Try failures and events wrapped in Try Successes
+    // (with an unparse error state i.e unparseResult.isError) are collected and thrown to stop
+    // the execution of the xmlReader
+    if (infosetEventWithResponse.isFailure || infosetEventWithResponse.get.isError) {
+      val causeError = if(infosetEventWithResponse.isFailure) {
+        infosetEventWithResponse.failed.get
+      } else {
+        infosetEventWithResponse.get.causeError.get
+      }
+      causeError match {
+        case unparseError: DaffodilUnparseErrorSAXException =>
+          // although this is an expected error, we need to throw it so we can stop the xmlReader
+          // parse and this thread
+          throw unparseError
+        case unhandled: DaffodilUnhandledSAXException => throw unhandled
+        case unknown => throw new DaffodilUnhandledSAXException("Unknown exception: ", new Exception(unknown))
+      }
+    }
+  }
+
+  /**
+   * Use the prefixMapping and input parameters to set the localName and NamespaceURI of the
+   * SAXInfoset object.
+   */
+  private def setLocalNameAndNamespaceUri(uri:String, localName: String, qName: String): Unit = {
+    lazy val qNameArr = qName.split(":")
+    lazy val qNamePrefix = if (qNameArr.length > 1) {//there is a prefix
+      qNameArr.head
+    } else {
+      // if there is no prefix, we attempt to try to get the namespace when the prefix is "". Since
+      // namespacebinding doesn't take "", we convert to null.
+      null
+    }
+
+    val maybelocalName =
+      if (localName.nonEmpty) {
+        One(localName)
+      } else if (qName.nonEmpty) {
+        One(qNameArr.last)
+      } else {
+        Nope
+      }
+
+    val maybeNamespaceURI =
+      if (uri.nonEmpty) {
+        One(uri)
+      } else if (prefixMapping != null) {
+        try {
+          One(prefixMapping.getURI(qNamePrefix))
+        } catch {
+          case _: NullPointerException => Nope
+        }
+      } else {
+        Nope
+      }
+
+    infosetEvent.localName = maybelocalName
+    infosetEvent.namespaceURI = maybeNamespaceURI
+  }
+
+  override def ignorableWhitespace(ch: Array[Char], start: Int, length: Int): Unit = {
+    // do nothing
+  }
+
+  override def processingInstruction(target: String, data: String): Unit = {
+    // do nothing
+  }
+
+  override def skippedEntity(name: String): Unit = {
+    // do nothing
+  }
+}

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -34,9 +34,12 @@ import org.apache.daffodil.api.{ DataLocation => SDataLocation }
 import org.apache.daffodil.api.{ Diagnostic => SDiagnostic }
 import org.apache.daffodil.api.{ LocationInSchemaFile => SLocationInSchemaFile }
 import org.apache.daffodil.api.{ WithDiagnostics => SWithDiagnostics }
+import org.apache.daffodil.api.DFDL.{ DaffodilUnhandledSAXException => SDaffodilUnhandledSAXException }
+import org.apache.daffodil.api.DFDL.{ DaffodilUnparseErrorSAXException => SDaffodilUnparseErrorSAXException }
 import org.apache.daffodil.compiler.{ ProcessorFactory => SProcessorFactory }
 import org.apache.daffodil.processors.{ DataProcessor => SDataProcessor }
-import org.apache.daffodil.processors.{ DaffodilXMLReader => SDaffodilXMLReader }
+import org.apache.daffodil.processors.{ DaffodilParseXMLReader => SDaffodilParseXMLReader }
+import org.apache.daffodil.processors.{ DaffodilUnparseContentHandler => SDaffodilUnparseContentHandler }
 import org.apache.daffodil.processors.{ ParseResult => SParseResult }
 import org.apache.daffodil.processors.{ UnparseResult => SUnparseResult }
 import org.apache.daffodil.util.{ ConsoleWriter => SConsoleWriter }
@@ -57,6 +60,7 @@ import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Maybe._
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.xml.NS
+import org.apache.daffodil.xml.XMLUtils
 
 private class Daffodil private {
   // Having this empty but private companion class removes the constructor from
@@ -619,10 +623,17 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
   def save(output: WritableByteChannel): Unit = dp.save(output)
 
   /**
-   *  Obtain a new [[DaffodilXMLReader]] from the current [[DataProcessor]].
+   *  Obtain a new [[DaffodilParseXMLReader]] from the current [[DataProcessor]].
    */
-  def newXMLReaderInstance: DaffodilXMLReader =
-    new DaffodilXMLReader(xmlrdr = dp.newXMLReaderInstance.asInstanceOf[SDaffodilXMLReader])
+  def newXMLReaderInstance(): DaffodilParseXMLReader =
+    new DaffodilParseXMLReader(xmlrdr = dp.newXMLReaderInstance.asInstanceOf[SDaffodilParseXMLReader])
+
+  /**
+   *  Obtain a new [[DaffodilUnparseContentHandler]] from the current [[DataProcessor]].
+   */
+  def newContentHandlerInstance(output: WritableByteChannel): DaffodilUnparseContentHandler =
+    new DaffodilUnparseContentHandler(sContentHandler =
+      dp.newContentHandlerInstance(output).asInstanceOf[SDaffodilUnparseContentHandler])
 
   /**
    * Parse input data with a specified length
@@ -798,10 +809,33 @@ class InvalidParserException(cause: org.apache.daffodil.compiler.InvalidParserEx
 class InvalidUsageException(cause: org.apache.daffodil.processors.InvalidUsageException) extends Exception(cause.getMessage(), cause.getCause())
 
 /**
+ * This exception will be thrown when unparseResult.isError returns true during a SAX Unparse
+ */
+class DaffodilUnparseErrorSAXException private[sapi] (exception: SDaffodilUnparseErrorSAXException)
+  extends org.xml.sax.SAXException(exception.getMessage)
+
+/**
+ * This exception will be thrown when an unexpected error occurs during the SAX unparse
+ */
+class DaffodilUnhandledSAXException private[sapi] (exception: SDaffodilUnhandledSAXException)
+  extends org.xml.sax.SAXException(exception.getMessage, new Exception(exception.getCause))
+
+/**
+ * The full URIs needed for setting/getting properties for the [[DaffodilParseXMLReader]]
+ */
+object DaffodilParseXMLReader {
+  val DAFFODIL_SAX_URN_PARSERESULT: String = XMLUtils.DAFFODIL_SAX_URN_PARSERESULT
+  val DAFFODIL_SAX_URN_BLOBDIRECTORY: String = XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY
+  val DAFFODIL_SAX_URN_BLOBPREFIX: String = XMLUtils.DAFFODIL_SAX_URN_BLOBPREFIX
+  val DAFFODIL_SAX_URN_BLOBSUFFIX: String = XMLUtils.DAFFODIL_SAX_URN_BLOBSUFFIX
+}
+
+/**
  * SAX Method of parsing schema and getting the DFDL Infoset via designated
  * org.xml.sax.ContentHandler, based on the org.xml.sax.XMLReader interface
  */
-class DaffodilXMLReader private[sapi] (xmlrdr: SDaffodilXMLReader) extends org.xml.sax.XMLReader {
+class DaffodilParseXMLReader private[sapi] (xmlrdr: SDaffodilParseXMLReader) extends org.xml.sax.XMLReader {
+
   /**
    * Get the value of the feature flag
    * @param name feature flag whose value is to be retrieved
@@ -821,7 +855,15 @@ class DaffodilXMLReader private[sapi] (xmlrdr: SDaffodilXMLReader) extends org.x
    * @param name property whose value is to be retrieved
    * @return value of the property
    */
-  override def getProperty(name: String): AnyRef = xmlrdr.getProperty(name)
+  override def getProperty(name: String): AnyRef = {
+    val res = xmlrdr.getProperty(name)
+    if (name == DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT) {
+      val pr = new ParseResult(res.asInstanceOf[SParseResult], Nope)
+      pr
+    } else {
+      res
+    }
+  }
 
   /**
    * Set the value of the property
@@ -912,4 +954,72 @@ class DaffodilXMLReader private[sapi] (xmlrdr: SDaffodilXMLReader) extends org.x
    * @param arr data to be parsed
    */
   def parse(arr: Array[Byte]): Unit = xmlrdr.parse(arr)
+}
+
+/**
+ * Accepts SAX callback events from any SAX XMLReader for unparsing
+ */
+class DaffodilUnparseContentHandler private[sapi] (sContentHandler: SDaffodilUnparseContentHandler)
+  extends org.xml.sax.ContentHandler {
+
+  private val contentHandler: org.xml.sax.ContentHandler = sContentHandler
+
+  /**
+   * Returns the result of the SAX unparse containing diagnostic information. In the case of an
+   * DaffodilUnhandledSAXException, this will return null.
+   */
+  def getUnparseResult: UnparseResult = {
+    val ur = sContentHandler.getUnparseResult.asInstanceOf[SUnparseResult]
+    if (ur == null) null
+    else new UnparseResult(ur)
+  }
+
+  override def setDocumentLocator(locator: org.xml.sax.Locator): Unit =
+    contentHandler.setDocumentLocator(locator)
+
+  override def startDocument(): Unit =
+    try {
+      contentHandler.startDocument()
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def endDocument(): Unit =
+    try {
+      contentHandler.endDocument()
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def startPrefixMapping(prefix: String, uri: String): Unit =
+    contentHandler.startPrefixMapping(prefix, uri)
+  override def endPrefixMapping(prefix: String): Unit =
+    contentHandler.endPrefixMapping(prefix)
+
+  override def startElement(uri: String, localName: String, qName: String, atts: org.xml.sax.Attributes): Unit =
+    try {
+      contentHandler.startElement(uri, localName, qName, atts)
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def endElement(uri: String, localName: String, qName: String): Unit =
+    try {
+      contentHandler.endElement(uri, localName, qName)
+    } catch {
+      case e: SDaffodilUnparseErrorSAXException => throw new DaffodilUnparseErrorSAXException(e)
+      case e: SDaffodilUnhandledSAXException => throw  new DaffodilUnhandledSAXException(e)
+    }
+
+  override def characters(ch: Array[Char], start: Int, length: Int): Unit =
+    contentHandler.characters(ch, start, length)
+  override def ignorableWhitespace(ch: Array[Char], start: Int, length: Int): Unit =
+    contentHandler.ignorableWhitespace(ch, start, length)
+  override def processingInstruction(target: String, data: String): Unit =
+    contentHandler.processingInstruction(target, data)
+  override def skippedEntity(name: String): Unit =
+    contentHandler.skippedEntity(name)
 }

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
@@ -19,13 +19,17 @@ package org.apache.daffodil.tdml.processor
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.OutputStreamWriter
 import java.nio.channels.Channels
 import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.xml.Node
 
+import javax.xml.parsers.SAXParserFactory
 import org.apache.commons.io.IOUtils
+import org.apache.daffodil.api.DFDL.DaffodilUnhandledSAXException
+import org.apache.daffodil.api.DFDL.DaffodilUnparseErrorSAXException
 import org.apache.daffodil.api._
 import org.apache.daffodil.compiler.Compiler
 import org.apache.daffodil.debugger.Debugger
@@ -34,7 +38,7 @@ import org.apache.daffodil.debugger.TraceDebuggerRunner
 import org.apache.daffodil.dsom.ExpressionCompilers
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.externalvars.Binding
-import org.apache.daffodil.infoset.DaffodilOutputContentHandler
+import org.apache.daffodil.infoset.DaffodilParseOutputStreamContentHandler
 import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
 import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.processors.DataProcessor
@@ -44,10 +48,12 @@ import org.apache.daffodil.tdml.SchemaDataProcessorCache
 import org.apache.daffodil.tdml.TDMLException
 import org.apache.daffodil.tdml.TDMLInfosetInputter
 import org.apache.daffodil.tdml.TDMLInfosetOutputter
+import org.apache.daffodil.tdml.VerifyTestCase
 import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.xml.XMLUtils.XMLDifferenceException
 import org.xml.sax.ErrorHandler
+import org.xml.sax.InputSource
 import org.xml.sax.SAXParseException
 
 final class TDMLDFDLProcessorFactory private (
@@ -262,26 +268,31 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
   }
 
   override def unparse(infosetXML: scala.xml.Node, outStream: java.io.OutputStream): TDMLUnparseResult = {
-    val output = java.nio.channels.Channels.newChannel(outStream)
-
     val scalaInputter = new ScalaXMLInfosetInputter(infosetXML)
     // We can't compare against other inputters since we only have scala XML,
     // but we still need to use the TDMLInfosetInputter since it may make TDML
     // specific modifications to the input infoset (e.g. blob paths)
     val otherInputters = Seq.empty
     val inputter = new TDMLInfosetInputter(scalaInputter, otherInputters)
-    val actual = dp.unparse(inputter, output).asInstanceOf[UnparseResult]
-    output.close()
-    new DaffodilTDMLUnparseResult(actual, outStream)
+    unparse(inputter, infosetXML, outStream)
   }
 
   def unparse(parseResult: TDMLParseResult, outStream: java.io.OutputStream): TDMLUnparseResult = {
     val dafpr = parseResult.asInstanceOf[DaffodilTDMLParseResult]
     val inputter = dafpr.inputter
-    val output = java.nio.channels.Channels.newChannel(outStream)
-    val actual = dp.unparse(inputter, output)
-    output.close()
-    new DaffodilTDMLUnparseResult(actual, outStream)
+    val resNode = dafpr.getResult
+    unparse(inputter, resNode, outStream)
+  }
+
+  def unparse(inputter: TDMLInfosetInputter, infosetXML: scala.xml.Node, outStream: java.io
+  .OutputStream): TDMLUnparseResult = {
+    val bos = new ByteArrayOutputStream()
+    val osw = new OutputStreamWriter(bos)
+    scala.xml.XML.write(osw, infosetXML, "UTF-8", xmlDecl = true, null)
+    osw.flush()
+    osw.close()
+    val saxInstream = new ByteArrayInputStream(bos.toByteArray)
+    doUnparseWithBothApis(inputter, saxInstream, outStream)
   }
 
   def doParseWithBothApis(dpInputStream: java.io.InputStream, saxInputStream: java.io.InputStream,
@@ -291,8 +302,8 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
 
     val xri = dp.newXMLReaderInstance
     val errorHandler = new DaffodilTDMLSAXErrorHandler()
-    val outputStream = new ByteArrayOutputStream()
-    val saxHandler = new DaffodilOutputContentHandler(outputStream, pretty = false)
+    val saxOutputStream = new ByteArrayOutputStream()
+    val saxHandler = new DaffodilParseOutputStreamContentHandler(saxOutputStream, pretty = false)
     xri.setContentHandler(saxHandler)
     xri.setErrorHandler(errorHandler)
     xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY, blobDir)
@@ -308,16 +319,62 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
       dis.setBitLimit0b(MaybeULong(lengthLimitInBits))
       sis.setBitLimit0b(MaybeULong(lengthLimitInBits))
     }
-    xri.parse(sis)
-    val actual = dp.parse(dis, outputter)
 
+    val actual = dp.parse(dis, outputter)
+    xri.parse(sis)
 
     if (!actual.isError && !errorHandler.isError) {
-      verifySameParseOutput(outputter, outputStream)
+      verifySameParseOutput(outputter, saxOutputStream)
     }
-    verifySameDiagnostics(actual, errorHandler)
+    val dpParseDiag = actual.getDiagnostics.map(_.getMessage())
+    val saxParseDiag = errorHandler.getDiagnostics.map(_.getMessage())
+    verifySameDiagnostics(dpParseDiag, saxParseDiag)
 
     new DaffodilTDMLParseResult(actual, outputter)
+  }
+
+  def doUnparseWithBothApis(dpInputter: TDMLInfosetInputter, saxInputStream: java.io.InputStream,
+    dpOutputStream: java.io.OutputStream): DaffodilTDMLUnparseResult = {
+
+    val dpOutputChannel = java.nio.channels.Channels.newChannel(dpOutputStream)
+    val saxOutputStream = new ByteArrayOutputStream
+    val saxOutputChannel = java.nio.channels.Channels.newChannel(saxOutputStream)
+    val unparseContentHandler = dp.newContentHandlerInstance(saxOutputChannel)
+    unparseContentHandler.enableInputterResolutionOfRelativeInfosetBlobURIs()
+    val xmlReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    xmlReader.setContentHandler(unparseContentHandler)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, true)
+
+    val actualDP = dp.unparse(dpInputter, dpOutputChannel).asInstanceOf[UnparseResult]
+    dpOutputChannel.close()
+    // kick off SAX Unparsing
+    try {
+      xmlReader.parse(new InputSource(saxInputStream))
+    } catch {
+      case e: DaffodilUnhandledSAXException =>
+        // In the case of an unexpected errors, catch and throw as TDMLException
+        throw TDMLException("Unexpected error during SAX Unparse:" + e, None)
+      case _: DaffodilUnparseErrorSAXException =>
+        // do nothing as unparseResult and its diagnostics will be handled below
+    }
+
+    val actualSAX = unparseContentHandler.getUnparseResult
+    saxOutputChannel.close()
+    if (!actualDP.isError && !actualSAX.isError) {
+      val dpis = new ByteArrayInputStream(dpOutputStream.asInstanceOf[ByteArrayOutputStream]
+        .toByteArray)
+      if (actualDP.isScannable && actualSAX.isScannable) {
+        VerifyTestCase.verifyTextData(dpis, saxOutputStream, actualSAX.encodingName, None)
+      } else {
+        VerifyTestCase.verifyBinaryOrMixedData(dpis, saxOutputStream, None)
+      }
+    }
+    val dpUnparseDiag = actualDP.getDiagnostics.map(_.getMessage())
+    val saxUnparseDiag = actualSAX.getDiagnostics.map(_.getMessage())
+    verifySameDiagnostics(dpUnparseDiag, saxUnparseDiag)
+
+    new DaffodilTDMLUnparseResult(actualDP, dpOutputStream)
   }
 
   def verifySameParseOutput(dpOutputter: TDMLInfosetOutputter, outputStream: ByteArrayOutputStream): Unit = {
@@ -340,21 +397,20 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
     }
   }
 
-  private def verifySameDiagnostics(
-    actual: DFDL.ParseResult,
-    errorHandler: DaffodilTDMLSAXErrorHandler): Unit = {
-    val dpParseDiag = actual.getDiagnostics.map(_.getMessage()).sorted
-    val saxParseDiag = errorHandler.getDiagnostics.map(_.getMessage()).sorted
+  private def verifySameDiagnostics(seqDiagExpected: Seq[String], seqDiagActual: Seq[String]): Unit
+  = {
+    val expected = seqDiagExpected.sorted
+    val actual = seqDiagActual.sorted
 
-    if (dpParseDiag != saxParseDiag) {
+    if (expected != actual) {
       throw TDMLException(
         """SAX parse diagnostics do not match DataProcessor Parse diagnostics""" +
           "\n" +
-          """DataProcessor Parse diagnostics: """ + dpParseDiag +
-          (if (saxParseDiag.isEmpty) {
-            "\n No SAX diagnostics were generated."
+          """DataProcessor Parse diagnostics: """ + seqDiagExpected +
+          (if (seqDiagActual.isEmpty) {
+            "\nNo SAX diagnostics were generated."
           } else {
-            "\n SAX Parse diagnostics: " + saxParseDiag
+            "\nSAX Parse diagnostics: " + seqDiagActual
           }), None)
     }
   }


### PR DESCRIPTION
- add legacy coroutine class with 1 event ABQ
- add DaffodilInputContentHandler to collect SAXEvents from parsed XML
and convert to InfosetEvent for the SAXInfosetOutputter and the
dp.unparse
- add SAX unparsing to TDML
- Add errorHandler to unparse
- add features for namespace to xmlReader
- add DaffodilUnparserSAXException abnd DaffodilUnhandledSAXException case classes and error handling for errors during unparse
- add error info to events for communication b/w handler and inputter
- rename inputterEvent to infosetEvent
- add uri resolving for SAX simpleText (useful for TDML)
- some refactoring to isolate coroutine switching w/i contentHandler
- added comments for clarity
- change isNilled to nilValue so we can account for non-boolean values
- if getSimpleText has no value (i.e None), that is an error. Some(null)
or Some("") is indicative of an empty element
- add error handling so errors don't cause hanging

DAFFODIL-2383
