### PR TITLE
Ensure src/main directories exist to make Sonarcloud happy

### DIFF
--- a/daffodil-test-ibm1/src/main/.keep
+++ b/daffodil-test-ibm1/src/main/.keep
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sonarcloud requires that the src/main directory exist or it errors. This file
+# ensures this directory exists since git doesn't support empty directories.

--- a/daffodil-test/src/main/.keep
+++ b/daffodil-test/src/main/.keep
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sonarcloud requires that the src/main directory exist or it errors. This file
+# ensures this directory exists since git doesn't support empty directories.


### PR DESCRIPTION
Sonarcloud requires that the src/main directory exists for its scans,
even if there are no sources. Commit 064d7b8655 removed all the .keep
files which caused the src/main directory in daffodil-test and
daffodil-test-ibm1 to be deleted since those modules have no actual
sources. But this caused Sonarcloud failures.

To fix this, add back the .keep files for only these two directories so
that sonarcloud scan will work. It's also possible some IDE's might be
unhappy without src/main directories, so this isn't necessarily
sonarcloud specific.

DAFFODIL-2430