### PR TITLE
TDML Runner provides namespace. Disallows dup test names.

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -159,6 +159,7 @@
     <attribute name="name" type="xs:NCName" use="required"/>
     <attribute name="ID" type="xs:token" use="optional"/>
     <attribute name="root" type="xs:NCName" use="optional"/> <!-- only needed when there is no infoset. -->
+    <attribute name="rootNS" type="xs:string" use="optional"/> <!-- only needed when there is no infoset. -->
     <attribute name="model" type="xs:string" use="optional"/> <!-- is there a type for a path/uri? -->
     <attribute name="config" type="xs:string" use="optional"/> <!-- is there a type for a path/uri? -->
     <attribute name="roundTrip" type="tns:roundTripType" use="optional"/>


### PR DESCRIPTION
Set out to fix the fact that the TDML Runner needs to pass the
namespace of the root to the TDML processor, as some processors can't
(from their current APIs) search and resolve this themselves.

This fixes a problem with vcard and the IBM cross tester rig.

Picked off DAFFODIL-1299, because I was there in the code, and it was easy to do. 

DAFFODIL-1299, DAFFODIL-2440