### PR TITLE
Update debugger support of found delimiters/fields/diffs

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -1217,7 +1217,7 @@ class TestCLIdebugger {
     }
   }
 
-  @Test def test_CLI_Debugger_info_diff(): Unit = {
+  @Test def test_CLI_Debugger_info_diff_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables_01.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
     val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
@@ -1231,15 +1231,89 @@ class TestCLIdebugger {
       shell.sendLine("display info diff")
       shell.expect(contains("(debug)"))
       shell.sendLine("step")
-      shell.expect(contains("No differences"))
+      shell.expect(contains("(no differences)"))
       shell.sendLine("step")
-      shell.expect(contains("No differences"))
+      shell.expect(contains("(no differences)"))
       shell.sendLine("step")
       shell.expect(contains("variable: tns:v_with_default: 42 (default) -> 42 (read)"))
       shell.sendLine("step")
       shell.expect(contains("variable: tns:v_no_default: (undefined) -> 42 (set)"))
       shell.sendLine("step")
-      shell.expect(contains("No differences"))
+      shell.expect(contains("childIndex: 1 -> 2"))
+      shell.sendLine("step")
+      shell.expect(contains("variable: tns:v_no_default: 42 (set) -> 42 (read)"))
+      shell.sendLine("step")
+      shell.expect(contains("<d>42</d>"))
+      shell.expect(contains("<e>42</e>"))
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_info_diff_02(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r matrix %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("display info diff")
+      shell.expect(contains("(debug)"))
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.expect(contains("bitPosition: 0 -> 8"))
+      shell.expect(contains("foundDelimiter: (no value) -> ,"))
+      shell.expect(contains("foundField: (no value) -> 0"))
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.expect(contains("childIndex: 1 -> 2"))
+      shell.expect(contains("groupIndex: 1 -> 2"))
+      shell.expect(contains("occursIndex: 1 -> 2"))
+      shell.sendLine("step")
+      shell.expect(contains("bitPosition: 8 -> 16"))
+      shell.expect(contains("foundDelimiter: , -> (no value)"))
+      shell.expect(contains("foundField: 0 -> (no value)"))
+      shell.sendLine("quit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_info_diff_03(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input6.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s -r e %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+      shell.sendLine("display info diff")
+      shell.expect(contains("(debug)"))
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.expect(contains("hidden: false -> true"))
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      shell.expect(contains("hidden: true -> false"))
       shell.sendLine("quit")
     } finally {
       shell.close()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/events/ParseEventHandler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/events/ParseEventHandler.scala
@@ -34,7 +34,7 @@ trait EventHandler {
   /**
    * Parser Events
    */
-  def init(processor: Parser): Unit = {
+  def init(state: PState, processor: Parser): Unit = {
     //do nothing
   }
 
@@ -77,7 +77,7 @@ trait EventHandler {
   /**
    * Unparser Events
    */
-  def init(processor: Unparser): Unit = {
+  def init(state: UState, processor: Unparser): Unit = {
     //do nothing
   }
 
@@ -142,7 +142,7 @@ trait MultipleEventHandler extends EventHandler with Serializable {
   /**
    * Parser Events
    */
-  override def init(processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
+  override def init(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(state, processor) } }
 
   override def before(state: PState, processor: Parser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
 
@@ -173,7 +173,7 @@ trait MultipleEventHandler extends EventHandler with Serializable {
   /**
    * Unparser Events
    */
-  override def init(processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(processor) } }
+  override def init(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.init(state, processor) } }
 
   override def before(state: UState, processor: Unparser): Unit = { if (!(handlers eq Nil)) handlers.foreach { _.before(state, processor) } }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -434,7 +434,7 @@ class DataProcessor private (
       addEventHandler(debugger)
       state.notifyDebugging(true)
     }
-    state.dataProc.get.init(ssrd.parser)
+    state.dataProc.get.init(state, ssrd.parser)
     doParse(ssrd.parser, state)
     val pr = new ParseResult(this, state)
     if (!pr.isProcessingError) {
@@ -574,7 +574,7 @@ class DataProcessor private (
         addEventHandler(debugger)
         unparserState.notifyDebugging(true)
       }
-      unparserState.dataProc.get.init(ssrd.unparser)
+      unparserState.dataProc.get.init(unparserState, ssrd.unparser)
       out.setPriorBitOrder(ssrd.elementRuntimeData.defaultBitOrder)
       doUnparse(unparserState)
       unparserState.evalSuspensions(isFinal = true)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -71,23 +71,27 @@ import org.apache.daffodil.dsom.DPathCompileInfo
  * contains member functions for everything the debugger needs to be able to observe.
  */
 trait StateForDebugger {
-  def bytePos: Long
+  def currentLocation: DataLocation
+  def bitPos0b: Long
+  def bitLimit0b: MaybeULong
   def childPos: Long
   def groupPos: Long
-  def currentLocation: DataLocation
   def arrayPos: Long
-  def bitLimit0b: MaybeULong
   def variableMap: VariableMap
+  def delimitedParseResult: Maybe[dfa.ParseResult]
+  def withinHiddenNest: Boolean
 }
 
 case class TupleForDebugger(
-  val bytePos: Long,
+  val currentLocation: DataLocation,
+  val bitPos0b: Long,
+  val bitLimit0b: MaybeULong,
   val childPos: Long,
   val groupPos: Long,
-  val currentLocation: DataLocation,
   val arrayPos: Long,
-  val bitLimit0b: MaybeULong,
-  val variableMap: VariableMap)
+  val variableMap: VariableMap,
+  val delimitedParseResult: Maybe[dfa.ParseResult],
+  val withinHiddenNest: Boolean)
   extends StateForDebugger
 
 trait SetProcessorMixin {
@@ -427,13 +431,15 @@ abstract class ParseOrUnparseState protected (
 
   def copyStateForDebugger = {
     TupleForDebugger(
-      bytePos,
+      currentLocation,
+      bitPos0b,
+      bitLimit0b,
       childPos,
       groupPos,
-      currentLocation,
       arrayPos,
-      bitLimit0b,
       variableMap.copy(), // deep copy since variableMap is mutable
+      delimitedParseResult,
+      withinHiddenNest,
     )
   }
 
@@ -564,6 +570,7 @@ final class CompileState(tci: DPathCompileInfo, maybeDataProc: Maybe[DataProcess
   def dataStream = Nope
   def groupPos: Long = 0L
   def hasInfoset: Boolean = infoset_.isDefined
+  def delimitedParseResult = Nope
 
   private lazy val infoset_ : Maybe[DIElement] = Nope
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -352,6 +352,8 @@ abstract class UState(
   }
 
   final val releaseUnneededInfoset: Boolean = !areDebugging && tunable.releaseUnneededInfoset
+
+  def delimitedParseResult = Nope
 }
 
 /**


### PR DESCRIPTION
- Refactor how diff's are calculated so that all the logic is moved into
  the individual command objects that care about that piece of
  information. Now, any info command that is "diffable" must implement
  the InfoDiffable trait and the 'diff' function. The "info diff"
  command now automatically finds all commands that implement this trait
  and will call this diff function. This simplifies the info diff
  command and makes it so it doesn't need to know anything about other
  info commands or anything about the state.
- Instead of "info foundDelimiter" showing both the found delimiter and
  the found field, it now only shows the found delimiter. And add a new
  "info foundField" command to show the found field that "info
  foundDelimiter" used to show. This makes the code less complex and
  gives the user more control over what information they want to see.
  These new commands are also made diffable so they now show up in "info
  diff". When diffs are found, this command outputs something like this:
  ```
    diff:
      foundDelimiter: none -> ,
      foundField: none -> smith
  ```
  The above shows that a comma delimiter was found and that the field
  proceeding that delimiter was "smith".

DAFFODIL-758

> Note this doesn't fully resolve DAFFODIL-758, this is just an incremental step in improving trace output.