### PR TITLE
Added warning when multiple choice branches are empty

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -86,11 +86,15 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
     // in the arriving infoset for unparse.
     //
     val optDefaultBranch = {
-      val optEmpty: Option[Term] =
-        groupMembers.find { gm =>
+      val optEmpty: Option[Term] = {
+        val emptyBranches = groupMembers.filter { gm =>
           val ies = gm.identifyingEventsForChoiceBranch
           ies.pnes.isEmpty // empty event list makes it the default, not simply isOpen
         }
+        if (emptyBranches.length > 1)
+          SDW(WarnID.MultipleChoiceBranches, "Multiple choice branches with no required elements detected and the infoset does not specify a branch, selecting the first branch for unparsing")
+        emptyBranches.headOption
+      }
       val optOpen: Option[Term] =
         optEmpty.orElse {
           groupMembers.find { gm =>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -1735,9 +1735,15 @@
 
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="choiceBranchVariables" root="root"
+  <!-- This test describes a situation where a choice is used to simply set a variable and nothing else.
+    In the choice of this test the branches only contain empty sequences that call setVariable on different
+    variables, depending on the branch. This works as expected during parsing, but because nothing gets
+    added to the infoset for these setVariable calls, on unparsing only the first branch of the choice is
+    ever used, which if the choice is part of an array, as it is in this test, results in the setVariable
+    call in the first branch being called multiple times, resulting in a double set error.
+  -->
+  <tdml:unparserTestCase name="multipleBranchesWithNoElementsSetVariableError" root="root"
     model="choice_branch_variables" description="Section 7 - setVariable - relative path expression - DFDL-7-126R">
-    <tdml:document>1,2</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <root>
@@ -1752,7 +1758,19 @@
         </root>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-  </tdml:parserTestCase>
+    <tdml:warnings>
+      <tdml:warning>Multiple choice branches</tdml:warning>
+      <tdml:warning>no required elements</tdml:warning>
+      <tdml:warning>infoset does not specify</tdml:warning>
+      <tdml:warning>selecting the first branch</tdml:warning>
+    </tdml:warnings>
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Cannot set variable</tdml:error>
+      <tdml:error>twice</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
   <tdml:defineSchema name="variables_nilled_element">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -100,7 +100,7 @@ class TestVariables {
   @Test def test_variables_nilled_element(): Unit = { runner.runOneTest("variables_nilled_element") }
 
   // DFDL-2375
-  //@Test def test_choiceBranchVariables(): Unit = { runner.runOneTest("choiceBranchVariables") }
+  @Test def test_multipleBranchesWithNoElementsSetVariableError(): Unit = { runner.runOneTest("multipleBranchesWithNoElementsSetVariableError") }
 
   @Test def test_doubleSetErr_d(): Unit = { runner_01.runOneTest("doubleSetErr_d") }
   @Test def test_setVar1_d(): Unit = { runner_01.runOneTest("setVar1_d") }


### PR DESCRIPTION
It may not be obvious to the user that when a choice has multiple empty
branches only the first will ever be selected even if there is a
choiceBranchKey associated with each branch, as choiceDispatchKey is not
evaluated on unparse. In the test that has been added for this, this
behavior of always defaulting to the first empty branch results in a
multiple set error on a variable.

DAFFODIL-2375