### PR TITLE
Add SAX Unparse Event Batching

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
@@ -53,10 +53,11 @@ object TestSAXParseUnparseAPI {
   val testInfosetString: String = testInfoset.toString()
   val testData = "910"
 
-  lazy val dp: DataProcessor = testDataprocessor(testSchema)
+  lazy val dp: DataProcessor = testDataProcessor(testSchema)
 
-  def testDataprocessor(testSchema: scala.xml.Elem): DataProcessor = {
-    val schemaCompiler = Compiler()
+  def testDataProcessor(testSchema: scala.xml.Elem, tunablesArg: Map[String, String] = Map.empty): DataProcessor = {
+    val schemaCompiler = Compiler().withTunables(tunablesArg)
+
     val pf = schemaCompiler.compileNode(testSchema)
     if (pf.isError) {
       val msgs = pf.getDiagnostics.map { _.getMessage() }.mkString("\n")

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXUnparseAPI.scala
@@ -20,7 +20,10 @@ package org.apache.daffodil.processor
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
+import scala.xml.SAXException
+
 import javax.xml.parsers.SAXParserFactory
+import org.apache.daffodil.Implicits.intercept
 import org.apache.daffodil.xml.XMLUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -44,6 +47,27 @@ class TestSAXUnparseAPI {
     val ur = unparseContentHandler.getUnparseResult
     assertTrue(!ur.isError)
     assertEquals(testData, bao.toString)
+  }
+
+  /**
+   * Test the case when a user supplies 0 as the batch size. Minimum batchsize must be 1
+   */
+  @Test def testUnparseContentHandler_unparse_saxUnparseEventBatchSize_0(): Unit = {
+    val dpT = testDataProcessor(testSchema, Map("saxUnparseEventBatchSize" -> "0"))
+    val xmlReader: XMLReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    val bao = new ByteArrayOutputStream()
+    val wbc = java.nio.channels.Channels.newChannel(bao)
+    val unparseContentHandler = dpT.newContentHandlerInstance(wbc)
+    xmlReader.setContentHandler(unparseContentHandler)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, true)
+    val bai = new ByteArrayInputStream(testInfosetString.getBytes)
+    val e = intercept[SAXException] {
+      xmlReader.parse(new InputSource(bai))
+    }
+    val eMsg = e.getMessage
+    assertTrue(eMsg.contains("invalid saxUnparseEventBatchSize"))
+    assertTrue(eMsg.contains("minimum value is 1"))
   }
 
   @Test def testUnparseContentHandler_unparse_namespace_feature(): Unit = {

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -390,6 +390,18 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="saxUnparseEventBatchSize" type="xs:int" default="100" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Daffodil's SAX Unparse API allows events to be batched in memory to minimize the
+              frequency of context switching between the SAXInfosetInputter thread that processes
+              the events, and the DaffodilUnparseContentHandler thread that generates the events.
+              Setting this value to a low number will increase the frequency of context switching,
+              but will reduce the memory footprint. Swtting it to a high number will decrease the
+              frequency of context switching, but increase the memory footprint.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
         <xs:element name="suppressSchemaDefinitionWarnings" type="daf:TunableSuppressSchemaDefinitionWarnings" default="emptyElementParsePolicyError" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -269,14 +269,27 @@ object DFDL {
     }
   }
 
-  trait ProducerCoroutine extends Coroutine[SAXInfosetEvent] {
+  object SAXInfosetEvent {
+    def copyEvent(source: DFDL.SAXInfosetEvent, dest: DFDL.SAXInfosetEvent): Unit = {
+      if (source == null) dest.clear()
+      else {
+        dest.eventType = source.eventType
+        dest.namespaceURI = source.namespaceURI
+        dest.localName = source.localName
+        dest.nilValue = source.nilValue
+        dest.simpleText = source.simpleText
+      }
+    }
+  }
+
+  trait ProducerCoroutine extends Coroutine[Array[SAXInfosetEvent]] {
     override def isMain = true
     override protected def run(): Unit = {
       throw new Error("Main thread co-routine run method should not be called.")
     }
   }
 
-  trait ConsumerCoroutine extends Coroutine[SAXInfosetEvent]
+  trait ConsumerCoroutine extends Coroutine[Array[SAXInfosetEvent]]
 
   trait ParseResult extends Result with WithDiagnostics {
     def resultState: State

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testUnparserSAX.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testUnparserSAX.tdml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  suiteName="saxUnparserTests">
+
+  <tdml:defineSchema name="saxUnparseSchema.embedded.dfdl.xsd">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <xs:element name="record" type="ex:itemType"/>
+    <xs:complexType name="itemType">
+      <xs:sequence>
+        <xs:element name="item" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+
+  </tdml:defineSchema>
+
+  <tdml:defineConfig name="cfg_saxUnparseEventBatchSize_1">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:saxUnparseEventBatchSize>1</daf:saxUnparseEventBatchSize>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:defineConfig name="cfg_saxUnparseEventBatchSize_5">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:saxUnparseEventBatchSize>5</daf:saxUnparseEventBatchSize>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:defineConfig name="cfg_saxUnparseEventBatchSize_1000">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:saxUnparseEventBatchSize>1000</daf:saxUnparseEventBatchSize>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:unparserTestCase name="test_saxUnparseBatchSize_1" root="record"
+    model="saxUnparseSchema.embedded.dfdl.xsd"
+    roundTrip="true"
+    config="cfg_saxUnparseEventBatchSize_1">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <record xmlns="http://example.com">
+          <item>H</item>
+          <item>e</item>
+          <item>l</item>
+          <item>l</item>
+          <item>o</item>
+          <item>!</item>
+          <item>-</item>
+          <item>W</item>
+          <item>o</item>
+          <item>r</item>
+          <item>l</item>
+          <item>d</item>
+          <item>.</item>
+          <item>1</item>
+          <item>2</item>
+          <item>3</item>
+        </record>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+
+    <tdml:document>Hello!-World.123</tdml:document>
+
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="test_saxUnparseBatchSize_5" root="record"
+    model="saxUnparseSchema.embedded.dfdl.xsd"
+    roundTrip="true"
+    config="cfg_saxUnparseEventBatchSize_5">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <record xmlns="http://example.com">
+          <item>H</item>
+          <item>e</item>
+          <item>l</item>
+          <item>l</item>
+          <item>o</item>
+          <item>!</item>
+          <item>-</item>
+          <item>W</item>
+          <item>o</item>
+          <item>r</item>
+          <item>l</item>
+          <item>d</item>
+          <item>.</item>
+          <item>1</item>
+          <item>2</item>
+          <item>3</item>
+        </record>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+
+    <tdml:document>Hello!-World.123</tdml:document>
+
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="test_saxUnparseBatchSize_1000" root="record"
+    model="saxUnparseSchema.embedded.dfdl.xsd"
+    roundTrip="true"
+    config="cfg_saxUnparseEventBatchSize_1000">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <record xmlns="http://example.com">
+          <item>H</item>
+          <item>e</item>
+          <item>l</item>
+          <item>l</item>
+          <item>o</item>
+          <item>!</item>
+          <item>-</item>
+          <item>W</item>
+          <item>o</item>
+          <item>r</item>
+          <item>l</item>
+          <item>d</item>
+          <item>.</item>
+          <item>1</item>
+          <item>2</item>
+          <item>3</item>
+        </record>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:document>Hello!-World.123</tdml:document>
+
+  </tdml:unparserTestCase>
+</tdml:testSuite>
+

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserSAX.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserSAX.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestUnparserSAX {
+  val testDir = "/org/apache/daffodil/section00/general/"
+  val runner2 = Runner(testDir, "testUnparserSAX.tdml")
+
+  @AfterClass def shutDown: Unit = {
+    runner2.reset
+  }
+}
+
+class TestUnparserSAX {
+  import TestUnparserSAX._
+
+  @Test def test_saxUnparseBatchSize_1() = { runner2.runOneTest("test_saxUnparseBatchSize_1") }
+  @Test def test_saxUnparseBatchSize_5() = { runner2.runOneTest("test_saxUnparseBatchSize_5") }
+  @Test def test_saxUnparseBatchSize_1000() = { runner2.runOneTest("test_saxUnparseBatchSize_1000") }
+}


### PR DESCRIPTION
We use a SAXInfosetEvent array of tunable saxUnparseEventBatchSize size and pass the same array back and forth between the inputter and the unparseContentHandler, reusing its elements. The hope is this will reduce the context switching 
and result in a constant memory footprint as opposed to the having to create a new SAXInfosetEvent object for each event. 

- add saxUnparseEventBatchSize tunable with default 100
- update coroutine to not expect a generic type wrapped in a Try, but any generic event; the implementation can then pass in whatever they wish
- Add tests for tunables and batching tests

DAFFODIL-2383