### PR TITLE
Fixes sonarcloud duplication error

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,7 +22,10 @@ sonar.tests=src/it,src/test
 # TODO DAFFODIL-1747 Scala/Java APIs currently contain a lot of duplication
 #  by their nature. Best to exclude them. This will want to be removed when
 #  the ticket above is fixed
-sonar.cpd.exclusions=src/main/scala/org/apache/daffodil/sapi/Daffodil.scala,src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+# TODO DAFFODIL-1958 Main.scala already has a ticket to reduce duplication. 
+#  It can be excluded until that is resolved
+sonar.cpd.exclusions=src/main/scala/org/apache/daffodil/sapi/**/*,src/main/scala/org/apache/daffodil/japi/**/*,src/main/scala/org/apache/daffodil/Main.scala
+
 sonar.java.binaries=target/**/classes
 sonar.java.test.binaries=target/**/test-classes
 sonar.java.libraries=../lib_managed/**/*.jar


### PR DESCRIPTION
Sonarcloud is currently failing due to the sapi/japi and Main.scala code exceeding the duplication threshold. We add sapi/japi directories and Main.scala to cpd exclusions list so duplication checks are not done on them.

I was not able to replicate the failure state on my local instance, so this PR technically was not tested for the fix. It was tested to ensure a valid check could be run.