### PR TITLE
Improve newVariableInstace and defineVariable defaultValue expressions

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
@@ -62,7 +62,7 @@ class DFDLDefineVariable(node: Node, doc: SchemaDocument)
   final lazy val primType = PrimType.fromNameString(typeQName.local).getOrElse(
     this.SDE("Variables must have primitive type. Type was '%s'.", typeQName.toPrettyString))
 
-  final def createVariableInstance = variableRuntimeData.createVariableInstance()
+  final def createVariableInstance = variableRuntimeData.createVariableInstance
 
   final override lazy val runtimeData = variableRuntimeData
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
@@ -62,7 +62,7 @@ class DFDLDefineVariable(node: Node, doc: SchemaDocument)
   final lazy val primType = PrimType.fromNameString(typeQName.local).getOrElse(
     this.SDE("Variables must have primitive type. Type was '%s'.", typeQName.toPrettyString))
 
-  final def createVariableInstance = variableRuntimeData.createVariableInstance
+  final def createVariableInstance = variableRuntimeData.createVariableInstance()
 
   final override lazy val runtimeData = variableRuntimeData
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/externalvars/TestExternalVariablesLoader.scala
@@ -89,11 +89,11 @@ class TestExternalVariablesLoader extends Logging {
     val (sd, sset) = generateSD(topLevelAnnotations)
     val initialVMap = sset.variableMap
 
-    val stk_v_no_default = initialVMap.getVariableBindings(v_no_default)
-    val stk_v_with_default = initialVMap.getVariableBindings(v_with_default)
+    val abuf_v_no_default = initialVMap.getVariableBindings(v_no_default)
+    val abuf_v_with_default = initialVMap.getVariableBindings(v_with_default)
 
-    val var_v_no_default = stk_v_no_default.top
-    val var_v_with_default = stk_v_with_default.top
+    val var_v_no_default = abuf_v_no_default.last
+    val var_v_with_default = abuf_v_with_default.last
 
     val v_no_default_vrd = var_v_no_default.rd
     val v_with_default_vrd = var_v_with_default.rd

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -182,7 +182,7 @@ object MStackOfAnyRef {
  * things.
  */
 protected abstract class MStack[@specialized T] private[util] (
-  arrayAllocator: (Int) => Array[T], nullValue: T) extends Serializable {
+  arrayAllocator: (Int) => Array[T], nullValue: T) {
 
   private var index = 0
   private var table: Array[T] = null

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
@@ -88,7 +88,7 @@ class NewVariableInstanceStartUnparser(override val context: RuntimeData)
 
   override def unparse(state: UState) = {
     val vrd = context.asInstanceOf[VariableRuntimeData]
-    state.newVariableInstance(vrd, vrd, state)
+    state.newVariableInstance(vrd)
   }
 }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
@@ -87,7 +87,8 @@ class NewVariableInstanceStartUnparser(override val context: RuntimeData)
   override lazy val childProcessors = Vector()
 
   override def unparse(state: UState) = {
-    state.newVariableInstance(context.asInstanceOf[VariableRuntimeData])
+    val vrd = context.asInstanceOf[VariableRuntimeData]
+    state.newVariableInstance(vrd, vrd, state)
   }
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -491,6 +491,10 @@ class DataProcessor private (
       try {
         Assert.usageErrorUnless(state.dataInputStreamIsValid, "Attempted to use an invalid input source. This can happen due to our position in the input source not being properly reset after failed parse could not backtrack to its original position")
 
+        // Force the evaluation of any defineVariable's with non-constant default
+        // value expressions
+        state.variableMap.forceExpressionEvaluations(state)
+
         this.startElement(state, p)
         p.parse1(state)
         this.endElement(state, p)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -987,8 +987,17 @@ final class VariableRuntimeData(
       }
     }
 
-  def createVariableInstance(defaultValue: DataValuePrimitiveNullable = value): VariableInstance = {
+  // Pass by name/lazy arg is needed here as we need to postpone evaluating the
+  // defaultValue, which is most likely an expression, until after the inital
+  // VariableMap is created. Otherwise when we attempt to evaluate the
+  // expression it will look in the VariableMap, which hasn't been fully
+  // created yet and will trigger an OOLAG Circular Definition Exception
+  def createVariableInstance(defaultValue: => DataValuePrimitiveNullable): VariableInstance = {
     VariableInstance(state, defaultValue, this, maybeDefaultValueExpr)
+  }
+
+  def createVariableInstance(): VariableInstance = {
+    VariableInstance(state, value, this, maybeDefaultValueExpr)
   }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -987,6 +987,8 @@ final class VariableRuntimeData(
       }
     }
 
-  def createVariableInstance: VariableInstance = VariableInstance(state, value, this, maybeDefaultValueExpr)
+  def createVariableInstance(defaultValue: DataValuePrimitiveNullable = value): VariableInstance = {
+    VariableInstance(state, defaultValue, this, maybeDefaultValueExpr)
+  }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -156,7 +156,7 @@ class SetVariableParser(expr: CompiledExpression[AnyRef], decl: VariableRuntimeD
     log(LogLevel.Debug, "This is %s", toString) // important. Don't toString unless we have to log.
     val res = eval(start)
     if (start.processorStatus.isInstanceOf[Failure]) return
-    start.setVariable(decl, res, decl, start)
+    start.setVariable(decl, res, decl)
   }
 }
 
@@ -165,7 +165,7 @@ class NewVariableInstanceStartParser(override val context: VariableRuntimeData)
   override lazy val runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
-    start.newVariableInstance(context, context, start)
+    start.newVariableInstance(context)
   }
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -165,7 +165,7 @@ class NewVariableInstanceStartParser(override val context: VariableRuntimeData)
   override lazy val runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
-    start.newVariableInstance(context)
+    start.newVariableInstance(context, context, start)
   }
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -330,8 +330,8 @@ final class PState private (
     this.infoset = newParent
   }
 
