### PR TITLE
Enable pattern facet to use PUA characters

### DIFF
--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
@@ -33,13 +33,8 @@ import TestNulChars._
 class TestNulChars {
 
   // DAFFODIL-2363 &#xE000; (NUL replacement into XML) can't be used in pattern facet. With full validation.
-  // @Test def test_nulPattern1() = { runner.runOneTest("nulPattern1") }
+  @Test def test_nulPattern1() = { runner.runOneTest("nulPattern1") }
 
   // DAFFODIL-2364 - infinite loop
   // @Test def test_nulPad1() = { runner.runOneTest("nulPad1") }
-
-  @Test def ignoreThisDummyTestToPreventIDEFromRemovingImports(): Unit = {
-    // TODO Delete this dummy test once at least one of the above tests is made to work.
-    runner
-  }
 }


### PR DESCRIPTION
Enables patterns to validate the DFDL infoset
characters that are otherwise XML-Illegal such as
0xB or NUL (0x0), by expressing them as &amp;#xE00B; or
&amp;#xE000;

Test test_nulPattern1 verifies this.

DAFFODIL-2363