### PR TITLE
Tweaks to release candidate script, mainly to fix building Windows MS…

### DIFF
--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -22,8 +22,12 @@ WORKDIR /root
 COPY setup-container.sh /root/
 RUN /root/setup-container.sh
 
-COPY wix_wine.sh /root/wix311/\\bin\\candle.exe
-COPY wix_wine.sh /root/wix311/\\bin\\light.exe
+# Needed to get WiX to run in wine on Linux. See wix_wine.sh for more details
+# on why we need to do this and how it works
+RUN mv /root/wix311/{candle.exe,real-candle.exe}
+RUN mv /root/wix311/{light.exe,real-light.exe}
+COPY wix_wine.sh /root/wix311/candle.exe
+COPY wix_wine.sh /root/wix311/light.exe
 
 COPY daffodil-release-candidate /root/
 

--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -50,17 +50,6 @@ do
   esac
 done
 
-
-read -p "Pre Release label (e.g. rc1): " PRE_RELEASE
-read -p "Signing Key ID (long format): " PGP_SIGNING_KEY_ID
-read -p "Git Commit Name: " GIT_COMMIT_NAME
-read -p "Git Commit Email: " GIT_COMMIT_EMAIL
-read -p "Apache Username: " APACHE_USERNAME
-read -s -p "Apache Password: " APACHE_PASSWD
-
-echo
-echo
-
 gpg-agent --daemon --default-cache-ttl 3000 --max-cache-ttl 3000
 if [ $? -ne 0 ]; then
    echo -e "\n!!! Unable to change timeout of the gpg-agent !!!\n"
@@ -70,6 +59,29 @@ fi
 
 export GPG_TTY=$(tty)
 export WIX=/root/wix311/
+
+
+read -p "Pre Release label (e.g. rc1): " PRE_RELEASE
+
+echo
+echo "Available Signing Key IDs:"
+SHORT_SEC_KEY_IDS=`gpg --list-secret-keys --with-colons | grep '^sec'  | cut -d: -f 5`
+for SHORT_SEC_KEY_ID in $SHORT_SEC_KEY_IDS
+do
+    LONG_SEC_KEY_ID=`gpg --list-secret-keys --with-colons $SHORT_SEC_KEY_ID | grep -m 1 '^fpr' | cut -d: -f10`
+    SEC_KEY_UID=`gpg --list-secret-keys --with-colons $LONG_SEC_KEY_ID | grep '^uid' | cut -d: -f10`
+    echo "  $LONG_SEC_KEY_ID [$SEC_KEY_UID]"
+done
+echo
+
+read -p "Signing Key ID (long format): " PGP_SIGNING_KEY_ID
+read -p "Git Commit Name: " GIT_COMMIT_NAME
+read -p "Git Commit Email: " GIT_COMMIT_EMAIL
+read -p "Apache Username: " APACHE_USERNAME
+read -s -p "Apache Password: " APACHE_PASSWD
+
+echo
+echo
 
 echo "test" | gpg --default-key $PGP_SIGNING_KEY_ID --detach-sign --armor --output /dev/null
 if [ $? -ne 0 ]; then
@@ -111,7 +123,7 @@ DAFFODIL_DIST="incubator-daffodil-dist"
 echo "Cloning repos..."
 
 echo
-echo git clone ssh://git@github.com/apache/$DAFODIL_REPO.git
+echo git clone ssh://git@github.com/apache/$DAFFODIL_REPO.git
 git clone ssh://git@github.com/apache/$DAFFODIL_REPO.git
 echo
 echo git clone ssh://git@github.com/apache/$DAFFODIL_SITE_REPO.git

--- a/containers/release-candidate/setup-container.sh
+++ b/containers/release-candidate/setup-container.sh
@@ -24,7 +24,6 @@ rm ~/*
 #install dependencies
 curl https://bintray.com/sbt/rpm/rpm -o /etc/yum.repos.d/bintray-sbt-rpm.repo
 microdnf install git svn sbt java-1.8.0-devel wine winetricks unzip rpm-build rpm-sign vim-minimal
-winetricks --unattended dotnet45
 
 # install wix
 curl -L https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -o wix311-binaries.zip

--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -42,12 +42,12 @@ mappings in Universal ++= Seq(
   baseDirectory.value / "README.md" -> "README.md",
 )
 
+maintainer := "Apache Daffodil <dev@daffodil.apache.org>"
+
 //
 // RPM configuration
 //
 rpmVendor := "Apache Daffodil"
-
-maintainer in Rpm := "Apache Daffodil <dev@daffodil.apache.org>"
 
 packageArchitecture in Rpm := "noarch"
 
@@ -110,11 +110,6 @@ rpmPrefix := Some(defaultLinuxInstallLocation.value)
 // invocation is the same name as the direcotry you eventually
 // want to install into.
 name in Windows := "Daffodil" 
-
-// The Windows packager SBT plug-in maps the maintainer variable into
-// the WiX ManufacturerFullName field which is displayed in the properties
-// dialog box for the executable.
-maintainer in Windows := "Apache Daffodil Developers <dev@daffodil.apache.org>"
 
 // The Windows packager SBT plug-in maps the packageSummary variable
 // into the WiX productName field. Another strange choice. 


### PR DESCRIPTION
…I installer

- Commit 5061ed004f updated the SBT native packager plugin we use to
  build artifacts like the RPM and MSI installers. That plugin update
  changed where it looks for the candle.exe and light.exe executables
  used to build the MSI, so we need to change how we modify WiX so that
  it runs with wine.
- Removes the installation of .NET 4.5. It is unclear why that was
  originally needed, but it now causes the MSI build to fail with it
  installed. Perhaps building the container now installs an updated
  version of wine that comes with a working .NET version
- Fixes a typo when displaying a git clone command in the release
  candidate script
- Adds sbt-native-packager "maintainer" option globally rather than just
  for RPM and Windows to remove "missing maintainer" warning when
  building zip/tar
- Modifies release candidate script to display available signing keys
  for ease of use. Required moving the gpg timeout change to earlier in
  the script

DAFFODIL-2428