### PR TITLE
Update ratCheck to latest version, and check fail on unexpected binaries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,12 +232,11 @@ lazy val ratSettings = Seq(
   ratLicenses := Seq(
     ("BSD2 ", Rat.BSD2_LICENSE_NAME, Rat.LICENSE_TEXT_PASSERA)
   ),
-
   ratLicenseFamilies := Seq(
     Rat.BSD2_LICENSE_NAME
   ),
-
-  ratExcludes := Rat.excludes
+  ratExcludes := Rat.excludes,
+  ratFailBinaries := true,
 )
 
 lazy val unidocSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.5")
 
-addSbtPlugin("org.musigma" % "sbt-rat" % "0.6.0")
+addSbtPlugin("org.musigma" % "sbt-rat" % "0.7.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 


### PR DESCRIPTION
ASF policy is to not allow unexpected binaries in source/releases.
Unfortunately, ratCheck doesn't currently fail if binaries are
committed, so it is possible for them to unintentionally slip into the
code base. To ensure this doesn't happen, this updates the sbt-rat
plugin to the latest version and enables the new ratFailBinaries setting
so it fails if binaries are found in the repo. This now requires that
any binaries that are expected and allowed to be in the repo (e.g.
images, test data) are explicitly excluded in project/Rat.scala

DAFFODIL-2434