### PR TITLE
Add support for displaying variables in the debugger

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -750,7 +750,7 @@ class TestCLIdebugger {
       shell.sendLine("display info dne1")
       shell.expect(contains("error: undefined info command: dne1"))
       shell.sendLine("display info bitLimit dne2")
-      shell.expect(contains("error: undefined info command: dne2"))
+      shell.expect(contains("error: bitLimit command requires zero arguments"))
       shell.sendLine("display break")
       shell.expect(contains("error: undefined command: break"))
       shell.sendLine("quit")
@@ -1156,5 +1156,94 @@ class TestCLIdebugger {
     }
   }
 
+  @Test def test_CLI_Debugger_info_variables(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r matrix %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("info variables byteOrder")
+      shell.expect(contains("byteOrder: bigEndian (default)"))
+      shell.sendLine("quit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_info_data_text(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r matrix %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("display info data text")
+      shell.expect(contains("(debug)"))
+      shell.sendLine("step")
+      shell.expect(contains("0~,~1~,~2~"))
+      shell.sendLine("quit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_info_data_binary(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r matrix %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("display info data binary")
+      shell.expect(contains("(debug)"))
+      shell.sendLine("step")
+      shell.expect(contains("302c 312c 32"))
+      shell.sendLine("quit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_info_diff(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables_01.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r c %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("display info diff")
+      shell.expect(contains("(debug)"))
+      shell.sendLine("step")
+      shell.expect(contains("No differences"))
+      shell.sendLine("step")
+      shell.expect(contains("No differences"))
+      shell.sendLine("step")
+      shell.expect(contains("variable: tns:v_with_default: 42 (default) -> 42 (read)"))
+      shell.sendLine("step")
+      shell.expect(contains("variable: tns:v_no_default: (undefined) -> 42 (set)"))
+      shell.sendLine("step")
+      shell.expect(contains("No differences"))
+      shell.sendLine("quit")
+    } finally {
+      shell.close()
+    }
+  }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -77,6 +77,7 @@ trait StateForDebugger {
   def currentLocation: DataLocation
   def arrayPos: Long
   def bitLimit0b: MaybeULong
+  def variableMap: VariableMap
 }
 
 case class TupleForDebugger(
@@ -85,7 +86,8 @@ case class TupleForDebugger(
   val groupPos: Long,
   val currentLocation: DataLocation,
   val arrayPos: Long,
-  val bitLimit0b: MaybeULong)
+  val bitLimit0b: MaybeULong,
+  val variableMap: VariableMap)
   extends StateForDebugger
 
 trait SetProcessorMixin {
@@ -430,7 +432,9 @@ abstract class ParseOrUnparseState protected (
       groupPos,
       currentLocation,
       arrayPos,
-      bitLimit0b)
+      bitLimit0b,
+      variableMap.copy(), // deep copy since variableMap is mutable
+    )
   }
 
   final override def schemaFileLocation = getContext().schemaFileLocation

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
@@ -320,6 +320,10 @@ class VariableMap private(vTable: Map[GlobalQName, ArrayBuffer[VariableInstance]
     variab
   }
 
+  def qnames(): Seq[GlobalQName] = {
+    vTable.toSeq.map(_._1)
+  }
+
   def getVariableRuntimeData(qName: GlobalQName): Option[VariableRuntimeData] = {
     val optVariable = find(qName)
     if (optVariable.isDefined) Some(optVariable.get.rd) else None


### PR DESCRIPTION
Adds a new info subcommand called "variables" to show the current
in-scope state and value of variables. For example:

    (debug) info variables
      variables:
        ex:var1:  (undefined)
        {http://www.ogf.org/dfdl/dfdl-1.0/}binaryFloatRep: ieee (default)
        {http://www.ogf.org/dfdl/dfdl-1.0/}byteOrder: bigEndian (default)
        {http://www.ogf.org/dfdl/dfdl-1.0/}encoding: UTF-8 (default)
        {http://www.ogf.org/dfdl/dfdl-1.0/}outputNewLine: %LF; (default)

Also allows specifcying one or more variable names to only output those
if you don't want to see all variables, for example:

    (debug) info varibles var1 byteOrder
      variables:
        ex:var1:  (undefined)
        {http://www.ogf.org/dfdl/dfdl-1.0/}byteOrder: bigEndian (default)

This also modifies the info command so that you can provide parameters
to subcommands, which is needed to allow variable names after the "info
variables".

Fixes the "info data" command which at one point
had optional parameters to control how data should be output (either
text or binary). This was broken at some point, but is now available.

Allows the "clear" command to be used in the "display" command, e.g.

  (debug) display clear

This can be useful to clear the screen every time the debugger pauses,
sometimes making it easier to see what changed.

DAFFODIL-2453