### PR TITLE
Confirm behavior when compiling schemas without global elements

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -206,27 +206,19 @@ class TestCLIparsing {
   }
 
   @Test def test_1593_CLI_Parsing_MultifileSchema_noGlobalElem(): Unit = {
-    val tmp_filename: String = (System.currentTimeMillis / 1000).toString()
-    val file = new File(tmp_filename)
-    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/TopLevel.dfdl.xsd")
-    val inputFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/02nine_headers.txt")
-    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
-
-    val shell = Util.start("")
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_21.dfdl.xsd")
+    val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+    val shell = Util.startIncludeErrors("")
 
     try {
-      val cmd = String.format("%s parse -s %s -o %s %s", Util.binPath, testSchemaFile, tmp_filename, testInputFile)
+      val cmd = String.format(Util.echoN("does not matter") + " | %s parse -s %s", Util.binPath, testSchemaFile)
       shell.sendLine(cmd)
-
-      //TODO:update
-      //val err = shell.getCurrentStandardErrContents()
-      //assertEquals(err, "")
+      shell.expectIn(1, contains("No global elements"))
+      shell.expectIn(1, contains("multi_base_21.dfdl.xsd"))
       shell.sendLine("exit")
       shell.expect(eof)
     } finally {
       shell.close()
-      //Remove the temporary output file
-      assertTrue("Failed to remove temporary file: %s".format(file), file.delete)
     }
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_A_20.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_A_20.dfdl.xsd
@@ -45,4 +45,20 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:element name="base">
+    <xs:complexType>
+      <xs:sequence dfdl:separator=",">
+        <xs:element name="acolor" type="a20:color" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="base2">
+    <xs:complexType>
+      <xs:sequence dfdl:separator="/">
+        <xs:element name="seq" type="a20:simpleSeq" maxOccurs="3"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_A_21.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_A_21.dfdl.xsd
@@ -23,7 +23,7 @@
 
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="base:GeneralFormat" separator="'" alignment="implicit" alignmentUnits="bits" trailingSkip="0" initiator="" terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
+      <dfdl:format ref="a21:GeneralFormat" separator="'" alignment="implicit" alignmentUnits="bits" trailingSkip="0" initiator="" terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
         separatorSuppressionPolicy="anyEmpty" separatorPosition="infix" ignoreCase="no" representation="text" textNumberRep="standard" lengthKind="delimited" encoding="US-ASCII"/>
     </xs:appinfo>
   </xs:annotation>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_20.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_20.dfdl.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
    targetNamespace="http://baseSchema.com" xmlns:base="http://baseSchema.com" xmlns:a20="http://a20.com">
 
-  <xs:import namespace="http://a20.com" schemaLocation="org/apache/daffodil/section06/namespaces/multi_A_20.dfdl.xsd"/>
+  <xs:import namespace="http://a20.com" schemaLocation="multi_A_20.dfdl.xsd"/>
   <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
   <xs:annotation>
@@ -29,20 +29,8 @@
     </xs:appinfo>
   </xs:annotation>
 
-  <xs:element name="base">
-    <xs:complexType>
-      <xs:sequence dfdl:separator=",">
-        <xs:element name="acolor" type="a20:color" maxOccurs="unbounded"/>   
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:element ref="a20:base" />
   
-  <xs:element name="base2">
-    <xs:complexType>
-      <xs:sequence dfdl:separator="/">
-        <xs:element name="seq" type="a20:simpleSeq" maxOccurs="3"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="a20:base2" />
 
 </xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_21.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_21.dfdl.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
    targetNamespace="http://baseSchema.com" xmlns:base="http://baseSchema.com" xmlns:a21="http://a21.com">
 
-  <xs:import namespace="http://a21.com" schemaLocation="org/apache/daffodil/section06/namespaces/multi_A_21.dfdl.xsd"/>
+  <xs:import namespace="http://a21.com" schemaLocation="multi_A_21.dfdl.xsd"/>
   <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
   <xs:annotation>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
@@ -2370,7 +2370,8 @@
     Test name: schemaNoGlobalElems_01
     Schema: multi_base_20.dfdl.xsd
     Root: base
-    Purpose: This test demonstrates that you can have a schema with no global elements (only contains items that are referenced) 
+    Purpose: This test demonstrates that you can have a primary schema where the
+             only global elements are element references
   -->
 
   <tdml:parserTestCase name="schemaNoGlobalElems_01"
@@ -2391,7 +2392,8 @@
     Test name: schemaNoGlobalElems_02
     Schema: multi_base_20.dfdl.xsd
     Root: base2
-    Purpose: This test demonstrates that you can have a schema with no global elements (only contains items that are referenced) 
+    Purpose: This test demonstrates that you can have a primary schema where the
+             only global elements are element references
   -->
 
   <tdml:parserTestCase name="schemaNoGlobalElems_02"
@@ -2411,6 +2413,25 @@
             <elem>six</elem>
           </seq>
         </base2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: schemaNoGlobalElems_03
+    Schema: multi_base_21.dfdl.xsd
+    Root: base2
+    Purpose: This test demonstrates that you can have a schema if there are
+             no global elements in the primary schema, as long as the root element is
+             specified (the TDML Runner always specifies the root)
+  -->
+
+  <tdml:parserTestCase name="schemaNoGlobalElems_03"
+    root="distant_element" model="multi_base_21.dfdl.xsd" description="">
+    <tdml:document>test string</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <distant_element>test string</distant_element>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
@@ -47,6 +47,7 @@ class TestNamespaces {
 
   @Test def test_schemaNoGlobalElems_01(): Unit = { runner.runOneTest("schemaNoGlobalElems_01") }
   @Test def test_schemaNoGlobalElems_02(): Unit = { runner.runOneTest("schemaNoGlobalElems_02") }
+  @Test def test_schemaNoGlobalElems_03(): Unit = { runner.runOneTest("schemaNoGlobalElems_03") }
 
   @Test def test_schemaSameDir_01(): Unit = { runner.runOneTest("schemaSameDir_01") }
   @Test def test_schemaSameDir_02(): Unit = { runner.runOneTest("schemaSameDir_02") }


### PR DESCRIPTION
If a primary schema does not contain any global elements, and no root
element is given when compiling the schema, the correct behavior is a
schema definition error. If a root element is provided when compiling a
schema, we are able to search included/imported schemas for this
element. This adds/modifies tests to confirm this behavior.

Note that TDML runner always provides a root element, so testing the
negative case requires a CLI test. This also slightly modifies related
tests that were not quite correct based on the description of the test.

DAFFODIL-913