### PR TITLE
Make FillByte a required property.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -124,14 +124,10 @@ trait TermRuntimeValuedPropertiesMixin
     } else
       Nope
 
-  final lazy val maybeFillByteEv = {
-    if (optionFillByteRaw.isDefined) {
-      val ev = new FillByteEv(fillByte, charsetEv, tci)
-      ev.compile(tunable)
-      One(ev)
-    } else {
-      Nope
-    }
+  final lazy val fillByteEv = {
+    val ev = new FillByteEv(fillByte, charsetEv, tci)
+    ev.compile(tunable)
+    ev
   }
 
   /*

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -189,7 +189,7 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
       alignmentValueInBits,
       hasNoSkipRegions,
       optIgnoreCase,
-      maybeFillByteEv,
+      fillByteEv,
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharsetEv)
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
@@ -199,7 +199,7 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
       if (isOutputValueCalc) Some(ovcCompiledExpression) else None,
       maybeBinaryFloatRepEv,
       maybeByteOrderEv,
-      maybeFillByteEv,
+      fillByteEv,
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharsetEv,
       isQuasiElement)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SequenceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SequenceTermRuntime1Mixin.scala
@@ -21,6 +21,7 @@ import org.apache.daffodil.dsom.ChoiceBranchImpliedSequence
 import org.apache.daffodil.dsom.SequenceTermBase
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.processors.FillByteUseNotAllowedEv
 
 trait SequenceTermRuntime1Mixin { self: SequenceTermBase =>
 
@@ -44,7 +45,7 @@ trait SequenceTermRuntime1Mixin { self: SequenceTermBase =>
       alignmentValueInBits,
       hasNoSkipRegions,
       optIgnoreCase,
-      maybeFillByteEv,
+      fillByteEv,
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharsetEv)
   }
@@ -70,7 +71,7 @@ trait ChoiceBranchImpliedSequenceRuntime1Mixin { self: ChoiceBranchImpliedSequen
       alignmentValueInBits,
       true,
       None,
-      Maybe.Nope,
+      FillByteUseNotAllowedEv,
       Maybe.Nope,
       Maybe.Nope)
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvEncoding.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvEncoding.scala
@@ -154,3 +154,10 @@ class FillByteEv(fillByteRaw: String, charsetEv: CharsetEv, tci: DPathCompileInf
   }
 
 }
+
+object FillByteUseNotAllowedEv
+  extends FillByteEv(fillByteRaw = null, charsetEv = null, tci = null) {
+  override protected def compute(state: ParseOrUnparseState): Integer =
+    Assert.invariantFailed("Not supposed to use fill byte.")
+}
+

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -284,7 +284,8 @@ abstract class ParseOrUnparseState protected (
 
   final def fillByte: Byte = {
     if (maybeCachedFillByte.isEmpty)
-      maybeCachedFillByte = MaybeInt(termRuntimeData.maybeFillByteEv.get.evaluate(this).toInt)
+      maybeCachedFillByte = MaybeInt(termRuntimeData.fillByteEv.evaluate(this))
+
     maybeCachedFillByte.get.toByte
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -118,7 +118,7 @@ sealed abstract class TermRuntimeData(
   val hasNoSkipRegions: Boolean,
   val defaultBitOrder:  BitOrder,
   val optIgnoreCase: Option[YesNo],
-  @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
+  @TransientParam fillByteEvArg: => FillByteEv,
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
   extends RuntimeData {
@@ -155,7 +155,7 @@ sealed abstract class TermRuntimeData(
   lazy val dpathCompileInfo = dpathCompileInfoArg
   lazy val couldHaveText = couldHaveTextArg
   lazy val alignmentValueInBits = alignmentValueInBitsArg
-  lazy val maybeFillByteEv = maybeFillByteEvArg
+  lazy val fillByteEv = fillByteEvArg
   lazy val maybeCheckByteAndBitOrderEv = maybeCheckByteAndBitOrderEvArg
   lazy val maybeCheckBitOrderAndCharsetEv = maybeCheckBitOrderAndCharsetEvArg
 
@@ -166,7 +166,7 @@ sealed abstract class TermRuntimeData(
     dpathCompileInfo
     couldHaveText
     alignmentValueInBits
-    maybeFillByteEv
+    fillByteEv
     maybeCheckByteAndBitOrderEv
     maybeCheckBitOrderAndCharsetEv
   }
@@ -595,13 +595,13 @@ sealed class ElementRuntimeData(
   @TransientParam outputValueCalcExprArg: => Option[CompiledExpression[AnyRef]],
   @TransientParam maybeBinaryFloatRepEvArg: => Maybe[BinaryFloatRepEv],
   @TransientParam maybeByteOrderEvArg: => Maybe[ByteOrderEv],
-  @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
+  @TransientParam fillByteEvArg: => FillByteEv,
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv],
   @TransientParam isQuasiElementArg: => Boolean)
   extends TermRuntimeData(positionArg, partialNextElementResolverArg,
     encInfoArg, dpathElementCompileInfoArg, isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg,
-    defaultBitOrderArg, optIgnoreCaseArg, maybeFillByteEvArg,
+    defaultBitOrderArg, optIgnoreCaseArg, fillByteEvArg,
     maybeCheckByteAndBitOrderEvArg,
     maybeCheckBitOrderAndCharsetEvArg) {
 
@@ -761,7 +761,7 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
     null, // outputValueCalcExprArg: => Option[CompiledExpression[AnyRef]],
     Nope, // maybeBinaryFloatRepEvArg: => Maybe[BinaryFloatRepEv],
     Nope, // maybeByteOrderEvArg: => Maybe[ByteOrderEv],
-    Nope, // maybeFillByteEvArg: => Maybe[FillByteEv],
+    null, // fillByteEvArg => FillByteEv
     Nope, // maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
     Nope, // maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv],
     false // isQuasiElementArg: => Boolean
@@ -844,13 +844,13 @@ sealed abstract class ModelGroupRuntimeData(
   alignmentValueInBitsArg:  Int,
   hasNoSkipRegionsArg:  Boolean,
   optIgnoreCaseArg: Option[YesNo],
-  @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
+  @TransientParam fillByteEvArg: => FillByteEv,
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
   extends TermRuntimeData(
     positionArg, partialNextElementResolverArg,
     encInfoArg, ciArg, isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg,
-    defaultBitOrderArg, optIgnoreCaseArg, maybeFillByteEvArg,
+    defaultBitOrderArg, optIgnoreCaseArg, fillByteEvArg,
     maybeCheckByteAndBitOrderEvArg,
     maybeCheckBitOrderAndCharsetEvArg) {
 
@@ -899,13 +899,13 @@ final class SequenceRuntimeData(
   alignmentValueInBitsArg: Int,
   hasNoSkipRegionsArg: Boolean,
   optIgnoreCaseArg: Option[YesNo],
-  @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
+  @TransientParam fillByteEvArg: => FillByteEv,
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
   extends ModelGroupRuntimeData(positionArg, partialNextElementResolverArg,
     variableMapArg, encInfoArg, schemaFileLocationArg, ciArg, diagnosticDebugNameArg, pathArg, defaultBitOrderArg, groupMembersArg,
     isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg, optIgnoreCaseArg,
-    maybeFillByteEvArg,
+    fillByteEvArg,
     maybeCheckByteAndBitOrderEvArg,
     maybeCheckBitOrderAndCharsetEvArg)
 
@@ -934,12 +934,12 @@ final class ChoiceRuntimeData(
   alignmentValueInBitsArg: Int,
   hasNoSkipRegionsArg: Boolean,
   optIgnoreCaseArg: Option[YesNo],
-  @TransientParam maybeFillByteEvArg: => Maybe[FillByteEv],
+  @TransientParam fillByteEvArg: => FillByteEv,
   @TransientParam maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
   @TransientParam maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv])
   extends ModelGroupRuntimeData(positionArg, partialNextElementResolverArg,
     variableMapArg, encInfoArg, schemaFileLocationArg, ciArg, diagnosticDebugNameArg, pathArg, defaultBitOrderArg, groupMembersArg,
-    isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg, optIgnoreCaseArg, maybeFillByteEvArg,
+    isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg, optIgnoreCaseArg, fillByteEvArg,
     maybeCheckByteAndBitOrderEvArg,
     maybeCheckBitOrderAndCharsetEvArg)
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
@@ -269,7 +269,7 @@
       trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
       terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
       initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
-      escapeSchemeRef="" encodingErrorPolicy="replace"/>
+      escapeSchemeRef="" encodingErrorPolicy="replace" fillByte="%NUL;" />
 
 		<xs:element name="root">
 			<xs:complexType>
@@ -365,7 +365,7 @@
       trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
       terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
       initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
-      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no"/>
+      escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no" fillByte="%NUL;" />
 
 		<xs:element name="root">
 			<xs:complexType>
@@ -461,7 +461,7 @@
       trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
       terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
       initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
-      escapeSchemeRef="" encodingErrorPolicy="error" textBidi="no"/>
+      escapeSchemeRef="" encodingErrorPolicy="error" textBidi="no" fillByte="%NUL;" />
 
 		<xs:element name="root">
 			<xs:complexType>
@@ -507,7 +507,7 @@
       trailingSkip="0" encoding="US-ASCII" alignment="1" alignmentUnits="bytes" initiator=""
       terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
       initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
-      escapeSchemeRef="" textBidi="no"/>
+      escapeSchemeRef="" textBidi="no" fillByte="%NUL;" />
 
 		<xs:element name="root">
 			<xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section10/representation_properties/RepProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section10/representation_properties/RepProps.tdml
@@ -251,7 +251,7 @@
       terminator="" separator="" ignoreCase="no" occursCountKind="implicit" lengthUnits="bytes"
       initiatedContent="no" textPadKind="none" truncateSpecifiedLengthString="no" textTrimKind="none"
       escapeSchemeRef="" encodingErrorPolicy="replace" textBidi="no" floating="no"
-      byteOrder="bigEndian"/>
+      byteOrder="bigEndian" fillByte="%NUL;" />
 
     <xs:element name="hb_01" type="xs:hexBinary"
       dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes" dfdl:length="4"/>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/aligned_data/Aligned_Data.tdml
@@ -21,7 +21,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com"
   defaultRoundTrip="true">
 
-
+ 
   <tdml:defineSchema name="s1">
 
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
@@ -3680,7 +3680,174 @@
       <tdml:error>%ES;</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
+ 
+  <tdml:defineSchema name="schemaWithNoFillByte"
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    elementFormDefault="unqualified">
 
+    <dfdl:defineFormat name="myFormat">
+      <dfdl:format
+        textBidi="no"
+        floating="no"
+        encodingErrorPolicy="replace"
+        leadingSkip="0"
+        alignmentUnits="bytes"
+        alignment="1"
+        trailingSkip="0"
+        textPadKind="none"
+        escapeSchemeRef=""
+        truncateSpecifiedLengthString="no"
+        textTrimKind="none"
+        binaryNumberRep="binary"
+
+        representation="binary"
+        byteOrder="littleEndian"
+        encoding="ISO-8859-1"
+        sequenceKind="ordered"
+        initiator=""
+        terminator=""
+        separator=""
+        ignoreCase = "yes"
+        initiatedContent="no" />
+    </dfdl:defineFormat>
+
+    <dfdl:format ref="ex:myFormat" />
+
+    <xs:element name="input"
+      dfdl:lengthKind="implicit"
+      dfdl:lengthUnits="bytes">
+      <xs:complexType>
+        <xs:sequence dfdl:fillByte="%NUL;">
+          <xs:element name="A" type="xs:unsignedInt"
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="1"
+            dfdl:alignmentUnits="bytes"/>
+          <xs:element name="B" type="xs:unsignedInt"
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="2"
+            dfdl:alignmentUnits="bytes" />
+          <xs:element name="C" type="xs:unsignedInt"
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="2"
+            dfdl:alignmentUnits="bytes" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="schemaWithFillByte" 
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    elementFormDefault="unqualified">
+
+    <dfdl:defineFormat name="myFormat">
+      <dfdl:format 
+      textBidi="no"
+      floating="no"
+      encodingErrorPolicy="replace"
+      leadingSkip="0" 
+      alignmentUnits="bytes"
+      alignment="1" 
+      trailingSkip="0"
+      textPadKind="none"
+      escapeSchemeRef=""
+      truncateSpecifiedLengthString="no"
+      textTrimKind="none" 
+      binaryNumberRep="binary"
+
+      representation="binary"
+      byteOrder="littleEndian"
+      encoding="ISO-8859-1"
+      sequenceKind="ordered"
+      initiator=""
+      terminator=""
+      separator=""
+      ignoreCase = "yes"
+      fillByte="x"
+      initiatedContent="no" />
+    </dfdl:defineFormat>
+
+    <dfdl:format ref="ex:myFormat" />
+
+    <xs:element name="input"
+      dfdl:lengthKind="implicit"
+      dfdl:lengthUnits="bytes" >
+      <xs:complexType>
+        <xs:sequence dfdl:fillByte="%NUL;">
+          <xs:element name="A" type="xs:unsignedInt" 
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="1"
+            dfdl:alignmentUnits="bytes" />
+          <xs:element name="B" type="xs:unsignedInt" 
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="2"
+            dfdl:alignmentUnits="bytes" />
+          <xs:element name="C" type="xs:unsignedInt" 
+            dfdl:lengthKind="explicit"
+            dfdl:length="1"
+            dfdl:lengthUnits="bytes"
+            dfdl:alignment="2"
+            dfdl:alignmentUnits="bytes" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+	</tdml:defineSchema>
+
+  <!--
+     Test Name: alignmentFillByteNotDefined
+        Schema: schemaWithNoFillByte
+          Root: input
+       Purpose: This test demonstrates the fix for DAFFODIL-2377 - the fillByte 
+       property is required when data is not aligned to the proper boundary for 
+       encoding. Now when fillByte is not defined, an SDE is thrown instead of 
+       an abort message.
+  -->
+  <tdml:unparserTestCase name="alignmentFillByteNotDefined"
+    model="schemaWithNoFillByte" roundTrip="onePass" root="input"
+    validation="off">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:input>
+          <A>49</A>
+          <B>50</B>
+          <C>51</C>
+        </ex:input>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document />
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Property fillByte is not defined</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="alignmentFillByteDefined"
+    model="schemaWithFillByte" roundTrip="onePass" root="input"
+    validation="off">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:input>
+          <A>49</A>
+          <B>50</B>
+          <C>51</C>
+        </ex:input>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[1x2x3]]></tdml:documentPart>
+    </tdml:document>
+  </tdml:unparserTestCase>
 
   <tdml:defineSchema name="separatorMTA">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
@@ -192,5 +192,8 @@ class TestAlignedData {
   @Test def test_fillByte_05() = { runner1.runOneTest("fillByte_05") }
   @Test def test_fillByte_06() = { runner1.runOneTest("fillByte_06") }
 
+  @Test def test_alignmentFillByteNotDefined() = { runner1.runOneTest("alignmentFillByteNotDefined") }
+  @Test def test_alignmentFillByteDefined() = { runner1.runOneTest("alignmentFillByteDefined") }
+
   @Test def test_separatorMTA_01() = { runner1.runOneTest("separatorMTA_01") }
 }


### PR DESCRIPTION
Changed maybeFillByteEv in RuntimePropertyMixins.scala so that it is no
longer a Maybe.
Changed the name to fillByteEv.
Updated all references to maybeFillByteEv to fillByteEv.
maybeCachedFillByte in abstract class ParseOrUnparseState in
ProcessorStateBases.scala is still a Maybe because the cached value
would be a Nope initially.

Added tests in daffodil-test -> section12 --> aligned_data.