-  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: VariableRuntimeData, pstate: PState): Unit = {
-    variableMap.setVariable(vrd, newValue, referringContext, pstate)
+  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: VariableRuntimeData): Unit = {
+    variableMap.setVariable(vrd, newValue, referringContext, this)
     changedVariablesStack.top += vrd.globalQName
   }
 
@@ -343,8 +343,8 @@ final class PState private (
     changedVariablesStack.top += vrd.globalQName
   }
 
-  def newVariableInstance(vrd: VariableRuntimeData, referringContext: VariableRuntimeData, pstate: PState): Unit = {
-    variableMap.newVariableInstance(vrd, referringContext, pstate)
+  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
+    variableMap.newVariableInstance(vrd, this)
     changedVariablesStack.top += vrd.globalQName
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -343,8 +343,8 @@ final class PState private (
     changedVariablesStack.top += vrd.globalQName
   }
 
-  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
-    variableMap.newVariableInstance(vrd)
+  def newVariableInstance(vrd: VariableRuntimeData, referringContext: VariableRuntimeData, pstate: PState): Unit = {
+    variableMap.newVariableInstance(vrd, referringContext, pstate)
     changedVariablesStack.top += vrd.globalQName
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -343,8 +343,8 @@ abstract class UState(
 
   def documentElement: DIDocument
 
-  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
-    variableMap.newVariableInstance(vrd)
+  def newVariableInstance(vrd: VariableRuntimeData, referringContext: VariableRuntimeData, ustate: UState): Unit = {
+    variableMap.newVariableInstance(vrd, referringContext, ustate)
   }
 
   def removeVariableInstance(vrd: VariableRuntimeData): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -343,8 +343,8 @@ abstract class UState(
 
   def documentElement: DIDocument
 
-  def newVariableInstance(vrd: VariableRuntimeData, referringContext: VariableRuntimeData, ustate: UState): Unit = {
-    variableMap.newVariableInstance(vrd, referringContext, ustate)
+  def newVariableInstance(vrd: VariableRuntimeData): Unit = {
+    variableMap.newVariableInstance(vrd, this)
   }
 
   def removeVariableInstance(vrd: VariableRuntimeData): Unit = {

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -33,10 +33,12 @@
       defaultValue="16" />
     <dfdl:defineVariable name="myVar3" type="xs:int"
       defaultValue="26" />
-    <!--<dfdl:defineVariable name="myVar4" type="xs:int"
+    <dfdl:defineVariable name="myVar4" type="xs:int"
       defaultValue="36" />
     <dfdl:defineVariable name="nonConstVar" type="xs:int"
-      defaultValue="{ $ex:myVar4 }" />-->
+      defaultValue="{ $ex:myVar4 }" />
+    <dfdl:defineVariable name="nonConstVar2" type="xs:int"
+      defaultValue="{ $ex:nonConstVar }" />
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" />
     <xs:element name="c">
@@ -435,13 +437,15 @@
       </xs:complexType>
     </xs:element>
 
-    <!--<xs:element name="defNonConst">
+    <xs:element name="defNonConst">
       <xs:complexType>
         <xs:sequence>
+          <xs:element name="test" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="1" />
           <xs:element name="value" type="xsd:int" dfdl:inputValueCalc="{ $ex:nonConstVar }" />
+          <xs:element name="value2" type="xsd:int" dfdl:inputValueCalc="{ $ex:nonConstVar2 }" />
         </xs:sequence>
       </xs:complexType>
-    </xs:element>-->
+    </xs:element>
 
     <xs:element name="e1">
       <xs:complexType>
@@ -966,18 +970,39 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <!--<tdml:parserTestCase name="defineVariable_nonConstantExpression" root="defNonConst"
+  <tdml:parserTestCase name="defineVariable_nonConstantExpression" root="defNonConst"
     model="v"
     description="defineVariable with a non-constant expression as defaultValue">
+
+    <tdml:document><![CDATA[7]]></tdml:document>
 
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <defNonConst xmlns="http://example.com">
+          <test>7</test>
           <value>36</value>
+          <value2>36</value2>
         </defNonConst>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-  </tdml:parserTestCase>-->
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="defineVariable_nonConstantExpression_unp" root="defNonConst"
+    model="v"
+    description="defineVariable with a non-constant expression as defaultValue" roundTrip="false">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <defNonConst xmlns="http://example.com">
+          <test>7</test>
+          <value>36</value>
+          <value2>36</value2>
+        </defNonConst>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:document><![CDATA[7]]></tdml:document>
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="varAsSeparator" root="e1"
     model="v"
@@ -1947,6 +1972,108 @@
             <str>f</str>
           </records>
         </file>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="circular_defineVariable">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="circular1" type="xs:int"
+      defaultValue="{ $ex:circular2 }" />
+    <dfdl:defineVariable name="circular2" type="xs:int"
+      defaultValue="{ $ex:circular1 }" />
+    <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ $ex:circular1 }" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="circular_defineVariable_err" root="root"
+    model="circular_defineVariable" description="Section 7 - ">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>part of a circular definition</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="defineVariable_ref_infoset">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="badRef" type="xs:int"
+      defaultValue="{ ex:root }" />
+    <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ 42 }" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="defineVariable_ref_infoset_err" root="root"
+    model="defineVariable_ref_infoset" description="Section 7 - ">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>????</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="defineVariable_ref_noDefault">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="noDefault" type="xs:int" />
+    <dfdl:defineVariable name="badRef" type="xs:int"
+      defaultValue="{ $ex:noDefault }" />
+    <xs:element name="root" type="xs:int" dfdl:inputValueCalc="{ $ex:badRef }" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="defineVariable_ref_noDefault_err" root="root"
+    model="defineVariable_ref_noDefault" description="Section 7 - ">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>has no value. It was not set</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="defineVariable_nonConstantExpression_setVar">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <dfdl:defineVariable name="var1" type="xs:int"
+      defaultValue="{ 5 }" />
+    <dfdl:defineVariable name="var2" type="xs:int"
+      defaultValue="{ $ex:var1 }" />
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:setVariable ref="ex:var2">2</dfdl:setVariable>
+              <dfdl:setVariable ref="ex:var1">1</dfdl:setVariable>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:element name="e1" type="xs:int" dfdl:inputValueCalc="{ $ex:var1 }" />
+          <xs:element name="e2" type="xs:int" dfdl:inputValueCalc="{ $ex:var2 }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="defineVariable_nonConstantExpression_setVar_err" root="root"
+    model="defineVariable_nonConstantExpression_setVar" description="Section 7 - ">
+    <tdml:document/>
+    <tdml:warnings>
+      <tdml:warning>Runtime Schema Definition Warning</tdml:warning>
+      <tdml:warning>Cannot set variable</tdml:warning>
+      <tdml:warning>after reading the default value</tdml:warning>
+    </tdml:warnings>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root>
+          <e1>1</e1>
+          <e2>2</e2>
+        </root>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -33,6 +33,10 @@
       defaultValue="16" />
     <dfdl:defineVariable name="myVar3" type="xs:int"
       defaultValue="26" />
+    <!--<dfdl:defineVariable name="myVar4" type="xs:int"
+      defaultValue="36" />
+    <dfdl:defineVariable name="nonConstVar" type="xs:int"
+      defaultValue="{ $ex:myVar4 }" />-->
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" />
     <xs:element name="c">
@@ -407,6 +411,37 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
+
+    <xs:element name="nvi12">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="oldVarValue" type="xsd:int" dfdl:inputValueCalc="{ $ex:myVar1 }" />
+          <xs:element name="newDefaultValue" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="innerSeq">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:annotation>
+                  <xs:appinfo source="http://www.ogf.org/dfdl/">
+                    <dfdl:newVariableInstance ref="ex:myVar1"
+                      defaultValue="{ ../ex:newDefaultValue }" />
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:element name="newVarValue" type="xs:int"
+                  dfdl:inputValueCalc="{ $ex:myVar1 }" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <!--<xs:element name="defNonConst">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="value" type="xsd:int" dfdl:inputValueCalc="{ $ex:nonConstVar }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>-->
 
     <xs:element name="e1">
       <xs:complexType>
@@ -911,6 +946,38 @@
       <tdml:error>Assertion failed: Assertion failed for pattern \d</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="varInstance_12" root="nvi12"
+    model="v"
+    description="newVariablesInstance with a non-constant expression as defaultValue">
+
+    <tdml:document><![CDATA[7]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <nvi12 xmlns="http://example.com">
+          <oldVarValue xsi:type="xsd:int">6</oldVarValue>
+          <newDefaultValue xsi:type="xsd:int">7</newDefaultValue>
+          <innerSeq>
+            <newVarValue xsi:type="xsd:int">7</newVarValue>
+          </innerSeq>
+        </nvi12>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--<tdml:parserTestCase name="defineVariable_nonConstantExpression" root="defNonConst"
+    model="v"
+    description="defineVariable with a non-constant expression as defaultValue">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <defNonConst xmlns="http://example.com">
+          <value>36</value>
+        </defNonConst>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>-->
 
   <tdml:parserTestCase name="varAsSeparator" root="e1"
     model="v"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -59,6 +59,9 @@ class TestVariables {
   @Test def test_varInstance_09(): Unit = { runner.runOneTest("varInstance_09") }
   @Test def test_varInstance_10(): Unit = { runner.runOneTest("varInstance_10") }
   @Test def test_varInstance_11(): Unit = { runner.runOneTest("varInstance_11") }
+  @Test def test_varInstance_12(): Unit = { runner.runOneTest("varInstance_12") }
+  // Causes OOLAG Circular Definition
+  // @Test def test_defineVariable_nonConstantExpression(): Unit = { runner.runOneTest("defineVariable_nonConstantExpression") }
   @Test def test_setVarChoice(): Unit = { runner.runOneTest("setVarChoice") }
   @Test def test_unparse_setVarChoice(): Unit = { runner.runOneTest("unparse_setVarChoice") }
   @Test def test_setVarOnSeqAndElemRef(): Unit = { runner.runOneTest("setVarOnSeqAndElemRef") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -60,8 +60,16 @@ class TestVariables {
   @Test def test_varInstance_10(): Unit = { runner.runOneTest("varInstance_10") }
   @Test def test_varInstance_11(): Unit = { runner.runOneTest("varInstance_11") }
   @Test def test_varInstance_12(): Unit = { runner.runOneTest("varInstance_12") }
-  // Causes OOLAG Circular Definition
-  // @Test def test_defineVariable_nonConstantExpression(): Unit = { runner.runOneTest("defineVariable_nonConstantExpression") }
+
+  @Test def test_defineVariable_nonConstantExpression(): Unit = { runner.runOneTest("defineVariable_nonConstantExpression") }
+  @Test def test_defineVariable_nonConstantExpression_unp(): Unit = { runner.runOneTest("defineVariable_nonConstantExpression_unp") }
+  @Test def test_circular_defineVariable_err(): Unit = { runner.runOneTest("circular_defineVariable_err") }
+  @Test def test_defineVariable_ref_noDefault_err(): Unit = { runner.runOneTest("defineVariable_ref_noDefault_err") }
+  @Test def test_defineVariable_nonConstantExpression_setVar_err(): Unit = { runner.runOneTest("defineVariable_nonConstantExpression_setVar_err") }
+
+  // This test triggers an unhandled NoSuchElement exception, which if handled then runs into an Assert.invariant
+  //@Test def test_defineVariable_ref_infoset_err(): Unit = { runner.runOneTest("defineVariable_ref_infoset_err") }
+
   @Test def test_setVarChoice(): Unit = { runner.runOneTest("setVarChoice") }
   @Test def test_unparse_setVarChoice(): Unit = { runner.runOneTest("unparse_setVarChoice") }
   @Test def test_setVarOnSeqAndElemRef(): Unit = { runner.runOneTest("setVarOnSeqAndElemRef") }


### PR DESCRIPTION
This commit enables newVariableInstance's to have non-constant default
value expressions.  These expressions are evaluated when the
newVariableInstance is created.

DAFFODIL-2352

This is WIP because dfdl:defineVariable defaultValue's also allow for expressions referencing other variables with default values (as long as they evaluate to a constant) and that currently causes a cirularity error to occur (see the commented out test case). This may involve so more low-level changes to 1) Get rid of the circularity error, and 2) Perform more thorough checking to see if the referenced variable's defaultValue expression evaluates to a constant.  I feel this may warrant a separate ticket, but wanted to bring this up for discussion and possibly allow the newVariableInstance fix to get into the 3.0.0 release.