### PR TITLE
Fix Legacy/SAX Discrepancy with NamespaceBindings

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
@@ -136,7 +136,7 @@ class SAXInfosetOutputter(xmlReader: DFDL.DaffodilXMLReader)
       diElem.diParent.erd.minimizedScope
     }
     var n = nsbStart
-    while (n != nsbEnd) {
+    while (n != nsbEnd && n != null && n != scala.xml.TopScope) {
       val prefix = if (n.prefix == null) "" else n.prefix
       val uri = if (n.uri == null) "" else n.uri
       contentHandler.startPrefixMapping(prefix, uri)
@@ -153,7 +153,7 @@ class SAXInfosetOutputter(xmlReader: DFDL.DaffodilXMLReader)
         .minimizedScope
     }
     var n = nsbStart
-    while (n != nsbEnd) {
+    while (n != nsbEnd && n != null && n != scala.xml.TopScope) {
       val prefix = if (n.prefix == null) "" else n.prefix
       contentHandler.endPrefixMapping(prefix)
       n = n.parent

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
@@ -292,7 +292,7 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
     val xri = dp.newXMLReaderInstance
     val errorHandler = new DaffodilTDMLSAXErrorHandler()
     val outputStream = new ByteArrayOutputStream()
-    val saxHandler = new DaffodilOutputContentHandler(outputStream, pretty = true)
+    val saxHandler = new DaffodilOutputContentHandler(outputStream, pretty = false)
     xri.setContentHandler(saxHandler)
     xri.setErrorHandler(errorHandler)
     xri.setProperty(XMLUtils.DAFFODIL_SAX_URN_BLOBDIRECTORY, blobDir)


### PR DESCRIPTION
Fixes nullpointer exception error as can be seen in [this DAFFODIL-2383 comment](https://issues.apache.org/jira/browse/DAFFODIL-2383?focusedCommentId=17210164&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17210164) by making sure that n stops when it is null, and ensure we stop when the current mapping is equal to the TopScope, as there is an issue with mininmizeScope (DAFFODIL-2282) and nsbStart doesn't always have a mapping that'd equal nsbEnd

DAFFODIL-2383